### PR TITLE
feat: add Wayland keyboard injection with X11 fallback

### DIFF
--- a/key/keycode_c.h
+++ b/key/keycode_c.h
@@ -1,5 +1,32 @@
 #include "keycode.h"
 #include <stdlib.h>
+#if defined(IS_LINUX) && defined(DISPLAY_SERVER_WAYLAND)
+#include <xkbcommon/xkbcommon.h>
+
+/*
+ * keysym_to_keycode converts an XKB keysym to a keycode using the
+ * supplied keymap. The function iterates over all keycodes in the
+ * keymap searching for the first entry that produces the requested
+ * keysym. It returns XKB_KEY_NoSymbol when no match is found.
+ */
+static xkb_keycode_t keysym_to_keycode(struct xkb_keymap *keymap, xkb_keysym_t keysym) {
+    if (!keymap) {
+        return XKB_KEY_NoSymbol;
+    }
+    xkb_keycode_t min = xkb_keymap_min_keycode(keymap);
+    xkb_keycode_t max = xkb_keymap_max_keycode(keymap);
+    for (xkb_keycode_t code = min; code <= max; code++) {
+        const xkb_keysym_t *syms = NULL;
+        int n = xkb_keymap_key_get_syms_by_level(keymap, code, 0, 0, &syms);
+        for (int i = 0; i < n; i++) {
+            if (syms[i] == keysym) {
+                return code;
+            }
+        }
+    }
+    return XKB_KEY_NoSymbol;
+}
+#endif
 
 #if defined(IS_MACOSX)
 	#include <CoreFoundation/CoreFoundation.h>

--- a/key/keypress.h
+++ b/key/keypress.h
@@ -20,16 +20,16 @@
 #elif defined(IS_LINUX)
 #if defined(DISPLAY_SERVER_WAYLAND)
         #include <xkbcommon/xkbcommon.h>
-        enum _MMKeyFlags {
+        typedef xkb_mod_mask_t MMKeyFlags;
+        enum MMKeyFlagsBits {
                 MOD_NONE = 0,
                 MOD_META = XKB_MOD_MASK_LOGO,
                 MOD_ALT = XKB_MOD_MASK_ALT,
                 MOD_CONTROL = XKB_MOD_MASK_CTRL,
                 MOD_SHIFT = XKB_MOD_MASK_SHIFT
         };
-        typedef xkb_mod_mask_t MMKeyFlags;
 #else
-        enum _MMKeyFlags {
+        enum MMKeyFlagsBits {
                 MOD_NONE = 0,
                 MOD_META = Mod4Mask,
                 MOD_ALT = Mod1Mask,


### PR DESCRIPTION
## Summary
- define Wayland `MMKeyFlags` via xkbcommon modifiers
- add keysym to keycode conversion helper
- implement Wayland virtual keyboard injection with fallback to X11 when DISPLAY is set
- fix unmatched `#endif` in Wayland keyboard support

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b369ac92f08324a6d832776f3fdfd8