### PR TITLE
ci: install Wayland dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,11 @@ jobs:
           apt -y install gcc libc6-dev
           libx11-dev xorg-dev libxtst-dev
           xsel xclip
+          pkg-config libwayland-dev libwayland-cursor-dev libwayland-egl1-mesa libxkbcommon-dev wayland-protocols
           # libpng++-dev
-          # xcb libxcb-xkb-dev x11-xkb-utils libx11-xcb-dev libxkbcommon-x11-dev libxkbcommon-dev
+          # xcb libxcb-xkb-dev x11-xkb-utils libx11-xcb-dev libxkbcommon-x11-dev
       - run: apt -y install xvfb
+      - run: echo 'export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH' >> $BASH_ENV
       #
       #  override:
       - run: go get -v -t -d ./...


### PR DESCRIPTION
## Summary
- install pkg-config and Wayland-related libraries in CI
- ensure PKG_CONFIG_PATH includes default pkg-config directories

## Testing
- `go mod tidy`
- `go generate ./...`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...` *(fails: errcheck, staticcheck, unused)*
- `xvfb-run go test -v ./...`
- `xvfb-run go test -v -tags wayland ./...` *(fails: C source files not allowed when not using cgo or SWIG: keycode_wayland.c)*

------
https://chatgpt.com/codex/tasks/task_e_68b362ca316483249cb335080f2f5bd5