### PR TITLE
feat: detect display server at runtime

### DIFF
--- a/keycode.go
+++ b/keycode.go
@@ -11,8 +11,7 @@
 package robotgo
 
 import (
-	"os"
-
+	"github.com/marang/robotgo/base"
 	"github.com/vcaesar/keycode"
 )
 
@@ -40,11 +39,10 @@ var Special = keycode.Special
 var specialWayland = keycode.Special
 
 // CurrentSpecialTable returns the special key map for the active
-// display server. If the environment indicates a Wayland session
-// (WAYLAND_DISPLAY is set and DISPLAY is empty) the Wayland table is
-// returned, otherwise the X11 table is used.
+// display server. DetectDisplayServer determines whether the Wayland or
+// X11 table should be returned.
 func CurrentSpecialTable() map[string]string {
-	if os.Getenv("WAYLAND_DISPLAY") != "" && os.Getenv("DISPLAY") == "" {
+	if base.DetectDisplayServer() == base.Wayland {
 		return specialWayland
 	}
 	return Special

--- a/robotgo_linux.go
+++ b/robotgo_linux.go
@@ -34,7 +34,8 @@ import (
 
 var xu *xgbutil.XUtil
 
-// GetBounds get the window bounds
+// GetBounds returns the window bounds and dispatches to the appropriate
+// Wayland or X11 implementation based on DetectDisplayServer.
 func GetBounds(pid int, args ...int) (int, int, int, int) {
 	if base.DetectDisplayServer() == base.Wayland {
 		display := C.wl_display_connect(nil)
@@ -67,7 +68,8 @@ func GetBounds(pid int, args ...int) (int, int, int, int) {
 	return internalGetBounds(int(xid), isPid)
 }
 
-// GetClient get the window client bounds
+// GetClient returns the client bounds of the window and dispatches to the
+// Wayland or X11 implementation based on DetectDisplayServer.
 func GetClient(pid int, args ...int) (int, int, int, int) {
 	if base.DetectDisplayServer() == base.Wayland {
 		display := C.wl_display_connect(nil)


### PR DESCRIPTION
## Summary
- use DetectDisplayServer for key map selection
- document runtime dispatch for window bounds and client retrieval

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b372e858208324ac993194ed3c7c89