### PR TITLE
refactor: centralize display server detection for key events

### DIFF
--- a/key/keycode_c.h
+++ b/key/keycode_c.h
@@ -1,6 +1,8 @@
 #include "keycode.h"
 #include <stdlib.h>
-#if defined(IS_LINUX) && defined(DISPLAY_SERVER_WAYLAND)
+#if defined(IS_LINUX)
+#include "../base/os.h"
+#if defined(DISPLAY_SERVER_WAYLAND)
 #include <xkbcommon/xkbcommon.h>
 
 /*
@@ -26,6 +28,7 @@ static xkb_keycode_t keysym_to_keycode(struct xkb_keymap *keymap, xkb_keysym_t k
     }
     return XKB_KEY_NoSymbol;
 }
+#endif
 #endif
 
 #if defined(IS_MACOSX)
@@ -86,10 +89,9 @@ MMKeyCode keyCodeForChar(const char c) {
 
 		return code;
         #elif defined(IS_LINUX)
-                const char* wayland = getenv("WAYLAND_DISPLAY");
-                const char* x11 = getenv("DISPLAY");
+                DisplayServer server = detectDisplayServer();
 #if defined(DISPLAY_SERVER_WAYLAND)
-                if (wayland && (!x11 || *x11 == '\0')) {
+                if (server == Wayland) {
                         char buf[2];
                         buf[0] = c;
                         buf[1] = '\0';
@@ -110,7 +112,7 @@ MMKeyCode keyCodeForChar(const char c) {
                                 return K_NOT_A_KEY;
                         }
                         return code;
-                }
+                } else
 #endif
                 {
                         char buf[2];

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -21,6 +21,7 @@
 #elif defined(IS_LINUX)
         #include <X11/extensions/XTest.h>
         #include <stdlib.h>
+        #include "../base/os.h"
         // #include "../base/xdisplay_c.h"
 #if defined(DISPLAY_SERVER_WAYLAND)
 #define _GNU_SOURCE
@@ -411,10 +412,9 @@ void toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags, uintptr pi
 
 	win32KeyEvent(code, dwFlags, pid, 0);
 #elif defined(IS_LINUX)
-        const char* wayland = getenv("WAYLAND_DISPLAY");
-        const char* x11 = getenv("DISPLAY");
+        DisplayServer server = detectDisplayServer();
 #if defined(DISPLAY_SERVER_WAYLAND)
-        if (wayland && (!x11 || *x11 == '\0')) {
+        if (server == Wayland) {
                 const Bool is_press = down ? True : False;
 
                 if (flags & MOD_META) { WL_KEY_EVENT_WAIT(K_META, is_press); }


### PR DESCRIPTION
## Summary
- replace environment checks in keycode and keypress with detectDisplayServer

## Testing
- `go vet ./...` *(fails: cannot convert pbit to CBitmap)*
- `golangci-lint run` *(fails: typecheck)*
- `go test ./...` *(fails: build failed)*


------
https://chatgpt.com/codex/tasks/task_e_68b73088316483249427b1b5451441c2