### PR TITLE
feat: detect dmabuf render node via libdrm

### DIFF
--- a/drm_device_test.go
+++ b/drm_device_test.go
@@ -1,0 +1,62 @@
+//go:build cgo && linux && wayland && test
+// +build cgo,linux,wayland,test
+
+package robotgo
+
+/*
+#cgo pkg-config: libdrm
+#include <stdint.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+int drm_find_render_node(dev_t dev);
+
+static int findRenderNode(uint32_t maj, uint32_t min) {
+    dev_t d = makedev(maj, min);
+    int fd = drm_find_render_node(d);
+    if (fd >= 0) {
+        close(fd);
+        return 0;
+    }
+    return -1;
+}
+*/
+import "C"
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestDrmFindRenderNodeSuccess(t *testing.T) {
+	var maj, min uint32
+	found := false
+	filepath.Walk("/dev/dri", func(path string, info os.FileInfo, err error) error {
+		if err != nil || found {
+			return nil
+		}
+		if info.Mode()&os.ModeCharDevice != 0 && strings.HasPrefix(info.Name(), "renderD") {
+			stat := info.Sys().(*unix.Stat_t)
+			maj = uint32(unix.Major(uint64(stat.Rdev)))
+			min = uint32(unix.Minor(uint64(stat.Rdev)))
+			found = true
+		}
+		return nil
+	})
+	if !found {
+		t.Skip("no drm render node")
+	}
+	if C.findRenderNode(C.uint32_t(maj), C.uint32_t(min)) != 0 {
+		t.Fatalf("expected success opening render node")
+	}
+}
+
+func TestDrmFindRenderNodeFailure(t *testing.T) {
+	if C.findRenderNode(0, 0) == 0 {
+		t.Fatalf("expected failure for invalid device")
+	}
+}

--- a/robotgo_linux.go
+++ b/robotgo_linux.go
@@ -14,8 +14,8 @@
 package robotgo
 
 /*
-#cgo pkg-config: wayland-client wayland-cursor wayland-egl xkbcommon gbm
-#cgo LDFLAGS: -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon -lgbm
+#cgo pkg-config: wayland-client wayland-cursor wayland-egl xkbcommon gbm libdrm
+#cgo LDFLAGS: -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon -lgbm -ldrm
 #cgo CFLAGS: -DROBOTGO_USE_WAYLAND
 #include "window/get_bounds_wayland.h"
 */


### PR DESCRIPTION
## Summary
- use libdrm to locate render node from dmabuf feedback
- link wayland build against libdrm
- test render node lookup success and failure paths

## Testing
- `go mod tidy`
- `go fmt ./...`
- `go vet ./...` *(fails: cannot convert pbit (variable of pointer type portal.CBitmap) to type CBitmap)*
- `golangci-lint run` *(fails: typecheck errors)*
- `go test -tags test,wayland ./...` *(fails: use of cgo in test drm_device_test.go not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b73f543d1c8324ba34156fb854759d