### PR TITLE
feat: handle wayland dmabuf feedback and portal fallback

### DIFF
--- a/screen/screengrab_wayland.c
+++ b/screen/screengrab_wayland.c
@@ -517,7 +517,8 @@ MMBitmapRef capture_screen_wayland(int32_t x, int32_t y, int32_t w, int32_t h,
     cleanup_capture(&cap);
     return NULL;
   }
-  if (cap.dmabuf) {
+  if (cap.dmabuf &&
+      wl_proxy_get_version((struct wl_proxy *)cap.dmabuf) >= 4) {
     cap.fb.fb = zwp_linux_dmabuf_v1_get_default_feedback(cap.dmabuf);
     if (cap.fb.fb) {
       zwp_linux_dmabuf_feedback_v1_add_listener(cap.fb.fb, &feedback_listener,


### PR DESCRIPTION
## Summary
- guard `zwp_linux_dmabuf_v1_get_default_feedback` call by interface version to avoid protocol errors on compositors exposing dmabuf < v1.4

## Testing
- `go vet ./...` *(fails: X11/extensions/XTest.h: No such file or directory)*
- `go test ./...` *(fails: X11/extensions/XTest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b70509b92c832488c81d8e74a43546