### PR TITLE
feat: add Pure-Go macOS capture parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,12 +407,13 @@ fmt.Println("process:", caps.Process.Available, caps.Process.Backend)
 ```
 
 In a `CGO_ENABLED=0` build, `Capture`, `CaptureImg`, `CaptureScreen`,
-`CaptureGo`, and `CaptureBitmapStr` use the Pure-Go CoreGraphics, Windows, or
-X11 screenshot backend where available. Wayland sessions use this fork's
-hardened screenshot portal and preserve `ROBOTGO_DISABLE_PORTAL`; unsupported
-targets return `ErrNotSupported` explicitly. On macOS, capture returns
-`ErrPermissionDenied` with remediation when Screen Recording access is absent;
-capability inspection never requests that permission implicitly.
+`CaptureGo`, `CaptureBitmapStr`, `GetPixelColor`, and `GetPxColor` use the
+Pure-Go CoreGraphics, Windows, or X11 screenshot backend where available.
+Wayland sessions use this fork's hardened screenshot portal and preserve
+`ROBOTGO_DISABLE_PORTAL`; unsupported targets return `ErrNotSupported`
+explicitly. On macOS, capture returns `ErrPermissionDenied` with remediation
+when Screen Recording access is absent; capability inspection never requests
+that permission implicitly.
 
 Use `CaptureImg()` with no arguments for a full-screen capture. Region capture
 requires at least `x, y, width, height`; partial argument lists, non-positive

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Current technical differences include:
 - Sway, Hyprland, generic wlroots, and Wayland-core window backend resolution,
   with partial operations reported honestly instead of universal support being
   implied.
-- A defined non-CGO contract: Pure-Go capture is available on Windows and X11,
-  Wayland capture uses the consent-aware Screenshot portal, and unavailable GUI
-  operations return `ErrNotSupported` rather than plausible zero values.
+- A defined non-CGO contract: Pure-Go capture is available through CoreGraphics
+  on macOS, native APIs on Windows, and X11; Wayland capture uses the
+  consent-aware Screenshot portal, and unavailable GUI operations return
+  `ErrNotSupported` rather than plausible zero values.
 - Hermetic portal/compositor tests, tagged Wayland integration suites, and CI
   coverage for Linux, macOS, Windows, Wayland, portal, lint, and non-CGO modes.
 - Open, auditable native and Go backend code, including explicit resource
@@ -60,21 +61,22 @@ for this fork.
 | Windows | Active window, title, close, minimize/maximize, topmost queries/setters, bounds/client geometry, and compositor-specific Wayland variants where supported |
 | Processes | Enumerate, inspect, find, activate, and terminate processes |
 | Images | Go image/bitmap conversion, template helpers, encoding, saving, and optional OCR |
-| Diagnostics | Display-server detection, selected capture backend, and Linux feature capability/fallback reporting |
+| Diagnostics | Build/backend detection plus feature-level capability, permission, fallback, and unsupported reporting |
 
 Availability is platform- and backend-dependent. Prefer error-returning APIs
-and inspect `GetLinuxCapabilities` on Linux when an operation is required for a
-workflow.
+and inspect `GetRuntimeCapabilities` when an operation is required for a
+workflow. `GetLinuxCapabilities` provides additional compositor detail.
 
 ## Support overview
 
 | Platform/session | Build | Current behavior |
 |---|---|---|
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
+| macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture and display bounds with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |
-| Any platform without CGO | `CGO_ENABLED=0` | Pure-Go capture works on Windows and Linux/X11; Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
+| Other supported platforms without CGO | `CGO_ENABLED=0` | Pure-Go capture works on Windows and Linux/X11; Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
 
 Wayland compositors intentionally restrict global automation. GNOME and KDE can
 use consent-aware Screenshot and RemoteDesktop portal paths. The explicit
@@ -393,11 +395,24 @@ fmt.Println("platform:", info.GOOS, info.GOARCH)
 fmt.Println("display:", info.DisplayServer)
 ```
 
-In a `CGO_ENABLED=0` build, `CaptureImg`, `CaptureScreen`, `CaptureGo`, and
-`CaptureBitmapStr` now use the Pure-Go Windows or X11 screenshot backend where
-available. Wayland sessions use this fork's hardened screenshot portal and
-preserve `ROBOTGO_DISABLE_PORTAL`; unsupported targets return
-`ErrNotSupported` explicitly.
+`GetRuntimeCapabilities` adds feature-level status. It may perform bounded
+runtime probes, but never opens a consent dialog:
+
+```go
+caps := robotgo.GetRuntimeCapabilities()
+fmt.Println("capture:", caps.Capture.Available, caps.Capture.Backend, caps.Capture.Reason)
+fmt.Println("bounds:", caps.Bounds.Available, caps.Bounds.Backend, caps.Bounds.Reason)
+fmt.Println("keyboard:", caps.Keyboard.Available, caps.Keyboard.Backend, caps.Keyboard.Reason)
+fmt.Println("process:", caps.Process.Available, caps.Process.Backend)
+```
+
+In a `CGO_ENABLED=0` build, `Capture`, `CaptureImg`, `CaptureScreen`,
+`CaptureGo`, and `CaptureBitmapStr` use the Pure-Go CoreGraphics, Windows, or
+X11 screenshot backend where available. Wayland sessions use this fork's
+hardened screenshot portal and preserve `ROBOTGO_DISABLE_PORTAL`; unsupported
+targets return `ErrNotSupported` explicitly. On macOS, capture returns
+`ErrPermissionDenied` with remediation when Screen Recording access is absent;
+capability inspection never requests that permission implicitly.
 
 Use `CaptureImg()` with no arguments for a full-screen capture. Region capture
 requires at least `x, y, width, height`; partial argument lists, non-positive
@@ -436,6 +451,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Screen capture and pixels](examples/screen/main.go)
 - [Full-screen capture with backend reporting](examples/screen_full/main.go)
 - [Linux capabilities](examples/linux_capabilities/main.go)
+- [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
 - [Consent-aware RemoteDesktop portal input](examples/remote_desktop_input/main.go)
 - [Persistent ScreenCast/PipeWire capture](examples/screencast_capture/main.go)
 - [Window and process helpers](examples/window/main.go)

--- a/TEST.md
+++ b/TEST.md
@@ -23,10 +23,11 @@ go test -tags "ocr" ./...
 ```
 
 The non-CGO suite runs on Linux, macOS, and Windows in CI. It also verifies
-runtime build/feature introspection and hermetic Pure-Go capture dispatch for
-CoreGraphics, X11, Windows, and the Wayland screenshot portal. macOS tests use
-fake CoreGraphics bindings for deterministic permission, pixel, bounds, and
-resource-lifecycle coverage; they do not require a Screen Recording grant.
+runtime build/feature introspection, pixel-color parity, and hermetic Pure-Go
+capture dispatch for CoreGraphics, X11, Windows, and the Wayland screenshot
+portal. macOS tests use fake CoreGraphics bindings for deterministic permission,
+pixel, bounds, and resource-lifecycle coverage; they do not require a Screen
+Recording grant.
 
 Opt-in macOS runtime capture benchmark:
 

--- a/TEST.md
+++ b/TEST.md
@@ -23,8 +23,24 @@ go test -tags "ocr" ./...
 ```
 
 The non-CGO suite runs on Linux, macOS, and Windows in CI. It also verifies
-runtime build introspection and the hermetic Pure-Go capture dispatch for X11,
-Windows, and the Wayland screenshot portal.
+runtime build/feature introspection and hermetic Pure-Go capture dispatch for
+CoreGraphics, X11, Windows, and the Wayland screenshot portal. macOS tests use
+fake CoreGraphics bindings for deterministic permission, pixel, bounds, and
+resource-lifecycle coverage; they do not require a Screen Recording grant.
+
+Opt-in macOS runtime capture benchmark:
+
+```bash
+ROBOTGO_CAPTURE_BENCHMARK=1 \
+  go test -run '^$' -bench BenchmarkCaptureImgRuntime -benchmem .
+CGO_ENABLED=0 ROBOTGO_CAPTURE_BENCHMARK=1 \
+  go test -run '^$' -bench BenchmarkCaptureImgRuntime -benchmem .
+```
+
+Run this from a GUI session after granting Screen Recording access to the test
+binary or terminal. Running the same benchmark with and without CGO provides a
+direct backend comparison. The hermetic macOS conversion benchmark is available
+without a real capture using `-bench BenchmarkDarwinCapturePipeline`.
 
 ## Special Test Suites (Build Tags)
 

--- a/backend_info.go
+++ b/backend_info.go
@@ -10,6 +10,16 @@ const (
 	RuntimeImplementationNativeCGO RuntimeImplementation = "native-cgo"
 	// RuntimeImplementationPureGo identifies a build without CGO.
 	RuntimeImplementationPureGo RuntimeImplementation = "pure-go"
+
+	featureBackendNativeCGO          = "native-cgo"
+	featureBackendPureGoPrefix       = "pure-go-"
+	featureBackendPureGoCoreGraphics = "pure-go-coregraphics"
+	featureBackendPureGoWindows      = "pure-go-windows"
+	featureBackendPureGoX11          = "pure-go-x11"
+	featureBackendGoProcess          = "go-process"
+	featureBackendGoClipboard        = "go-clipboard"
+	featureBackendPureGoProcess      = "pure-go-process"
+	featureBackendPureGoClipboard    = "pure-go-clipboard"
 )
 
 // RuntimeBackendInfo describes the implementation compiled into the current
@@ -20,6 +30,23 @@ type RuntimeBackendInfo struct {
 	CGOEnabled          bool
 	BuildImplementation RuntimeImplementation
 	DisplayServer       DisplayServer
+}
+
+// RuntimeCapabilities reports feature-level backend availability for the
+// current platform and build. Availability may include bounded runtime probes;
+// inspecting RuntimeBackendInfo never performs those probes.
+type RuntimeCapabilities struct {
+	Runtime       RuntimeBackendInfo
+	Capture       FeatureCapability
+	Bounds        FeatureCapability
+	Keyboard      FeatureCapability
+	Mouse         FeatureCapability
+	RemoteDesktop FeatureCapability
+	Window        FeatureCapability
+	Process       FeatureCapability
+	Clipboard     FeatureCapability
+	Hook          FeatureCapability
+	Events        FeatureCapability
 }
 
 // GetRuntimeBackendInfo reports build-time backend information without probing
@@ -36,4 +63,11 @@ func GetRuntimeBackendInfo() RuntimeBackendInfo {
 		BuildImplementation: runtimeBuildImplementation,
 		DisplayServer:       displayServer,
 	}
+}
+
+// GetRuntimeCapabilities reports the feature backends available to the current
+// binary. Unlike GetRuntimeBackendInfo, this function may perform bounded
+// platform probes, but it never opens a consent dialog.
+func GetRuntimeCapabilities() RuntimeCapabilities {
+	return runtimeCapabilities()
 }

