### PR TITLE
Add bitmap serialization/search, color search, and Wayland window-state capability reporting

### DIFF
--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -8,10 +8,12 @@ Current implementation baseline:
 - `ROBOTGO_FORCE_PORTAL=1` is supported for forcing portal capture.
 - `ROBOTGO_WAYLAND_BACKEND` (`auto|dmabuf|wl_shm|portal`) is supported.
 - `ROBOTGO_CAPTURE_DEBUG=1` logs backend selection/fallback details.
-- Linux runtime capability introspection is available via `GetLinuxCapabilities`.
+- Linux runtime capability introspection is available via `GetLinuxCapabilities`,
+  including hook/event capability status.
 - Window-control APIs now expose explicit Wayland NotSupported errors via
   error-returning variants (`SetActiveE`, `MinWindowE`, `MaxWindowE`,
-  `CloseWindowE`, `GetTitleE`).
+  `CloseWindowE`, `GetTitleE`, `IsTopMostE`, `IsMinimizedE`,
+  `IsMaximizedE`, `SetTopMostE`).
 - Wayland window backend resolver is layered:
   - compositor-specific (`sway`, `hyprland`)
   - wlroots family generic backend (`wlroots-generic`)
@@ -19,6 +21,9 @@ Current implementation baseline:
 - `wlroots-generic` currently implements active-window minimize/maximize
   (state=true) when `wlrctl` is available; unsupported operations remain
   explicit.
+- Bitmap string helpers are available via `CaptureBitmapStr`,
+  `FindBitmapStr`, `BitmapFromStr`, and `ToStrBitmap`.
+- Region/tolerance color search is available via `FindColorCS`/`FindcolorCS`.
 - Runtime integration tests cover backend capability selection for
   `sway`/`hyprland`/`wlroots-generic` with explicit skip behavior when runtime
   preconditions are not present.
@@ -36,18 +41,21 @@ Window backend support matrix (current):
 
 - Priority Backlog (1-7):
   - 1. Full Wayland screencast portal backend (PipeWire session stream), not only screenshot fallback. `[new vs robotgo-pro]`
-  - 2. Window state/query API parity with explicit errors:
-    - `IsTopMost`, `IsMinimized`, `IsMaximized`, `SetTopMost`. `[parity]`
-  - 3. Bitmap serialization API parity:
-    - `CaptureBitmapStr`, `FindBitmapStr`, `BitmapFromStr`, `ToStrBitmap`. `[parity]`
-  - 4. Region/tolerance color search parity:
-    - `FindColorCS` with consistent behavior across platforms. `[parity]`
+  - 2. Window state/query API parity with explicit errors: partial.
+    - `IsTopMost`, `IsMinimized`, `IsMaximized`, `SetTopMost` now expose
+      explicit error-returning variants where Linux/Wayland state is unsupported.
+  - 3. Bitmap serialization API parity: implemented.
+    - `CaptureBitmapStr`, `FindBitmapStr`, `BitmapFromStr`, `ToStrBitmap`.
+  - 4. Region/tolerance color search parity: implemented.
+    - `FindColorCS`/`FindcolorCS` with platform-neutral bitmap scanning.
   - 5. Wayland reliability matrix tests across wlroots/GNOME/KDE:
     - multi-output, fractional scale, transforms, portal consent/fallback. `[new vs robotgo-pro]`
-  - 6. Hook/event support status for Wayland:
-    - capability detection and explicit unsupported contract where needed. `[new vs robotgo-pro]`
-  - 7. Expand capability introspection:
-    - include additional feature granularity and troubleshooting metadata. `[follow-up]`
+  - 6. Hook/event support status for Wayland: partial.
+    - `GetLinuxCapabilities` now reports hook/event status as explicitly
+      unsupported under Wayland compositor policy.
+  - 7. Expand capability introspection: partial.
+    - capture, bounds, keyboard, mouse, window, hook, and event capability
+      fields are present; finer troubleshooting metadata remains follow-up.
 
 - Screen Capture:
   - Validate on wlroots, GNOME and KDE.
@@ -65,12 +73,12 @@ Window backend support matrix (current):
   - Make `GetBounds`/`GetClient` robust via `xdg-output` (multi-output + fractional scaling).
   - Add resource‑leak checks for Wayland window helpers.
 - API Parity Backlog:
