### PR TITLE
feat: enable pure-Go capture backends

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -115,7 +115,11 @@ jobs:
       - name: Test
         run: go test -v ./...
   nocgo:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -124,12 +128,15 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
-      - name: Test explicit unsupported non-CGO build
+      - name: Test Pure-Go build
         env:
           CGO_ENABLED: "0"
-        run: |
-          go test -v ./...
-          go test -tags ocr ./...
+        run: go test -v ./...
+      - name: Test non-CGO OCR compatibility stubs
+        if: runner.os == 'Linux'
+        env:
+          CGO_ENABLED: "0"
+        run: go test -tags ocr ./...
   ocr:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Current technical differences include:
 - Sway, Hyprland, generic wlroots, and Wayland-core window backend resolution,
   with partial operations reported honestly instead of universal support being
   implied.
-- A defined non-CGO contract: builds remain possible, while unavailable GUI
+- A defined non-CGO contract: Pure-Go capture is available on Windows and X11,
+  Wayland capture uses the consent-aware Screenshot portal, and unavailable GUI
   operations return `ErrNotSupported` rather than plausible zero values.
 - Hermetic portal/compositor tests, tagged Wayland integration suites, and CI
   coverage for Linux, macOS, Windows, Wayland, portal, lint, and non-CGO modes.
@@ -73,7 +74,7 @@ workflow.
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |
-| Any platform without CGO | `CGO_ENABLED=0` | The portable high-level API remains available; native GUI operations return `ErrNotSupported`, while explicit Linux RemoteDesktop portal sessions provide a limited Pure-Go input path |
+| Any platform without CGO | `CGO_ENABLED=0` | Pure-Go capture works on Windows and Linux/X11; Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
 
 Wayland compositors intentionally restrict global automation. GNOME and KDE can
 use consent-aware Screenshot and RemoteDesktop portal paths. The explicit
@@ -368,6 +369,10 @@ Useful capture controls:
 Wayland applications can call `CloseWaylandInput` to release persistent virtual
 pointer and keyboard objects; later input calls reconnect lazily.
 
+Successful non-CGO capture reports `BackendX11` on supported X11 systems,
+`BackendPortal` on Linux/Wayland, and `BackendPureGo` on other supported
+Pure-Go platforms.
+
 Global pointer position and global foreign-window control are not universally
 available in Wayland core. `LocationE` and unsupported window operations return
 `ErrNotSupported`. Sway, Hyprland, and some wlroots environments have partial
@@ -375,6 +380,32 @@ window support through compositor-specific tools; inspect capabilities instead
 of assuming parity with X11.
 
 ### Runtime diagnostics
+
+`GetRuntimeBackendInfo` is platform-neutral and reports whether the current
+binary contains native CGO backends or the Pure-Go compatibility build. It does
+not open portals or contact a compositor:
+
+```go
+info := robotgo.GetRuntimeBackendInfo()
+fmt.Println("implementation:", info.BuildImplementation)
+fmt.Println("cgo:", info.CGOEnabled)
+fmt.Println("platform:", info.GOOS, info.GOARCH)
+fmt.Println("display:", info.DisplayServer)
+```
+
+In a `CGO_ENABLED=0` build, `CaptureImg`, `CaptureScreen`, `CaptureGo`, and
+`CaptureBitmapStr` now use the Pure-Go Windows or X11 screenshot backend where
+available. Wayland sessions use this fork's hardened screenshot portal and
+preserve `ROBOTGO_DISABLE_PORTAL`; unsupported targets return
+`ErrNotSupported` explicitly.
+
+Use `CaptureImg()` with no arguments for a full-screen capture. Region capture
+requires at least `x, y, width, height`; partial argument lists, non-positive
+region dimensions other than the explicit `0x0` full-screen request,
+coordinate overflow, and a non-zero origin combined with a
+`0x0` full-screen request are rejected before a portal request is created.
+Explicit regions whose 32-bit RGBA buffer would exceed 512 MiB are also
+rejected before a backend allocates capture memory.
 
 `GetLinuxCapabilities` reports the detected session, compositor, selected
 feature backends, fallbacks, and unsupported reasons:

--- a/TEST.md
+++ b/TEST.md
@@ -12,7 +12,7 @@ go test ./...
 
 This is the baseline suite used for regular development and should stay green.
 
-The explicit unsupported non-CGO variant is also part of CI:
+The non-CGO contract is also part of CI:
 
 ```bash
 CGO_ENABLED=0 go test ./...
@@ -21,6 +21,10 @@ CGO_ENABLED=0 go test -tags "ocr" ./...
 # Optional in-process OCR backend (requires Tesseract and Leptonica development files)
 go test -tags "ocr" ./...
 ```
+
+The non-CGO suite runs on Linux, macOS, and Windows in CI. It also verifies
+runtime build introspection and the hermetic Pure-Go capture dispatch for X11,
+Windows, and the Wayland screenshot portal.
 
 ## Special Test Suites (Build Tags)
 

--- a/backend_info.go
+++ b/backend_info.go
@@ -1,0 +1,39 @@
+package robotgo
+
+import "runtime"
+
+// RuntimeImplementation identifies how the current RobotGo binary was built.
+type RuntimeImplementation string
+
+const (
+	// RuntimeImplementationNativeCGO identifies a build with native CGO backends.
+	RuntimeImplementationNativeCGO RuntimeImplementation = "native-cgo"
+	// RuntimeImplementationPureGo identifies a build without CGO.
+	RuntimeImplementationPureGo RuntimeImplementation = "pure-go"
+)
+
+// RuntimeBackendInfo describes the implementation compiled into the current
+// binary. Use GetLinuxCapabilities for feature-specific Linux backend status.
+type RuntimeBackendInfo struct {
+	GOOS                string
+	GOARCH              string
+	CGOEnabled          bool
+	BuildImplementation RuntimeImplementation
+	DisplayServer       DisplayServer
+}
+
+// GetRuntimeBackendInfo reports build-time backend information without probing
+// portals, compositors, permissions, or other external services.
+func GetRuntimeBackendInfo() RuntimeBackendInfo {
+	displayServer := DisplayServerUnknown
+	if runtime.GOOS == "linux" {
+		displayServer = DetectDisplayServer()
+	}
+	return RuntimeBackendInfo{
+		GOOS:                runtime.GOOS,
+		GOARCH:              runtime.GOARCH,
+		CGOEnabled:          runtimeCGOEnabled,
+		BuildImplementation: runtimeBuildImplementation,
+		DisplayServer:       displayServer,
+	}
+}

--- a/backend_info_cgo.go
+++ b/backend_info_cgo.go
@@ -1,0 +1,8 @@
+//go:build cgo
+
+package robotgo
+
+const (
+	runtimeCGOEnabled          = true
+	runtimeBuildImplementation = RuntimeImplementationNativeCGO
+)

--- a/backend_info_cgo_test.go
+++ b/backend_info_cgo_test.go
@@ -1,0 +1,12 @@
+//go:build cgo
+
+package robotgo
+
+import "testing"
+
+func TestRuntimeBackendInfoReportsCGOBuild(t *testing.T) {
+	info := GetRuntimeBackendInfo()
+	if !info.CGOEnabled || info.BuildImplementation != RuntimeImplementationNativeCGO {
+		t.Fatalf("runtime backend info = %+v, want native CGO build", info)
+	}
+}

