### PR TITLE
test: skip X11 capture when display unavailable

### DIFF
--- a/screen/capture_test.go
+++ b/screen/capture_test.go
@@ -1,6 +1,7 @@
 package screen
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -8,20 +9,32 @@ import (
 )
 
 func TestCaptureScreen(t *testing.T) {
-	// X11 path
-	t.Setenv("DISPLAY", ":0")
-	t.Setenv("WAYLAND_DISPLAY", "")
-	if _, err := robotgo.CaptureScreen(); err != nil {
-		t.Skipf("X11 capture skipped: %v", err)
-	}
-	if _, err := robotgo.GetPixelColor(0, 0); err != nil {
-		t.Skipf("X11 pixel skipped: %v", err)
-	}
+	t.Run("X11", func(t *testing.T) {
+		display := os.Getenv("DISPLAY")
+		if display == "" {
+			t.Skip("DISPLAY not set")
+		}
+		if !openXDisplay(display) {
+			t.Skipf("cannot open DISPLAY %q", display)
+		}
 
-	// Wayland path should not report missing display server
-	t.Setenv("DISPLAY", "")
-	t.Setenv("WAYLAND_DISPLAY", "wayland-0")
-	if _, err := robotgo.CaptureScreen(); err != nil && strings.Contains(err.Error(), "no display server found") {
-		t.Fatalf("unexpected no display server error: %v", err)
-	}
+		t.Setenv("WAYLAND_DISPLAY", "")
+		if _, err := robotgo.CaptureScreen(); err != nil {
+			t.Skipf("X11 capture skipped: %v", err)
+		}
+		if _, err := robotgo.GetPixelColor(0, 0); err != nil {
+			t.Skipf("X11 pixel skipped: %v", err)
+		}
+	})
+
+	t.Run("Wayland", func(t *testing.T) {
+		wayland := os.Getenv("WAYLAND_DISPLAY")
+		if wayland == "" {
+			t.Skip("WAYLAND_DISPLAY not set")
+		}
+		t.Setenv("DISPLAY", "")
+		if _, err := robotgo.CaptureScreen(); err != nil && strings.Contains(err.Error(), "no display server found") {
+			t.Fatalf("unexpected no display server error: %v", err)
+		}
+	})
 }

--- a/screen/xdisplay_linux.go
+++ b/screen/xdisplay_linux.go
@@ -1,0 +1,20 @@
+package screen
+
+/*
+#cgo linux LDFLAGS: -lX11
+#include <stdlib.h>
+#include <X11/Xlib.h>
+*/
+import "C"
+import "unsafe"
+
+func openXDisplay(name string) bool {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	d := C.XOpenDisplay(cName)
+	if d == nil {
+		return false
+	}
+	C.XCloseDisplay(d)
+	return true
+}


### PR DESCRIPTION
## Summary
- avoid forcing `DISPLAY` in screen tests
- skip X11 capture when display can't be opened
- run Wayland checks only when `WAYLAND_DISPLAY` is set

## Testing
- `go vet ./screen`
- `go test -v ./screen`
- `WAYLAND_DISPLAY=wayland-0 go test -v ./screen`


------
https://chatgpt.com/codex/tasks/task_e_68b5ef0676e483249871c227941ad3da