### PR TITLE
test: improve display server and wayland integration tests

### DIFF
--- a/base/display_server_test.go
+++ b/base/display_server_test.go
@@ -2,32 +2,29 @@
 
 package base
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestDetectDisplayServer(t *testing.T) {
-	t.Run("Wayland", func(t *testing.T) {
-		t.Setenv("WAYLAND_DISPLAY", "wayland-0")
-		t.Setenv("DISPLAY", "")
-		if ds := DetectDisplayServer(); ds != Wayland {
-			t.Fatalf("expected Wayland, got %v", ds)
-		}
-	})
 
-	t.Run("X11", func(t *testing.T) {
-		t.Setenv("WAYLAND_DISPLAY", "")
-		t.Setenv("DISPLAY", ":0")
-		if ds := DetectDisplayServer(); ds != X11 {
-			t.Fatalf("expected X11, got %v", ds)
-		}
-	})
+	tests := []struct {
+		name           string
+		waylandDisplay string
+		display        string
+		want           DisplayServer
+	}{
+		{name: "Wayland", waylandDisplay: "wayland-0", display: "", want: Wayland},
+		{name: "X11", waylandDisplay: "", display: ":0", want: X11},
+		{name: "Unknown", waylandDisplay: "", display: "", want: Unknown},
+	}
 
-	t.Run("Unknown", func(t *testing.T) {
-		t.Setenv("WAYLAND_DISPLAY", "")
-		t.Setenv("DISPLAY", "")
-		if ds := DetectDisplayServer(); ds != Unknown {
-			t.Fatalf("expected Unknown, got %v", ds)
-		}
-	})
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("WAYLAND_DISPLAY", tt.waylandDisplay)
+			t.Setenv("DISPLAY", tt.display)
+			if got := DetectDisplayServer(); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
 }

--- a/window/wayland_test.go
+++ b/window/wayland_test.go
@@ -1,4 +1,4 @@
-//go:build linux && wayland
+//go:build linux && wayland && integration
 
 package window
 


### PR DESCRIPTION
## Summary
- add table-driven tests covering Wayland, X11 and fallback detection
- mark Wayland compositor tests as integration-only

## Testing
- `go vet -tags "wayland integration" ./...` *(fails: C source files not allowed when not using cgo)*
- `golangci-lint run ./...` *(fails: pkg-config missing wayland-client, wayland-cursor, wayland-egl, xkbcommon)*
- `go test -tags "wayland integration" ./...` *(fails: pkg-config missing wayland-client et al.; C source files not allowed when not using cgo)*

------
https://chatgpt.com/codex/tasks/task_e_68b3764736c08324b7a170dbfc7f7430