### PR TITLE
fix(lint): address golangci-lint issues and remove unused Wayland scaffold

### DIFF
--- a/examples/screen_full/main.go
+++ b/examples/screen_full/main.go
@@ -1,51 +1,51 @@
 package main
 
 import (
-    "fmt"
-    "time"
+	"fmt"
+	"os"
+	"time"
 
-    "github.com/marang/robotgo"
-    "os"
+	"github.com/marang/robotgo"
 )
 
 func main() {
-    // Environment + display server info
-    fmt.Println("display server:", robotgo.DetectDisplayServer())
-    fmt.Println("env WAYLAND_DISPLAY=", os.Getenv("WAYLAND_DISPLAY"))
-    fmt.Println("env DISPLAY=", os.Getenv("DISPLAY"))
-    fmt.Println("env XDG_SESSION_TYPE=", os.Getenv("XDG_SESSION_TYPE"))
-    if os.Getenv("ROBOTGO_FORCE_PORTAL") != "" {
-        fmt.Println("env ROBOTGO_FORCE_PORTAL=1 (forcing portal path)")
-    }
+	// Environment + display server info
+	fmt.Println("display server:", robotgo.DetectDisplayServer())
+	fmt.Println("env WAYLAND_DISPLAY=", os.Getenv("WAYLAND_DISPLAY"))
+	fmt.Println("env DISPLAY=", os.Getenv("DISPLAY"))
+	fmt.Println("env XDG_SESSION_TYPE=", os.Getenv("XDG_SESSION_TYPE"))
+	if os.Getenv("ROBOTGO_FORCE_PORTAL") != "" {
+		fmt.Println("env ROBOTGO_FORCE_PORTAL=1 (forcing portal path)")
+	}
 
-    // Capture the full current screen using the display bounds.
-    // This ensures correct dimensions even on Wayland where defaults
-    // may be unavailable without explicit bounds.
-    x, y, w, h := robotgo.GetDisplayBounds(0)
-    img, err := robotgo.CaptureImg(x, y, w, h)
-    if err != nil {
-        fmt.Println("CaptureImg error:", err)
-        return
-    }
+	// Capture the full current screen using the display bounds.
+	// This ensures correct dimensions even on Wayland where defaults
+	// may be unavailable without explicit bounds.
+	x, y, w, h := robotgo.GetDisplayBounds(0)
+	img, err := robotgo.CaptureImg(x, y, w, h)
+	if err != nil {
+		fmt.Println("CaptureImg error:", err)
+		return
+	}
 
-    name := fmt.Sprintf("full_%d.png", time.Now().Unix())
-    if err := robotgo.Save(img, name); err != nil {
-        fmt.Println("Save error:", err)
-        return
-    }
+	name := fmt.Sprintf("full_%d.png", time.Now().Unix())
+	if err := robotgo.Save(img, name); err != nil {
+		fmt.Println("Save error:", err)
+		return
+	}
 
-    // Identify which backend handled the capture
-    backend := robotgo.LastBackend()
-    method := "unknown"
-    switch backend {
-    case robotgo.BackendScreencopy:
-        method = "Wayland native (wlr-screencopy)"
-    case robotgo.BackendPortal:
-        method = "xdg-desktop-portal (Screenshot)"
-    case robotgo.BackendX11:
-        method = "X11 (XGetImage)"
-    default:
-        method = string(backend)
-    }
-    fmt.Println("saved:", name, "backend:", backend, "method:", method)
+	// Identify which backend handled the capture
+	backend := robotgo.LastBackend()
+	var method string
+	switch backend {
+	case robotgo.BackendScreencopy:
+		method = "Wayland native (wlr-screencopy)"
+	case robotgo.BackendPortal:
+		method = "xdg-desktop-portal (Screenshot)"
+	case robotgo.BackendX11:
+		method = "X11 (XGetImage)"
+	default:
+		method = string(backend)
+	}
+	fmt.Println("saved:", name, "backend:", backend, "method:", method)
 }

