### PR TITLE
test: add build constraint for Wayland screengrab test

### DIFF
--- a/screen/screengrab_wayland_test.go
+++ b/screen/screengrab_wayland_test.go
@@ -1,0 +1,18 @@
+//go:build cgo && linux
+// +build cgo,linux
+
+package screen
+
+import (
+	"testing"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+func TestScreengrabWayland(t *testing.T) {
+	t.Setenv("DISPLAY", "")
+	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
+	if _, err := robotgo.CaptureScreen(); err != nil {
+		t.Skipf("Wayland capture skipped: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add cgo+linux build tag to Wayland screengrab test

## Testing
- `go fmt screen/screengrab_wayland_test.go`
- `go vet ./screen` *(fails: Package wayland-client was not found in the pkg-config search path)*
- `golangci-lint run ./screen` *(fails: could not import github.com/marang/robotgo: Package 'wayland-client', required by 'virtual:world', not found)*
- `go test ./screen` *(fails: Package wayland-client was not found in the pkg-config search path)*


------
https://chatgpt.com/codex/tasks/task_e_68b4308e9abc8324866ee83da2f62bda