### PR TITLE
refactor: make os header C friendly

### DIFF
--- a/base/os.h
+++ b/base/os.h
@@ -2,8 +2,7 @@
 #ifndef OS_H
 #define OS_H
 
-#include <cstdlib>  // For getenv()
-#include <string>   // For std::string
+#include <stdlib.h>  // For getenv()
 
 #if !defined(IS_MACOSX) && defined(__APPLE__) && defined(__MACH__)
     #define IS_MACOSX
@@ -59,26 +58,26 @@
 // ---------------------
 // Display Server Detection (Runtime)
 // ---------------------
-enum class DisplayServer {
+typedef enum {
     Wayland,
     X11,
     Unknown
-};
+} DisplayServer;
 
-inline DisplayServer detectDisplayServer() {
+static inline DisplayServer detectDisplayServer(void) {
 #if defined(IS_LINUX)
-    const char* wayland = std::getenv("WAYLAND_DISPLAY");
-    const char* x11 = std::getenv("DISPLAY");
+    const char* wayland = getenv("WAYLAND_DISPLAY");
+    const char* x11 = getenv("DISPLAY");
 
     if (wayland && *wayland != '\0') {
-        return DisplayServer::Wayland;
+        return Wayland;
     } else if (x11 && *x11 != '\0') {
-        return DisplayServer::X11;
+        return X11;
     } else {
-        return DisplayServer::Unknown;
+        return Unknown;
     }
 #else
-    return DisplayServer::Unknown;
+    return Unknown;
 #endif
 }
 

--- a/base/os_display.go
+++ b/base/os_display.go
@@ -1,0 +1,22 @@
+//go:build linux
+
+package base
+
+/*
+#include "os.h"
+*/
+import "C"
+
+// DisplayServer mirrors the values from the C enum in os.h.
+type DisplayServer int
+
+const (
+	Wayland DisplayServer = C.Wayland
+	X11     DisplayServer = C.X11
+	Unknown DisplayServer = C.Unknown
+)
+
+// DetectDisplayServer calls the C detectDisplayServer function.
+func DetectDisplayServer() DisplayServer {
+	return DisplayServer(C.detectDisplayServer())
+}

--- a/base/os_test.go
+++ b/base/os_test.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package base
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDetectDisplayServer(t *testing.T) {
+	t.Run("Wayland", func(t *testing.T) {
+		os.Setenv("WAYLAND_DISPLAY", "wayland-0")
+		os.Unsetenv("DISPLAY")
+		if ds := DetectDisplayServer(); ds != Wayland {
+			t.Fatalf("expected Wayland, got %v", ds)
+		}
+		os.Unsetenv("WAYLAND_DISPLAY")
+	})
+
+	t.Run("X11", func(t *testing.T) {
+		os.Unsetenv("WAYLAND_DISPLAY")
+		os.Setenv("DISPLAY", ":0")
+		if ds := DetectDisplayServer(); ds != X11 {
+			t.Fatalf("expected X11, got %v", ds)
+		}
+		os.Unsetenv("DISPLAY")
+	})
+}


### PR DESCRIPTION
## Summary
- replace c++ headers and enum in base/os.h with C equivalents
- expose DetectDisplayServer to Go and add tests

## Testing
- `gcc -I. -c /tmp/test.c` (base/types.h)
- `gcc -I. -c /tmp/test.c` (base/microsleep.h)
- `gcc -I. -c /tmp/test.c` (key/keycode.h)
- `gcc -I. -c /tmp/test.c` (key/keypress.h)
- `gcc -I. -c /tmp/test.c` (mouse/mouse.h)
- `gcc -I. -c /tmp/test.c` (window/win_sys.h)
- `go test -run TestDetectDisplayServer -v ./base`
- `go test ./...` *(fails: X11/extensions/XTest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b34fbfa4f483249b69f376a7ba3119