### PR TITLE
test: skip GUI tests when no display

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -115,6 +115,7 @@ Run **`make help`** for live descriptions. Typical targets:
 - Integration tests live in `/test`; can use Docker services; guard with build tag `integration`.
 - Run `-race` in CI for tests; keep flakes out of main.
 - Benchmarks belong with the code; compare with previous runs on PRs if possible.
+- GUI tests are skipped when no display server is available (`DISPLAY` and `WAYLAND_DISPLAY` unset).
 
 Example test skeleton:
 

--- a/robot_info_test.go
+++ b/robot_info_test.go
@@ -13,12 +13,20 @@ package robotgo_test
 import (
 	"fmt"
 	"log"
+	"os"
 	"runtime"
 	"testing"
 
 	"github.com/marang/robotgo"
 	"github.com/vcaesar/tt"
 )
+
+func requireDisplay(t *testing.T) {
+	t.Helper()
+	if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
+		t.Skip("no display available")
+	}
+}
 
 func TestGetVer(t *testing.T) {
 	fmt.Println("go version: ", runtime.Version())
@@ -28,6 +36,7 @@ func TestGetVer(t *testing.T) {
 }
 
 func TestGetScreenSize(t *testing.T) {
+	requireDisplay(t)
 	x, y := robotgo.GetScreenSize()
 	log.Println("Get screen size: ", x, y)
 
@@ -39,6 +48,7 @@ func TestGetScreenSize(t *testing.T) {
 }
 
 func TestGetSysScale(t *testing.T) {
+	requireDisplay(t)
 	s := robotgo.SysScale()
 	log.Println("SysScale: ", s)
 
@@ -47,6 +57,7 @@ func TestGetSysScale(t *testing.T) {
 }
 
 func TestGetTitle(t *testing.T) {
+	requireDisplay(t)
 	// just exercise the function, it used to crash with a segfault + "Maximum
 	// number of clients reached"
 	for i := 0; i < 128; i++ {

--- a/window/wayland_test.go
+++ b/window/wayland_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/marang/robotgo/base"
 )
 
+func requireDisplay(t *testing.T) {
+	t.Helper()
+	if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
+		t.Skip("no display available")
+	}
+}
+
 // startHeadlessWeston launches a headless Wayland compositor using weston.
 // It returns a cleanup function to stop the compositor and remove temp files.
 func startHeadlessWeston(t *testing.T) func() {
@@ -48,6 +55,7 @@ func startHeadlessWeston(t *testing.T) func() {
 }
 
 func TestGetBoundsWayland(t *testing.T) {
+	requireDisplay(t)
 	cleanup := startHeadlessWeston(t)
 	defer cleanup()
 
@@ -62,6 +70,7 @@ func TestGetBoundsWayland(t *testing.T) {
 }
 
 func TestKeyboardRoundTripWayland(t *testing.T) {
+	requireDisplay(t)
 	cmd := exec.Command(os.Args[0], "-test.run", "TestKeyboardRoundTripHelper")
 	cmd.Env = append(os.Environ(), "GO_WAYLAND_HELPER=1")
 	if err := cmd.Run(); err != nil {
@@ -73,6 +82,7 @@ func TestKeyboardRoundTripHelper(t *testing.T) {
 	if os.Getenv("GO_WAYLAND_HELPER") != "1" {
 		t.Skip("helper process")
 	}
+	requireDisplay(t)
 	cleanup := startHeadlessWeston(t)
 	defer cleanup()
 	if err := robotgo.KeyTap("a"); err != nil {
@@ -81,6 +91,7 @@ func TestKeyboardRoundTripHelper(t *testing.T) {
 }
 
 func TestMouseRoundTripWayland(t *testing.T) {
+	requireDisplay(t)
 	cmd := exec.Command(os.Args[0], "-test.run", "TestMouseRoundTripHelper")
 	cmd.Env = append(os.Environ(), "GO_WAYLAND_HELPER=1")
 	if err := cmd.Run(); err != nil {
@@ -92,6 +103,7 @@ func TestMouseRoundTripHelper(t *testing.T) {
 	if os.Getenv("GO_WAYLAND_HELPER") != "1" {
 		t.Skip("helper process")
 	}
+	requireDisplay(t)
 	cleanup := startHeadlessWeston(t)
 	defer cleanup()
 	robotgo.Move(20, 30)


### PR DESCRIPTION
## Summary
- guard display-dependent tests to skip when DISPLAY and WAYLAND_DISPLAY are unset
- note in CRUSH that GUI tests are skipped in headless environments

## Testing
- `go vet ./...` (fails: possible misuse of unsafe.Pointer in img.go)
- `golangci-lint run ./...` (fails: lint issues in existing code)
- `go test ./...`
- `go test -tags wayland ./window`


------
https://chatgpt.com/codex/tasks/task_e_68b35d35bb388324b1e33c6e3f67bc10