### PR TITLE
test: extract wayland mock server

### DIFF
--- a/screen/mock_server.go
+++ b/screen/mock_server.go
@@ -1,0 +1,20 @@
+//go:build cgo && linux && wayland && test
+// +build cgo,linux,wayland,test
+
+package screen
+
+/*
+#cgo pkg-config: wayland-server
+#include "testdata/mock_server.c"
+*/
+import "C"
+import "unsafe"
+
+func startMockServer(socket string, maj, min uint32, modifier uint64, done chan struct{}) {
+	csock := C.CString(socket)
+	go func() {
+		C.run_mock_server(csock, C.uint32_t(maj), C.uint32_t(min), C.uint64_t(modifier))
+		C.free(unsafe.Pointer(csock))
+		close(done)
+	}()
+}

--- a/screen/testdata/README.md
+++ b/screen/testdata/README.md
@@ -1,0 +1,12 @@
+# Mock Wayland Server
+
+`mock_server.c` contains a minimal Wayland compositor used during tests to exercise screencopy and dmabuf code paths.
+
+If the Wayland protocol definitions change, regenerate the headers with [wayland-scanner](https://wayland.freedesktop.org/wayland-scanner.html).
+From the repository root run:
+
+```
+go run wayland_generate.go
+```
+
+The mock server will be rebuilt automatically the next time `go test` is executed.

--- a/screen/testdata/mock_server.c
+++ b/screen/testdata/mock_server.c
@@ -1,11 +1,7 @@
 //go:build cgo && linux && wayland && test
 // +build cgo,linux,wayland,test
 
-package screen
-
-/*
 #define _GNU_SOURCE
-#cgo pkg-config: wayland-server
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -14,8 +10,8 @@ package screen
 #include <sys/sysmacros.h>
 #include <unistd.h>
 #include <wayland-server.h>
-#include "../wlr-screencopy-unstable-v1-client-protocol.h"
-#include "../linux-dmabuf-unstable-v1-server-protocol.h"
+#include "../../wlr-screencopy-unstable-v1-client-protocol.h"
+#include "../../linux-dmabuf-unstable-v1-server-protocol.h"
 
 #define ZWLR_SCREENCOPY_FRAME_V1_LINUX_DMABUF 5
 #define ZWLR_SCREENCOPY_FRAME_V1_BUFFER_DONE 6
@@ -157,15 +153,4 @@ void run_mock_server(const char *socket, uint32_t maj, uint32_t min, uint64_t mo
     wl_display_run(mock_display);
     wl_display_destroy(mock_display);
 }
-*/
-import "C"
-import "unsafe"
 
-func startMockServer(socket string, maj, min uint32, modifier uint64, done chan struct{}) {
-	csock := C.CString(socket)
-	go func() {
-		C.run_mock_server(csock, C.uint32_t(maj), C.uint32_t(min), C.uint64_t(modifier))
-		C.free(unsafe.Pointer(csock))
-		close(done)
-	}()
-}


### PR DESCRIPTION
## Summary
- move Wayland screengrab mock server C code into `screen/testdata/mock_server.c`
- add Go wrapper that links to the C helper for tests
- document how to regenerate mock server protocol headers

## Testing
- `go vet ./...` *(fails: cannot convert pbit (pointer type) to CBitmap)*
- `golangci-lint run ./...` *(fails: typecheck errors and missing C preprocessing)*
- `go test ./...` *(fails: build failed in robotgo and examples packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b744b46614832491f865f1fc9b78df