--- a/backend_info_nocgo.go
+++ b/backend_info_nocgo.go
@@ -1,0 +1,8 @@
+//go:build !cgo
+
+package robotgo
+
+const (
+	runtimeCGOEnabled          = false
+	runtimeBuildImplementation = RuntimeImplementationPureGo
+)

--- a/backend_info_nocgo_test.go
+++ b/backend_info_nocgo_test.go
@@ -1,0 +1,12 @@
+//go:build !cgo
+
+package robotgo
+
+import "testing"
+
+func TestRuntimeBackendInfoReportsPureGoBuild(t *testing.T) {
+	info := GetRuntimeBackendInfo()
+	if info.CGOEnabled || info.BuildImplementation != RuntimeImplementationPureGo {
+		t.Fatalf("runtime backend info = %+v, want Pure-Go build", info)
+	}
+}

--- a/backend_info_test.go
+++ b/backend_info_test.go
@@ -1,0 +1,37 @@
+package robotgo
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestGetRuntimeBackendInfo(t *testing.T) {
+	info := GetRuntimeBackendInfo()
+	if info.GOOS != runtime.GOOS || info.GOARCH != runtime.GOARCH {
+		t.Fatalf("platform = %s/%s, want %s/%s", info.GOOS, info.GOARCH, runtime.GOOS, runtime.GOARCH)
+	}
+	if info.CGOEnabled != runtimeCGOEnabled {
+		t.Fatalf("CGOEnabled = %v, want %v", info.CGOEnabled, runtimeCGOEnabled)
+	}
+	if info.BuildImplementation != runtimeBuildImplementation {
+		t.Fatalf("BuildImplementation = %q, want %q", info.BuildImplementation, runtimeBuildImplementation)
+	}
+	if runtime.GOOS != "linux" && info.DisplayServer != DisplayServerUnknown {
+		t.Fatalf("DisplayServer = %q on %s, want unknown", info.DisplayServer, runtime.GOOS)
+	}
+}
+
+func TestGetRuntimeBackendInfoDetectsLinuxDisplayServerWithoutProbes(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux display-server detection test")
+	}
+	t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+	t.Setenv("DISPLAY", ":99")
+	if got := GetRuntimeBackendInfo().DisplayServer; got != DisplayServerWayland {
+		t.Fatalf("DisplayServer = %q, want %q", got, DisplayServerWayland)
+	}
+	t.Setenv("WAYLAND_DISPLAY", "")
+	if got := GetRuntimeBackendInfo().DisplayServer; got != DisplayServerX11 {
+		t.Fatalf("DisplayServer = %q, want %q", got, DisplayServerX11)
+	}
+}

--- a/capture_args.go
+++ b/capture_args.go
@@ -1,0 +1,55 @@
+package robotgo
+
+import "fmt"
+
+const (
+	minCaptureCoordinate = -1 << 31
+	maxCaptureCoordinate = 1<<31 - 1
+	captureBytesPerPixel = 4
+)
+
+func validateCaptureArguments(args []int) error {
+	if len(args) > 0 && len(args) < 4 {
+		return fmt.Errorf("capture requires either zero arguments or at least x, y, width, height; got %d", len(args))
+	}
+	if len(args) >= 4 {
+		return validateCaptureRegionRequest(args[0], args[1], args[2], args[3])
+	}
+	return nil
+}
+
+func captureRegionFromArgs(args []int) (x, y, width, height int, err error) {
+	if err := validateCaptureArguments(args); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	if len(args) >= 4 {
+		return args[0], args[1], args[2], args[3], nil
+	}
+	return 0, 0, 0, 0, nil
+}
+
+func validateCaptureRegionRequest(x, y, width, height int) error {
+	if width == 0 && height == 0 {
+		if x != 0 || y != 0 {
+			return fmt.Errorf("full-screen capture requires zero origin, got %d,%d", x, y)
+		}
+		return nil
+	}
+	if width <= 0 || height <= 0 {
+		return fmt.Errorf("invalid capture region size %dx%d", width, height)
+	}
+	if x+width < x || y+height < y {
+		return fmt.Errorf("capture region overflows integer coordinates: %d,%d %dx%d", x, y, width, height)
+	}
+	if x < minCaptureCoordinate || y < minCaptureCoordinate ||
+		x > maxCaptureCoordinate || y > maxCaptureCoordinate ||
+		width > maxCaptureCoordinate || height > maxCaptureCoordinate ||
+		x+width > maxCaptureCoordinate || y+height > maxCaptureCoordinate {
+		return fmt.Errorf("capture region exceeds backend coordinate range: %d,%d %dx%d", x, y, width, height)
+	}
+	if width > maxBitmapBufferSize/captureBytesPerPixel ||
+		height > maxBitmapBufferSize/(width*captureBytesPerPixel) {
+		return fmt.Errorf("capture region buffer exceeds %d bytes: %dx%d", maxBitmapBufferSize, width, height)
+	}
+	return nil
+}

--- a/capture_args_test.go
+++ b/capture_args_test.go
@@ -1,0 +1,58 @@
+package robotgo
+
+import "testing"
+
+func TestValidateCaptureArguments(t *testing.T) {
+	valid := [][]int{
+		nil,
+		{0, 0, 0, 0},
+		{-10, 20, 30, 40},
+		{0, 0, 1, 1, 2},
+	}
+	for _, args := range valid {
+		if err := validateCaptureArguments(args); err != nil {
+			t.Fatalf("validateCaptureArguments(%v): %v", args, err)
+		}
+	}
+
+	maxInt := int(^uint(0) >> 1)
+	invalid := [][]int{
+		{1},
+		{1, 2},
+		{1, 2, 3},
+		{1, 0, 0, 0},
+		{0, 1, 0, 0},
+		{0, 0, 0, 1},
+		{0, 0, 1, 0},
+		{0, 0, -1, 1},
+		{0, 0, 1, -1},
+		{maxInt, 0, 1, 1},
+		{maxCaptureCoordinate, 0, 1, 1},
+		{0, 0, maxBitmapBufferSize/captureBytesPerPixel + 1, 1},
+		{0, 0, 16384, maxBitmapBufferSize/(16384*captureBytesPerPixel) + 1},
+	}
+	for _, args := range invalid {
+		if err := validateCaptureArguments(args); err == nil {
+			t.Fatalf("validateCaptureArguments(%v) unexpectedly succeeded", args)
+		}
+	}
+}
+
+func TestCaptureEntryPointsRejectInvalidArgumentsBeforeBackend(t *testing.T) {
+	invalid := [][]int{
+		{1},
+		{1, 0, 0, 0},
+		{0, 0, maxBitmapBufferSize/captureBytesPerPixel + 1, 1},
+	}
+	for _, args := range invalid {
+		if _, err := Capture(args...); err == nil {
+			t.Fatalf("Capture(%v) unexpectedly succeeded", args)
+		}
+		if _, err := CaptureScreen(args...); err == nil {
+			t.Fatalf("CaptureScreen(%v) unexpectedly succeeded", args)
+		}
+		if _, err := CaptureImg(args...); err == nil {
+			t.Fatalf("CaptureImg(%v) unexpectedly succeeded", args)
+		}
+	}
+}

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -35,7 +35,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in branch | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Confirm new CI jobs on remote branch |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and blocking geometry/transform matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | Foundation only | Non-CGO builds fail explicitly instead of degrading silently | Useful selected Pure-Go backends, parity tests, benchmarks, backend introspection |
+| 3. Pure-Go | First backend active | Build introspection plus non-CGO Windows/X11 and Wayland-portal capture with parity/error tests and a three-OS CI matrix | Additional selectively justified backends, runtime benchmarks, and broader feature-level introspection |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -127,8 +127,13 @@ Priority order:
    DMA-BUF path and deterministic resource handling.
 
 Current status: the non-CGO API surface compiles and returns explicit
