### PR TITLE
fix: harden Wayland capture geometry

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -178,5 +178,5 @@ jobs:
           # Compile the consent-driven harness; real runs use remote-desktop-e2e.yml.
           go test -tags "integration" ./input/portal -run '^$'
           go test -tags "wayland test" ./screen -run TestScreencopy -v
-          go test -tags "wayland test" . -run TestDrmFindRenderNode -v
+          go test -tags "wayland test" . -run 'Test(DrmFindRenderNode|Wayland)' -v
           go test -tags "wayland integration" . ./mouse ./window -v

--- a/TEST.md
+++ b/TEST.md
@@ -30,13 +30,15 @@ Some tests are intentionally gated because they require OS-specific runtime depe
 
 Purpose:
 - Linux Wayland screencopy/mock-server coverage
+- Hermetic native crop mapping for multi-output coordinates, fractional scale,
+  overflow boundaries, and all eight output transforms
 - DRM helper tests
 
 Typical command:
 
 ```bash
 go test -tags "wayland test" ./screen -run TestScreencopy -v
-go test -tags "wayland test" . -run TestDrmFindRenderNode -v
+go test -tags "wayland test" . -run 'Test(DrmFindRenderNode|Wayland)' -v
 ```
 
 Prerequisites:
@@ -144,6 +146,8 @@ Purpose:
   file-descriptor ownership, and deterministic teardown
 - Reusable PipeWire consumer compilation and frame/crop behavior
 - Fractional logical-to-physical region mapping and repeated-frame lifecycle
+- Multi-output positions (including negative origins), clipped regions, and
+  non-zero frame origins
 - Native C packed-pixel conversion plus SPA crop/transform metadata processing
 - Explicit cursor-metadata rejection for the image capture API
 

--- a/docs/compatibility/wayland-capture.md
+++ b/docs/compatibility/wayland-capture.md
@@ -6,6 +6,7 @@ passing result.
 
 | Date | Desktop | Backend | Build | Result | Evidence |
 |---|---|---|---|---|---|
+| 2026-07-14 | Hermetic Linux | Native screencopy geometry | `cgo,wayland,test` | pass | Negative/positive output origins, clipped and overflowing regions, fractional scaling, all eight output transforms, enclosing-edge crop semantics |
 | 2026-07-11 | Hermetic Linux | ScreenCast/PipeWire | `cgo,pipewire` | pass | Session/request cleanup, FD duplication, repeated consumer lifecycle, crop/fractional scaling, eight transforms, pixel buffer validation, race and lint gates |
 | pending | GNOME | ScreenCast/PipeWire | `cgo,pipewire,integration` | no runner | Protected runner label `gnome`; workflow artifact `screencast-gnome` |
 | pending | KDE Plasma | ScreenCast/PipeWire | `cgo,pipewire,integration` | no runner | Protected runner label `kde`; workflow artifact `screencast-kde` |

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -28,13 +28,13 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
   Weston integration, race, and vet variants.
 
-## Execution Status (2026-07-11)
+## Execution Status (2026-07-14)
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
 | Current baseline | Complete in branch | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Confirm new CI jobs on remote branch |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
-| 2. Capture | Active; persistent backend implemented | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup and integration harness | Real GNOME/KDE/wlroots evidence and full multi-output/fractional-scale/transform/leak gates |
+| 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and blocking geometry/transform matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
 | 3. Pure-Go | Foundation only | Non-CGO builds fail explicitly instead of degrading silently | Useful selected Pure-Go backends, parity tests, benchmarks, backend introspection |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
@@ -98,8 +98,10 @@ exposes stream/restore metadata, and provides hermetic plus opt-in runtime
 tests. Native readiness is bounded, PipeWire initialization is balanced, and
 idle sessions do not convert unrequested frames. `CaptureScreen` can reuse the active session after native
 screencopy failure or select it explicitly. Output geometry, scale, and
-transform handling still need the complete real-compositor matrix required by
-this phase.
+transform handling now share enclosing-edge crop semantics and have a blocking
+hermetic matrix for negative output origins, fractional scale, clipped regions,
+overflow boundaries, and all eight transforms. The complete real-compositor
+matrix is still required by this phase.
 
 Exit criteria:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -99,11 +99,13 @@ Window backend support matrix (current):
   - `GetLinuxCapabilities` reports hook/event status explicitly.
 
 - Screen Capture:
-  - Validate on wlroots, GNOME and KDE.
-  - Validate and harden existing scale/transform mapping for fractional scale
-    and every output transform.
-  - Complete multi-output selection and bounds tests using `xdg-output`.
-  - Region-crop correctness tests across backends.
+  - The blocking hermetic matrix now covers positive/negative output origins,
+    fractional scaling, clipped/overflowing regions, and all eight transforms
+    across native screencopy and PipeWire mapping.
+  - Validate the same scale/transform and region-crop behavior on real wlroots,
+    GNOME, and KDE sessions.
+  - Complete real-compositor multi-output selection and bounds evidence using
+    `xdg-output`.
 - Portal Path:
   - Expand troubleshooting for xdg-desktop-portal backend selection and consent prompts.
   - Validate the existing high-level RemoteDesktop input fallback on GNOME/KDE.

--- a/screen/portal/pipewire.go
+++ b/screen/portal/pipewire.go
@@ -150,29 +150,80 @@ func cropPipeWireFrame(frame *image.RGBA, stream ScreenCastStream, x, y, width, 
 	if width <= 0 || height <= 0 {
 		return nil, fmt.Errorf("PipeWire capture region has invalid size %dx%d", width, height)
 	}
-	logical := image.Rect(0, 0, frame.Bounds().Dx(), frame.Bounds().Dy())
+	frameBounds := frame.Bounds()
+	logicalWidth, logicalHeight := int64(frameBounds.Dx()), int64(frameBounds.Dy())
 	if stream.HasSize {
 		if stream.Size.Width <= 0 || stream.Size.Height <= 0 {
 			return nil, fmt.Errorf("PipeWire stream has invalid logical size %dx%d", stream.Size.Width, stream.Size.Height)
 		}
-		logical = image.Rect(0, 0, int(stream.Size.Width), int(stream.Size.Height))
+		logicalWidth, logicalHeight = int64(stream.Size.Width), int64(stream.Size.Height)
 	}
-	localX, localY := x, y
+	localX, localY := int64(x), int64(y)
 	if stream.HasPosition {
-		localX -= int(stream.Position.X)
-		localY -= int(stream.Position.Y)
+		localX = saturatingAdd64(localX, -int64(stream.Position.X))
+		localY = saturatingAdd64(localY, -int64(stream.Position.Y))
 	}
-	requested := image.Rect(localX, localY, localX+width, localY+height).Intersect(logical)
-	if requested.Empty() {
-		return nil, fmt.Errorf("PipeWire capture region %v is outside stream bounds %v", image.Rect(localX, localY, localX+width, localY+height), logical)
+	requestedRight := saturatingAdd64(localX, int64(width))
+	requestedBottom := saturatingAdd64(localY, int64(height))
+	left := max64(localX, 0)
+	top := max64(localY, 0)
+	right := min64(requestedRight, logicalWidth)
+	bottom := min64(requestedBottom, logicalHeight)
+	if left >= right || top >= bottom {
+		return nil, fmt.Errorf(
+			"PipeWire capture region (%d,%d)-(%d,%d) is outside stream bounds (0,0)-(%d,%d)",
+			localX, localY, requestedRight, requestedBottom, logicalWidth, logicalHeight,
+		)
 	}
-	frameBounds := frame.Bounds()
-	left := requested.Min.X * frameBounds.Dx() / logical.Dx()
-	top := requested.Min.Y * frameBounds.Dy() / logical.Dy()
-	right := (requested.Max.X*frameBounds.Dx() + logical.Dx() - 1) / logical.Dx()
-	bottom := (requested.Max.Y*frameBounds.Dy() + logical.Dy() - 1) / logical.Dy()
-	pixelRegion := image.Rect(left, top, right, bottom).Intersect(frameBounds)
+	pixelRegion := image.Rect(
+		frameBounds.Min.X+int(scaleFloor(left, int64(frameBounds.Dx()), logicalWidth)),
+		frameBounds.Min.Y+int(scaleFloor(top, int64(frameBounds.Dy()), logicalHeight)),
+		frameBounds.Min.X+int(scaleCeil(right, int64(frameBounds.Dx()), logicalWidth)),
+		frameBounds.Min.Y+int(scaleCeil(bottom, int64(frameBounds.Dy()), logicalHeight)),
+	).Intersect(frameBounds)
 	result := image.NewRGBA(image.Rect(0, 0, pixelRegion.Dx(), pixelRegion.Dy()))
 	draw.Draw(result, result.Bounds(), frame, pixelRegion.Min, draw.Src)
 	return result, nil
+}
+
+// scaleFloor and scaleCeil map a non-negative logical coordinate into a pixel
+// extent without overflowing when the pixel extent is close to the int limit.
+func scaleFloor(value, extent, logicalExtent int64) int64 {
+	return (extent/logicalExtent)*value + (extent%logicalExtent)*value/logicalExtent
+}
+
+func scaleCeil(value, extent, logicalExtent int64) int64 {
+	quotient := (extent / logicalExtent) * value
+	remainder := (extent % logicalExtent) * value
+	result := quotient + remainder/logicalExtent
+	if remainder%logicalExtent != 0 {
+		result++
+	}
+	return result
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func saturatingAdd64(a, b int64) int64 {
+	const maxInt64 = int64(^uint64(0) >> 1)
+	const minInt64 = -maxInt64 - 1
+	if b > 0 && a > maxInt64-b {
+		return maxInt64
+	}
+	if b < 0 && a < minInt64-b {
+		return minInt64
+	}
+	return a + b
 }

--- a/screen/portal/pipewire_test.go
+++ b/screen/portal/pipewire_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"image"
+	"image/color"
+	"math"
 	"os"
 	"reflect"
 	"strings"
@@ -192,4 +194,98 @@ func TestCropPipeWireFrameRejectsPartialOrNegativeSize(t *testing.T) {
 			t.Fatalf("size %v unexpectedly accepted", size)
 		}
 	}
+}
+
+func TestCropPipeWireFrameOutputGeometryMatrix(t *testing.T) {
+	tests := []struct {
+		name           string
+		frame          image.Rectangle
+		stream         ScreenCastStream
+		region         image.Rectangle
+		want           image.Rectangle
+		wantFirstPixel image.Point
+	}{
+		{
+			name:  "negative-origin fractional-scale output",
+			frame: image.Rect(0, 0, 2560, 1440),
+			stream: ScreenCastStream{
+				Position: ScreenCastPoint{X: -1920}, HasPosition: true,
+				Size: ScreenCastSize{Width: 1920, Height: 1080}, HasSize: true,
+			},
+			region: image.Rect(-1440, 270, -960, 810),
+			want:   image.Rect(0, 0, 640, 720),
+		},
+		{
+			name:  "positive-origin output with negative vertical origin",
+			frame: image.Rect(0, 0, 1920, 1080),
+			stream: ScreenCastStream{
+				Position: ScreenCastPoint{X: 1280, Y: -720}, HasPosition: true,
+				Size: ScreenCastSize{Width: 1280, Height: 720}, HasSize: true,
+			},
+			region: image.Rect(1600, -600, 1920, -360),
+			want:   image.Rect(0, 0, 480, 360),
+		},
+		{
+			name:  "left edge is clipped to selected output",
+			frame: image.Rect(0, 0, 1500, 1000),
+			stream: ScreenCastStream{
+				Position: ScreenCastPoint{X: -1000, Y: 100}, HasPosition: true,
+				Size: ScreenCastSize{Width: 1000, Height: 500}, HasSize: true,
+			},
+			region: image.Rect(-1100, 200, -800, 300),
+			want:   image.Rect(0, 0, 300, 200),
+		},
+		{
+			name:  "fractional rounding encloses every touched pixel",
+			frame: image.Rect(0, 0, 1920, 1080),
+			stream: ScreenCastStream{
+				Size: ScreenCastSize{Width: 1279, Height: 719}, HasSize: true,
+			},
+			region: image.Rect(1, 1, 2, 2),
+			want:   image.Rect(0, 0, 3, 3),
+		},
+		{
+			name:           "non-zero frame origin is preserved while copying",
+			frame:          image.Rect(10, 20, 14, 24),
+			stream:         ScreenCastStream{},
+			region:         image.Rect(1, 1, 3, 3),
+			want:           image.Rect(0, 0, 2, 2),
+			wantFirstPixel: image.Pt(11, 21),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			frame := image.NewRGBA(test.frame)
+			for y := test.frame.Min.Y; y < test.frame.Max.Y; y++ {
+				for x := test.frame.Min.X; x < test.frame.Max.X; x++ {
+					frame.SetRGBA(x, y, coordinateColor(x, y))
+				}
+			}
+			got, err := cropPipeWireFrame(frame, test.stream, test.region.Min.X, test.region.Min.Y, test.region.Dx(), test.region.Dy())
+			if err != nil {
+				t.Fatalf("cropPipeWireFrame error: %v", err)
+			}
+			if got.Bounds() != test.want {
+				t.Fatalf("crop bounds = %v, want %v", got.Bounds(), test.want)
+			}
+			if test.wantFirstPixel != (image.Point{}) {
+				wantColor := coordinateColor(test.wantFirstPixel.X, test.wantFirstPixel.Y)
+				if gotColor := got.At(0, 0); gotColor != wantColor {
+					t.Fatalf("first pixel = %v, want source pixel %v at %v", gotColor, wantColor, test.wantFirstPixel)
+				}
+			}
+		})
+	}
+}
+
+func TestCropPipeWireFrameRejectsOverflowingRegion(t *testing.T) {
+	frame := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	stream := ScreenCastStream{Size: ScreenCastSize{Width: 2, Height: 2}, HasSize: true}
+	if _, err := cropPipeWireFrame(frame, stream, math.MaxInt, 0, math.MaxInt, 1); err == nil {
+		t.Fatal("overflowing disjoint region unexpectedly accepted")
+	}
+}
+
+func coordinateColor(x, y int) color.RGBA {
+	return color.RGBA{R: uint8(x), G: uint8(y), B: uint8(x + y), A: 0xff}
 }