--- a/backend_info_test.go
+++ b/backend_info_test.go
@@ -21,6 +21,25 @@ func TestGetRuntimeBackendInfo(t *testing.T) {
 	}
 }
 
+func TestGetRuntimeCapabilitiesIncludeBuildAndPortableHelpers(t *testing.T) {
+	capabilities := GetRuntimeCapabilities()
+	if runtime.GOOS == "linux" {
+		// Live Wayland capability probes may initialize reusable native protocol
+		// objects. Keep this cross-platform contract test isolated from tests that
+		// intentionally replace the display environment.
+		CloseWaylandInput()
+	}
+	if capabilities.Runtime != GetRuntimeBackendInfo() {
+		t.Fatalf("runtime capabilities build info = %+v, want %+v", capabilities.Runtime, GetRuntimeBackendInfo())
+	}
+	if !capabilities.Process.Available || capabilities.Process.Backend == "" {
+		t.Fatalf("process capability = %+v, want available backend", capabilities.Process)
+	}
+	if !capabilities.Clipboard.Available || capabilities.Clipboard.Backend == "" {
+		t.Fatalf("clipboard capability = %+v, want available backend", capabilities.Clipboard)
+	}
+}
+
 func TestGetRuntimeBackendInfoDetectsLinuxDisplayServerWithoutProbes(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Linux display-server detection test")

--- a/capture_benchmark_test.go
+++ b/capture_benchmark_test.go
@@ -1,0 +1,23 @@
+package robotgo
+
+import (
+	"os"
+	"testing"
+)
+
+const envCaptureBenchmark = "ROBOTGO_CAPTURE_BENCHMARK"
+
+// BenchmarkCaptureImgRuntime measures the same public capture path in native
+// CGO and Pure-Go builds. It is opt-in because it requires a real desktop and
+// may require an OS consent grant.
+func BenchmarkCaptureImgRuntime(b *testing.B) {
+	if os.Getenv(envCaptureBenchmark) == "" {
+		b.Skip("set ROBOTGO_CAPTURE_BENCHMARK=1 in an authorized GUI session")
+	}
+	b.ReportAllocs()
+	for range b.N {
+		if _, err := CaptureImg(0, 0, 640, 480); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/darwin_capture_permission.go
+++ b/darwin_capture_permission.go
@@ -1,0 +1,30 @@
+//go:build darwin
+
+package robotgo
+
+import (
+	"fmt"
+
+	"github.com/ebitengine/purego"
+)
+
+const coreGraphicsFramework = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+
+func darwinScreenCapturePreflight() (granted, supported bool, err error) {
+	handle, err := purego.Dlopen(coreGraphicsFramework, purego.RTLD_NOW|purego.RTLD_LOCAL)
+	if err != nil {
+		return false, false, fmt.Errorf("load CoreGraphics: %w", err)
+	}
+	defer func() {
+		if closeErr := purego.Dlclose(handle); err == nil && closeErr != nil {
+			err = fmt.Errorf("close CoreGraphics: %w", closeErr)
+		}
+	}()
+	symbol, err := purego.Dlsym(handle, "CGPreflightScreenCaptureAccess")
+	if err != nil {
+		return false, false, nil
+	}
+	var preflight func() bool
+	purego.RegisterFunc(&preflight, symbol)
+	return preflight(), true, nil
+}

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -35,13 +35,14 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in branch | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Confirm new CI jobs on remote branch |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and blocking geometry/transform matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | First backend active | Build introspection plus non-CGO Windows/X11 and Wayland-portal capture with parity/error tests and a three-OS CI matrix | Additional selectively justified backends, runtime benchmarks, and broader feature-level introspection |
+| 3. Pure-Go | Cross-platform capture active | Build and feature-level introspection plus non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture, permission/error contracts, hermetic parity tests, runtime benchmark harness, and a three-OS CI matrix | Record native-vs-Pure-Go runtime benchmark evidence and evaluate further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
-an infrastructure blocker. The active implementation slice is Phase 2 capture.
+an infrastructure blocker. The active implementation slice is Phase 3 Pure-Go
+backend parity and measurement.
 
 ## Delivery Order
 
@@ -127,13 +128,16 @@ Priority order:
    DMA-BUF path and deterministic resource handling.
 
 Current status: the non-CGO API surface compiles and returns explicit
-unsupported errors. `GetRuntimeBackendInfo` now reports the platform, display
-server, CGO mode, and whether the binary contains native-CGO or Pure-Go build
-paths without triggering runtime probes. `CaptureImg`, `CaptureScreen`,
-`CaptureGo`, and `CaptureBitmapStr` now provide useful non-CGO capture through
-the Pure-Go Windows/X11 implementation and the hardened screenshot portal on
-Wayland, with explicit unsupported and portal-failure contracts. This is the
-first selectively enabled GUI backend, not completion of the phase.
+unsupported errors. `GetRuntimeBackendInfo` reports build facts without probes,
+while `GetRuntimeCapabilities` reports feature backends, permission state,
+fallbacks, and actionable reasons without opening consent dialogs. `Capture`,
+`CaptureImg`, `CaptureScreen`, `CaptureGo`, and `CaptureBitmapStr` provide
+non-CGO capture through CoreGraphics on macOS, native Windows/X11 paths, and the
+hardened screenshot portal on Wayland. macOS display enumeration, Screen
+Recording preflight, RGBA conversion, and CoreGraphics ownership are covered
+hermetically on both supported architectures. Runtime benchmark harnesses are
+present; recorded native-vs-Pure-Go evidence is still required before any
+default backend switch.
 
 Exit criteria:
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -131,13 +131,13 @@ Current status: the non-CGO API surface compiles and returns explicit
 unsupported errors. `GetRuntimeBackendInfo` reports build facts without probes,
 while `GetRuntimeCapabilities` reports feature backends, permission state,
 fallbacks, and actionable reasons without opening consent dialogs. `Capture`,
-`CaptureImg`, `CaptureScreen`, `CaptureGo`, and `CaptureBitmapStr` provide
-non-CGO capture through CoreGraphics on macOS, native Windows/X11 paths, and the
-hardened screenshot portal on Wayland. macOS display enumeration, Screen
-Recording preflight, RGBA conversion, and CoreGraphics ownership are covered
-hermetically on both supported architectures. Runtime benchmark harnesses are
-present; recorded native-vs-Pure-Go evidence is still required before any
-default backend switch.
+`CaptureImg`, `CaptureScreen`, `CaptureGo`, `CaptureBitmapStr`, and the pixel
+color APIs provide non-CGO capture through CoreGraphics on macOS, native
+Windows/X11 paths, and the hardened screenshot portal on Wayland. macOS display
+enumeration, Screen Recording preflight, RGBA conversion, and CoreGraphics
+ownership are covered hermetically on both supported architectures. Runtime
+benchmark harnesses are present; recorded native-vs-Pure-Go evidence is still
+required before any default backend switch.
 
 Exit criteria:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -14,6 +14,9 @@ Current implementation baseline:
 - Platform-neutral build introspection is available via
   `GetRuntimeBackendInfo`, including CGO/Pure-Go mode and display-server
   detection without portal or compositor probes.
+- Platform-neutral feature introspection is available via
+  `GetRuntimeCapabilities`; macOS non-CGO builds report CoreGraphics capture,
+  display bounds, and Screen Recording permission state without prompting.
 - Non-CGO `CaptureImg`/`CaptureScreen` and their Go-bitmap/string variants use
   the hardened screenshot portal on Wayland and the Pure-Go screenshot backend
   on X11/Windows; unsupported targets fail explicitly.

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -17,9 +17,9 @@ Current implementation baseline:
 - Platform-neutral feature introspection is available via
   `GetRuntimeCapabilities`; macOS non-CGO builds report CoreGraphics capture,
   display bounds, and Screen Recording permission state without prompting.
-- Non-CGO `CaptureImg`/`CaptureScreen` and their Go-bitmap/string variants use
-  the hardened screenshot portal on Wayland and the Pure-Go screenshot backend
-  on X11/Windows; unsupported targets fail explicitly.
+- Non-CGO `CaptureImg`/`CaptureScreen`, their Go-bitmap/string variants, and
+  pixel-color queries use the hardened screenshot portal on Wayland and the
+  Pure-Go screenshot backend on X11/Windows; unsupported targets fail explicitly.
 - Capability introspection probes the live screencopy protocol, desktop portal
   D-Bus owner, virtual pointer and virtual keyboard instead of inferring support
   solely from session environment variables.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,189 +1,36 @@
-# Robotgo examples
+# RobotGo examples
 
-## Install:
-```
-go get -u github.com/go-vgo/robotgo  
-```
+These examples use this fork's module path:
 
-## [Examples:](https://github.com/go-vgo/robotgo/blob/master/examples)
-
-#### [Linux Capabilities](https://github.com/go-vgo/robotgo/blob/master/examples/linux_capabilities/main.go)
-
-```Go
-package main
-
-import (
-	"encoding/json"
-	"fmt"
-	"log"
-
-	"github.com/go-vgo/robotgo"
-)
-
-func main() {
-	caps := robotgo.GetLinuxCapabilities()
-	data, err := json.MarshalIndent(caps, "", "  ")
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(string(data))
-}
+```bash
+go get github.com/marang/robotgo
 ```
 
-#### [Mouse](https://github.com/go-vgo/robotgo/blob/master/examples/mouse/main.go)
+Run an example from the repository root, for example:
 
-```Go
-package main
-
-import (
-	"github.com/go-vgo/robotgo"
-)
-
-func main() {
-  // robotgo.ScrollMouse(10, "up")
-  robotgo.Scroll(0, 10)
-  robotgo.MouseClick("left", true)
-  robotgo.MoveSmooth(100, 200, 1.0, 100.0)
-} 
-``` 
-
-#### [Keyboard](https://github.com/go-vgo/robotgo/blob/master/examples/key/main.go)
-
-```Go
-package main
-
-import (
-  "fmt"
-
-  "github.com/go-vgo/robotgo"
-)
-
-func main() {
-  robotgo.TypeStr("Hello World")
-  // robotgo.TypeStr("だんしゃり")
-  robotgo.TypeStr("だんしゃり")
-  // ustr := uint32(robotgo.CharCodeAt("だんしゃり", 0))
-  // robotgo.UnicodeType(ustr)
-
-  robotgo.KeyTap("enter")
-  robotgo.TypeStr("en")
-  robotgo.KeyTap("i", "alt", "command")
-  arr := []string{"alt", "command"}
-  robotgo.KeyTap("i", arr)
-
-  robotgo.WriteAll("Test")
-  text, err := robotgo.ReadAll()
-  if err == nil {
-    fmt.Println(text)
-  }
-} 
+```bash
+go run ./examples/runtime_capabilities
+go run ./examples/screen_full
 ```
 
-#### [Screen](https://github.com/go-vgo/robotgo/blob/master/examples/screen/main.go)
+Available examples:
 
-```Go
-package main
+- [`runtime_capabilities`](runtime_capabilities/main.go): cross-platform build,
+  backend, feature, permission, and unsupported diagnostics.
+- [`linux_capabilities`](linux_capabilities/main.go): detailed Linux display
+  server, compositor, portal, and fallback diagnostics.
+- [`screen`](screen/main.go): capture, pixel, bitmap, and display operations.
+- [`screen_full`](screen_full/main.go): full-screen capture with selected
+  backend reporting.
+- [`screencast_capture`](screencast_capture/main.go): persistent
+  ScreenCast/PipeWire capture on supported Wayland builds.
+- [`remote_desktop_input`](remote_desktop_input/main.go): explicit,
+  consent-aware RemoteDesktop portal input.
+- [`mouse`](mouse/main.go): pointer movement, clicks, and scrolling.
+- [`key`](key/main.go): keyboard and clipboard operations.
+- [`window`](window/main.go): window and process helpers.
+- [`scale`](scale/main.go): display scaling information.
 
-import (
-	"fmt"
-
-	"github.com/go-vgo/robotgo"
-)
-
-func main() {
-  x, y := robotgo.Location()
-  fmt.Println("pos:", x, y)
-  color := robotgo.GetPixelColor(100, 200)
-  fmt.Println("color----", color)
-} 
-```
-
-#### [Bitmap](https://github.com/go-vgo/robotgo/blob/master/examples/bitmap/main.go)
-
-```Go
-package main
-
-import (
-	"fmt"
-
-	"github.com/go-vgo/robotgo"
-)
-
-func main() {
-  bitmap := robotgo.CaptureScreen(10, 20, 30, 40)
-  // use `defer robotgo.FreeBitmap(bit)` to free the bitmap
-  defer robotgo.FreeBitmap(bitmap)
-  fmt.Println("...", bitmap)
-
-  fx, fy := robotgo.FindBitmap(bitmap)
-  fmt.Println("FindBitmap------", fx, fy)
-
-  robotgo.SaveBitmap(bitmap, "test.png")
-} 
-```
-
-#### [Event](https://github.com/go-vgo/robotgo/blob/master/examples/event/main.go)
-
-```Go
-package main
-
-import (
-	"fmt"
-
-	"github.com/go-vgo/robotgo"
-)
-
-func main() {
-  keve := robotgo.AddEvent("k")
-  if keve {
-    fmt.Println("you press...", "k")
-  }
-
-  mleft := robotgo.AddEvent("mleft")
-  if mleft {
-    fmt.Println("you press...", "mouse left button")
-  }
-} 
-```
-
-#### [Window](https://github.com/go-vgo/robotgo/blob/master/examples/window/main.go)
-
-```Go
-package main
-
-import (
-	"fmt"
-
-	"github.com/go-vgo/robotgo"
-)
-
-func main() {
-  fpid, err := robotgo.FindIds("Google")
-  if err == nil {
-    fmt.Println("pids...", fpid)
-
-    if len(fpid) > 0 {
-      robotgo.ActivePID(fpid[0])
-
-      robotgo.Kill(fpid[0])
-    }
-  }
-
-  robotgo.ActiveName("chrome")
-
-  isExist, err := robotgo.PidExists(100)
-  if err == nil && isExist {
-    fmt.Println("pid exists is", isExist)
-
-    robotgo.Kill(100)
-  }
-
-  abool := robotgo.ShowAlert("test", "robotgo")
-  if abool == 0 {
- 	  fmt.Println("ok@@@", "ok")
-  }
-
-  title := robotgo.GetTitle()
-  fmt.Println("title@@@", title)
-} 
-```
+Examples perform real desktop actions. Inspect them before running, especially
+the input and window/process examples. Portal examples may show a consent dialog
+only when explicitly asked to connect or demonstrate an operation.

--- a/examples/runtime_capabilities/main.go
+++ b/examples/runtime_capabilities/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	capabilities := robotgo.GetRuntimeCapabilities()
+	fmt.Printf(
+		"RobotGo %s/%s (%s)\n",
+		capabilities.Runtime.GOOS,
+		capabilities.Runtime.GOARCH,
+		capabilities.Runtime.BuildImplementation,
+	)
+	printFeature("capture", capabilities.Capture)
+	printFeature("bounds", capabilities.Bounds)
+	printFeature("keyboard", capabilities.Keyboard)
+	printFeature("mouse", capabilities.Mouse)
+	printFeature("remote desktop", capabilities.RemoteDesktop)
+	printFeature("window", capabilities.Window)
+	printFeature("process", capabilities.Process)
+	printFeature("clipboard", capabilities.Clipboard)
+	printFeature("hook", capabilities.Hook)
+	printFeature("events", capabilities.Events)
+}
+
+func printFeature(name string, capability robotgo.FeatureCapability) {
+	fmt.Printf(
+		"%-15s available=%-5t backend=%-24s reason=%s\n",
+		name,
+		capability.Available,
+		capability.Backend,
+		capability.Reason,
+	)
+	if capability.Notes != "" {
+		fmt.Printf("  note: %s\n", capability.Notes)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/marang/robotgo
 go 1.25.0
 
 require (
+	github.com/ebitengine/purego v0.10.1
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/jezek/xgb v1.3.1
 	github.com/jezek/xgbutil v0.0.0-20260124183602-9fd151d6a51a
@@ -18,7 +19,6 @@ require (
 
 require (
 	github.com/dblohm7/wingoes v0.0.0-20240820181039-f2b84150679e // indirect
-	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/gen2brain/shm v0.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260627054121-477a66015f15 // indirect

--- a/robotgo.go
+++ b/robotgo.go
@@ -128,7 +128,7 @@ const (
 	DisplayServerUnknown DisplayServer = "unknown"
 )
 
-// FeatureCapability describes runtime availability for a Linux feature path.
+// FeatureCapability describes runtime availability for a feature backend.
 type FeatureCapability struct {
 	Available bool
 	Fallback  bool
@@ -491,16 +491,17 @@ func selectedWaylandBackend() WaylandBackend {
 }
 
 var (
-	ErrWaylandDisplay  = errors.New("wayland connect failed")
-	ErrNoScreencopy    = errors.New("screencopy manager not available")
-	ErrNoOutputs       = errors.New("no outputs")
-	ErrDmabufDevice    = errors.New("screencopy dmabuf device unsupported")
-	ErrDmabufModifiers = errors.New("screencopy dmabuf modifiers unsupported")
-	ErrDmabufImport    = errors.New("screencopy dmabuf import failed")
-	ErrDmabufMap       = errors.New("screencopy dmabuf map failed")
-	ErrWaylandFailed   = errors.New("wayland capture failed")
-	ErrPortalFailed    = errors.New("portal capture failed")
-	ErrNotSupported    = errors.New("operation not supported on current platform/backend")
+	ErrWaylandDisplay   = errors.New("wayland connect failed")
+	ErrNoScreencopy     = errors.New("screencopy manager not available")
+	ErrNoOutputs        = errors.New("no outputs")
+	ErrDmabufDevice     = errors.New("screencopy dmabuf device unsupported")
+	ErrDmabufModifiers  = errors.New("screencopy dmabuf modifiers unsupported")
+	ErrDmabufImport     = errors.New("screencopy dmabuf import failed")
+	ErrDmabufMap        = errors.New("screencopy dmabuf map failed")
+	ErrWaylandFailed    = errors.New("wayland capture failed")
+	ErrPortalFailed     = errors.New("portal capture failed")
+	ErrNotSupported     = errors.New("operation not supported on current platform/backend")
+	ErrPermissionDenied = errors.New("permission denied by desktop security policy")
 )
 
 func waylandWindowNotSupported(op string) error {

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -82,16 +82,17 @@ const (
 )
 
 var (
-	ErrWaylandDisplay  = errors.New("wayland connect failed")
-	ErrNoScreencopy    = errors.New("screencopy manager not available")
-	ErrNoOutputs       = errors.New("no outputs")
-	ErrDmabufDevice    = errors.New("screencopy dmabuf device unsupported")
-	ErrDmabufModifiers = errors.New("screencopy dmabuf modifiers unsupported")
-	ErrDmabufImport    = errors.New("screencopy dmabuf import failed")
-	ErrDmabufMap       = errors.New("screencopy dmabuf map failed")
-	ErrWaylandFailed   = errors.New("wayland capture failed")
-	ErrPortalFailed    = errors.New("portal capture failed")
-	ErrNotSupported    = errors.New("operation not supported on current platform/backend")
+	ErrWaylandDisplay   = errors.New("wayland connect failed")
+	ErrNoScreencopy     = errors.New("screencopy manager not available")
+	ErrNoOutputs        = errors.New("no outputs")
+	ErrDmabufDevice     = errors.New("screencopy dmabuf device unsupported")
+	ErrDmabufModifiers  = errors.New("screencopy dmabuf modifiers unsupported")
+	ErrDmabufImport     = errors.New("screencopy dmabuf import failed")
+	ErrDmabufMap        = errors.New("screencopy dmabuf map failed")
+	ErrWaylandFailed    = errors.New("wayland capture failed")
+	ErrPortalFailed     = errors.New("portal capture failed")
+	ErrNotSupported     = errors.New("operation not supported on current platform/backend")
+	ErrPermissionDenied = errors.New("permission denied by desktop security policy")
 )
 
 type (
@@ -213,7 +214,7 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		conflict := pureGoX11EnvironmentConflict()
 		capabilities.Capture = FeatureCapability{
 			Available: compiled && !conflict,
-			Backend:   capabilityBackendPureGoX11,
+			Backend:   featureBackendPureGoX11,
 			Reason:    "Pure-Go X11 screenshot backend is selected; runtime access is not probed",
 			Notes:     "runtime X server access is validated when capture starts",
 		}
@@ -223,6 +224,19 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		} else if conflict {
 			capabilities.Capture.Reason = envXDGSessionType + " selects Wayland while DISPLAY selects X11"
 			capabilities.Capture.Notes = "capture refuses the screenshot dependency's implicit portal fallback"
+		}
+		capabilities.Bounds = FeatureCapability{
+			Available: compiled && !conflict,
+			Backend:   featureBackendPureGoX11,
+			Reason:    "Pure-Go X11 display enumeration is selected; runtime access is not probed",
+			Notes:     "runtime X server access is validated when bounds are queried",
+		}
+		if !compiled {
+			capabilities.Bounds.Reason = fmt.Sprintf("Pure-Go X11 bounds are not compiled for %s/%s", runtime.GOOS, runtime.GOARCH)
+			capabilities.Bounds.Notes = ErrNotSupported.Error()
+		} else if conflict {
+			capabilities.Bounds.Reason = envXDGSessionType + " selects Wayland while DISPLAY selects X11"
+			capabilities.Bounds.Notes = "bounds refuse the screenshot dependency's implicit portal fallback"
 		}
 	}
 	return capabilities
@@ -490,15 +504,31 @@ func ScrollE(x, y int, args ...int) error {
 	}
 	return finishRemoteDesktopMouseEvent(err, msDelay)
 }
-func ScrollDir(int, ...interface{})  {}
-func Location() (int, int)           { return 0, 0 }
-func LocationE() (int, int, error)   { return 0, 0, ErrNotSupported }
-func MouseReady() error              { return RemoteDesktopInputReady(RemoteDesktopPointer) }
-func CloseWaylandInput()             { _ = CloseRemoteDesktopInput() }
-func GetScreenSize() (int, int)      { return 0, 0 }
-func GetScreenRect(...int) Rect      { return Rect{} }
-func GetScaleSize(...int) (int, int) { return 0, 0 }
-func DisplaysNum() int               { return 0 }
+func ScrollDir(int, ...interface{}) {}
+func Location() (int, int)          { return 0, 0 }
+func LocationE() (int, int, error)  { return 0, 0, ErrNotSupported }
+func MouseReady() error             { return RemoteDesktopInputReady(RemoteDesktopPointer) }
+func CloseWaylandInput()            { _ = CloseRemoteDesktopInput() }
+func GetScreenSize() (int, int) {
+	displayID := currentDisplayID()
+	if displayID < 0 {
+		displayID = 0
+	}
+	_, _, width, height := GetDisplayBounds(displayID)
+	return width, height
+}
+func GetScreenRect(displayID ...int) Rect {
+	id := currentDisplayID()
+	if id < 0 {
+		id = 0
+	}
+	if len(displayID) > 0 {
+		id = displayID[0]
+	}
+	return GetDisplayRect(id)
+}
+func GetScaleSize(...int) (int, int) { return GetScreenSize() }
+func DisplaysNum() int               { return platformDisplayCount() }
 func GetPixelColor(int, int, ...int) (string, error) {
 	return "", ErrNotSupported
 }

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"image/color"
 	"os"
 	"runtime"
 	"time"
@@ -529,10 +530,34 @@ func GetScreenRect(displayID ...int) Rect {
 }
 func GetScaleSize(...int) (int, int) { return GetScreenSize() }
 func DisplaysNum() int               { return platformDisplayCount() }
-func GetPixelColor(int, int, ...int) (string, error) {
-	return "", ErrNotSupported
+
+// GetPixelColor returns the pixel color at (x, y) as a six-digit RGB string.
+func GetPixelColor(x, y int, displayID ...int) (string, error) {
+	value, err := GetPxColor(x, y, displayID...)
+	if err != nil {
+		return "", err
+	}
+	return PadHex(value), nil
 }
-func GetPxColor(int, int, ...int) (uint32, error) { return 0, ErrNotSupported }
+
+// GetPxColor returns the pixel color at (x, y) through the active Pure-Go
+// capture backend. The optional display index follows CaptureImg semantics.
+func GetPxColor(x, y int, displayID ...int) (uint32, error) {
+	args := []int{x, y, 1, 1}
+	if len(displayID) > 0 {
+		args = append(args, displayID[0])
+	}
+	img, err := CaptureImg(args...)
+	if err != nil {
+		return 0, err
+	}
+	bounds := img.Bounds()
+	if bounds.Empty() {
+		return 0, errors.New("Pure-Go pixel capture returned an empty image")
+	}
+	pixel := color.NRGBAModel.Convert(img.At(bounds.Min.X, bounds.Min.Y)).(color.NRGBA)
+	return RgbToHex(pixel.R, pixel.G, pixel.B), nil
+}
 func ToBitmap(bit CBitmap) Bitmap {
 	if bit == nil {
 		return Bitmap{}

--- a/robotgo_nocgo_capture.go
+++ b/robotgo_nocgo_capture.go
@@ -19,15 +19,14 @@ import (
 )
 
 const (
-	envCaptureDebug            = "ROBOTGO_CAPTURE_DEBUG"
-	envWaylandBackend          = "ROBOTGO_WAYLAND_BACKEND"
-	envForcePortal             = "ROBOTGO_FORCE_PORTAL"
-	envDisablePortal           = "ROBOTGO_DISABLE_PORTAL"
-	envXDGSessionType          = "XDG_SESSION_TYPE"
-	sessionTypeWayland         = "wayland"
-	waylandBackendPortalName   = "portal"
-	waylandBackendScreenCast   = "screencast"
-	capabilityBackendPureGoX11 = "pure-go-x11"
+	envCaptureDebug          = "ROBOTGO_CAPTURE_DEBUG"
+	envWaylandBackend        = "ROBOTGO_WAYLAND_BACKEND"
+	envForcePortal           = "ROBOTGO_FORCE_PORTAL"
+	envDisablePortal         = "ROBOTGO_DISABLE_PORTAL"
+	envXDGSessionType        = "XDG_SESSION_TYPE"
+	sessionTypeWayland       = "wayland"
+	waylandBackendPortalName = "portal"
+	waylandBackendScreenCast = "screencast"
 )
 
 var (
@@ -151,6 +150,8 @@ func pureGoScreenshotSupported(goos, goarch string) bool {
 		return false
 	}
 	switch goos {
+	case "darwin":
+		return goarch == "amd64" || goarch == "arm64"
 	case "windows", "linux", "freebsd", "openbsd", "netbsd":
 		return true
 	default:

--- a/robotgo_nocgo_capture_test.go
+++ b/robotgo_nocgo_capture_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"image"
+	"image/color"
 	"runtime"
 	"strings"
 	"testing"
@@ -291,6 +292,64 @@ func TestPureGoCaptureImgUsesX11Backend(t *testing.T) {
 	}
 	if decoded.Width != 3 || decoded.Height != 2 {
 		t.Fatalf("decoded bitmap = %+v, want 3x2", decoded)
+	}
+}
+
+func TestPureGoPixelColorUsesCaptureBackend(t *testing.T) {
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		t.Skip("Pure-Go X11 screenshot dependency is unsupported on this architecture")
+	}
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", ":99")
+	t.Setenv(envXDGSessionType, "x11")
+	pureGoCaptureImage = func(args ...int) (image.Image, error) {
+		want := []int{-10, 20, 1, 1, 2}
+		if len(args) != len(want) {
+			t.Fatalf("capture args = %v, want %v", args, want)
+		}
+		for i := range want {
+			if args[i] != want[i] {
+				t.Fatalf("capture args = %v, want %v", args, want)
+			}
+		}
+		img := image.NewNRGBA(image.Rect(4, 7, 5, 8))
+		img.SetNRGBA(4, 7, color.NRGBA{R: 0x0a, G: 0xb0, B: 0x0c, A: 0x80})
+		return img, nil
+	}
+
+	value, err := GetPxColor(-10, 20, 2)
+	if err != nil {
+		t.Fatalf("GetPxColor error: %v", err)
+	}
+	if value != 0x0ab00c {
+		t.Fatalf("GetPxColor = %#06x, want %#06x", value, uint32(0x0ab00c))
+	}
+	hex, err := GetPixelColor(-10, 20, 2)
+	if err != nil {
+		t.Fatalf("GetPixelColor error: %v", err)
+	}
+	if hex != "0ab00c" {
+		t.Fatalf("GetPixelColor = %q, want %q", hex, "0ab00c")
+	}
+}
+
+func TestPureGoPixelColorPreservesCaptureError(t *testing.T) {
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		t.Skip("Pure-Go X11 screenshot dependency is unsupported on this architecture")
+	}
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", ":99")
+	t.Setenv(envXDGSessionType, "x11")
+	wantErr := errors.New("pixel capture failed")
+	pureGoCaptureImage = func(...int) (image.Image, error) { return nil, wantErr }
+
+	if _, err := GetPxColor(1, 2); !errors.Is(err, wantErr) {
+		t.Fatalf("GetPxColor error = %v, want wrapped capture error", err)
+	}
+	if _, err := GetPixelColor(1, 2); !errors.Is(err, wantErr) {
+		t.Fatalf("GetPixelColor error = %v, want wrapped capture error", err)
 	}
 }
 

--- a/robotgo_nocgo_capture_test.go
+++ b/robotgo_nocgo_capture_test.go
@@ -48,7 +48,8 @@ func TestPureGoScreenshotPlatformSupport(t *testing.T) {
 		{goos: "freebsd", goarch: "amd64", supported: true, backend: BackendX11},
 		{goos: "linux", goarch: "s390x", supported: false, backend: BackendX11},
 		{goos: "linux", goarch: "ppc64le", supported: false, backend: BackendX11},
-		{goos: "darwin", goarch: "amd64", supported: false, backend: BackendPureGo},
+		{goos: "darwin", goarch: "amd64", supported: true, backend: BackendPureGo},
+		{goos: "darwin", goarch: "arm64", supported: true, backend: BackendPureGo},
 	}
 	for _, test := range tests {
 		t.Run(test.goos+"/"+test.goarch, func(t *testing.T) {
@@ -96,8 +97,12 @@ func TestPureGoLinuxCaptureCapabilities(t *testing.T) {
 		t.Setenv(envXDGSessionType, "x11")
 		capture := GetLinuxCapabilities().Capture
 		wantAvailable := pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH)
-		if capture.Available != wantAvailable || capture.Backend != capabilityBackendPureGoX11 {
+		if capture.Available != wantAvailable || capture.Backend != featureBackendPureGoX11 {
 			t.Fatalf("capture capability = %+v", capture)
+		}
+		bounds := GetLinuxCapabilities().Bounds
+		if bounds.Available != wantAvailable || bounds.Backend != featureBackendPureGoX11 {
+			t.Fatalf("bounds capability = %+v", bounds)
 		}
 	})
 	t.Run("Wayland portal ready", func(t *testing.T) {

--- a/runtime_capabilities_cgo.go
+++ b/runtime_capabilities_cgo.go
@@ -1,0 +1,58 @@
+//go:build cgo
+
+package robotgo
+
+import "runtime"
+
+func runtimeCapabilities() RuntimeCapabilities {
+	unsupported := FeatureCapability{
+		Reason: ErrNotSupported.Error(),
+		Notes:  "no matching runtime backend is active on this platform",
+	}
+	result := RuntimeCapabilities{
+		Runtime:       GetRuntimeBackendInfo(),
+		Capture:       unsupported,
+		Bounds:        unsupported,
+		Keyboard:      unsupported,
+		Mouse:         unsupported,
+		RemoteDesktop: unsupported,
+		Window:        unsupported,
+		Hook:          unsupported,
+		Events:        unsupported,
+	}
+	if runtime.GOOS == "linux" {
+		linux := GetLinuxCapabilities()
+		result.Capture = linux.Capture
+		result.Bounds = linux.Bounds
+		result.Keyboard = linux.Keyboard
+		result.Mouse = linux.Mouse
+		result.RemoteDesktop = linux.RemoteDesktop
+		result.Window = linux.Window
+		result.Hook = linux.Hook
+		result.Events = linux.Events
+	} else {
+		native := FeatureCapability{
+			Available: true,
+			Backend:   featureBackendNativeCGO,
+			Reason:    "native CGO backend is compiled for this platform",
+			Notes:     "runtime permissions are validated when an operation starts",
+		}
+		result.Capture, result.Bounds = nativePlatformCaptureCapabilities()
+		result.Keyboard = native
+		result.Mouse = native
+		result.Window = native
+		result.Hook = native
+		result.Events = native
+	}
+	result.Process = FeatureCapability{
+		Available: true,
+		Backend:   featureBackendGoProcess,
+		Reason:    "process helpers are compiled for this platform",
+	}
+	result.Clipboard = FeatureCapability{
+		Available: true,
+		Backend:   featureBackendGoClipboard,
+		Reason:    "clipboard helpers are compiled for this platform",
+	}
+	return result
+}

--- a/runtime_capabilities_cgo_darwin.go
+++ b/runtime_capabilities_cgo_darwin.go
@@ -1,0 +1,41 @@
+//go:build cgo && darwin
+
+package robotgo
+
+import "fmt"
+
+func nativePlatformCaptureCapabilities() (FeatureCapability, FeatureCapability) {
+	const backend = featureBackendNativeCGO
+	capture := FeatureCapability{Backend: backend}
+	bounds := FeatureCapability{Backend: backend}
+	displays := DisplaysNum()
+	if displays <= 0 {
+		capture.Reason = "CoreGraphics reports no active displays"
+		capture.Notes = "an active macOS GUI session is required"
+		bounds.Reason = capture.Reason
+		bounds.Notes = capture.Notes
+		return capture, bounds
+	}
+	bounds.Available = true
+	bounds.Reason = "native CoreGraphics display enumeration is available"
+	bounds.Notes = fmt.Sprintf("active displays=%d", displays)
+	granted, supported, err := darwinScreenCapturePreflight()
+	if err != nil {
+		capture.Reason = err.Error()
+		capture.Notes = "Screen Recording permission could not be inspected"
+		return capture, bounds
+	}
+	if supported && !granted {
+		capture.Reason = ErrPermissionDenied.Error()
+		capture.Notes = "grant Screen Recording access to this application in System Settings"
+		return capture, bounds
+	}
+	capture.Available = true
+	capture.Reason = "native CoreGraphics capture is available"
+	if supported {
+		capture.Notes = "Screen Recording permission is granted"
+	} else {
+		capture.Notes = "this macOS version does not expose a permission preflight; capture validates access"
+	}
+	return capture, bounds
+}

--- a/runtime_capabilities_cgo_default.go
+++ b/runtime_capabilities_cgo_default.go
@@ -1,0 +1,13 @@
+//go:build cgo && !darwin
+
+package robotgo
+
+func nativePlatformCaptureCapabilities() (FeatureCapability, FeatureCapability) {
+	native := FeatureCapability{
+		Available: true,
+		Backend:   featureBackendNativeCGO,
+		Reason:    "native CGO backend is compiled for this platform",
+		Notes:     "runtime permissions are validated when an operation starts",
+	}
+	return native, native
+}

--- a/runtime_capabilities_nocgo.go
+++ b/runtime_capabilities_nocgo.go
@@ -1,0 +1,47 @@
+//go:build !cgo
+
+package robotgo
+
+import "runtime"
+
+func runtimeCapabilities() RuntimeCapabilities {
+	unsupported := FeatureCapability{
+		Reason: ErrNotSupported.Error(),
+		Notes:  "no matching Pure-Go backend is active in this build",
+	}
+	result := RuntimeCapabilities{
+		Runtime:       GetRuntimeBackendInfo(),
+		Capture:       unsupported,
+		Bounds:        unsupported,
+		Keyboard:      unsupported,
+		Mouse:         unsupported,
+		RemoteDesktop: unsupported,
+		Window:        unsupported,
+		Hook:          unsupported,
+		Events:        unsupported,
+		Process: FeatureCapability{
+			Available: true,
+			Backend:   featureBackendPureGoProcess,
+			Reason:    "process helpers do not require CGO",
+		},
+		Clipboard: FeatureCapability{
+			Available: true,
+			Backend:   featureBackendPureGoClipboard,
+			Reason:    "clipboard helpers do not require CGO",
+		},
+	}
+	if runtime.GOOS == "linux" {
+		linux := GetLinuxCapabilities()
+		result.Capture = linux.Capture
+		result.Bounds = linux.Bounds
+		result.Keyboard = linux.Keyboard
+		result.Mouse = linux.Mouse
+		result.RemoteDesktop = linux.RemoteDesktop
+		result.Window = linux.Window
+		result.Hook = linux.Hook
+		result.Events = linux.Events
+		return result
+	}
+	result.Capture, result.Bounds = pureGoPlatformCaptureCapabilities()
+	return result
+}

--- a/runtime_capabilities_nocgo_default.go
+++ b/runtime_capabilities_nocgo_default.go
@@ -1,0 +1,34 @@
+//go:build !cgo && !darwin
+
+package robotgo
+
+import "runtime"
+
+func pureGoPlatformCaptureCapabilities() (FeatureCapability, FeatureCapability) {
+	backend := featureBackendPureGoPrefix + runtime.GOOS
+	if runtime.GOOS == "windows" {
+		backend = featureBackendPureGoWindows
+	}
+	if pureGoScreenshotBackend(runtime.GOOS) == BackendX11 {
+		backend = featureBackendPureGoX11
+	}
+	compiled := pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH)
+	capture := FeatureCapability{
+		Available: compiled,
+		Backend:   backend,
+		Reason:    "Pure-Go capture backend is compiled; runtime access is checked when capture starts",
+	}
+	bounds := FeatureCapability{
+		Available: compiled,
+		Backend:   backend,
+		Reason:    "Pure-Go display enumeration is compiled; runtime access is checked when queried",
+	}
+	if !compiled {
+		reason := "Pure-Go capture and display enumeration are unavailable on " + runtime.GOOS + "/" + runtime.GOARCH
+		capture.Reason = reason
+		capture.Notes = ErrNotSupported.Error()
+		bounds.Reason = reason
+		bounds.Notes = ErrNotSupported.Error()
+	}
+	return capture, bounds
+}

--- a/runtime_capabilities_nocgo_default_test.go
+++ b/runtime_capabilities_nocgo_default_test.go
@@ -1,0 +1,19 @@
+//go:build !cgo && !linux && !darwin
+
+package robotgo
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestPureGoPlatformCapabilitiesMatchCompiledCaptureBackend(t *testing.T) {
+	capabilities := GetRuntimeCapabilities()
+	wantAvailable := pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH)
+	if capabilities.Capture.Available != wantAvailable || capabilities.Bounds.Available != wantAvailable {
+		t.Fatalf("runtime capabilities = %+v, want capture/bounds available=%v", capabilities, wantAvailable)
+	}
+	if capabilities.Capture.Backend == "" || capabilities.Bounds.Backend == "" {
+		t.Fatalf("runtime capabilities = %+v, want named capture/bounds backends", capabilities)
+	}
+}

--- a/screen.go
+++ b/screen.go
@@ -13,14 +13,11 @@ package robotgo
 
 import (
 	"image"
-
-	// "github.com/kbinani/screenshot"
-	"github.com/vcaesar/screenshot"
 )
 
 // GetDisplayBounds gets the display screen bounds
 func GetDisplayBounds(i int) (x, y, w, h int) {
-	bs := screenshot.GetDisplayBounds(i)
+	bs := platformDisplayBounds(i)
 	return bs.Min.X, bs.Min.Y, bs.Dx(), bs.Dy()
 }
 
@@ -56,7 +53,7 @@ func Capture(args ...int) (*image.RGBA, error) {
 		return nil, err
 	}
 
-	return screenshot.Capture(x, y, w, h)
+	return platformCapture(x, y, w, h)
 }
 
 // SaveCapture capture screen and save the screenshot to image

--- a/screen_backend_darwin_nocgo.go
+++ b/screen_backend_darwin_nocgo.go
@@ -1,0 +1,267 @@
+//go:build darwin && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"image"
+	"math"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+const (
+	cgErrorSuccess                 int32  = 0
+	cgWindowListOptionOnScreenOnly uint32 = 1 << 0
+	cgWindowImageDefault           uint32 = 0
+	cgImageAlphaPremultipliedLast  uint32 = 1
+	cgBitmapByteOrder32Big         uint32 = 4 << 12
+)
+
+type cgPoint struct {
+	X float64
+	Y float64
+}
+
+type cgSize struct {
+	Width  float64
+	Height float64
+}
+
+type cgRect struct {
+	Origin cgPoint
+	Size   cgSize
+}
+
+type darwinGraphicsAPI struct {
+	close                     func() error
+	preflightCaptureAccess    func() bool
+	getActiveDisplayList      func(uint32, *uint32, *uint32) int32
+	displayBounds             func(uint32) cgRect
+	windowListCreateImage     func(cgRect, uint32, uint32, uint32) uintptr
+	imageRelease              func(uintptr)
+	colorSpaceCreateDeviceRGB func() uintptr
+	colorSpaceRelease         func(uintptr)
+	bitmapContextCreate       func(unsafe.Pointer, uintptr, uintptr, uintptr, uintptr, uintptr, uint32) uintptr
+	bitmapContextGetData      func(uintptr) unsafe.Pointer
+	contextRelease            func(uintptr)
+	contextTranslateCTM       func(uintptr, float64, float64)
+	contextScaleCTM           func(uintptr, float64, float64)
+	contextDrawImage          func(uintptr, cgRect, uintptr)
+}
+
+var openDarwinGraphics = openDarwinCoreGraphics
+
+func openDarwinCoreGraphics() (*darwinGraphicsAPI, error) {
+	handle, err := purego.Dlopen(coreGraphicsFramework, purego.RTLD_NOW|purego.RTLD_LOCAL)
+	if err != nil {
+		return nil, fmt.Errorf("load CoreGraphics: %w", err)
+	}
+	api := &darwinGraphicsAPI{close: func() error { return purego.Dlclose(handle) }}
+	bind := func(target any, name string) error {
+		symbol, err := purego.Dlsym(handle, name)
+		if err != nil {
+			return fmt.Errorf("resolve CoreGraphics symbol %s: %w", name, err)
+		}
+		purego.RegisterFunc(target, symbol)
+		return nil
+	}
+	required := []struct {
+		target any
+		name   string
+	}{
+		{&api.getActiveDisplayList, "CGGetActiveDisplayList"},
+		{&api.displayBounds, "CGDisplayBounds"},
+		{&api.windowListCreateImage, "CGWindowListCreateImage"},
+		{&api.imageRelease, "CGImageRelease"},
+		{&api.colorSpaceCreateDeviceRGB, "CGColorSpaceCreateDeviceRGB"},
+		{&api.colorSpaceRelease, "CGColorSpaceRelease"},
+		{&api.bitmapContextCreate, "CGBitmapContextCreate"},
+		{&api.bitmapContextGetData, "CGBitmapContextGetData"},
+		{&api.contextRelease, "CGContextRelease"},
+		{&api.contextTranslateCTM, "CGContextTranslateCTM"},
+		{&api.contextScaleCTM, "CGContextScaleCTM"},
+		{&api.contextDrawImage, "CGContextDrawImage"},
+	}
+	for _, function := range required {
+		if err := bind(function.target, function.name); err != nil {
+			_ = api.close()
+			return nil, errors.Join(ErrNotSupported, err)
+		}
+	}
+	if symbol, err := purego.Dlsym(handle, "CGPreflightScreenCaptureAccess"); err == nil {
+		purego.RegisterFunc(&api.preflightCaptureAccess, symbol)
+	}
+	return api, nil
+}
+
+func pureGoPlatformCaptureCapabilities() (FeatureCapability, FeatureCapability) {
+	const backend = featureBackendPureGoCoreGraphics
+	capture := FeatureCapability{Backend: backend}
+	bounds := FeatureCapability{Backend: backend}
+	api, err := openDarwinGraphics()
+	if err != nil {
+		capture.Reason = err.Error()
+		capture.Notes = ErrNotSupported.Error()
+		bounds.Reason = capture.Reason
+		bounds.Notes = capture.Notes
+		return capture, bounds
+	}
+	defer func() { _ = api.close() }()
+	count, err := darwinDisplayCount(api)
+	if err != nil || count == 0 {
+		if err != nil {
+			capture.Reason = err.Error()
+		} else {
+			capture.Reason = "CoreGraphics reports no active displays"
+		}
+		capture.Notes = "an active macOS GUI session is required"
+		bounds.Reason = capture.Reason
+		bounds.Notes = capture.Notes
+		return capture, bounds
+	}
+	bounds.Available = true
+	bounds.Reason = "CoreGraphics display enumeration is available"
+	bounds.Notes = fmt.Sprintf("active displays=%d", count)
+	if api.preflightCaptureAccess != nil && !api.preflightCaptureAccess() {
+		capture.Reason = ErrPermissionDenied.Error()
+		capture.Notes = "grant Screen Recording access to this application in System Settings"
+		return capture, bounds
+	}
+	capture.Available = true
+	capture.Reason = "CoreGraphics capture is available without CGO"
+	capture.Notes = "Screen Recording permission is granted or cannot be preflighted on this macOS version"
+	return capture, bounds
+}
+
+func platformDisplayCount() int {
+	api, err := openDarwinGraphics()
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = api.close() }()
+	count, err := darwinDisplayCount(api)
+	if err != nil {
+		return 0
+	}
+	return count
+}
+
+func platformDisplayBounds(displayIndex int) image.Rectangle {
+	api, err := openDarwinGraphics()
+	if err != nil {
+		return image.Rectangle{}
+	}
+	defer func() { _ = api.close() }()
+	bounds, err := darwinDisplayBounds(api, displayIndex)
+	if err != nil {
+		return image.Rectangle{}
+	}
+	return bounds
+}
+
+func platformCapture(x, y, width, height int) (*image.RGBA, error) {
+	api, err := openDarwinGraphics()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = api.close() }()
+	return captureDarwinWithAPI(api, image.Rect(x, y, x+width, y+height))
+}
+
+func darwinDisplayCount(api *darwinGraphicsAPI) (int, error) {
+	var count uint32
+	if result := api.getActiveDisplayList(0, nil, &count); result != cgErrorSuccess {
+		return 0, fmt.Errorf("query active displays: CoreGraphics error %d", result)
+	}
+	return int(count), nil
+}
+
+func darwinDisplayBounds(api *darwinGraphicsAPI, displayIndex int) (image.Rectangle, error) {
+	if displayIndex < 0 {
+		return image.Rectangle{}, fmt.Errorf("invalid display index %d", displayIndex)
+	}
+	count, err := darwinDisplayCount(api)
+	if err != nil {
+		return image.Rectangle{}, err
+	}
+	if displayIndex >= count {
+		return image.Rectangle{}, fmt.Errorf("display index %d out of range (active displays: %d)", displayIndex, count)
+	}
+	displays := make([]uint32, count)
+	written := uint32(count)
+	if result := api.getActiveDisplayList(uint32(count), &displays[0], &written); result != cgErrorSuccess {
+		return image.Rectangle{}, fmt.Errorf("list active displays: CoreGraphics error %d", result)
+	}
+	if displayIndex >= int(written) {
+		return image.Rectangle{}, fmt.Errorf("display index %d disappeared during enumeration", displayIndex)
+	}
+	bounds := api.displayBounds(displays[displayIndex])
+	minX := int(math.Floor(bounds.Origin.X))
+	minY := int(math.Floor(bounds.Origin.Y))
+	maxX := int(math.Ceil(bounds.Origin.X + bounds.Size.Width))
+	maxY := int(math.Ceil(bounds.Origin.Y + bounds.Size.Height))
+	result := image.Rect(minX, minY, maxX, maxY)
+	if result.Empty() {
+		return image.Rectangle{}, fmt.Errorf("display %d returned empty bounds", displayIndex)
+	}
+	return result, nil
+}
+
+func captureDarwinWithAPI(api *darwinGraphicsAPI, region image.Rectangle) (*image.RGBA, error) {
+	if region.Empty() {
+		return nil, fmt.Errorf("invalid macOS capture region %v", region)
+	}
+	if api.preflightCaptureAccess != nil && !api.preflightCaptureAccess() {
+		return nil, fmt.Errorf("%w: grant Screen Recording access to this application in System Settings", ErrPermissionDenied)
+	}
+	cgRegion := cgRect{
+		Origin: cgPoint{X: float64(region.Min.X), Y: float64(region.Min.Y)},
+		Size:   cgSize{Width: float64(region.Dx()), Height: float64(region.Dy())},
+	}
+	captured := api.windowListCreateImage(
+		cgRegion,
+		cgWindowListOptionOnScreenOnly,
+		0,
+		cgWindowImageDefault,
+	)
+	if captured == 0 {
+		return nil, errors.New("CoreGraphics returned no screen image; verify Screen Recording permission and an active GUI session")
+	}
+	defer api.imageRelease(captured)
+
+	result := image.NewRGBA(image.Rect(0, 0, region.Dx(), region.Dy()))
+	colorSpace := api.colorSpaceCreateDeviceRGB()
+	if colorSpace == 0 {
+		return nil, errors.New("CoreGraphics could not create an RGB color space")
+	}
+	defer api.colorSpaceRelease(colorSpace)
+	context := api.bitmapContextCreate(
+		nil,
+		uintptr(result.Rect.Dx()),
+		uintptr(result.Rect.Dy()),
+		8,
+		uintptr(result.Stride),
+		colorSpace,
+		cgImageAlphaPremultipliedLast|cgBitmapByteOrder32Big,
+	)
+	if context == 0 {
+		return nil, errors.New("CoreGraphics could not create an RGBA bitmap context")
+	}
+	defer api.contextRelease(context)
+
+	api.contextTranslateCTM(context, 0, float64(result.Rect.Dy()))
+	api.contextScaleCTM(context, 1, -1)
+	api.contextDrawImage(context, cgRect{Size: cgSize{
+		Width:  float64(result.Rect.Dx()),
+		Height: float64(result.Rect.Dy()),
+	}}, captured)
+	data := api.bitmapContextGetData(context)
+	if data == nil {
+		return nil, errors.New("CoreGraphics bitmap context returned no pixel buffer")
+	}
+	copy(result.Pix, unsafe.Slice((*byte)(data), len(result.Pix)))
+	return result, nil
+}

--- a/screen_backend_darwin_nocgo_test.go
+++ b/screen_backend_darwin_nocgo_test.go
@@ -1,0 +1,171 @@
+//go:build darwin && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"image"
+	"testing"
+	"unsafe"
+)
+
+type darwinGraphicsCounters struct {
+	closeCalls        int
+	imageReleaseCalls int
+	colorReleaseCalls int
+	contextCalls      int
+	drawCalls         int
+}
+
+func fakeDarwinGraphics(bounds cgRect, counters *darwinGraphicsCounters) *darwinGraphicsAPI {
+	var bitmapData []byte
+	return &darwinGraphicsAPI{
+		close:                  func() error { counters.closeCalls++; return nil },
+		preflightCaptureAccess: func() bool { return true },
+		getActiveDisplayList: func(max uint32, displays *uint32, count *uint32) int32 {
+			*count = 1
+			if max > 0 && displays != nil {
+				*displays = 42
+			}
+			return cgErrorSuccess
+		},
+		displayBounds:         func(uint32) cgRect { return bounds },
+		windowListCreateImage: func(cgRect, uint32, uint32, uint32) uintptr { return 11 },
+		imageRelease:          func(uintptr) { counters.imageReleaseCalls++ },
+		colorSpaceCreateDeviceRGB: func() uintptr {
+			return 12
+		},
+		colorSpaceRelease: func(uintptr) { counters.colorReleaseCalls++ },
+		bitmapContextCreate: func(data unsafe.Pointer, width, height, _ uintptr, bytesPerRow uintptr, _ uintptr, _ uint32) uintptr {
+			if data != nil {
+				return 0
+			}
+			bitmapData = make([]byte, int(height*bytesPerRow))
+			for offset := 0; offset < len(bitmapData); offset += 4 {
+				bitmapData[offset], bitmapData[offset+1], bitmapData[offset+2], bitmapData[offset+3] = 1, 2, 3, 255
+			}
+			if width == 0 || height == 0 {
+				return 0
+			}
+			return 13
+		},
+		bitmapContextGetData: func(uintptr) unsafe.Pointer {
+			if len(bitmapData) == 0 {
+				return nil
+			}
+			return unsafe.Pointer(&bitmapData[0])
+		},
+		contextRelease:      func(uintptr) { counters.contextCalls++ },
+		contextTranslateCTM: func(uintptr, float64, float64) {},
+		contextScaleCTM:     func(uintptr, float64, float64) {},
+		contextDrawImage:    func(uintptr, cgRect, uintptr) { counters.drawCalls++ },
+	}
+}
+
+func TestCaptureDarwinWithAPIProducesOwnedRGBA(t *testing.T) {
+	counters := &darwinGraphicsCounters{}
+	api := fakeDarwinGraphics(cgRect{}, counters)
+	img, err := captureDarwinWithAPI(api, image.Rect(-2, 4, 1, 6))
+	if err != nil {
+		t.Fatalf("captureDarwinWithAPI error: %v", err)
+	}
+	if img.Bounds() != image.Rect(0, 0, 3, 2) {
+		t.Fatalf("bounds = %v, want 3x2 zero-origin image", img.Bounds())
+	}
+	if got := img.RGBAAt(0, 0); got.R != 1 || got.G != 2 || got.B != 3 || got.A != 255 {
+		t.Fatalf("pixel = %#v, want RGBA(1,2,3,255)", got)
+	}
+	if counters.imageReleaseCalls != 1 || counters.colorReleaseCalls != 1 || counters.contextCalls != 1 || counters.drawCalls != 1 {
+		t.Fatalf("resource counters = %+v, want every CoreGraphics object released once", counters)
+	}
+}
+
+func TestCaptureDarwinWithAPIReportsPermissionDenial(t *testing.T) {
+	counters := &darwinGraphicsCounters{}
+	api := fakeDarwinGraphics(cgRect{}, counters)
+	api.preflightCaptureAccess = func() bool { return false }
+	imageCalls := 0
+	api.windowListCreateImage = func(cgRect, uint32, uint32, uint32) uintptr {
+		imageCalls++
+		return 0
+	}
+	_, err := captureDarwinWithAPI(api, image.Rect(0, 0, 1, 1))
+	if !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("error = %v, want ErrPermissionDenied", err)
+	}
+	if imageCalls != 0 {
+		t.Fatalf("capture calls = %d, want permission denial before capture", imageCalls)
+	}
+}
+
+func TestDarwinDisplayBoundsUseEnclosingEdges(t *testing.T) {
+	counters := &darwinGraphicsCounters{}
+	api := fakeDarwinGraphics(cgRect{
+		Origin: cgPoint{X: -10.25, Y: 20.5},
+		Size:   cgSize{Width: 30.5, Height: 40.25},
+	}, counters)
+	bounds, err := darwinDisplayBounds(api, 0)
+	if err != nil {
+		t.Fatalf("darwinDisplayBounds error: %v", err)
+	}
+	if want := image.Rect(-11, 20, 21, 61); bounds != want {
+		t.Fatalf("bounds = %v, want %v", bounds, want)
+	}
+	if _, err := darwinDisplayBounds(api, 1); err == nil {
+		t.Fatal("out-of-range display index unexpectedly succeeded")
+	}
+}
+
+func TestPureGoDarwinCaptureEntryPoint(t *testing.T) {
+	previous := openDarwinGraphics
+	counters := &darwinGraphicsCounters{}
+	openDarwinGraphics = func() (*darwinGraphicsAPI, error) {
+		return fakeDarwinGraphics(cgRect{Size: cgSize{Width: 3, Height: 2}}, counters), nil
+	}
+	t.Cleanup(func() { openDarwinGraphics = previous })
+
+	img, err := Capture()
+	if err != nil {
+		t.Fatalf("Capture error: %v", err)
+	}
+	if img.Bounds() != image.Rect(0, 0, 3, 2) {
+		t.Fatalf("Capture bounds = %v, want 3x2", img.Bounds())
+	}
+	if counters.closeCalls != 2 {
+		t.Fatalf("CoreGraphics close calls = %d, want bounds and capture handles closed", counters.closeCalls)
+	}
+}
+
+func TestPureGoDarwinCapabilitiesSeparateBoundsFromPermission(t *testing.T) {
+	previous := openDarwinGraphics
+	counters := &darwinGraphicsCounters{}
+	openDarwinGraphics = func() (*darwinGraphicsAPI, error) {
+		api := fakeDarwinGraphics(cgRect{Size: cgSize{Width: 3, Height: 2}}, counters)
+		api.preflightCaptureAccess = func() bool { return false }
+		return api, nil
+	}
+	t.Cleanup(func() { openDarwinGraphics = previous })
+
+	capture, bounds := pureGoPlatformCaptureCapabilities()
+	if capture.Available || capture.Backend != featureBackendPureGoCoreGraphics || capture.Reason != ErrPermissionDenied.Error() {
+		t.Fatalf("capture capability = %+v, want explicit permission denial", capture)
+	}
+	if !bounds.Available || bounds.Backend != featureBackendPureGoCoreGraphics {
+		t.Fatalf("bounds capability = %+v, want available CoreGraphics bounds", bounds)
+	}
+	if counters.closeCalls != 1 {
+		t.Fatalf("CoreGraphics close calls = %d, want 1", counters.closeCalls)
+	}
+}
+
+func BenchmarkDarwinCapturePipeline(b *testing.B) {
+	counters := &darwinGraphicsCounters{}
+	api := fakeDarwinGraphics(cgRect{}, counters)
+	region := image.Rect(0, 0, 640, 480)
+	b.ReportAllocs()
+	for range b.N {
+		if _, err := captureDarwinWithAPI(api, region); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/screen_backend_screenshot.go
+++ b/screen_backend_screenshot.go
@@ -1,0 +1,17 @@
+//go:build cgo || !darwin
+
+package robotgo
+
+import (
+	"image"
+
+	"github.com/vcaesar/screenshot"
+)
+
+func platformDisplayBounds(displayIndex int) image.Rectangle {
+	return screenshot.GetDisplayBounds(displayIndex)
+}
+
+func platformCapture(x, y, width, height int) (*image.RGBA, error) {
+	return screenshot.Capture(x, y, width, height)
+}

--- a/screen_backend_screenshot_nocgo.go
+++ b/screen_backend_screenshot_nocgo.go
@@ -1,0 +1,9 @@
+//go:build !cgo && !darwin
+
+package robotgo
+
+import "github.com/vcaesar/screenshot"
+
+func platformDisplayCount() int {
+	return screenshot.NumActiveDisplays()
+}


### PR DESCRIPTION
## Goal

Advance Phase 3 with a useful, explicit non-CGO capture backend on macOS while preserving native defaults and cross-platform contracts.

## Changes

- add a Pure-Go CoreGraphics capture and display-bounds backend for darwin/amd64 and darwin/arm64
- preflight Screen Recording permission without prompting and return ErrPermissionDenied with remediation
- keep CoreGraphics and dynamic-library ownership deterministic, without retaining Go memory in native code
- add platform-neutral build and feature capability diagnostics
- add non-CGO pixel-color parity through the selected capture backend
- add hermetic CoreGraphics pixel, bounds, permission, error, and cleanup tests
- add runtime and conversion benchmark harnesses plus a runnable capability example
- update README, TEST guide, examples index, Wayland status, and product roadmap

## Backend policy

- no existing CGO default is changed
- macOS non-CGO uses CoreGraphics
- Windows and X11 retain the existing Pure-Go screenshot path
- Wayland non-CGO retains the hardened Screenshot portal path
- unavailable backends and permissions return explicit errors

## Validation

- go test -count=1 ./...
- CGO_ENABLED=0 go test -count=1 ./...
- go test -race -count=1 ./...
- go vet ./...
- CGO_ENABLED=0 go vet ./...
- golangci-lint run --timeout=5m ./...
- govulncheck ./...
- go test -count=1 -tags wayland ./...
- portal, Wayland screencopy, and DRM targeted suites
- non-CGO cross-compilation for darwin/arm64, darwin/amd64, and windows/amd64
- GitHub Actions push and PR matrices: all 11 jobs green, including execution on hosted macOS runners in CGO and non-CGO modes

## Risk and non-blocking follow-up

CoreGraphics screen capture remains subject to macOS Screen Recording consent. Hosted CI validates framework loading, ABI, hermetic behavior, error contracts, and both macOS build modes, but it cannot provide an interactive permission grant.

A real native-vs-Pure-Go capture benchmark from an authorized macOS GUI session is explicitly non-blocking for this PR because no existing default backend changes here. Record that evidence through a future contributor or temporary authorized runner before considering any default switch. The included benchmark harness documents the exact reproducible commands.