### PR TITLE
ci: pin golangci-lint v2 install and use Go 1.25 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       # using custom image, see .circleci/images/primary/Dockerfile
       # - image: govgo/robotgoci:1.10.3
-      - image: golang:1.24.0
+      - image: golang:1.25.0
     working_directory: /gopath/src/github.com/marang/robotgo
     steps:
       - checkout
@@ -22,7 +22,7 @@ jobs:
       - run: echo 'export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH' >> $BASH_ENV
       # Install golangci-lint and add GOPATH/bin to PATH for subsequent steps
       - run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
           echo 'export PATH=$(go env GOPATH)/bin:$PATH' >> $BASH_ENV
       #
       #  override:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go 1.24.0
+      - name: Set up Go 1.25.0
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.0
+          go-version: 1.25.0
       - name: Install system dependencies for cgo typecheck
         run: |
           sudo apt-get update
@@ -23,7 +23,7 @@ jobs:
             libwayland-dev libxkbcommon-dev wayland-protocols \
             libgbm-dev libdrm-dev
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
       - name: Add golangci-lint to PATH
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: Run golangci-lint
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go 1.24.0
+      - name: Set up Go 1.25.0
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.0
+          go-version: 1.25.0
         id: go
 
       - name: Get dependencies
@@ -59,10 +59,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go 1.24.0
+      - name: Set up Go 1.25.0
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.0
+          go-version: 1.25.0
       - name: Install Wayland test dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
### Motivation
- Fix CI failures when installing `golangci-lint` by aligning CI toolchains with the module's Go requirement and using the v2 module install path instead of the legacy `@latest` path.

### Description
- Update `.github/workflows/go.yml` and `.circleci/config.yml` to use Go `1.25.0`, change CircleCI Docker image to `golang:1.25.0`, and install the linter with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4` (replacing the old `github.com/golangci/golangci-lint/cmd/golangci-lint@latest`).

### Testing
- Ran an automated sanity check script that asserts the CI files reference the new v2 install path and no longer use the legacy `@latest`, which succeeded; and ran `go list -m github.com/golangci/golangci-lint/v2@v2.11.4` which resolved successfully; a direct `go install` attempt hit a transient module-proxy download error (502) during dependency fetch but did not block verification that the v2 module is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5098e61e908324be8aa886a8bead3d)