-  - Add explicit topmost/min/max status APIs where missing:
-    - `IsTopMost`, `SetTopMost`, `IsMinimized`, `IsMaximized`
-  - Evaluate/implement bitmap string helper parity where missing:
-    - `CaptureBitmapStr`, `FindBitmapStr`, `BitmapFromStr`, `ToStrBitmap`
-  - Evaluate/implement region color-search parity where missing:
-    - `FindColorCS` surface and compatibility behavior
+  - Extend compositor-backed implementations for existing topmost/min/max
+    status APIs where Wayland protocols or helpers make the state observable:
+  - Extend bitmap string helper coverage beyond current in-memory string
+    helpers where needed (file open/save helpers remain separate).
+  - Keep `FindColorCS` compatibility behavior covered across platform capture
+    backends.
   - Keep any new APIs consistent with Wayland semantics:
     - Return explicit `NotSupported` where protocol/compositor limitations apply.
 - Build/Tooling:

--- a/img_test.go
+++ b/img_test.go
@@ -94,8 +94,9 @@ func TestFindColorCSSignatureOrder(t *testing.T) {
 
 	// Compile-time compatibility check for the documented
 	// FindColorCS(x, y, w, h int, color CHex) argument order.
-	var _ func(int, int, int, int, CHex, ...float64) (int, int, error) = FindColorCS
-	var _ func(int, int, int, int, CHex, ...float64) (int, int, error) = FindcolorCS
+	acceptFindColorCS := func(func(int, int, int, int, CHex, ...float64) (int, int, error)) {}
+	acceptFindColorCS(FindColorCS)
+	acceptFindColorCS(FindcolorCS)
 }
 
 func TestBitmapStringInvalid(t *testing.T) {

--- a/img_test.go
+++ b/img_test.go
@@ -67,6 +67,37 @@ func TestBitmapStringRoundTripAndFind(t *testing.T) {
 	}
 }
 
+func TestOwnedBitmapFromCStaysValidAfterFree(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	src.SetRGBA(0, 0, color.RGBA{R: 21, G: 22, B: 23, A: 255})
+
+	cbit := ToCBitmap(RGBAToBitmap(src))
+	owned, err := ownedBitmapFromC(cbit)
+	FreeBitmap(cbit)
+	if err != nil {
+		t.Fatalf("ownedBitmapFromC error: %v", err)
+	}
+
+	got := ToRGBAGo(owned)
+	if !bytes.Equal(src.Pix, got.Pix) {
+		t.Fatalf("owned bitmap mismatch after FreeBitmap: %v vs %v", src.Pix, got.Pix)
+	}
+	if _, err := ToStrBitmap(owned); err != nil {
+		t.Fatalf("ToStrBitmap on owned bitmap after FreeBitmap error: %v", err)
+	}
+}
+
+func TestFindColorCSSignatureOrder(t *testing.T) {
+	t.Parallel()
+
+	// Compile-time compatibility check for the documented
+	// FindColorCS(x, y, w, h int, color CHex) argument order.
+	var _ func(int, int, int, int, CHex, ...float64) (int, int, error) = FindColorCS
+	var _ func(int, int, int, int, CHex, ...float64) (int, int, error) = FindcolorCS
+}
+
 func TestBitmapStringInvalid(t *testing.T) {
 	t.Parallel()
 

--- a/img_test.go
+++ b/img_test.go
@@ -26,3 +26,73 @@ func TestBitmapRoundTrip(t *testing.T) {
 		t.Fatalf("ImgToBitmap/ToRGBAGo mismatch: %v vs %v", src.Pix, got2.Pix)
 	}
 }