--- a/screen/screengrab_wayland_impl.c
+++ b/screen/screengrab_wayland_impl.c
@@ -154,16 +154,38 @@ static void output_logical_origin(const struct output *out, int *ox, int *oy) {
 static long long rect_intersection_area(struct int_rect a, struct int_rect b) {
   int x1 = a.x > b.x ? a.x : b.x;
   int y1 = a.y > b.y ? a.y : b.y;
-  int x2a = a.x + a.w;
-  int y2a = a.y + a.h;
-  int x2b = b.x + b.w;
-  int y2b = b.y + b.h;
-  int x2 = x2a < x2b ? x2a : x2b;
-  int y2 = y2a < y2b ? y2a : y2b;
+  long long x2a = (long long)a.x + (long long)a.w;
+  long long y2a = (long long)a.y + (long long)a.h;
+  long long x2b = (long long)b.x + (long long)b.w;
+  long long y2b = (long long)b.y + (long long)b.h;
+  long long x2 = x2a < x2b ? x2a : x2b;
+  long long y2 = y2a < y2b ? y2a : y2b;
   if (x2 <= x1 || y2 <= y1) {
     return 0;
   }
-  return (long long)(x2 - x1) * (long long)(y2 - y1);
+  return (x2 - x1) * (y2 - y1);
+}
+
+static int rect_candidate_is_better(struct int_rect request,
+                                    struct int_rect candidate,
+                                    long long best_area,
+                                    long long *candidate_area) {
+  long long area = rect_intersection_area(request, candidate);
+  if (candidate_area) {
+    *candidate_area = area;
+  }
+  return area > best_area;
+}
+
+static int scale_floor_coord(int value, int extent, int logical_extent) {
+  return (int)(((long long)value * (long long)extent) /
+               (long long)logical_extent);
+}
+
+static int scale_ceil_coord(int value, int extent, int logical_extent) {
+  long long product = (long long)value * (long long)extent;
+  return (int)((product + (long long)logical_extent - 1) /
+               (long long)logical_extent);
 }
 
 static int transform_is_rotated(int32_t transform) {
@@ -171,63 +193,6 @@ static int transform_is_rotated(int32_t transform) {
          transform == WL_OUTPUT_TRANSFORM_270 ||
          transform == WL_OUTPUT_TRANSFORM_FLIPPED_90 ||
          transform == WL_OUTPUT_TRANSFORM_FLIPPED_270;
-}
-
-static void transform_inverse_uv(int32_t transform, double u, double v,
-                                 double *out_u, double *out_v) {
-  double x = u;
-  double y = v;
-  switch (transform) {
-  case WL_OUTPUT_TRANSFORM_90:
-    x = v;
-    y = 1.0 - u;
-    break;
-  case WL_OUTPUT_TRANSFORM_180:
-    x = 1.0 - u;
-    y = 1.0 - v;
-    break;
-  case WL_OUTPUT_TRANSFORM_270:
-    x = 1.0 - v;
-    y = u;
-    break;
-  case WL_OUTPUT_TRANSFORM_FLIPPED:
-    x = 1.0 - u;
-    y = v;
-    break;
-  case WL_OUTPUT_TRANSFORM_FLIPPED_90:
-    x = v;
-    y = u;
-    break;
-  case WL_OUTPUT_TRANSFORM_FLIPPED_180:
-    x = u;
-    y = 1.0 - v;
-    break;
-  case WL_OUTPUT_TRANSFORM_FLIPPED_270:
-    x = 1.0 - v;
-    y = 1.0 - u;
-    break;
-  case WL_OUTPUT_TRANSFORM_NORMAL:
-  default:
-    break;
-  }
-  if (x < 0.0) {
-    x = 0.0;
-  }
-  if (x > 1.0) {
-    x = 1.0;
-  }
-  if (y < 0.0) {
-    y = 0.0;
-  }
-  if (y > 1.0) {
-    y = 1.0;
-  }
-  if (out_u) {
-    *out_u = x;
-  }
-  if (out_v) {
-    *out_v = y;
-  }
 }
 
 static void map_logical_rect_to_buffer(const struct output *out, int cap_w, int cap_h,
@@ -242,6 +207,8 @@ static void map_logical_rect_to_buffer(const struct output *out, int cap_w, int 
   int ly = *y;
   int lw = *w;
   int lh = *h;
+  long long x2_long = (lw <= 0) ? logical_w : (long long)lx + (long long)lw;
+  long long y2_long = (lh <= 0) ? logical_h : (long long)ly + (long long)lh;
   if (lx < 0) {
     lx = 0;
   }
@@ -249,8 +216,8 @@ static void map_logical_rect_to_buffer(const struct output *out, int cap_w, int 
     ly = 0;
   }
 
-  int x2 = (lw <= 0) ? logical_w : (lx + lw);
-  int y2 = (lh <= 0) ? logical_h : (ly + lh);
+  int x2 = x2_long > INT_MAX ? INT_MAX : (int)x2_long;
+  int y2 = y2_long > INT_MAX ? INT_MAX : (int)y2_long;
   if (x2 > logical_w) {
     x2 = logical_w;
   }
@@ -284,12 +251,10 @@ static void map_logical_rect_to_buffer(const struct output *out, int cap_w, int 
   }
 
   if (!use_transform) {
-    double sx = (double)cap_w / (double)logical_w;
-    double sy = (double)cap_h / (double)logical_h;
-    int bx1 = (int)((double)lx * sx + 0.5);
-    int by1 = (int)((double)ly * sy + 0.5);
-    int bx2 = (int)((double)x2 * sx + 0.5);
-    int by2 = (int)((double)y2 * sy + 0.5);
+    int bx1 = scale_floor_coord(lx, cap_w, logical_w);
+    int by1 = scale_floor_coord(ly, cap_h, logical_h);
+    int bx2 = scale_ceil_coord(x2, cap_w, logical_w);
+    int by2 = scale_ceil_coord(y2, cap_h, logical_h);
     if (bx1 < 0) bx1 = 0;
     if (by1 < 0) by1 = 0;
     if (bx2 > cap_w) bx2 = cap_w;
@@ -303,30 +268,64 @@ static void map_logical_rect_to_buffer(const struct output *out, int cap_w, int 
     return;
   }
 
-  double ux1 = (double)lx / (double)logical_w;
-  double uy1 = (double)ly / (double)logical_h;
-  double ux2 = (double)x2 / (double)logical_w;
-  double uy2 = (double)y2 / (double)logical_h;
-
-  double tu[4], tv[4];
-  transform_inverse_uv(out->transform, ux1, uy1, &tu[0], &tv[0]);
-  transform_inverse_uv(out->transform, ux2, uy1, &tu[1], &tv[1]);
-  transform_inverse_uv(out->transform, ux1, uy2, &tu[2], &tv[2]);
-  transform_inverse_uv(out->transform, ux2, uy2, &tu[3], &tv[3]);
-
-  double min_u = tu[0], max_u = tu[0];
-  double min_v = tv[0], max_v = tv[0];
-  for (int i = 1; i < 4; i++) {
-    if (tu[i] < min_u) min_u = tu[i];
-    if (tu[i] > max_u) max_u = tu[i];
-    if (tv[i] < min_v) min_v = tv[i];
-    if (tv[i] > max_v) max_v = tv[i];
+  int tx1 = lx, tx2 = x2, tx_extent = logical_w;
+  int ty1 = ly, ty2 = y2, ty_extent = logical_h;
+  switch (out->transform) {
+  case WL_OUTPUT_TRANSFORM_90:
+    tx1 = ly;
+    tx2 = y2;
+    tx_extent = logical_h;
+    ty1 = logical_w - x2;
+    ty2 = logical_w - lx;
+    ty_extent = logical_w;
+    break;
+  case WL_OUTPUT_TRANSFORM_180:
+    tx1 = logical_w - x2;
+    tx2 = logical_w - lx;
+    ty1 = logical_h - y2;
+    ty2 = logical_h - ly;
+    break;
+  case WL_OUTPUT_TRANSFORM_270:
+    tx1 = logical_h - y2;
+    tx2 = logical_h - ly;
+    tx_extent = logical_h;
+    ty1 = lx;
+    ty2 = x2;
+    ty_extent = logical_w;
+    break;
+  case WL_OUTPUT_TRANSFORM_FLIPPED:
+    tx1 = logical_w - x2;
+    tx2 = logical_w - lx;
+    break;
+  case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+    tx1 = ly;
+    tx2 = y2;
+    tx_extent = logical_h;
+    ty1 = lx;
+    ty2 = x2;
+    ty_extent = logical_w;
+    break;
+  case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+    ty1 = logical_h - y2;
+    ty2 = logical_h - ly;
+    break;
+  case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+    tx1 = logical_h - y2;
+    tx2 = logical_h - ly;
+    tx_extent = logical_h;
+    ty1 = logical_w - x2;
+    ty2 = logical_w - lx;
+    ty_extent = logical_w;
+    break;
+  case WL_OUTPUT_TRANSFORM_NORMAL:
+  default:
+    break;
   }
 
-  int bx1 = (int)(min_u * (double)cap_w + 0.5);
-  int by1 = (int)(min_v * (double)cap_h + 0.5);
-  int bx2 = (int)(max_u * (double)cap_w + 0.5);
-  int by2 = (int)(max_v * (double)cap_h + 0.5);
+  int bx1 = scale_floor_coord(tx1, cap_w, tx_extent);
+  int by1 = scale_floor_coord(ty1, cap_h, ty_extent);
+  int bx2 = scale_ceil_coord(tx2, cap_w, tx_extent);
+  int by2 = scale_ceil_coord(ty2, cap_h, ty_extent);
 
   if (bx1 < 0) bx1 = 0;
   if (by1 < 0) by1 = 0;
@@ -340,6 +339,40 @@ static void map_logical_rect_to_buffer(const struct output *out, int cap_w, int 
   *w = bx2 - bx1;
   *h = by2 - by1;
 }
+
+#ifdef ROBOTGO_WAYLAND_TEST
+void robotgo_wayland_map_logical_rect_for_test(int cap_w, int cap_h,
+                                                int logical_w, int logical_h,
+                                                int transform, int *x, int *y,
+                                                int *w, int *h) {
+  struct output out = {0};
+  out.transform = transform;
+  map_logical_rect_to_buffer(&out, cap_w, cap_h, logical_w, logical_h, x, y,
+                             w, h);
+}
+
+int robotgo_wayland_select_output_rect_for_test(int req_x, int req_y,
+                                                 int req_w, int req_h,
+                                                 const int *rects,
+                                                 int rect_count) {
+  if (!rects || rect_count <= 0) {
+    return -1;
+  }
+  struct int_rect request = {req_x, req_y, req_w, req_h};
+  long long best_area = -1;
+  int best_index = -1;
+  for (int index = 0; index < rect_count; index++) {
+    struct int_rect candidate = {rects[index * 4], rects[index * 4 + 1],
+                                 rects[index * 4 + 2], rects[index * 4 + 3]};
+    long long area = 0;
+    if (rect_candidate_is_better(request, candidate, best_area, &area)) {
+      best_area = area;
+      best_index = index;
+    }
+  }
+  return best_index;
+}
+#endif
 
 static void output_geometry(void *data, struct wl_output *output, int32_t x,
                             int32_t y, int32_t physical_width,
@@ -1097,7 +1130,7 @@ MMBitmapRef capture_screen_wayland_impl(int32_t x, int32_t y, int32_t w,
       idx++;
     }
   }
-  if (!out && (x != 0 || y != 0)) {
+  if (!out) {
     struct int_rect req = {x, y, w > 0 ? w : 1, h > 0 ? h : 1};
     long long best_area = -1;
     struct output *it;
@@ -1115,8 +1148,8 @@ MMBitmapRef capture_screen_wayland_impl(int32_t x, int32_t y, int32_t w,
         continue;
       }
       struct int_rect out_rect = {ox, oy, lw, lh};
-      long long area = rect_intersection_area(req, out_rect);
-      if (area > best_area) {
+      long long area = 0;
+      if (rect_candidate_is_better(req, out_rect, best_area, &area)) {
         best_area = area;
         out = it;
       }
@@ -1141,22 +1174,14 @@ MMBitmapRef capture_screen_wayland_impl(int32_t x, int32_t y, int32_t w,
   output_logical_origin(out, &out_ox, &out_oy);
   output_logical_size(out, &out_lw, &out_lh);
 
-  int crop_lx = x - out_ox;
-  int crop_ly = y - out_oy;
+  long long local_x = (long long)x - (long long)out_ox;
+  long long local_y = (long long)y - (long long)out_oy;
+  int crop_lx = local_x > INT_MAX ? INT_MAX :
+                local_x < INT_MIN ? INT_MIN : (int)local_x;
+  int crop_ly = local_y > INT_MAX ? INT_MAX :
+                local_y < INT_MIN ? INT_MIN : (int)local_y;
   int crop_lw = w;
   int crop_lh = h;
-  if (crop_lx < 0) {
-    crop_lx = 0;
-  }
-  if (crop_ly < 0) {
-    crop_ly = 0;
-  }
-  if (out_lw > 0 && crop_lx > out_lw) {
-    crop_lx = out_lw;
-  }
-  if (out_lh > 0 && crop_ly > out_lh) {
-    crop_ly = out_lh;
-  }
   x = crop_lx;
   y = crop_ly;
   w = crop_lw;

--- a/wayland_geometry_test.go
+++ b/wayland_geometry_test.go
@@ -1,0 +1,113 @@
+//go:build cgo && linux && wayland && test
+
+package robotgo
+
+import "testing"
+
+func TestWaylandLogicalCropTransformMatrix(t *testing.T) {
+	tests := []struct {
+		name      string
+		transform int
+		capture   [2]int
+		want      [4]int
+	}{
+		{name: "normal", transform: 0, capture: [2]int{200, 100}, want: [4]int{20, 20, 40, 20}},
+		{name: "90", transform: 1, capture: [2]int{100, 200}, want: [4]int{20, 140, 20, 40}},
+		{name: "180", transform: 2, capture: [2]int{200, 100}, want: [4]int{140, 60, 40, 20}},
+		{name: "270", transform: 3, capture: [2]int{100, 200}, want: [4]int{60, 20, 20, 40}},
+		{name: "flipped", transform: 4, capture: [2]int{200, 100}, want: [4]int{140, 20, 40, 20}},
+		{name: "flipped-90", transform: 5, capture: [2]int{100, 200}, want: [4]int{20, 20, 20, 40}},
+		{name: "flipped-180", transform: 6, capture: [2]int{200, 100}, want: [4]int{20, 60, 40, 20}},
+		{name: "flipped-270", transform: 7, capture: [2]int{100, 200}, want: [4]int{60, 140, 20, 40}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := mapWaylandLogicalRectForTest(test.capture[0], test.capture[1], 100, 50, test.transform, [4]int{10, 10, 20, 10})
+			if got != test.want {
+				t.Fatalf("mapped crop = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWaylandLogicalCropFractionalScaleEnclosesTouchedPixels(t *testing.T) {
+	got := mapWaylandLogicalRectForTest(1920, 1080, 1279, 719, 0, [4]int{1, 1, 1, 1})
+	want := [4]int{1, 1, 3, 3}
+	if got != want {
+		t.Fatalf("mapped crop = %v, want %v", got, want)
+	}
+}
+
+func TestWaylandLogicalCropFractionalScaleTransformMatrix(t *testing.T) {
+	for transform := 0; transform < 8; transform++ {
+		t.Run(string(rune('0'+transform)), func(t *testing.T) {
+			capture := [2]int{1920, 1080}
+			if transform == 1 || transform == 3 || transform == 5 || transform == 7 {
+				capture = [2]int{1080, 1920}
+			}
+			got := mapWaylandLogicalRectForTest(capture[0], capture[1], 1279, 719, transform, [4]int{1, 1, 1, 1})
+			if got[2] != 3 || got[3] != 3 {
+				t.Fatalf("mapped fractional crop = %v, want 3x3 pixels", got)
+			}
+			if got[0] < 0 || got[1] < 0 || got[0]+got[2] > capture[0] || got[1]+got[3] > capture[1] {
+				t.Fatalf("mapped fractional crop %v exceeds capture %v", got, capture)
+			}
+		})
+	}
+}
+
+func TestWaylandLogicalCropClipsOverflowingRegion(t *testing.T) {
+	const maxInt32 = int(^uint32(0) >> 1)
+	got := mapWaylandLogicalRectForTest(200, 100, 100, 50, 0, [4]int{90, 40, maxInt32, maxInt32})
+	want := [4]int{180, 80, 20, 20}
+	if got != want {
+		t.Fatalf("mapped crop = %v, want %v", got, want)
+	}
+}
+
+func TestWaylandLogicalCropClipsWithoutShiftingOppositeEdge(t *testing.T) {
+	tests := []struct {
+		name string
+		rect [4]int
+		want [4]int
+	}{
+		{name: "left", rect: [4]int{-10, 0, 30, 10}, want: [4]int{0, 0, 40, 20}},
+		{name: "right", rect: [4]int{90, 0, 30, 10}, want: [4]int{180, 0, 20, 20}},
+		{name: "top", rect: [4]int{0, -10, 10, 30}, want: [4]int{0, 0, 20, 40}},
+		{name: "bottom", rect: [4]int{0, 40, 10, 30}, want: [4]int{0, 80, 20, 20}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := mapWaylandLogicalRectForTest(200, 100, 100, 50, 0, test.rect)
+			if got != test.want {
+				t.Fatalf("mapped clipped crop = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWaylandMultiOutputSelectionMatrix(t *testing.T) {
+	outputs := [][4]int{
+		{-1920, 0, 1920, 1080},
+		{0, 0, 1280, 720},
+		{0, 720, 1280, 1024},
+	}
+	tests := []struct {
+		name    string
+		request [4]int
+		want    int
+	}{
+		{name: "origin selects primary instead of registry-first negative output", request: [4]int{0, 0, 1, 1}, want: 1},
+		{name: "negative origin selects left output", request: [4]int{-1200, 100, 100, 100}, want: 0},
+		{name: "positive vertical origin selects lower output", request: [4]int{100, 900, 100, 100}, want: 2},
+		{name: "largest intersection wins across output edge", request: [4]int{-100, 0, 300, 100}, want: 1},
+		{name: "disjoint request falls back deterministically", request: [4]int{5000, 5000, 100, 100}, want: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := selectWaylandOutputRectForTest(test.request, outputs); got != test.want {
+				t.Fatalf("selected output = %d, want %d", got, test.want)
+			}
+		})
+	}
+}

--- a/wayland_geometry_testhelper.go
+++ b/wayland_geometry_testhelper.go
@@ -1,0 +1,41 @@
+//go:build cgo && linux && wayland && test
+
+package robotgo
+
+/*
+#cgo CFLAGS: -DROBOTGO_WAYLAND_TEST
+void robotgo_wayland_map_logical_rect_for_test(int cap_w, int cap_h,
+                                                int logical_w, int logical_h,
+                                                int transform, int *x, int *y,
+                                                int *w, int *h);
+int robotgo_wayland_select_output_rect_for_test(int req_x, int req_y,
+                                                 int req_w, int req_h,
+                                                 const int *rects,
+                                                 int rect_count);
+*/
+import "C"
+
+import "unsafe"
+
+func mapWaylandLogicalRectForTest(capWidth, capHeight, logicalWidth, logicalHeight, transform int, rect [4]int) [4]int {
+	x, y, width, height := C.int(rect[0]), C.int(rect[1]), C.int(rect[2]), C.int(rect[3])
+	C.robotgo_wayland_map_logical_rect_for_test(
+		C.int(capWidth), C.int(capHeight), C.int(logicalWidth), C.int(logicalHeight), C.int(transform),
+		&x, &y, &width, &height,
+	)
+	return [4]int{int(x), int(y), int(width), int(height)}
+}
+
+func selectWaylandOutputRectForTest(request [4]int, outputs [][4]int) int {
+	if len(outputs) == 0 {
+		return -1
+	}
+	values := make([]C.int, 0, len(outputs)*4)
+	for _, output := range outputs {
+		values = append(values, C.int(output[0]), C.int(output[1]), C.int(output[2]), C.int(output[3]))
+	}
+	return int(C.robotgo_wayland_select_output_rect_for_test(
+		C.int(request[0]), C.int(request[1]), C.int(request[2]), C.int(request[3]),
+		(*C.int)(unsafe.Pointer(&values[0])), C.int(len(outputs)),
+	))
+}


### PR DESCRIPTION
## Goal

Complete the hermetic Phase 2 capture geometry slice while preserving native Wayland-first behavior and cross-platform builds.

## What changed

- align native screencopy and PipeWire logical-to-pixel crops with enclosing floor/ceil edge semantics
- fix clipped regions so clamping one edge does not shift the opposite edge
- handle negative and positive multi-output origins deterministically
- avoid coordinate overflow and preserve non-zero frame origins
- cover all eight Wayland output transforms and fractional scaling
- make the geometry matrix a blocking Wayland CI gate
- update the test guide, compatibility evidence, and product roadmap

## Root causes

The native and portal paths used different rounding rules, native clipping discarded the original far edge after clamping, and output selection at the global origin could incorrectly prefer registry order. PipeWire crops also assumed zero-origin image bounds.

## Validation

- `go test ./...`
- `go test -race ./...`
- `CGO_ENABLED=0 go test ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test -tags wayland ./...`
- `go test -tags "wayland test" . ./screen`
- `go test -race -tags pipewire ./screen/portal`

## Remaining external evidence

Real GNOME, KDE, and wlroots capture validation still requires the protected self-hosted desktop runners. A sanitizer-backed native leak gate remains tracked separately.