### PR TITLE
fix: stub openXDisplay on non-linux systems

### DIFF
--- a/screen/capture_test.go
+++ b/screen/capture_test.go
@@ -14,6 +14,8 @@ func TestCaptureScreen(t *testing.T) {
 		if display == "" {
 			t.Skip("DISPLAY not set")
 		}
+		// openXDisplay returns false when the X server is unavailable
+		// (including when running on platforms without X11).
 		if !openXDisplay(display) {
 			t.Skipf("cannot open DISPLAY %q", display)
 		}

--- a/screen/xdisplay_stub.go
+++ b/screen/xdisplay_stub.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package screen
+
+// openXDisplay always reports that an X display is unavailable on non-Linux systems.
+func openXDisplay(name string) bool {
+	return false
+}


### PR DESCRIPTION
## Summary
- add xdisplay stub that reports X11 unavailable on non-Linux platforms
- clarify capture tests to skip when openXDisplay fails

## Testing
- `go vet ./screen` *(fails: X11/extensions/XTest.h: No such file or directory)*
- `golangci-lint run ./screen` *(fails: could not import github.com/marang/robotgo)*
- `go test ./screen` *(fails: X11/extensions/XTest.h: No such file or directory)*
- `GOOS=darwin GOARCH=amd64 go test ./screen` *(fails: undefined: Bitmap, Rect, etc.)*
- `GOOS=windows GOARCH=amd64 go test ./screen` *(fails: undefined: Bitmap, Rect, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b5f12f5bb88324ad3e383f6bbf937c