+
+func TestBitmapStringRoundTripAndFind(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 3, 2))
+	src.SetRGBA(0, 0, color.RGBA{R: 1, G: 2, B: 3, A: 255})
+	src.SetRGBA(1, 0, color.RGBA{R: 4, G: 5, B: 6, A: 255})
+	src.SetRGBA(2, 0, color.RGBA{R: 7, G: 8, B: 9, A: 255})
+	src.SetRGBA(0, 1, color.RGBA{R: 10, G: 11, B: 12, A: 255})
+	src.SetRGBA(1, 1, color.RGBA{R: 13, G: 14, B: 15, A: 255})
+	src.SetRGBA(2, 1, color.RGBA{R: 16, G: 17, B: 18, A: 255})
+
+	str, err := ToStrBitmap(RGBAToBitmap(src))
+	if err != nil {
+		t.Fatalf("ToStrBitmap error: %v", err)
+	}
+	bmp, err := BitmapFromStr(str)
+	if err != nil {
+		t.Fatalf("BitmapFromStr error: %v", err)
+	}
+	got := ToRGBAGo(bmp)
+	if !bytes.Equal(src.Pix, got.Pix) {
+		t.Fatalf("BitmapFromStr/ToRGBAGo mismatch: %v vs %v", src.Pix, got.Pix)
+	}
+
+	needle := image.NewRGBA(image.Rect(0, 0, 2, 1))
+	needle.SetRGBA(0, 0, color.RGBA{R: 13, G: 14, B: 15, A: 255})
+	needle.SetRGBA(1, 0, color.RGBA{R: 16, G: 17, B: 18, A: 255})
+	needleStr, err := ToStrBitmap(RGBAToBitmap(needle))
+	if err != nil {
+		t.Fatalf("ToStrBitmap needle error: %v", err)
+	}
+	x, y, err := FindBitmapStr(needleStr, str)
+	if err != nil {
+		t.Fatalf("FindBitmapStr error: %v", err)
+	}
+	if x != 1 || y != 1 {
+		t.Fatalf("FindBitmapStr got (%d,%d), want (1,1)", x, y)
+	}
+}
+
+func TestBitmapStringInvalid(t *testing.T) {
+	t.Parallel()
+
+	if _, err := BitmapFromStr("not-json"); err == nil {
+		t.Fatalf("expected invalid bitmap string error")
+	}
+	if _, err := ToStrBitmap(Bitmap{}); err == nil {
+		t.Fatalf("expected invalid bitmap error")
+	}
+}
+
+func TestBitmapColorHelpers(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	src.SetRGBA(0, 0, color.RGBA{R: 10, G: 20, B: 30, A: 255})
+	bmp := RGBAToBitmap(src)
+
+	r, g, b, ok := bitmapRGBAt(bmp, 0, 0)
+	if !ok {
+		t.Fatalf("bitmapRGBAt failed")
+	}
+	if r != 10 || g != 20 || b != 30 {
+		t.Fatalf("bitmapRGBAt got %d,%d,%d; want 10,20,30", r, g, b)
+	}
+	if !rgbSimilar(10, 20, 31, 10, 20, 30, 0.01) {
+		t.Fatalf("expected color similarity within tolerance")
+	}
+}

--- a/robotgo.go
+++ b/robotgo.go
@@ -58,6 +58,8 @@ import "C"
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"image"
@@ -142,6 +144,8 @@ type LinuxCapabilities struct {
 	Keyboard       FeatureCapability
 	Mouse          FeatureCapability
 	Window         FeatureCapability
+	Hook           FeatureCapability
+	Events         FeatureCapability
 }
 
 // DetectDisplayServer inspects the environment and reports the active display server.
@@ -244,6 +248,14 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		if c.Window.Backend == "native" {
 			c.Window.Backend = "wayland-core"
 		}
+		c.Hook = FeatureCapability{
+			Available: false,
+			Fallback:  false,
+			Backend:   "wayland",
+			Reason:    "global hooks are restricted by Wayland compositor policy",
+			Notes:     "hook/event APIs must report unsupported unless a compositor-specific protocol is implemented",
+		}
+		c.Events = c.Hook
 
 	case DisplayServerX11:
 		c.Capture = FeatureCapability{Available: true, Backend: "x11", Reason: "x11 session detected", Notes: "x11 capture path"}
@@ -251,6 +263,8 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		c.Keyboard = FeatureCapability{Available: true, Backend: "x11", Reason: "x11 session detected", Notes: "x11 keyboard path"}
 		c.Mouse = FeatureCapability{Available: true, Backend: "x11", Reason: "x11 session detected", Notes: "x11 mouse path"}
 		c.Window = FeatureCapability{Available: true, Backend: "x11", Reason: "x11 session detected", Notes: "x11 window management path"}
