### PR TITLE
fix(screen): isolate X display stub from Linux implementation

### DIFF
--- a/screen/xdisplay_linux.go
+++ b/screen/xdisplay_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package screen
 
 /*

--- a/screen/xdisplay_stub.go
+++ b/screen/xdisplay_stub.go
@@ -1,4 +1,5 @@
 //go:build !linux
+// +build !linux
 
 package screen
 


### PR DESCRIPTION
## Summary
- add linux build tags to xdisplay implementation
- guard stub for non-linux builds

## Testing
- `go vet ./...` *(fails: X11/extensions/XTest.h: No such file or directory)*
- `golangci-lint run` *(fails: fatal error: X11/extensions/XTest.h: No such file or directory)*
- `go test ./...` *(fails: X11/extensions/XTest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b69d7adc6483249a2a865f9f842b0a