### PR TITLE
fix wayland build tags and linking

### DIFF
--- a/robotgo_wayland.go
+++ b/robotgo_wayland.go
@@ -1,11 +1,12 @@
-//go:build wayland
-// +build wayland
+//go:build linux && wayland
+// +build linux,wayland
 
 package robotgo
 
 /*
-#cgo pkg-config: wayland-client
+#cgo pkg-config: wayland-client wayland-cursor wayland-egl xkbcommon
 #cgo CFLAGS: -DUSE_WAYLAND
+#cgo LDFLAGS: -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
 #include "window/get_bounds_wayland_c.h"
 */
 import "C"

--- a/wayland_n.go
+++ b/wayland_n.go
@@ -1,2 +1,0 @@
-// +bulid linux,next
-package robotgo


### PR DESCRIPTION
## Summary
- restrict wayland support to linux builds and add linker flags for wayland libraries
- remove obsolete wayland stubs that interfered with cgo builds

## Testing
- `go build -tags wayland robotgo_wayland.go` *(fails: Package wayland-client was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68b3408593008324a58c426dcdc3af9b