### PR TITLE
docs: add CRUSH guide and ignore .crush folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ examples/bitmap/imgToBitmap/test.png
 examples/bitmap/imgToBitmap/test_7.jpeg
 robot_img.png
 examples/bitmap/bitmapTobytes/out.jpg
+
+# CRUSH tooling
+.crush/

--- a/Agents.md
+++ b/Agents.md
@@ -1,0 +1,1 @@
+Please follow the instructions in CRUSH.md.

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -1,0 +1,2 @@
+RobotGo is a Go library for desktop automation and control.
+Our current goal is to extend RobotGo with Wayland support.


### PR DESCRIPTION
## Summary
- document project goal to add Wayland support in new CRUSH.md
- instruct contributors via Agents.md to follow CRUSH guidelines
- ignore local `.crush` work directory

## Testing
- `go test ./...` *(fails: X11/extensions/XTest.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b331507f1c8324b0027c1388cd5d9e