+		c.Hook = FeatureCapability{Available: true, Backend: "x11", Reason: "x11 session detected", Notes: "x11 hook/event path"}
+		c.Events = c.Hook
 
 	default:
 		c.Capture = FeatureCapability{Available: false, Backend: "", Reason: "no display server detected", Notes: "no detected display server"}
@@ -258,6 +272,8 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		c.Keyboard = FeatureCapability{Available: false, Backend: "", Reason: "no display server detected", Notes: "no detected display server"}
 		c.Mouse = FeatureCapability{Available: false, Backend: "", Reason: "no display server detected", Notes: "no detected display server"}
 		c.Window = FeatureCapability{Available: false, Backend: "", Reason: "no display server detected", Notes: "no detected display server"}
+		c.Hook = FeatureCapability{Available: false, Backend: "", Reason: "no display server detected", Notes: "no detected display server"}
+		c.Events = c.Hook
 	}
 
 	return c
@@ -308,6 +324,13 @@ var (
 
 func waylandWindowNotSupported(op string) error {
 	return fmt.Errorf("%w: %s on Wayland", ErrNotSupported, op)
+}
+
+func linuxWindowStateNotSupported(op string) error {
+	if isWaylandSession() {
+		return waylandWindowNotSupported(op)
+	}
+	return fmt.Errorf("%w: %s on Linux", ErrNotSupported, op)
 }
 
 func isWaylandSession() bool {
@@ -719,6 +742,18 @@ type Bitmap struct {
 	buf []uint8 // keep Go memory alive for ImgBuf
 }
 
+const bitmapStringFormat = "robotgo.bitmap.v1"
+
+type bitmapStringPayload struct {
+	Format        string `json:"format"`
+	Width         int    `json:"width"`
+	Height        int    `json:"height"`
+	Bytewidth     int    `json:"bytewidth"`
+	BitsPixel     uint8  `json:"bitsPixel"`
+	BytesPerPixel uint8  `json:"bytesPerPixel"`
+	Data          string `json:"data"`
+}
+
 // Point is point struct
 type Point struct {
 	X int
@@ -856,6 +891,49 @@ func GetPixelColor(x, y int, displayId ...int) (string, error) {
 func GetLocationColor(displayId ...int) (string, error) {
 	x, y := Location()
 	return GetPixelColor(x, y, displayId...)
+}
+
+// FindColorCS searches a captured screen region for color with an optional
+// tolerance. It returns the absolute screen coordinate of the first matching
+// pixel, or (-1, -1) when the color is not found.
+func FindColorCS(color CHex, x, y, w, h int, tolerance ...float64) (int, int, error) {
+	if w <= 0 || h <= 0 {
+		return -1, -1, fmt.Errorf("invalid search region %dx%d", w, h)
+	}
+
+	tol := 0.0
+	if len(tolerance) > 0 {
+		tol = tolerance[0]
+	}
+	if tol < 0 {
+		return -1, -1, fmt.Errorf("invalid color tolerance %f", tol)
+	}
+
+	bmp, err := CaptureGo(x, y, w, h)
+	if err != nil {
+		return -1, -1, err
+	}
+
+	r, g, b := splitHex(uint32(color))
+	for yy := 0; yy < bmp.Height; yy++ {
+		for xx := 0; xx < bmp.Width; xx++ {
+			pr, pg, pb, ok := bitmapRGBAt(bmp, xx, yy)
+			if !ok {
+				return -1, -1, errors.New("invalid bitmap pixel layout")
+			}
+			if rgbSimilar(pr, pg, pb, r, g, b, tol) {
+				return x + xx, y + yy, nil
+			}
+		}
+	}
+
+	return -1, -1, nil
+}
+
+// FindcolorCS is kept for compatibility with the historical RobotGo-Pro
+// spelling.
+func FindcolorCS(color CHex, x, y, w, h int, tolerance ...float64) (int, int, error) {
+	return FindColorCS(color, x, y, w, h, tolerance...)
 }
 
 // IsMain is main display
@@ -1128,6 +1206,126 @@ func ToBitmap(bit CBitmap) Bitmap {
 	return bitmap
 }
 
+func bitmapBufferLen(bit Bitmap) (int, error) {
+	if bit.Width <= 0 || bit.Height <= 0 {
+		return 0, fmt.Errorf("invalid bitmap dimensions %dx%d", bit.Width, bit.Height)
+	}
+	if bit.Bytewidth <= 0 || bit.BytesPerPixel == 0 {
+		return 0, fmt.Errorf("invalid bitmap layout bytewidth=%d bytesPerPixel=%d", bit.Bytewidth, bit.BytesPerPixel)
+	}
+	if bit.Bytewidth < bit.Width*int(bit.BytesPerPixel) {
+		return 0, fmt.Errorf("invalid bitmap stride %d for width=%d bytesPerPixel=%d", bit.Bytewidth, bit.Width, bit.BytesPerPixel)
+	}
+	total := bit.Bytewidth * bit.Height
+	if total <= 0 {
+		return 0, errors.New("invalid bitmap buffer size")
+	}
+	return total, nil
+}
+
+func bitmapBytes(bit Bitmap) ([]byte, error) {
+	total, err := bitmapBufferLen(bit)
+	if err != nil {
+		return nil, err
+	}
+	if bit.ImgBuf == nil {
+		return nil, errors.New("bitmap image buffer is nil")
+	}
+	src := unsafe.Slice((*byte)(unsafe.Pointer(bit.ImgBuf)), total)
+	dst := make([]byte, total)
+	copy(dst, src)
+	return dst, nil
+}
+
+// ToStrBitmap serializes a Bitmap into a stable JSON/base64 string.
+func ToStrBitmap(bit Bitmap) (string, error) {
+	data, err := bitmapBytes(bit)
+	if err != nil {
+		return "", err
+	}
+	payload := bitmapStringPayload{
+		Format:        bitmapStringFormat,
+		Width:         bit.Width,
+		Height:        bit.Height,
+		Bytewidth:     bit.Bytewidth,
+		BitsPixel:     bit.BitsPixel,
+		BytesPerPixel: bit.BytesPerPixel,
+		Data:          base64.StdEncoding.EncodeToString(data),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+// BitmapFromStr decodes a bitmap string produced by ToStrBitmap.
+func BitmapFromStr(str string) (Bitmap, error) {
+	var payload bitmapStringPayload
+	if err := json.Unmarshal([]byte(str), &payload); err != nil {
+		return Bitmap{}, err
+	}
+	if payload.Format != bitmapStringFormat {
+		return Bitmap{}, fmt.Errorf("unsupported bitmap string format %q", payload.Format)
+	}
+	data, err := base64.StdEncoding.DecodeString(payload.Data)
+	if err != nil {
+		return Bitmap{}, err
+	}
+	bit := Bitmap{
+		Width:         payload.Width,
+		Height:        payload.Height,
+		Bytewidth:     payload.Bytewidth,
+		BitsPixel:     payload.BitsPixel,
+		BytesPerPixel: payload.BytesPerPixel,
+		buf:           data,
+	}
+	if _, err := bitmapBufferLen(bit); err != nil {
+		return Bitmap{}, err
+	}
+	if len(data) != bit.Bytewidth*bit.Height {
+		return Bitmap{}, fmt.Errorf("bitmap payload length %d does not match layout size %d", len(data), bit.Bytewidth*bit.Height)
+	}
+	if len(bit.buf) > 0 {
+		bit.ImgBuf = &bit.buf[0]
+	}
+	return bit, nil
+}
+
+// CaptureBitmapStr captures the screen and returns the serialized bitmap.
+func CaptureBitmapStr(args ...int) (string, error) {
+	bit, err := CaptureGo(args...)
+	if err != nil {
+		return "", err
+	}
+	return ToStrBitmap(bit)
+}
+
+// FindBitmapStr searches for needleStr inside haystackStr. When only one
+// string is provided, the current screen is captured and searched for that
+// bitmap. It returns (-1, -1) when no match is found.
+func FindBitmapStr(needleStr string, haystackStr ...string) (int, int, error) {
+	needle, err := BitmapFromStr(needleStr)
+	if err != nil {
+		return -1, -1, err
+	}
+
+	var haystack Bitmap
+	if len(haystackStr) > 0 {
+		haystack, err = BitmapFromStr(haystackStr[0])
+		if err != nil {
+			return -1, -1, err
+		}
+	} else {
+		haystack, err = CaptureGo()
+		if err != nil {
+			return -1, -1, err
+		}
+	}
+
+	return findBitmap(haystack, needle)
+}
+
 // ToCBitmap trans Bitmap to C.MMBitmapRef
 func ToCBitmap(bit Bitmap) CBitmap {
 	total := bit.Bytewidth * bit.Height
@@ -1175,6 +1373,75 @@ func ImgToCBitmap(img image.Image) CBitmap {
 func ByteToCBitmap(by []byte) CBitmap {
 	img, _ := ByteToImg(by)
 	return ImgToCBitmap(img)
+}
+
+func splitHex(hex uint32) (uint8, uint8, uint8) {
+	return uint8((hex >> 16) & 0xff), uint8((hex >> 8) & 0xff), uint8(hex & 0xff)
+}
+
+func rgbSimilar(r1, g1, b1, r2, g2, b2 uint8, tolerance float64) bool {
+	if tolerance <= 0 {
+		return r1 == r2 && g1 == g2 && b1 == b2
+	}
+	dr := float64(int(r1) - int(r2))
+	dg := float64(int(g1) - int(g2))
+	db := float64(int(b1) - int(b2))
+	return dr*dr+dg*dg+db*db <= (tolerance*442.0)*(tolerance*442.0)
+}
+
+func bitmapRGBAt(bit Bitmap, x, y int) (uint8, uint8, uint8, bool) {
+	if x < 0 || y < 0 || x >= bit.Width || y >= bit.Height {
+		return 0, 0, 0, false
+	}
+	total, err := bitmapBufferLen(bit)
+	if err != nil || bit.ImgBuf == nil {
+		return 0, 0, 0, false
+	}
+	offset := y*bit.Bytewidth + x*int(bit.BytesPerPixel)
+	if offset+2 >= total {
+		return 0, 0, 0, false
+	}
+	buf := unsafe.Slice((*byte)(unsafe.Pointer(bit.ImgBuf)), total)
+	return buf[offset+2], buf[offset+1], buf[offset], true
+}
+
+func findBitmap(haystack, needle Bitmap) (int, int, error) {
+	if _, err := bitmapBufferLen(haystack); err != nil {
+		return -1, -1, err
+	}
+	if _, err := bitmapBufferLen(needle); err != nil {
+		return -1, -1, err
+	}
+	if needle.Width > haystack.Width || needle.Height > haystack.Height {
+		return -1, -1, nil
+	}
+	for y := 0; y <= haystack.Height-needle.Height; y++ {
+		for x := 0; x <= haystack.Width-needle.Width; x++ {
+			if bitmapMatchesAt(haystack, needle, x, y) {
+				return x, y, nil
+			}
+		}
+	}
+	return -1, -1, nil
+}
+
+func bitmapMatchesAt(haystack, needle Bitmap, startX, startY int) bool {
+	for y := 0; y < needle.Height; y++ {
+		for x := 0; x < needle.Width; x++ {
+			hr, hg, hb, ok := bitmapRGBAt(haystack, startX+x, startY+y)
+			if !ok {
+				return false
+			}
+			nr, ng, nb, ok := bitmapRGBAt(needle, x, y)
+			if !ok {
+				return false
+			}
+			if hr != nr || hg != ng || hb != nb {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // SetXDisplayName set XDisplay name (Linux)
@@ -1599,6 +1866,69 @@ func IsValid() bool {
 	abool := C.is_valid()
 	gbool := bool(abool)
 	return gbool
+}
+
+// IsTopMost reports whether the current active window is topmost.
+func IsTopMost() bool {
+	ok, _ := IsTopMostE()
+	return ok
+}
+
+// IsTopMostE reports whether the current active window is topmost and returns
+// an explicit unsupported error on Linux backends without reliable state
+// query support.
+func IsTopMostE() (bool, error) {
+	if runtime.GOOS == "linux" {
+		return false, linuxWindowStateNotSupported("query topmost state")
+	}
+	return bool(C.IsTopMost()), nil
+}
+
+// IsMinimized reports whether the current active window is minimized.
+func IsMinimized() bool {
+	ok, _ := IsMinimizedE()
+	return ok
+}
+
+// IsMinimizedE reports whether the current active window is minimized and
+// returns an explicit unsupported error on Linux backends without reliable
+// state query support.
+func IsMinimizedE() (bool, error) {
+	if runtime.GOOS == "linux" {
+		return false, linuxWindowStateNotSupported("query minimized state")
+	}
+	return bool(C.IsMinimized()), nil
+}
+
+// IsMaximized reports whether the current active window is maximized.
+func IsMaximized() bool {
+	ok, _ := IsMaximizedE()
+	return ok
+}
+
+// IsMaximizedE reports whether the current active window is maximized and
+// returns an explicit unsupported error on Linux backends without reliable
+// state query support.
+func IsMaximizedE() (bool, error) {
+	if runtime.GOOS == "linux" {
+		return false, linuxWindowStateNotSupported("query maximized state")
+	}
+	return bool(C.IsMaximized()), nil
+}
+
+// SetTopMost updates topmost state for platforms that support it.
+func SetTopMost(state bool) {
+	_ = SetTopMostE(state)
+}
+
+// SetTopMostE updates topmost state and returns an explicit unsupported error
+// on Linux backends without reliable topmost support.
+func SetTopMostE(state bool) error {
+	if runtime.GOOS == "linux" {
+		return linuxWindowStateNotSupported("set topmost state")
+	}
+	C.SetTopMost(C.bool(state))
+	return nil
 }
 
 // SetActive set the window active

--- a/robotgo.go
+++ b/robotgo.go
@@ -896,7 +896,7 @@ func GetLocationColor(displayId ...int) (string, error) {
 // FindColorCS searches a captured screen region for color with an optional
 // tolerance. It returns the absolute screen coordinate of the first matching
 // pixel, or (-1, -1) when the color is not found.
-func FindColorCS(color CHex, x, y, w, h int, tolerance ...float64) (int, int, error) {
+func FindColorCS(x, y, w, h int, color CHex, tolerance ...float64) (int, int, error) {
 	if w <= 0 || h <= 0 {
 		return -1, -1, fmt.Errorf("invalid search region %dx%d", w, h)
 	}
@@ -932,8 +932,8 @@ func FindColorCS(color CHex, x, y, w, h int, tolerance ...float64) (int, int, er
 
 // FindcolorCS is kept for compatibility with the historical RobotGo-Pro
 // spelling.
-func FindcolorCS(color CHex, x, y, w, h int, tolerance ...float64) (int, int, error) {
-	return FindColorCS(color, x, y, w, h, tolerance...)
+func FindcolorCS(x, y, w, h int, color CHex, tolerance ...float64) (int, int, error) {
+	return FindColorCS(x, y, w, h, color, tolerance...)
 }
 
 // IsMain is main display
@@ -1159,7 +1159,7 @@ func CaptureGo(args ...int) (Bitmap, error) {
 	}
 	defer FreeBitmap(bit)
 
-	return ToBitmap(bit), nil
+	return ownedBitmapFromC(bit)
 }
 
 // CaptureImg capture the screen and return image.Image, error
@@ -1204,6 +1204,19 @@ func ToBitmap(bit CBitmap) Bitmap {
 	}
 
 	return bitmap
+}
+
+func ownedBitmapFromC(bit CBitmap) (Bitmap, error) {
+	bitmap := ToBitmap(bit)
+	data, err := bitmapBytes(bitmap)
+	if err != nil {
+		return Bitmap{}, err
+	}
+	bitmap.buf = data
+	if len(bitmap.buf) > 0 {
+		bitmap.ImgBuf = &bitmap.buf[0]
+	}
+	return bitmap, nil
 }
 
 func bitmapBufferLen(bit Bitmap) (int, error) {

--- a/robotgo_wayland_cap_test.go
+++ b/robotgo_wayland_cap_test.go
@@ -1,6 +1,7 @@
 package robotgo
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -151,6 +152,15 @@ func TestGetLinuxCapabilitiesWaylandFallback(t *testing.T) {
 	if c.Window.Backend == "" {
 		t.Fatalf("expected window backend annotation")
 	}
+	if c.Hook.Available {
+		t.Fatalf("expected hook capability unavailable in wayland core path")
+	}
+	if c.Hook.Reason == "" {
+		t.Fatalf("expected hook unsupported reason")
+	}
+	if c.Events != c.Hook {
+		t.Fatalf("expected event capability to mirror hook capability")
+	}
 }
 
 func TestGetLinuxCapabilitiesWaylandInvalidFallback(t *testing.T) {
@@ -185,5 +195,32 @@ func TestGetLinuxCapabilitiesWaylandInvalidFallback(t *testing.T) {
 	}
 	if c.Bounds.Fallback {
 		t.Fatalf("expected no fallback capability when wayland-info is invalid")
+	}
+}
+
+func TestLinuxWindowStateAPIsReturnUnsupported(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+
+	t.Setenv(envWaylandDisplay, testWaylandDisplay)
+	t.Setenv(envDisplay, "")
+
+	stateChecks := []struct {
+		name string
+		fn   func() (bool, error)
+	}{
+		{"IsTopMostE", IsTopMostE},
+		{"IsMinimizedE", IsMinimizedE},
+		{"IsMaximizedE", IsMaximizedE},
+	}
+	for _, tc := range stateChecks {
+		_, err := tc.fn()
+		if !errors.Is(err, ErrNotSupported) {
+			t.Fatalf("%s expected ErrNotSupported, got %v", tc.name, err)
+		}
+	}
+	if err := SetTopMostE(true); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("SetTopMostE expected ErrNotSupported, got %v", err)
 	}
 }

--- a/window/goWindow_wayland_stub.h
+++ b/window/goWindow_wayland_stub.h
@@ -57,6 +57,22 @@ static inline void max_window(uintptr pid, bool state, int8_t isPid) {
 	(void)isPid;
 }
 
+static inline bool IsTopMost(void) {
+	return false;
+}
+
+static inline bool IsMinimized(void) {
+	return false;
+}
+
+static inline bool IsMaximized(void) {
+	return false;
+}
+
+static inline void SetTopMost(bool state) {
+	(void)state;
+}
+
 static inline uintptr get_handle(void) {
 	return pub_mData.XWin;
 }


### PR DESCRIPTION
### Motivation

- Expose additional Linux/Wayland runtime capability information (hook/event state) and make window-state APIs explicitly report unsupported where Wayland/compositor policy prevents reliable queries. 
- Provide platform-neutral bitmap serialization and in-memory search helpers to enable stable bitmap round-trip, capture-as-string, and needle/haystack searching across runtimes. 
- Add region/tolerance color search helpers to unify color lookups across capture backends.

### Description

- Extended `LinuxCapabilities` with `Hook` and `Events` `FeatureCapability` fields and set Wayland defaults to explicitly report hooks/events as unavailable.  
- Added `linuxWindowStateNotSupported` helper and implemented explicit error-returning window-state APIs: `IsTopMostE`, `IsMinimizedE`, `IsMaximizedE`, and `SetTopMostE` with convenience wrappers `IsTopMost`, `IsMinimized`, `IsMaximized`, and `SetTopMost`; Wayland stubs in `window/goWindow_wayland_stub.h` supply safe no-op/false semantics.  
- Implemented stable bitmap string format and helpers: `ToStrBitmap`, `BitmapFromStr`, `CaptureBitmapStr`, `FindBitmapStr`, plus internal helpers `bitmapBufferLen`, `bitmapBytes`, `bitmapRGBAt`, `findBitmap`, and `bitmapMatchesAt`.  
- Added color-search helpers `FindColorCS` and backward-compatible `FindcolorCS` which capture a region and search for a color with optional tolerance using `rgbSimilar`.  
- Added JSON/base64 payload format constant `robotgo.bitmap.v1` and supporting payload struct for serialization.  
- Updated docs `docs/wayland-tasks.md` to reflect implemented parity items (bitmap helpers, color search) and partial Wayland parity for window state and capability introspection. 

### Testing

- Ran unit tests with `go test ./...`; all tests completed successfully.  
- Added and ran image/bitmap unit tests `TestBitmapRoundTrip`, `TestBitmapStringRoundTripAndFind`, `TestBitmapStringInvalid`, and `TestBitmapColorHelpers`, which validate serialization round-trip, find-by-string, invalid input handling, and color helper correctness; all passed.  
- Added and ran Wayland capability/state test `TestLinuxWindowStateAPIsReturnUnsupported` which verifies Linux/Wayland returns `ErrNotSupported` for state queries and `SetTopMostE`; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50d05e263c8324a588e2068be3652d)