-unsupported errors. No useful Pure-Go GUI backend is enabled yet; this is a
-safety baseline, not completion of the phase.
+unsupported errors. `GetRuntimeBackendInfo` now reports the platform, display
+server, CGO mode, and whether the binary contains native-CGO or Pure-Go build
+paths without triggering runtime probes. `CaptureImg`, `CaptureScreen`,
+`CaptureGo`, and `CaptureBitmapStr` now provide useful non-CGO capture through
+the Pure-Go Windows/X11 implementation and the hardened screenshot portal on
+Wayland, with explicit unsupported and portal-failure contracts. This is the
+first selectively enabled GUI backend, not completion of the phase.
 
 Exit criteria:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -11,6 +11,12 @@ Current implementation baseline:
 - `ROBOTGO_CAPTURE_DEBUG=1` logs backend selection/fallback details.
 - Linux runtime capability introspection is available via `GetLinuxCapabilities`,
   including hook/event capability status.
+- Platform-neutral build introspection is available via
+  `GetRuntimeBackendInfo`, including CGO/Pure-Go mode and display-server
+  detection without portal or compositor probes.
+- Non-CGO `CaptureImg`/`CaptureScreen` and their Go-bitmap/string variants use
+  the hardened screenshot portal on Wayland and the Pure-Go screenshot backend
+  on X11/Windows; unsupported targets fail explicitly.
 - Capability introspection probes the live screencopy protocol, desktop portal
   D-Bus owner, virtual pointer and virtual keyboard instead of inferring support
   solely from session environment variables.

