### PR TITLE
ci: use available Wayland EGL package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           apt -y install gcc libc6-dev
           libx11-dev xorg-dev libxtst-dev
           xsel xclip
-          pkg-config libwayland-dev libwayland-cursor0 libwayland-egl1-mesa libxkbcommon-dev wayland-protocols
+          pkg-config libwayland-dev libwayland-cursor0 libwayland-egl1 libxkbcommon-dev wayland-protocols
           # libpng++-dev
           # xcb libxcb-xkb-dev x11-xkb-utils libx11-xcb-dev libxkbcommon-x11-dev
       - run: apt -y install xvfb


### PR DESCRIPTION
### Motivation
- Fix CircleCI apt install failures caused by the removed `libwayland-egl1-mesa` package by using the available `libwayland-egl1` runtime package.

### Description
- Update `.circleci/config.yml` to replace `libwayland-egl1-mesa` with `libwayland-egl1` in the apt install list and commit the change.

### Testing
- Ran `apt-cache policy libwayland-egl1 libwayland-egl1-mesa` (confirmed `libwayland-egl1` candidate and no candidate for `libwayland-egl1-mesa`), an `apt-get -s install ...` simulation of the CircleCI package list (succeeded), and parsed `.circleci/config.yml` with `ruby -e 'require "yaml"; YAML.load_file(".circleci/config.yml")'` (succeeded); a `python3` YAML parse attempt failed due to a missing local `yaml` module but was unnecessary because Ruby parsing succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50bb48f250832483709a9e91516720)