### PR TITLE
feat: add display server detection and Wayland capture stub

### DIFF
--- a/examples/screen/main.go
+++ b/examples/screen/main.go
@@ -19,6 +19,7 @@ import (
 )
 
 func bitmap() {
+	fmt.Println("display server:", robotgo.DetectDisplayServer())
 	bit, err := robotgo.CaptureScreen()
 	if err != nil {
 		fmt.Println("CaptureScreen error:", err)

--- a/screen/capture_test.go
+++ b/screen/capture_test.go
@@ -1,29 +1,22 @@
 package screen
 
 import (
-	"os"
 	"testing"
 
 	robotgo "github.com/marang/robotgo"
 )
 
 func TestCaptureScreen(t *testing.T) {
-	t.Parallel()
-	originalDisplay := os.Getenv("DISPLAY")
-	originalWayland := os.Getenv("WAYLAND_DISPLAY")
-	defer os.Setenv("DISPLAY", originalDisplay)
-	defer os.Setenv("WAYLAND_DISPLAY", originalWayland)
-
 	// X11 path
-	os.Setenv("DISPLAY", ":0")
-	os.Unsetenv("WAYLAND_DISPLAY")
+	t.Setenv("DISPLAY", ":0")
+	t.Setenv("WAYLAND_DISPLAY", "")
 	if _, err := robotgo.CaptureScreen(); err != nil {
 		t.Skipf("X11 capture skipped: %v", err)
 	}
 
 	// Wayland path should return an error
-	os.Unsetenv("DISPLAY")
-	os.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	t.Setenv("DISPLAY", "")
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
 	if _, err := robotgo.CaptureScreen(); err == nil {
 		t.Fatalf("expected error on Wayland capture")
 	}

--- a/screen/screengrab_c.h
+++ b/screen/screengrab_c.h
@@ -7,11 +7,12 @@
 	#include <ApplicationServices/ApplicationServices.h>
 	#include <ScreenCaptureKit/ScreenCaptureKit.h>
 #elif defined(IS_LINUX)
-	#include <X11/Xlib.h>
-	#include <X11/Xutil.h>
-	#include "../base/xdisplay_c.h"
+        #include <X11/Xlib.h>
+        #include <X11/Xutil.h>
+        #include "../base/xdisplay_c.h"
+        MMBitmapRef capture_screen_wayland(int32_t x, int32_t y, int32_t w, int32_t h, int32_t display_id, int8_t isPid);
 #elif defined(IS_WINDOWS)
-	#include <string.h>
+        #include <string.h>
 #endif
 #include "screen_c.h"
 
@@ -195,3 +196,7 @@ MMBitmapRef copyMMBitmapFromDisplayInRect(MMRectInt32 rect, int32_t display_id, 
 	return bitmap;
 #endif
 }
+
+#if defined(IS_LINUX)
+#include "screengrab_wayland.c"
+#endif

--- a/screen/screengrab_wayland.c
+++ b/screen/screengrab_wayland.c
@@ -1,8 +1,9 @@
 //go:build ignore
 // +build ignore
 
-#include "screen_c.h"
-#include "../base/bitmap_free_c.h"
+// This file is included from screengrab_c.h, which already provides the
+// necessary declarations and includes. Avoid including headers here to prevent
+// duplicate symbol definitions when screengrab_wayland.c is embedded.
 
 #if defined(IS_LINUX)
 // capture_screen_wayland attempts to capture the screen using a Wayland protocol.

--- a/screen/screengrab_wayland.c
+++ b/screen/screengrab_wayland.c
@@ -1,0 +1,14 @@
+//go:build ignore
+// +build ignore
+
+#include "screen_c.h"
+#include "../base/bitmap_free_c.h"
+
+#if defined(IS_LINUX)
+// capture_screen_wayland attempts to capture the screen using a Wayland protocol.
+// This is a stub that currently returns NULL to signal unsupported capture.
+MMBitmapRef capture_screen_wayland(int32_t x, int32_t y, int32_t w, int32_t h, int32_t display_id, int8_t isPid) {
+        (void)x; (void)y; (void)w; (void)h; (void)display_id; (void)isPid;
+        return NULL;
+}
+#endif


### PR DESCRIPTION
## Summary
- detect X11 vs Wayland at runtime
- stub out Wayland screen capture and expose error
- show display server in example and test detection paths

## Testing
- `go mod tidy`
- `go vet ./...`
- `golangci-lint run ./... -v` *(fails: interrupted)*
- `go test ./...` *(fails: no output; command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b37bae4d0c8324a2138ee7ed9aad82