--- a/examples/linux_capabilities/main.go
+++ b/examples/linux_capabilities/main.go
@@ -12,6 +12,11 @@ import (
 )
 
 func main() {
+	runtimeInfo := robotgo.GetRuntimeBackendInfo()
+	fmt.Printf("RobotGo build: implementation=%s cgo=%t platform=%s/%s display=%s\n",
+		runtimeInfo.BuildImplementation, runtimeInfo.CGOEnabled,
+		runtimeInfo.GOOS, runtimeInfo.GOARCH, runtimeInfo.DisplayServer)
+
 	if runtime.GOOS != "linux" {
 		fmt.Println("GetLinuxCapabilities is Linux-specific")
 		return

--- a/robotgo.go
+++ b/robotgo.go
@@ -445,6 +445,7 @@ const (
 	BackendPortal     CaptureBackend = "portal"
 	BackendScreenCast CaptureBackend = "screencast"
 	BackendX11        CaptureBackend = "x11"
+	BackendPureGo     CaptureBackend = "pure-go"
 )
 
 var (
@@ -1209,6 +1210,10 @@ func GetScaleSize(displayId ...int) (int, int) {
 //
 // robotgo.CaptureScreen(x, y, w, h int)
 func CaptureScreen(args ...int) (CBitmap, error) {
+	argX, argY, argW, argH, argErr := captureRegionFromArgs(args)
+	if argErr != nil {
+		return nil, argErr
+	}
 	var x, y, w, h C.int32_t
 	displayId := -1
 	if configured := currentDisplayID(); configured != -1 {
@@ -1222,10 +1227,10 @@ func CaptureScreen(args ...int) (CBitmap, error) {
 	ds := DetectDisplayServer()
 
 	if len(args) > 3 {
-		x = C.int32_t(args[0])
-		y = C.int32_t(args[1])
-		w = C.int32_t(args[2])
-		h = C.int32_t(args[3])
+		x = C.int32_t(argX)
+		y = C.int32_t(argY)
+		w = C.int32_t(argW)
+		h = C.int32_t(argH)
 	} else {
 		if runtime.GOOS != "linux" || ds == DisplayServerX11 {
 			if runtime.GOOS == "linux" && !x11MainDisplayAvailable() {
@@ -1233,6 +1238,9 @@ func CaptureScreen(args ...int) (CBitmap, error) {
 			}
 			// Get the main screen rect.
 			rect := GetScreenRect(displayId)
+			if err := validateCaptureRegionRequest(rect.X, rect.Y, rect.W, rect.H); err != nil {
+				return nil, err
+			}
 			if runtime.GOOS == "windows" {
 				x = C.int32_t(rect.X)
 				y = C.int32_t(rect.Y)

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -70,6 +70,7 @@ const (
 	BackendPortal     CaptureBackend = "portal"
 	BackendScreenCast CaptureBackend = "screencast"
 	BackendX11        CaptureBackend = "x11"
+	BackendPureGo     CaptureBackend = "pure-go"
 )
 
 type WaylandBackend int
@@ -150,9 +151,19 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		Hook:           unsupported,
 		Events:         unsupported,
 	}
+	overrideCapture, captureOverridden := pureGoCaptureOverrideCapability()
+	if captureOverridden {
+		capabilities.Capture = overrideCapture
+	}
 	if runtime.GOOS == "linux" && ds == DisplayServerWayland {
+		if !captureOverridden {
+			capabilities.Capture = pureGoPortalCaptureCapability(
+				"Pure-Go Wayland capture uses the screenshot portal",
+				"capture APIs may prompt for consent",
+			)
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-		portalCapability, err := inputportal.Probe(ctx)
+		portalCapability, err := remoteDesktopStatusProbe(ctx)
 		cancel()
 		if err != nil && portalCapability.ScreenCastIssue == "" {
 			capabilities.RemoteDesktop = FeatureCapability{
@@ -197,16 +208,74 @@ func GetLinuxCapabilities() LinuxCapabilities {
 			}
 		}
 	}
+	if runtime.GOOS == "linux" && ds == DisplayServerX11 && !captureOverridden {
+		compiled := pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH)
+		conflict := pureGoX11EnvironmentConflict()
+		capabilities.Capture = FeatureCapability{
+			Available: compiled && !conflict,
+			Backend:   capabilityBackendPureGoX11,
+			Reason:    "Pure-Go X11 screenshot backend is selected; runtime access is not probed",
+			Notes:     "runtime X server access is validated when capture starts",
+		}
+		if !compiled {
+			capabilities.Capture.Reason = fmt.Sprintf("Pure-Go X11 capture is not compiled for %s/%s", runtime.GOOS, runtime.GOARCH)
+			capabilities.Capture.Notes = ErrNotSupported.Error()
+		} else if conflict {
+			capabilities.Capture.Reason = envXDGSessionType + " selects Wayland while DISPLAY selects X11"
+			capabilities.Capture.Notes = "capture refuses the screenshot dependency's implicit portal fallback"
+		}
+	}
 	return capabilities
 }
 
-func LastBackend() CaptureBackend            { return BackendNone }
-func SetWaylandBackend(WaylandBackend)       {}
-func MilliSleep(tm int)                      { time.Sleep(time.Duration(tm) * time.Millisecond) }
-func Sleep(tm int)                           { time.Sleep(time.Duration(tm) * time.Second) }
-func FreeBitmap(CBitmap)                     {}
-func CaptureScreen(...int) (CBitmap, error)  { return nil, ErrNotSupported }
-func CaptureImg(...int) (image.Image, error) { return nil, ErrNotSupported }
+func pureGoCaptureOverrideCapability() (FeatureCapability, bool) {
+	if runtime.GOOS != "linux" {
+		return FeatureCapability{}, false
+	}
+	override := pureGoWaylandBackendOverride()
+	if override == waylandBackendScreenCast {
+		return FeatureCapability{
+			Backend: string(BackendScreenCast),
+			Reason:  "persistent ScreenCast capture requires a CGO PipeWire backend",
+			Notes:   ErrNotSupported.Error(),
+		}, true
+	}
+	if !pureGoPortalForced(override) {
+		return FeatureCapability{}, false
+	}
+	return pureGoPortalCaptureCapability(
+		"screenshot portal capture is forced by runtime configuration",
+		"capture APIs may prompt for consent",
+	), true
+}
+
+func pureGoPortalCaptureCapability(reason, notes string) FeatureCapability {
+	capability := FeatureCapability{
+		Backend: string(BackendPortal),
+		Reason:  reason,
+		Notes:   notes,
+	}
+	if os.Getenv(envDisablePortal) != "" {
+		capability.Reason = "screenshot portal disabled by " + envDisablePortal
+		capability.Notes = "remove the override to enable consent-aware Pure-Go capture"
+		return capability
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	available, err := pureGoPortalAvailable(ctx)
+	cancel()
+	capability.Available = available && err == nil
+	if err != nil {
+		capability.Reason = err.Error()
+	} else if !available {
+		capability.Reason = "screenshot portal service is not available"
+	}
+	return capability
+}
+
+func SetWaylandBackend(WaylandBackend) {}
+func MilliSleep(tm int)                { time.Sleep(time.Duration(tm) * time.Millisecond) }
+func Sleep(tm int)                     { time.Sleep(time.Duration(tm) * time.Second) }
+func FreeBitmap(CBitmap)               {}
 
 func alertArgs(args ...string) (string, string) {
 	defaultButton := "Ok"
@@ -434,7 +503,6 @@ func GetPixelColor(int, int, ...int) (string, error) {
 	return "", ErrNotSupported
 }
 func GetPxColor(int, int, ...int) (uint32, error) { return 0, ErrNotSupported }
-func CaptureGo(...int) (Bitmap, error)            { return Bitmap{}, ErrNotSupported }
 func ToBitmap(bit CBitmap) Bitmap {
 	if bit == nil {
 		return Bitmap{}

--- a/robotgo_nocgo_capture.go
+++ b/robotgo_nocgo_capture.go
@@ -1,0 +1,204 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/draw"
+	"log"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+
+	portalpkg "github.com/marang/robotgo/screen/portal"
+	"github.com/vcaesar/screenshot"
+)
+
+const (
+	envCaptureDebug            = "ROBOTGO_CAPTURE_DEBUG"
+	envWaylandBackend          = "ROBOTGO_WAYLAND_BACKEND"
+	envForcePortal             = "ROBOTGO_FORCE_PORTAL"
+	envDisablePortal           = "ROBOTGO_DISABLE_PORTAL"
+	envXDGSessionType          = "XDG_SESSION_TYPE"
+	sessionTypeWayland         = "wayland"
+	waylandBackendPortalName   = "portal"
+	waylandBackendScreenCast   = "screencast"
+	capabilityBackendPureGoX11 = "pure-go-x11"
+)
+
+var (
+	pureGoCaptureImage = func(args ...int) (image.Image, error) {
+		return Capture(args...)
+	}
+	pureGoPortalCaptureImage = portalpkg.CaptureRegionImage
+	pureGoPortalAvailable    = portalpkg.Available
+
+	pureGoCaptureBackendMu sync.RWMutex
+	pureGoCaptureBackend   CaptureBackend
+)
+
+// LastBackend reports the backend used by the latest successful capture.
+func LastBackend() CaptureBackend {
+	pureGoCaptureBackendMu.RLock()
+	defer pureGoCaptureBackendMu.RUnlock()
+	return pureGoCaptureBackend
+}
+
+func setPureGoCaptureBackend(backend CaptureBackend) {
+	pureGoCaptureBackendMu.Lock()
+	pureGoCaptureBackend = backend
+	pureGoCaptureBackendMu.Unlock()
+}
+
+func captureDebugf(format string, args ...interface{}) {
+	if os.Getenv(envCaptureDebug) != "" {
+		log.Printf("robotgo capture: "+format, args...)
+	}
+}
+
+// CaptureImg captures an image through a backend that does not require CGO.
+// Linux Wayland sessions use the screenshot portal; Linux X11 and Windows use
+// the Pure-Go screenshot backend. Unsupported targets return ErrNotSupported.
+func CaptureImg(args ...int) (image.Image, error) {
+	if err := validateCaptureArguments(args); err != nil {
+		return nil, err
+	}
+	if runtime.GOOS == "linux" {
+		backendOverride := pureGoWaylandBackendOverride()
+		if backendOverride == waylandBackendScreenCast {
+			return nil, fmt.Errorf("%w: persistent ScreenCast capture requires a CGO PipeWire backend", ErrNotSupported)
+		}
+		if pureGoPortalForced(backendOverride) {
+			return capturePureGoPortal(args, "forced")
+		}
+		switch DetectDisplayServer() {
+		case DisplayServerWayland:
+			if backendOverride != "" && backendOverride != "auto" {
+				captureDebugf("Pure-Go build cannot use requested %s backend; falling back to screenshot portal", backendOverride)
+			}
+			return capturePureGoPortal(args, "Wayland")
+		case DisplayServerX11:
+			// Continue with the Pure-Go X11 backend below.
+		default:
+			return nil, fmt.Errorf("%w: no supported Linux display server detected", ErrNotSupported)
+		}
+	}
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		return nil, fmt.Errorf("%w: Pure-Go capture is unavailable on %s/%s", ErrNotSupported, runtime.GOOS, runtime.GOARCH)
+	}
+	backend := pureGoScreenshotBackend(runtime.GOOS)
+	if backend == BackendX11 && pureGoX11EnvironmentConflict() {
+		return nil, fmt.Errorf(
+			"%w: the X11 backend is selected but %s selects Wayland; refusing the screenshot dependency's implicit portal fallback",
+			ErrNotSupported, envXDGSessionType,
+		)
+	}
+
+	img, err := pureGoCaptureImage(args...)
+	if err != nil {
+		if errors.Is(err, screenshot.ErrUnsupported) {
+			return nil, fmt.Errorf("%w: Pure-Go capture on %s via %s: %w", ErrNotSupported, runtime.GOOS, backend, err)
+		}
+		return nil, fmt.Errorf("Pure-Go capture on %s via %s: %w", runtime.GOOS, backend, err)
+	}
+	if img == nil || img.Bounds().Empty() {
+		return nil, errors.New("Pure-Go capture returned an empty image")
+	}
+	setPureGoCaptureBackend(backend)
+	captureDebugf("Pure-Go capture used %s backend", backend)
+	return img, nil
+}
+
+func pureGoWaylandBackendOverride() string {
+	return strings.ToLower(strings.TrimSpace(os.Getenv(envWaylandBackend)))
+}
+
+func pureGoPortalForced(backendOverride string) bool {
+	return os.Getenv(envForcePortal) != "" || backendOverride == waylandBackendPortalName
+}
+
+func capturePureGoPortal(args []int, selection string) (image.Image, error) {
+	if os.Getenv(envDisablePortal) != "" {
+		return nil, fmt.Errorf("%w: screenshot portal disabled by %s", ErrNotSupported, envDisablePortal)
+	}
+	x, y, width, height, err := captureRegionFromArgs(args)
+	if err != nil {
+		return nil, errors.Join(ErrPortalFailed, err)
+	}
+	img, err := pureGoPortalCaptureImage(context.Background(), x, y, width, height)
+	if err != nil {
+		return nil, errors.Join(ErrPortalFailed, err)
+	}
+	img, err = zeroOriginCaptureImage(img)
+	if err != nil {
+		return nil, errors.Join(ErrPortalFailed, err)
+	}
+	setPureGoCaptureBackend(BackendPortal)
+	captureDebugf("%s screenshot portal capture used (rect=%d,%d %dx%d)", selection, x, y, width, height)
+	return img, nil
+}
+
+func pureGoX11EnvironmentConflict() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(envXDGSessionType)), sessionTypeWayland)
+}
+
+func pureGoScreenshotSupported(goos, goarch string) bool {
+	if goarch == "s390x" || goarch == "ppc64le" {
+		return false
+	}
+	switch goos {
+	case "windows", "linux", "freebsd", "openbsd", "netbsd":
+		return true
+	default:
+		return false
+	}
+}
+
+func pureGoScreenshotBackend(goos string) CaptureBackend {
+	switch goos {
+	case "linux", "freebsd", "openbsd", "netbsd":
+		return BackendX11
+	default:
+		return BackendPureGo
+	}
+}
+
+// CaptureScreen captures a Pure-Go image and converts it to the compatibility
+// bitmap representation owned by Go memory.
+func CaptureScreen(args ...int) (CBitmap, error) {
+	img, err := CaptureImg(args...)
+	if err != nil {
+		return nil, err
+	}
+	bitmap, err := ImgToCBitmapE(img)
+	if err != nil {
+		return nil, fmt.Errorf("convert Pure-Go capture to bitmap: %w", err)
+	}
+	return bitmap, nil
+}
+
+// CaptureGo captures the screen into a Go-owned bitmap without CGO.
+func CaptureGo(args ...int) (Bitmap, error) {
+	bitmap, err := CaptureScreen(args...)
+	if err != nil {
+		return Bitmap{}, err
+	}
+	return ToBitmap(bitmap), nil
+}
+
+func zeroOriginCaptureImage(img image.Image) (image.Image, error) {
+	if img == nil || img.Bounds().Empty() {
+		return nil, errors.New("Pure-Go capture returned an empty image")
+	}
+	bounds := img.Bounds()
+	if bounds.Min == (image.Point{}) {
+		return img, nil
+	}
+	result := image.NewRGBA(image.Rect(0, 0, bounds.Dx(), bounds.Dy()))
+	draw.Draw(result, result.Bounds(), img, bounds.Min, draw.Src)
+	return result, nil
+}

--- a/robotgo_nocgo_capture_nonlinux_test.go
+++ b/robotgo_nocgo_capture_nonlinux_test.go
@@ -1,0 +1,40 @@
+//go:build !cgo && !linux
+
+package robotgo
+
+import (
+	"errors"
+	"image"
+	"runtime"
+	"testing"
+)
+
+func TestPureGoCaptureImgUsesPortableNativeBackend(t *testing.T) {
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		if _, err := CaptureImg(); !errors.Is(err, ErrNotSupported) {
+			t.Fatalf("CaptureImg error = %v, want ErrNotSupported", err)
+		}
+		return
+	}
+	t.Setenv(envXDGSessionType, "x11")
+	nativeCapture := pureGoCaptureImage
+	backend := LastBackend()
+	t.Cleanup(func() {
+		pureGoCaptureImage = nativeCapture
+		setPureGoCaptureBackend(backend)
+	})
+	pureGoCaptureImage = func(args ...int) (image.Image, error) {
+		return image.NewRGBA(image.Rect(0, 0, 3, 2)), nil
+	}
+	img, err := CaptureImg(10, 20, 3, 2)
+	if err != nil {
+		t.Fatalf("CaptureImg error: %v", err)
+	}
+	if img.Bounds() != image.Rect(0, 0, 3, 2) {
+		t.Fatalf("capture bounds = %v", img.Bounds())
+	}
+	wantBackend := pureGoScreenshotBackend(runtime.GOOS)
+	if LastBackend() != wantBackend {
+		t.Fatalf("LastBackend = %q, want %q", LastBackend(), wantBackend)
+	}
+}

--- a/robotgo_nocgo_capture_test.go
+++ b/robotgo_nocgo_capture_test.go
@@ -1,0 +1,392 @@
+//go:build !cgo && linux
+
+package robotgo
+
+import (
+	"context"
+	"errors"
+	"image"
+	"runtime"
+	"strings"
+	"testing"
+
+	inputportal "github.com/marang/robotgo/input/portal"
+	"github.com/vcaesar/screenshot"
+)
+
+func preservePureGoCaptureFakes(t *testing.T) {
+	t.Helper()
+	nativeCapture := pureGoCaptureImage
+	portalCapture := pureGoPortalCaptureImage
+	portalAvailable := pureGoPortalAvailable
+	remoteDesktopProbe := remoteDesktopStatusProbe
+	backend := LastBackend()
+	t.Setenv(envForcePortal, "")
+	t.Setenv(envWaylandBackend, "")
+	t.Setenv(envCaptureDebug, "")
+	remoteDesktopStatusProbe = func(context.Context) (inputportal.Capability, error) {
+		return inputportal.Capability{}, inputportal.ErrUnavailable
+	}
+	t.Cleanup(func() {
+		pureGoCaptureImage = nativeCapture
+		pureGoPortalCaptureImage = portalCapture
+		pureGoPortalAvailable = portalAvailable
+		remoteDesktopStatusProbe = remoteDesktopProbe
+		setPureGoCaptureBackend(backend)
+	})
+}
+
+func TestPureGoScreenshotPlatformSupport(t *testing.T) {
+	tests := []struct {
+		goos      string
+		goarch    string
+		supported bool
+		backend   CaptureBackend
+	}{
+		{goos: "windows", goarch: "amd64", supported: true, backend: BackendPureGo},
+		{goos: "linux", goarch: "amd64", supported: true, backend: BackendX11},
+		{goos: "freebsd", goarch: "amd64", supported: true, backend: BackendX11},
+		{goos: "linux", goarch: "s390x", supported: false, backend: BackendX11},
+		{goos: "linux", goarch: "ppc64le", supported: false, backend: BackendX11},
+		{goos: "darwin", goarch: "amd64", supported: false, backend: BackendPureGo},
+	}
+	for _, test := range tests {
+		t.Run(test.goos+"/"+test.goarch, func(t *testing.T) {
+			if got := pureGoScreenshotSupported(test.goos, test.goarch); got != test.supported {
+				t.Fatalf("pureGoScreenshotSupported = %v, want %v", got, test.supported)
+			}
+			if got := pureGoScreenshotBackend(test.goos); got != test.backend {
+				t.Fatalf("pureGoScreenshotBackend = %q, want %q", got, test.backend)
+			}
+		})
+	}
+}
+
+func TestPureGoX11RejectsImplicitDependencyPortalFallback(t *testing.T) {
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		t.Skip("Pure-Go X11 screenshot dependency is unsupported on this architecture")
+	}
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	t.Setenv(envDisablePortal, "1")
+	calls := 0
+	pureGoCaptureImage = func(...int) (image.Image, error) {
+		calls++
+		return image.NewRGBA(image.Rect(0, 0, 1, 1)), nil
+	}
+	if _, err := CaptureImg(0, 0, 1, 1); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("CaptureImg error = %v, want ErrNotSupported", err)
+	}
+	if calls != 0 {
+		t.Fatalf("screenshot dependency calls = %d, want 0", calls)
+	}
+	capability := GetLinuxCapabilities().Capture
+	if capability.Available || !strings.Contains(capability.Reason, envXDGSessionType) {
+		t.Fatalf("conflicting X11 capability = %+v", capability)
+	}
+}
+
+func TestPureGoLinuxCaptureCapabilities(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Run("X11 ready", func(t *testing.T) {
+		t.Setenv("WAYLAND_DISPLAY", "")
+		t.Setenv("DISPLAY", ":99")
+		t.Setenv(envXDGSessionType, "x11")
+		capture := GetLinuxCapabilities().Capture
+		wantAvailable := pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH)
+		if capture.Available != wantAvailable || capture.Backend != capabilityBackendPureGoX11 {
+			t.Fatalf("capture capability = %+v", capture)
+		}
+	})
+	t.Run("Wayland portal ready", func(t *testing.T) {
+		t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+		t.Setenv("DISPLAY", "")
+		t.Setenv(envDisablePortal, "")
+		pureGoPortalAvailable = func(context.Context) (bool, error) { return true, nil }
+		capture := GetLinuxCapabilities().Capture
+		if !capture.Available || capture.Backend != string(BackendPortal) {
+			t.Fatalf("capture capability = %+v", capture)
+		}
+	})
+	t.Run("Wayland portal unavailable", func(t *testing.T) {
+		t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+		t.Setenv("DISPLAY", "")
+		t.Setenv(envDisablePortal, "")
+		pureGoPortalAvailable = func(context.Context) (bool, error) { return false, nil }
+		capture := GetLinuxCapabilities().Capture
+		if capture.Available || capture.Reason != "screenshot portal service is not available" {
+			t.Fatalf("capture capability = %+v", capture)
+		}
+	})
+}
+
+func TestPureGoCaptureImgRejectsInvalidPortalRegionBeforeRequest(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+	t.Setenv("DISPLAY", "")
+	t.Setenv(envDisablePortal, "")
+	calls := 0
+	pureGoPortalCaptureImage = func(context.Context, int, int, int, int) (image.Image, error) {
+		calls++
+		return image.NewRGBA(image.Rect(0, 0, 1, 1)), nil
+	}
+	for _, size := range [][2]int{{0, 2}, {2, 0}, {-1, 2}, {2, -1}} {
+		if _, err := CaptureImg(0, 0, size[0], size[1]); err == nil {
+			t.Fatalf("CaptureImg size %dx%d unexpectedly succeeded", size[0], size[1])
+		}
+	}
+	maxInt := int(^uint(0) >> 1)
+	if _, err := CaptureImg(maxInt, 0, 1, 1); err == nil {
+		t.Fatal("overflowing CaptureImg unexpectedly succeeded")
+	}
+	if _, err := CaptureImg(1, 0, 0, 0); err == nil {
+		t.Fatal("non-zero-origin full capture unexpectedly succeeded")
+	}
+	for argCount := 1; argCount <= 3; argCount++ {
+		args := make([]int, argCount)
+		if _, err := CaptureImg(args...); err == nil {
+			t.Fatalf("CaptureImg with %d arguments unexpectedly succeeded", argCount)
+		}
+	}
+	if calls != 0 {
+		t.Fatalf("portal capture calls = %d, want 0", calls)
+	}
+}
+
+func TestPureGoCaptureHonorsPortalOverrides(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	t.Setenv(envDisablePortal, "")
+	nativeCalls := 0
+	portalCalls := 0
+	pureGoCaptureImage = func(...int) (image.Image, error) {
+		nativeCalls++
+		return image.NewRGBA(image.Rect(0, 0, 2, 2)), nil
+	}
+	pureGoPortalCaptureImage = func(context.Context, int, int, int, int) (image.Image, error) {
+		portalCalls++
+		return image.NewRGBA(image.Rect(0, 0, 2, 2)), nil
+	}
+	pureGoPortalAvailable = func(context.Context) (bool, error) { return true, nil }
+
+	t.Run("force portal", func(t *testing.T) {
+		t.Setenv(envForcePortal, "1")
+		if _, err := CaptureImg(0, 0, 2, 2); err != nil {
+			t.Fatalf("CaptureImg error: %v", err)
+		}
+		capability := GetLinuxCapabilities().Capture
+		if !capability.Available || capability.Backend != string(BackendPortal) {
+			t.Fatalf("forced portal capability = %+v", capability)
+		}
+	})
+	t.Run("portal backend", func(t *testing.T) {
+		t.Setenv(envWaylandBackend, waylandBackendPortalName)
+		if _, err := CaptureImg(0, 0, 2, 2); err != nil {
+			t.Fatalf("CaptureImg error: %v", err)
+		}
+		capability := GetLinuxCapabilities().Capture
+		if !capability.Available || capability.Backend != string(BackendPortal) {
+			t.Fatalf("portal override capability = %+v", capability)
+		}
+	})
+	if nativeCalls != 0 || portalCalls != 2 {
+		t.Fatalf("capture calls: native=%d portal=%d, want native=0 portal=2", nativeCalls, portalCalls)
+	}
+	if LastBackend() != BackendPortal {
+		t.Fatalf("LastBackend = %q, want %q", LastBackend(), BackendPortal)
+	}
+
+	t.Run("screencast unavailable", func(t *testing.T) {
+		t.Setenv(envWaylandBackend, waylandBackendScreenCast)
+		if _, err := CaptureImg(0, 0, 2, 2); !errors.Is(err, ErrNotSupported) {
+			t.Fatalf("CaptureImg error = %v, want ErrNotSupported", err)
+		}
+		capability := GetLinuxCapabilities().Capture
+		if capability.Available || capability.Backend != string(BackendScreenCast) {
+			t.Fatalf("ScreenCast override capability = %+v", capability)
+		}
+	})
+	t.Run("disabled forced portal", func(t *testing.T) {
+		t.Setenv(envForcePortal, "1")
+		t.Setenv(envDisablePortal, "1")
+		if _, err := CaptureImg(0, 0, 2, 2); !errors.Is(err, ErrNotSupported) {
+			t.Fatalf("CaptureImg error = %v, want ErrNotSupported", err)
+		}
+		capability := GetLinuxCapabilities().Capture
+		if capability.Available || capability.Backend != string(BackendPortal) {
+			t.Fatalf("disabled forced portal capability = %+v", capability)
+		}
+	})
+	if nativeCalls != 0 || portalCalls != 2 {
+		t.Fatalf("failed override changed capture calls: native=%d portal=%d", nativeCalls, portalCalls)
+	}
+}
+
+func TestZeroOriginCaptureImageReusesNormalizedImage(t *testing.T) {
+	source := image.NewRGBA(image.Rect(0, 0, 3, 2))
+	got, err := zeroOriginCaptureImage(source)
+	if err != nil {
+		t.Fatalf("zeroOriginCaptureImage error: %v", err)
+	}
+	if got != source {
+		t.Fatal("zero-origin image was unnecessarily copied")
+	}
+}
+
+func TestPureGoCaptureImgUsesX11Backend(t *testing.T) {
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		t.Skip("Pure-Go X11 screenshot dependency is unsupported on this architecture")
+	}
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", ":99")
+	t.Setenv(envXDGSessionType, "x11")
+	pureGoCaptureImage = func(args ...int) (image.Image, error) {
+		if len(args) != 4 || args[0] != 10 || args[1] != 20 || args[2] != 3 || args[3] != 2 {
+			t.Fatalf("capture args = %v", args)
+		}
+		return image.NewRGBA(image.Rect(0, 0, 3, 2)), nil
+	}
+
+	img, err := CaptureImg(10, 20, 3, 2)
+	if err != nil {
+		t.Fatalf("CaptureImg error: %v", err)
+	}
+	if img.Bounds() != image.Rect(0, 0, 3, 2) {
+		t.Fatalf("capture bounds = %v", img.Bounds())
+	}
+	if LastBackend() != BackendX11 {
+		t.Fatalf("LastBackend = %q, want %q", LastBackend(), BackendX11)
+	}
+	bitmap, err := CaptureScreen(10, 20, 3, 2)
+	if err != nil {
+		t.Fatalf("CaptureScreen error: %v", err)
+	}
+	if bitmap == nil || bitmap.Width != 3 || bitmap.Height != 2 {
+		t.Fatalf("bitmap = %+v, want 3x2", bitmap)
+	}
+	owned, err := CaptureGo(10, 20, 3, 2)
+	if err != nil {
+		t.Fatalf("CaptureGo error: %v", err)
+	}
+	if owned.Width != 3 || owned.Height != 2 {
+		t.Fatalf("owned bitmap = %+v, want 3x2", owned)
+	}
+	serialized, err := CaptureBitmapStr(10, 20, 3, 2)
+	if err != nil {
+		t.Fatalf("CaptureBitmapStr error: %v", err)
+	}
+	decoded, err := BitmapFromStr(serialized)
+	if err != nil {
+		t.Fatalf("BitmapFromStr error: %v", err)
+	}
+	if decoded.Width != 3 || decoded.Height != 2 {
+		t.Fatalf("decoded bitmap = %+v, want 3x2", decoded)
+	}
+}
+
+func TestPureGoCaptureImgUsesHardenedWaylandPortal(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+	t.Setenv("DISPLAY", "")
+	t.Setenv(envDisablePortal, "")
+	pureGoCaptureImage = func(...int) (image.Image, error) {
+		t.Fatal("legacy screenshot backend called for Wayland")
+		return nil, nil
+	}
+	pureGoPortalCaptureImage = func(_ context.Context, x, y, width, height int) (image.Image, error) {
+		if x != -2 || y != 4 || width != 3 || height != 2 {
+			t.Fatalf("portal region = %d,%d %dx%d", x, y, width, height)
+		}
+		return image.NewRGBA(image.Rect(7, 9, 10, 11)), nil
+	}
+
+	img, err := CaptureImg(-2, 4, 3, 2)
+	if err != nil {
+		t.Fatalf("CaptureImg error: %v", err)
+	}
+	if img.Bounds() != image.Rect(0, 0, 3, 2) {
+		t.Fatalf("normalized capture bounds = %v", img.Bounds())
+	}
+	if LastBackend() != BackendPortal {
+		t.Fatalf("LastBackend = %q, want %q", LastBackend(), BackendPortal)
+	}
+	owned, err := CaptureGo(-2, 4, 3, 2)
+	if err != nil {
+		t.Fatalf("CaptureGo error: %v", err)
+	}
+	if owned.Width != 3 || owned.Height != 2 {
+		t.Fatalf("owned portal bitmap = %+v, want 3x2", owned)
+	}
+}
+
+func TestPureGoCaptureImgReportsExplicitUnsupported(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", "")
+	if _, err := CaptureImg(); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("CaptureImg error = %v, want ErrNotSupported", err)
+	}
+
+	t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+	t.Setenv(envDisablePortal, "1")
+	if _, err := CaptureImg(); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("disabled portal error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestPureGoCaptureImgWrapsPortalFailure(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+	t.Setenv("DISPLAY", "")
+	t.Setenv(envDisablePortal, "")
+	wantErr := errors.New("portal denied")
+	pureGoPortalCaptureImage = func(context.Context, int, int, int, int) (image.Image, error) {
+		return nil, wantErr
+	}
+	if _, err := CaptureImg(); !errors.Is(err, ErrPortalFailed) || !errors.Is(err, wantErr) {
+		t.Fatalf("CaptureImg error = %v, want joined portal failure", err)
+	}
+}
+
+func TestPureGoCaptureImgRejectsEmptyBackendImage(t *testing.T) {
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		t.Skip("Pure-Go X11 screenshot dependency is unsupported on this architecture")
+	}
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", ":99")
+	t.Setenv(envXDGSessionType, "x11")
+	pureGoCaptureImage = func(...int) (image.Image, error) { return nil, nil }
+	if _, err := CaptureImg(); err == nil {
+		t.Fatal("CaptureImg unexpectedly accepted a nil backend image")
+	}
+}
+
+func TestPureGoCaptureImgPreservesPortableBackendErrors(t *testing.T) {
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		t.Skip("Pure-Go X11 screenshot dependency is unsupported on this architecture")
+	}
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", ":99")
+	t.Setenv(envXDGSessionType, "x11")
+	pureGoCaptureImage = func(...int) (image.Image, error) {
+		return nil, screenshot.ErrUnsupported
+	}
+	_, err := CaptureImg(0, 0, 1, 1)
+	if !errors.Is(err, ErrNotSupported) || !errors.Is(err, screenshot.ErrUnsupported) {
+		t.Fatalf("unsupported error = %v, want both sentinels", err)
+	}
+
+	wantErr := errors.New("backend failed")
+	pureGoCaptureImage = func(...int) (image.Image, error) { return nil, wantErr }
+	_, err = CaptureImg(0, 0, 1, 1)
+	if !errors.Is(err, wantErr) || !strings.Contains(err.Error(), string(BackendX11)) {
+		t.Fatalf("backend error = %v, want wrapped error with backend context", err)
+	}
+}

--- a/robotgo_test.go
+++ b/robotgo_test.go
@@ -9,7 +9,8 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//go:build darwin || windows
+//go:build cgo && (darwin || windows)
+// +build cgo
 // +build darwin windows
 
 package robotgo

--- a/screen.go
+++ b/screen.go
@@ -34,6 +34,9 @@ func GetDisplayRect(i int) Rect {
 
 // Capture capture the screenshot, use the CaptureImg default
 func Capture(args ...int) (*image.RGBA, error) {
+	if err := validateCaptureArguments(args); err != nil {
+		return nil, err
+	}
 	displayId := 0
 	if configured := currentDisplayID(); configured != -1 {
 		displayId = configured
@@ -48,6 +51,9 @@ func Capture(args ...int) (*image.RGBA, error) {
 		x, y, w, h = args[0], args[1], args[2], args[3]
 	} else {
 		x, y, w, h = GetDisplayBounds(displayId)
+	}
+	if err := validateCaptureRegionRequest(x, y, w, h); err != nil {
+		return nil, err
 	}
 
 	return screenshot.Capture(x, y, w, h)

--- a/screen/capture_nocgo_test.go
+++ b/screen/capture_nocgo_test.go
@@ -1,4 +1,4 @@
-//go:build !cgo
+//go:build !cgo && linux
 
 package screen
 
@@ -10,6 +10,8 @@ import (
 )
 
 func TestCaptureReportsUnsupportedWithoutBackend(t *testing.T) {
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", "")
 	_, err := robotgo.CaptureImg()
 	if !errors.Is(err, robotgo.ErrNotSupported) {
 		t.Fatalf("CaptureImg error = %v, want ErrNotSupported", err)

--- a/screen/portal/screenshot_portal.go
+++ b/screen/portal/screenshot_portal.go
@@ -136,6 +136,9 @@ func portalSenderPath(uniqueName string) string {
 // capture a full-screen image and crops it client-side to x,y,w,h when a
 // non-empty region is requested. The portal may prompt the user.
 func CaptureRegionImage(ctx context.Context, x, y, w, h int) (img image.Image, retErr error) {
+	if err := validateCaptureRegion(x, y, w, h); err != nil {
+		return nil, err
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -153,6 +156,9 @@ func CaptureRegionImage(ctx context.Context, x, y, w, h int) (img image.Image, r
 }
 
 func captureRegionImage(ctx context.Context, portal screenshotPortal, x, y, w, h int) (image.Image, error) {
+	if err := validateCaptureRegion(x, y, w, h); err != nil {
+		return nil, err
+	}
 	ctx, cancel := context.WithTimeout(ctx, portalTimeout)
 	defer cancel()
 
@@ -207,6 +213,22 @@ func captureRegionImage(ctx context.Context, portal screenshotPortal, x, y, w, h
 			return nil, fmt.Errorf("portal: wait for response: %w", ctx.Err())
 		}
 	}
+}
+
+func validateCaptureRegion(x, y, w, h int) error {
+	if w == 0 && h == 0 {
+		if x != 0 || y != 0 {
+			return fmt.Errorf("portal: full-screen capture requires zero origin, got %d,%d", x, y)
+		}
+		return nil
+	}
+	if w <= 0 || h <= 0 {
+		return fmt.Errorf("portal: invalid capture region size %dx%d", w, h)
+	}
+	if x+w < x || y+h < y {
+		return fmt.Errorf("portal: capture region overflows integer coordinates: %d,%d %dx%d", x, y, w, h)
+	}
+	return nil
 }
 
 func responseURI(sig *dbus.Signal) (string, error) {
@@ -271,7 +293,10 @@ func cropImage(img image.Image, x, y, w, h int) (image.Image, error) {
 	if img == nil {
 		return nil, errors.New("portal: nil screenshot")
 	}
-	if w <= 0 || h <= 0 {
+	if err := validateCaptureRegion(x, y, w, h); err != nil {
+		return nil, err
+	}
+	if w == 0 && h == 0 {
 		return img, nil
 	}
 	requested := image.Rect(x, y, x+w, y+h)

--- a/screen/portal/screenshot_portal_test.go
+++ b/screen/portal/screenshot_portal_test.go
@@ -16,9 +16,10 @@ import (
 )
 
 type fakeScreenshotPortal struct {
-	matched  dbus.ObjectPath
-	signalCh chan<- *dbus.Signal
-	uri      string
+	matched         dbus.ObjectPath
+	signalCh        chan<- *dbus.Signal
+	uri             string
+	screenshotCalls int
 }
 
 func (p *fakeScreenshotPortal) uniqueName() string { return ":1.42" }
@@ -39,6 +40,7 @@ func (p *fakeScreenshotPortal) removeSignals(ch chan<- *dbus.Signal) {
 	}
 }
 func (p *fakeScreenshotPortal) screenshot(_ context.Context, options map[string]dbus.Variant) (dbus.ObjectPath, error) {
+	p.screenshotCalls++
 	token, _ := options["handle_token"].Value().(string)
 	path := dbus.ObjectPath("/org/freedesktop/portal/desktop/request/1_42/" + token)
 	// Deliver synchronously, before returning from the method call. This proves
@@ -105,10 +107,67 @@ func TestCaptureRegionImageHonorsCallerDeadline(t *testing.T) {
 	}
 }
 
+func TestCaptureRegionImageRejectsInvalidRegionBeforeRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		w    int
+		h    int
+	}{
+		{name: "missing width", w: 0, h: 2},
+		{name: "missing height", w: 2, h: 0},
+		{name: "negative width", w: -1, h: 2},
+		{name: "negative height", w: 2, h: -1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			portal := &fakeScreenshotPortal{}
+			if _, err := captureRegionImage(context.Background(), portal, 0, 0, test.w, test.h); err == nil {
+				t.Fatal("expected invalid-region error")
+			}
+			if portal.screenshotCalls != 0 {
+				t.Fatalf("screenshot requests = %d, want 0", portal.screenshotCalls)
+			}
+		})
+	}
+	portal := &fakeScreenshotPortal{}
+	maxInt := int(^uint(0) >> 1)
+	if _, err := captureRegionImage(context.Background(), portal, maxInt, 0, 1, 1); err == nil {
+		t.Fatal("expected coordinate-overflow error")
+	}
+	if portal.screenshotCalls != 0 {
+		t.Fatalf("overflow screenshot requests = %d, want 0", portal.screenshotCalls)
+	}
+	if _, err := captureRegionImage(context.Background(), portal, 1, 0, 0, 0); err == nil {
+		t.Fatal("expected non-zero full-screen origin error")
+	}
+	if portal.screenshotCalls != 0 {
+		t.Fatalf("non-zero-origin screenshot requests = %d, want 0", portal.screenshotCalls)
+	}
+}
+
 func TestCropImageRejectsDisjointRegion(t *testing.T) {
 	_, err := cropImage(image.NewRGBA(image.Rect(0, 0, 4, 4)), 20, 20, 2, 2)
 	if err == nil {
 		t.Fatal("expected out-of-bounds error")
+	}
+}
+
+func TestCropImageOnlyTreatsZeroByZeroAsFullScreenshot(t *testing.T) {
+	source := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	full, err := cropImage(source, 0, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("full screenshot: %v", err)
+	}
+	if full != source {
+		t.Fatal("full screenshot should return the source image")
+	}
+	if _, err := cropImage(source, 1, 0, 0, 0); err == nil {
+		t.Fatal("non-zero-origin full screenshot unexpectedly succeeded")
+	}
+	for _, size := range [][2]int{{0, 1}, {1, 0}, {-1, 1}, {1, -1}} {
+		if _, err := cropImage(source, 0, 0, size[0], size[1]); err == nil {
+			t.Fatalf("crop size %dx%d unexpectedly succeeded", size[0], size[1])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose runtime build/backend introspection
- add non-CGO capture for Windows, X11, and the Wayland screenshot portal
- harden capture argument and portal error contracts
- extend the cross-platform non-CGO CI matrix

## Validation
- go test -count=1 ./...
- CGO_ENABLED=0 go test -count=1 ./...
- Windows amd64 and macOS arm64 non-CGO cross-platform test compilation
- complete GitHub Actions Go matrix (run 29349835216)