--- a/examples/window/main.go
+++ b/examples/window/main.go
@@ -180,7 +180,9 @@ func window() {
 	pid := robotgo.GetPid()
 	fmt.Println("\n7. close window and kill process in 10 seconds", pid)
 	robotgo.Sleep(10)
-	robotgo.CloseWindowKill(pid)
+	if err := robotgo.CloseWindowKill(pid); err != nil {
+		fmt.Println("CloseWindowKill error:", err)
+	}
 }
 
 func main() {

--- a/img.go
+++ b/img.go
@@ -193,6 +193,8 @@ func GetTextImg(img image.Image, args ...string) (string, error) {
 	if err := SavePng(img, tmp); err != nil {
 		return "", err
 	}
-	defer os.Remove(tmp)
+	defer func() {
+		_ = os.Remove(tmp)
+	}()
 	return GetText(tmp, args...)
 }

--- a/screen/portal/screenshot_portal.go
+++ b/screen/portal/screenshot_portal.go
@@ -3,16 +3,16 @@
 package portal
 
 import (
-    "context"
-    "errors"
-    "image"
-    "image/png"
-    "net/url"
-    "os"
-    "strings"
-    "time"
+	"context"
+	"errors"
+	"image"
+	"image/png"
+	"net/url"
+	"os"
+	"strings"
+	"time"
 
-    "github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5"
 )
 
 // CaptureRegionImage uses the org.freedesktop.portal.Screenshot API to
@@ -20,100 +20,114 @@ import (
 // dimensions are provided. It returns an image.Image with the screenshot
 // contents. This requires a running desktop portal and may prompt the user.
 func CaptureRegionImage(ctx context.Context, x, y, w, h int) (image.Image, error) {
-    if ctx == nil {
-        ctx = context.Background()
-    }
-    conn, err := dbus.SessionBus()
-    if err != nil {
-        return nil, err
-    }
-    defer conn.Close()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
 
-    obj := conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
-    options := map[string]dbus.Variant{
-        // Non-interactive request. Some portals may still show consent.
-        "interactive": dbus.MakeVariant(false),
-    }
-    call := obj.CallWithContext(ctx, "org.freedesktop.portal.Screenshot.Screenshot", 0, "", options)
-    if call.Err != nil {
-        return nil, call.Err
-    }
+	obj := conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
+	options := map[string]dbus.Variant{
+		// Non-interactive request. Some portals may still show consent.
+		"interactive": dbus.MakeVariant(false),
+	}
+	call := obj.CallWithContext(ctx, "org.freedesktop.portal.Screenshot.Screenshot", 0, "", options)
+	if call.Err != nil {
+		return nil, call.Err
+	}
 
-    // The call returns a request handle object path. Wait for Response.
-    if len(call.Body) != 1 {
-        return nil, errors.New("unexpected screenshot response body")
-    }
-    handle, ok := call.Body[0].(dbus.ObjectPath)
-    if !ok {
-        return nil, errors.New("invalid screenshot handle type")
-    }
+	// The call returns a request handle object path. Wait for Response.
+	if len(call.Body) != 1 {
+		return nil, errors.New("unexpected screenshot response body")
+	}
+	handle, ok := call.Body[0].(dbus.ObjectPath)
+	if !ok {
+		return nil, errors.New("invalid screenshot handle type")
+	}
 
-    // Listen for the Response signal on the request path.
-    signalCh := make(chan *dbus.Signal, 1)
-    conn.Signal(signalCh)
-    defer conn.RemoveSignal(signalCh)
+	// Listen for the Response signal on the request path.
+	signalCh := make(chan *dbus.Signal, 1)
+	conn.Signal(signalCh)
+	defer conn.RemoveSignal(signalCh)
 
-    // Add match rule for the request path/interface.
-    _ = conn.AddMatchSignal(
-        dbus.WithMatchObjectPath(handle),
-        dbus.WithMatchInterface("org.freedesktop.portal.Request"),
-    )
+	// Add match rule for the request path/interface.
+	_ = conn.AddMatchSignal(
+		dbus.WithMatchObjectPath(handle),
+		dbus.WithMatchInterface("org.freedesktop.portal.Request"),
+	)
 
-    // Wait with timeout.
-    timeout := time.After(10 * time.Second)
-    for {
-        select {
-        case sig := <-signalCh:
-            if sig == nil || string(sig.Path) != string(handle) || sig.Name != "org.freedesktop.portal.Request.Response" {
-                continue
-            }
-            if len(sig.Body) < 2 {
-                return nil, errors.New("portal: malformed response")
-            }
-            code, _ := sig.Body[0].(uint32)
-            results, _ := sig.Body[1].(map[string]dbus.Variant)
-            if code != 0 {
-                return nil, errors.New("portal: request denied")
-            }
-            v, ok := results["uri"]
-            if !ok {
-                return nil, errors.New("portal: missing uri")
-            }
-            uri, _ := v.Value().(string)
-            if uri == "" {
-                return nil, errors.New("portal: empty uri")
-            }
-            // Open the file and decode PNG.
-            p := strings.TrimPrefix(uri, "file://")
-            if u, perr := url.PathUnescape(p); perr == nil {
-                p = u
-            }
-            f, err := os.Open(p)
-            if err != nil {
-                return nil, err
-            }
-            defer f.Close()
-            img, err := png.Decode(f)
-            if err != nil {
-                return nil, err
-            }
-            // Crop if requested (bounds check).
-            if w > 0 && h > 0 {
-                r := img.Bounds()
-                if x < r.Min.X { x = r.Min.X }
-                if y < r.Min.Y { y = r.Min.Y }
-                if x+w > r.Max.X { w = r.Max.X - x }
-                if h+y > r.Max.Y { h = r.Max.Y - y }
-                if w > 0 && h > 0 {
-                    type subImager interface{ SubImage(r image.Rectangle) image.Image }
-                    if s, ok := img.(subImager); ok {
-                        return s.SubImage(image.Rect(x, y, x+w, y+h)), nil
-                    }
-                }
-            }
-            return img, nil
-        case <-timeout:
-            return nil, errors.New("portal: timeout waiting for response")
-        }
-    }
+	// Wait with timeout.
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case sig := <-signalCh:
+			if sig == nil || string(sig.Path) != string(handle) || sig.Name != "org.freedesktop.portal.Request.Response" {
+				continue
+			}
+			if len(sig.Body) < 2 {
+				return nil, errors.New("portal: malformed response")
+			}
+			code, _ := sig.Body[0].(uint32)
+			results, _ := sig.Body[1].(map[string]dbus.Variant)
+			if code != 0 {
+				return nil, errors.New("portal: request denied")
+			}
+			v, ok := results["uri"]
+			if !ok {
+				return nil, errors.New("portal: missing uri")
+			}
+			uri, _ := v.Value().(string)
+			if uri == "" {
+				return nil, errors.New("portal: empty uri")
+			}
+			// Open the file and decode PNG.
+			p := strings.TrimPrefix(uri, "file://")
+			if u, perr := url.PathUnescape(p); perr == nil {
+				p = u
+			}
+			f, err := os.Open(p)
+			if err != nil {
+				return nil, err
+			}
+			defer func() {
+				_ = f.Close()
+			}()
+			img, err := png.Decode(f)
+			if err != nil {
+				return nil, err
+			}
+			// Crop if requested (bounds check).
+			if w > 0 && h > 0 {
+				r := img.Bounds()
+				if x < r.Min.X {
+					x = r.Min.X
+				}
+				if y < r.Min.Y {
+					y = r.Min.Y
+				}
+				if x+w > r.Max.X {
+					w = r.Max.X - x
+				}
+				if h+y > r.Max.Y {
+					h = r.Max.Y - y
+				}
+				if w > 0 && h > 0 {
+					type subImager interface {
+						SubImage(r image.Rectangle) image.Image
+					}
+					if s, ok := img.(subImager); ok {
+						return s.SubImage(image.Rect(x, y, x+w, y+h)), nil
+					}
+				}
+			}
+			return img, nil
+		case <-timeout:
+			return nil, errors.New("portal: timeout waiting for response")
+		}
+	}
 }

--- a/window_backend.go
+++ b/window_backend.go
@@ -133,10 +133,7 @@ func (nativeWindowBackend) Close(args ...int) error {
 	}
 
 	pid := args[0]
-	isPid := false
-	if len(args) > 1 || NotPid {
-		isPid = true
-	}
+	isPid := len(args) > 1 || NotPid
 	nativeCloseWindowByPid(pid, isPid)
 	return nil
 }
@@ -204,55 +201,6 @@ func (b waylandCoreWindowBackend) Close(args ...int) error {
 }
 
 func (b waylandCoreWindowBackend) Title(args ...int) (string, error) {
-	_ = args
-	return "", b.unsupported("get window title")
-}
-
-type limitedWaylandWindowBackend struct {
-	name   string
-	notes  string
-	reason string
-}
-
-func (b limitedWaylandWindowBackend) Name() string {
-	return b.name
-}
-
-func (b limitedWaylandWindowBackend) Capability() FeatureCapability {
-	return FeatureCapability{
-		Available: false,
-		Fallback:  false,
-		Backend:   b.name,
-		Reason:    b.reason,
-		Notes:     b.notes,
-	}
-}
-
-func (b limitedWaylandWindowBackend) unsupported(op string) error {
-	return fmt.Errorf("%w (backend=%s)", waylandWindowNotSupported(op), b.name)
-}
-
-func (b limitedWaylandWindowBackend) SetActive(win Handle) error {
-	_ = win
-	return b.unsupported("set active window")
-}
-
-func (b limitedWaylandWindowBackend) Minimize(pid int, state bool, isPid bool) error {
-	_, _, _ = pid, state, isPid
-	return b.unsupported("minimize window")
-}
-
-func (b limitedWaylandWindowBackend) Maximize(pid int, state bool, isPid bool) error {
-	_, _, _ = pid, state, isPid
-	return b.unsupported("maximize window")
-}
-
-func (b limitedWaylandWindowBackend) Close(args ...int) error {
-	_ = args
-	return b.unsupported("close window")
-}
-
-func (b limitedWaylandWindowBackend) Title(args ...int) (string, error) {
 	_ = args
 	return "", b.unsupported("get window title")
 }


### PR DESCRIPTION
### Motivation

- Resolve static analyzer and linter findings to keep the repository lint-clean under `go 1.25` and CGO-enabled checks. 
- Make example and library code explicit about ignored cleanup errors and surfaced runtime errors instead of silently discarding them.
- Remove unused Wayland scaffolding that triggered `staticcheck`/`unused` reports to reduce maintenance burden.

### Description

- Check and report the return value from `CloseWindowKill` in `examples/window/main.go` instead of ignoring it to surface runtime errors. 
- Explicitly ignore possible errors from deferred cleanup calls by assigning to `_` for the temporary OCR file and portal DBus/file handles in `img.go` and `screen/portal/screenshot_portal.go`. 
- Replace an ineffectual `method := "unknown"` assignment with a properly-typed `var method string` in `examples/screen_full/main.go`. 
- Simplify `isPid` detection in `window_backend.go` to `isPid := len(args) > 1 || NotPid` and remove the unused `limitedWaylandWindowBackend` type and its methods to satisfy `staticcheck`/`unused` findings.

### Testing

- Ran `CGO_ENABLED=1 golangci-lint run --timeout=5m ./...` and the linter reported no issues after the changes. 
- Ran `go test ./...` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50a202a9b483249d294b116e11d3cd)