### PR TITLE
feat(input): add Pure-Go X11 input parity

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,3 +6,4 @@ self-hosted-runner:
     - wlroots
 config-variables:
   - ROBOTGO_REMOTE_DESKTOP_E2E
+  - ROBOTGO_SCREENCAST_E2E

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -76,8 +76,10 @@ jobs:
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
       - name: Add golangci-lint to PATH
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Run golangci-lint
+      - name: Run golangci-lint for CGO build
         run: CGO_ENABLED=1 golangci-lint run --timeout=5m ./...
+      - name: Run golangci-lint for Pure-Go build
+        run: CGO_ENABLED=0 golangci-lint run --timeout=5m ./...
   test:
     # name: build
     strategy:
@@ -141,12 +143,18 @@ jobs:
         if: runner.os == 'Linux'
         env:
           CGO_ENABLED: "0"
+          ROBOTGO_REQUIRE_X11_INTEGRATION: "1"
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xvfb xauth
-          xvfb-run -a -s "-screen 0 1280x720x24 -nolisten tcp" \
-            env -u WAYLAND_DISPLAY go test -tags x11integration \
-            -run '^TestPureGoX11' -count=1 -timeout=30s -v .
+          sudo apt-get install -y --no-install-recommends \
+            xvfb xauth x11-xkb-utils libxkbcommon-tools
+          xvfb-run -a -s "-screen 0 1280x720x24 -nolisten tcp -noreset" \
+            sh -eu -c '
+              setxkbmap -layout us,de
+              env -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE \
+                go test -tags x11integration \
+                -run "^TestPureGoX11" -count=1 -timeout=30s -v .
+            '
   ocr:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -137,6 +137,16 @@ jobs:
         env:
           CGO_ENABLED: "0"
         run: go test -tags ocr ./...
+      - name: Test Pure-Go X11 input with Xvfb
+        if: runner.os == 'Linux'
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xvfb xauth
+          xvfb-run -a -s "-screen 0 1280x720x24 -nolisten tcp" \
+            env -u WAYLAND_DISPLAY go test -tags x11integration \
+            -run '^TestPureGoX11' -count=1 -timeout=30s -v .
   ocr:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Respect current tag split and do not collapse platform boundaries:
 - `linux && wayland && test`: tagged Wayland capture/DRM test paths
 - `linux && wayland && integration`: integration suites requiring compositor setup
 - `cgo && linux && waylandint`: keyboard integration harness
+- `linux && !cgo && x11integration`: Pure-Go X11/XTEST input integration suite
 
 Rules:
 
@@ -132,6 +133,7 @@ Common targeted suites:
 3. `go test -tags "wayland test" . -run TestDrmFindRenderNode -v`
 4. `go test -tags "wayland integration" ./mouse ./window -v`
 5. `go test -tags "waylandint" ./key -run TestWaylandUnicodeTypingIntegration -v`
+6. `CGO_ENABLED=0 ROBOTGO_REQUIRE_X11_INTEGRATION=1 xvfb-run -a -s "-screen 0 1280x720x24 -nolisten tcp -noreset" sh -eu -c 'setxkbmap -layout us,de; env -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE go test -tags x11integration -run "^TestPureGoX11" -count=1 -timeout=30s -v .'`
 
 Wayland-related code changes should include at least one of:
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Current technical differences include:
   with partial operations reported honestly instead of universal support being
   implied.
 - A defined non-CGO contract: Pure-Go capture is available through CoreGraphics
-  on macOS, native APIs on Windows, and X11; Wayland capture uses the
-  consent-aware Screenshot portal, and unavailable GUI operations return
-  `ErrNotSupported` rather than plausible zero values.
+  on macOS, native APIs on Windows, and X11. Linux/X11 additionally has an XTEST
+  keyboard/pointer backend; Wayland capture uses the consent-aware Screenshot
+  portal, and unavailable GUI operations return `ErrNotSupported` rather than
+  plausible zero values.
 - Hermetic portal/compositor tests, tagged Wayland integration suites, and CI
   coverage for Linux, macOS, Windows, Wayland, portal, lint, and non-CGO modes.
 - Open, auditable native and Go backend code, including explicit resource
@@ -75,8 +76,9 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture and display bounds with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
+| Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds plus XTEST mouse, keyboard, text/Unicode, pointer-location, smooth-move/drag, scroll, and live readiness probes |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |
-| Other supported platforms without CGO | `CGO_ENABLED=0` | Pure-Go capture works on Windows and Linux/X11; Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
+| Other supported platforms without CGO | `CGO_ENABLED=0` | Pure-Go capture works on macOS and Windows; Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
 
 Wayland compositors intentionally restrict global automation. GNOME and KDE can
 use consent-aware Screenshot and RemoteDesktop portal paths. The explicit
@@ -93,8 +95,8 @@ Persistent capture runtime evidence is tracked separately in the
 
 - Go 1.25 or newer, matching [`go.mod`](go.mod).
 - A CGO-compatible C toolchain for the full native desktop-automation feature
-  set. The explicitly started Linux RemoteDesktop portal subset also works in a
-  non-CGO build.
+  set. Pure-Go Linux/X11 capture/input and the explicitly started Linux
+  RemoteDesktop portal subset work in a non-CGO build.
 - Platform development libraries for the selected backend.
 
 ### macOS
@@ -218,6 +220,10 @@ Legacy APIs remain available for source compatibility. Their signatures may be
 unable to report all backend failures, so new reliability-sensitive code should
 use variants such as `MoveE`, `MoveRelativeE`, `ClickE`, `ScrollE`, `LocationE`,
 `TypeStrE`, `UnicodeTypeE`, and the error-returning window APIs.
+`KeyTap` and `KeyToggle` model keys rather than portable text entry. A selected
+backend may support a single non-ASCII rune directly (the RemoteDesktop portal
+and Pure-Go X11 do), while another native keymap can return `ErrNotSupported`.
+Use `TypeStrE` or `UnicodeTypeE` when the intent is text input.
 
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,
@@ -253,6 +259,43 @@ go build ./...
 An X11 session requires `DISPLAY` and an accessible X server. RobotGo does not
 silently route a Wayland-primary operation through X11 merely because Xwayland
 is present.
+
+Linux/X11 also supports capture, bounds, and input without a C compiler or X11
+development headers:
+
+```bash
+CGO_ENABLED=0 go build ./...
+```
+
+The input backend requires a reachable X server with XTEST 2.2 or newer. It
+supports the high-level mouse/keyboard error APIs, text and Unicode, smooth
+movement/drag, scroll, pointer location, and live
+`KeyboardReady`/`MouseReady` probes. Pure-Go X11 scroll calls are bounded to
+1,000 steps per axis. XTEST input is global; process-target (`pid`) arguments
+are rejected explicitly.
+Single-character keys are tap-only; persistent key state requires a named key.
+Persistent pointer-button toggles are limited to core X11 buttons 1–5; use
+`ScrollE` for wheel input.
+`GetRuntimeCapabilities` reports the selected `pure-go-x11` backend.
+Key taps without an unambiguous active mapping and text use a bounded pool of
+originally unmapped X11 keycodes so delayed XKB clients still decode input
+correctly. If one connection exhausts that server-dependent pool of distinct
+symbols, the operation fails before injecting more input. Call
+`CloseMainDisplayE` only after targets have processed all prior keyboard input
+to restore the mappings, verify cleanup, and reset the pool. Place that call in
+a scope whose lifetime includes any delayed target processing. These mappings
+are server-global: omitting cleanup or terminating abnormally can leave the
+formerly unused keycodes mapped until the X11 keymap is reset. A later RobotGo
+operation reconnects lazily. In a Wayland-primary session the backend remains
+disabled, even when `DISPLAY` points to Xwayland.
+If cleanup reports that a scratch keycode is pressed or became a modifier,
+release or restore that external state and retry `CloseMainDisplayE`.
+
+RobotGo briefly grabs the X server around mapping/state checks and composite
+synthetic events so another X client cannot race those transactions. Core X11
+cannot attribute simultaneous physical input, or another press while RobotGo
+intentionally holds a key/button; state ownership in those cases remains
+best-effort. Avoid mixing automation with concurrent human or synthetic input.
 
 Error-returning window APIs no longer report success for native operations that
 have no implementation. In particular, the current X11 minimize/maximize path
@@ -403,8 +446,15 @@ caps := robotgo.GetRuntimeCapabilities()
 fmt.Println("capture:", caps.Capture.Available, caps.Capture.Backend, caps.Capture.Reason)
 fmt.Println("bounds:", caps.Bounds.Available, caps.Bounds.Backend, caps.Bounds.Reason)
 fmt.Println("keyboard:", caps.Keyboard.Available, caps.Keyboard.Backend, caps.Keyboard.Reason)
+fmt.Println("mouse:", caps.Mouse.Available, caps.Mouse.Backend, caps.Mouse.Reason)
 fmt.Println("process:", caps.Process.Available, caps.Process.Backend)
 ```
+
+On Linux/X11 with `CGO_ENABLED=0`, capability inspection reports the selected
+`pure-go-x11` keyboard and mouse backends without opening an X connection. Call
+`KeyboardReady` or `MouseReady` for a live XTEST 2.2+ check before acting. A
+Wayland-primary session never selects that backend merely because an Xwayland
+`DISPLAY` is present.
 
 In a `CGO_ENABLED=0` build, `Capture`, `CaptureImg`, `CaptureScreen`,
 `CaptureGo`, `CaptureBitmapStr`, `GetPixelColor`, and `GetPxColor` use the
@@ -453,6 +503,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Full-screen capture with backend reporting](examples/screen_full/main.go)
 - [Linux capabilities](examples/linux_capabilities/main.go)
 - [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
+- [Pure-Go X11 input probe and opt-in demo](examples/purego_x11_input/main.go)
 - [Consent-aware RemoteDesktop portal input](examples/remote_desktop_input/main.go)
 - [Persistent ScreenCast/PipeWire capture](examples/screencast_capture/main.go)
 - [Window and process helpers](examples/window/main.go)
@@ -460,6 +511,18 @@ The checked-in examples use this fork's module path and track the current API:
 
 Examples perform real desktop actions. Read them before running them, especially
 the window/process example, which can close windows or terminate processes.
+The Pure-Go X11 example is safe to run as capability inspection by default; it
+performs global input only when both `-act` and an explicit action are supplied:
+
+```bash
+CGO_ENABLED=0 go run ./examples/purego_x11_input
+CGO_ENABLED=0 go run ./examples/purego_x11_input -act -move 100,100
+CGO_ENABLED=0 go run ./examples/purego_x11_input -act -key enter
+CGO_ENABLED=0 go run ./examples/purego_x11_input -act -text "Hello"
+```
+
+Keyboard actions keep scratch mappings alive for two seconds before verified
+cleanup. Increase `-settle` when the focused XKB client may process input later.
 
 ## Testing
 
@@ -470,6 +533,13 @@ go test ./...
 CGO_ENABLED=0 go test ./...
 go test -race ./input/portal
 ```
+
+Linux Pure-Go X11 input has a non-skipping Xvfb/XTEST CI test. It uses `us,de`
+layouts and fails its Linux non-CGO CI leg instead of skipping when the X11
+runtime is missing; see
+[the testing guide](TEST.md#x11integration-pure-go-x11-input) for the exact
+command and prerequisites. Protecting the resulting remote check remains a
+roadmap exit criterion.
 
 Wayland and portal code has additional tagged suites:
 
@@ -495,9 +565,11 @@ Real Wayland input results are tracked in the
 - [Product roadmap](docs/plan/product-roadmap.md)
 - [Wayland implementation history](docs/wayland-history.md)
 
-The active product priority is validating the explicit RemoteDesktop high-level
-fallback on real GNOME/KDE runtimes while retaining native virtual-input paths
-on wlroots compositors.
+The active product slice is Phase 3: hardening and measuring selective Pure-Go
+backends. Linux/X11 input is implemented and covered in CI; native-vs-Pure-Go
+behavioral and benchmark evidence is still required before any default backend
+switch. Real GNOME/KDE/wlroots validation remains an independent Wayland release
+gate.
 
 ## Upstream and attribution
 

--- a/TEST.md
+++ b/TEST.md
@@ -220,6 +220,33 @@ Prerequisites:
 Status:
 - Experimental tag. Keep this isolated from default CI until the broader Wayland-tagged compile path is fully stabilized in all environments.
 
+### `x11integration` (Pure-Go X11 input)
+
+Purpose:
+
+- Black-box validation of the Linux X11 input backend with `CGO_ENABLED=0`
+- Independent pointer-position checks through XGB
+- Real keyboard, pointer-button, and scroll delivery to a mapped X11 window
+- Capability/readiness probes plus deterministic `CloseMainDisplay` reconnect
+
+Command:
+
+```bash
+CGO_ENABLED=0 xvfb-run -a -s "-screen 0 1280x720x24 -nolisten tcp" \
+  env -u WAYLAND_DISPLAY go test -tags "x11integration" \
+  -run '^TestPureGoX11' -count=1 -timeout=30s -v .
+```
+
+Prerequisites:
+
+- Linux
+- `CGO_ENABLED=0`
+- An X11 server with the XTEST extension; `xvfb` and `xauth` are sufficient
+
+The suite skips cleanly when `DISPLAY` or XTEST is unavailable. The Linux
+non-CGO CI job runs it under Xvfb as a blocking gate, so a skip is not expected
+there.
+
 ## Useful Environment Variables
 
 - `WAYLAND_DISPLAY`

--- a/TEST.md
+++ b/TEST.md
@@ -22,12 +22,25 @@ CGO_ENABLED=0 go test -tags "ocr" ./...
 go test -tags "ocr" ./...
 ```
 
+Both build variants are blocking linter targets as well:
+
+```bash
+CGO_ENABLED=1 golangci-lint run --timeout=5m ./...
+CGO_ENABLED=0 golangci-lint run --timeout=5m ./...
+```
+
 The non-CGO suite runs on Linux, macOS, and Windows in CI. It also verifies
 runtime build/feature introspection, pixel-color parity, and hermetic Pure-Go
 capture dispatch for CoreGraphics, X11, Windows, and the Wayland screenshot
 portal. macOS tests use fake CoreGraphics bindings for deterministic permission,
 pixel, bounds, and resource-lifecycle coverage; they do not require a Screen
 Recording grant.
+
+Linux CI additionally runs the non-CGO X11 input backend against a real Xvfb
+server with XTEST 2.2 or newer and `us,de` keyboard layouts. That integration test is
+non-optional within the Linux non-CGO matrix leg: missing runtime prerequisites
+fail that leg rather than turning the test into a successful skip. Repository
+branch protection does not yet require the resulting remote check.
 
 Opt-in macOS runtime capture benchmark:
 
@@ -225,27 +238,47 @@ Status:
 Purpose:
 
 - Black-box validation of the Linux X11 input backend with `CGO_ENABLED=0`
-- Independent pointer-position checks through XGB
-- Real keyboard, pointer-button, and scroll delivery to a mapped X11 window
-- Capability/readiness probes plus deterministic `CloseMainDisplay` reconnect
+- Independent pointer-position checks and real motion, drag, button, and scroll
+  delivery through XGB/XTEST
+- Named-key toggles plus exact text/Unicode mapping under a multi-layout
+  `us,de` keymap, including a separately focused, deliberately delayed
+  `xkbcli` target and deterministic mapping restoration
+- Preservation of keys and pointer buttons held by another X11 client
+- Event-drain stress coverage plus deterministic owned-input release,
+  error-reporting `CloseMainDisplayE`, mapping restoration, and lazy reconnect
+- Side-effect-free capability selection plus explicit readiness probes against
+  the live X server
+- Adversarial replacement of a reserved mapping before injection; the default
+  non-CGO unit suite separately covers modifier-map exclusion and bounded-scroll
+  validation
 
 Command:
 
 ```bash
-CGO_ENABLED=0 xvfb-run -a -s "-screen 0 1280x720x24 -nolisten tcp" \
-  env -u WAYLAND_DISPLAY go test -tags "x11integration" \
-  -run '^TestPureGoX11' -count=1 -timeout=30s -v .
+CGO_ENABLED=0 ROBOTGO_REQUIRE_X11_INTEGRATION=1 \
+  xvfb-run -a -s "-screen 0 1280x720x24 -nolisten tcp -noreset" \
+  sh -eu -c '
+    setxkbmap -layout us,de
+    env -u WAYLAND_DISPLAY -u XDG_SESSION_TYPE \
+      go test -tags "x11integration" \
+      -run "^TestPureGoX11" -count=1 -timeout=30s -v .
+  '
 ```
 
 Prerequisites:
 
 - Linux
 - `CGO_ENABLED=0`
-- An X11 server with the XTEST extension; `xvfb` and `xauth` are sufficient
+- An X11 server with XTEST 2.2 or newer
+- `xvfb`, `xauth`, `setxkbmap` (Debian/Ubuntu package `x11-xkb-utils`),
+  `xkbcli` (`libxkbcommon-tools`), and `stdbuf` (`coreutils`)
 
-The suite skips cleanly when `DISPLAY` or XTEST is unavailable. The Linux
-non-CGO CI job runs it under Xvfb as a blocking gate, so a skip is not expected
-there.
+Without `ROBOTGO_REQUIRE_X11_INTEGRATION=1`, the suite skips cleanly when
+`DISPLAY` or XTEST is unavailable. The Linux non-CGO CI job sets that variable,
+configures both layouts, and treats an unavailable or misconfigured X11 runtime
+as a failure. The tagged suite verifies the active `us,de` layout itself; the
+default non-CGO unit suite separately proves that a Wayland-primary session
+never selects this backend through implicit Xwayland.
 
 ## Useful Environment Variables
 
@@ -269,6 +302,9 @@ there.
   - Opt-in for sway active-window title E2E integration (`GetTitleE`).
 - `ROBOTGO_HYPRLAND_TITLE_E2E=1`
   - Opt-in for hyprland active-window title E2E integration (`GetTitleE`).
+- `ROBOTGO_REQUIRE_X11_INTEGRATION=1`
+  - Makes missing `DISPLAY` or XTEST support fail the Pure-Go X11 integration
+    suite; CI always enables it.
 
 ## Recommended Local Sequence
 
@@ -281,7 +317,8 @@ go test -tags "pipewire" ./screen/portal -v
 go test -tags "wayland integration" . ./mouse ./window -v
 ```
 
-Run tag-gated suites as needed for the area you changed.
+Run tag-gated suites as needed for the area you changed. Pure-Go X11 input
+changes must also run the required `x11integration` command above.
 
 ## Sequential Crash-Tracking Run (No Parallelism)
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -22,6 +22,11 @@
 
 # Keys
 
+`KeyTap` and `KeyToggle` model physical or named keys. Single-rune Unicode
+keysyms are supported by the RemoteDesktop portal and Pure-Go X11 backend, but
+native keymaps may return `robotgo.ErrNotSupported` when no matching key exists.
+Use `TypeStrE` or `UnicodeTypeE` for portable text entry.
+
 ```Go
 	"A-Z a-z 0-9"
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -22,20 +22,20 @@ The July 2026 hardening work establishes the foundation for this roadmap:
   session environment variables alone.
 - Mouse, keyboard, capture, and window operations expose explicit errors where
   legacy APIs previously could hide unsupported behavior.
-- Non-CGO builds compile and return `ErrNotSupported` for native GUI operations;
-  the explicitly authorized RemoteDesktop portal is the first tested Pure-Go
-  input backend.
+- Non-CGO builds provide supported capture backends, explicit RemoteDesktop
+  portal input on Wayland, and an XGB/XTEST input backend for X11-primary Linux
+  sessions; remaining unavailable GUI operations return `ErrNotSupported`.
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
   Weston integration, race, and vet variants.
 
-## Execution Status (2026-07-14)
+## Execution Status (2026-07-15)
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
-| Current baseline | Complete in branch | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Confirm new CI jobs on remote branch |
+| Current baseline | Complete in branch | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Confirm all required jobs after the branch is pushed and protect them |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
-| 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and blocking geometry/transform matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | Cross-platform capture active | Build and feature-level introspection plus non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture, permission/error contracts, hermetic parity tests, runtime benchmark harness, and a three-OS CI matrix | Record native-vs-Pure-Go runtime benchmark evidence and evaluate further backends selectively |
+| 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
+| 3. Pure-Go | Partial: capture plus Linux/X11 input active | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Linux/X11 XGB/XTEST input; permission/error contracts; hermetic parity tests; runtime benchmark harness; three-OS CI; non-skipping multi-layout Xvfb input test in Linux CI | Protect the remote CI check, record native-vs-Pure-Go behavioral and runtime benchmark evidence, then evaluate further backends selectively; no default switch is justified yet |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -99,10 +99,10 @@ exposes stream/restore metadata, and provides hermetic plus opt-in runtime
 tests. Native readiness is bounded, PipeWire initialization is balanced, and
 idle sessions do not convert unrequested frames. `CaptureScreen` can reuse the active session after native
 screencopy failure or select it explicitly. Output geometry, scale, and
-transform handling now share enclosing-edge crop semantics and have a blocking
-hermetic matrix for negative output origins, fractional scale, clipped regions,
-overflow boundaries, and all eight transforms. The complete real-compositor
-matrix is still required by this phase.
+transform handling now share enclosing-edge crop semantics and have a
+non-skipping hermetic CI matrix for negative output origins, fractional scale,
+clipped regions, overflow boundaries, and all eight transforms. The complete
+real-compositor matrix is still required by this phase.
 
 Exit criteria:
 
@@ -132,12 +132,32 @@ unsupported errors. `GetRuntimeBackendInfo` reports build facts without probes,
 while `GetRuntimeCapabilities` reports feature backends, permission state,
 fallbacks, and actionable reasons without opening consent dialogs. `Capture`,
 `CaptureImg`, `CaptureScreen`, `CaptureGo`, `CaptureBitmapStr`, and the pixel
-color APIs provide non-CGO capture through CoreGraphics on macOS, native
-Windows/X11 paths, and the hardened screenshot portal on Wayland. macOS display
-enumeration, Screen Recording preflight, RGBA conversion, and CoreGraphics
-ownership are covered hermetically on both supported architectures. Runtime
-benchmark harnesses are present; recorded native-vs-Pure-Go evidence is still
-required before any default backend switch.
+color APIs provide non-CGO capture through CoreGraphics on macOS, Windows and
+X11 screenshot paths, and the hardened screenshot portal on Wayland. macOS
+display enumeration, Screen Recording preflight, RGBA conversion, and
+CoreGraphics ownership are covered hermetically on both supported
+architectures.
+
+Linux/X11 additionally has a Pure-Go XGB/XTEST keyboard and pointer backend for
+the error-returning input APIs, text/Unicode, pointer location, smooth
+movement/drag, scroll, live readiness probes, and deterministic connection and
+owned-input cleanup. Backend selection requires an X11-primary session and
+never treats Xwayland as an implicit Wayland fallback. An Xvfb CI test
+uses `us,de` layouts to exercise exact Unicode mappings, real input delivery,
+an independently delayed XKB target, foreign input-state preservation,
+event-drain stress, cleanup, and reconnect.
+The runnable example inspects selected capabilities without opening X11 by
+default and requires an explicit `-act` flag before it runs live readiness
+checks or injects global input.
+
+Phase 3 remains partial. Runtime benchmark harnesses are present, but recorded
+native-vs-Pure-Go behavioral and performance evidence is still required before
+any default backend switch or broader backend port. The non-CGO backend itself
+cannot currently run under Go's CGO-dependent Linux race detector; its
+concurrency stress tests remain mandatory while extracting the X11 core into a
+race-testable internal package is tracked. A scoped keyboard-input lifecycle (or
+equivalent crash-safe cleanup strategy) is also still needed to eliminate the
+server-global scratch-mapping risk after abnormal process termination.
 
 Exit criteria:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -17,6 +17,11 @@ Current implementation baseline:
 - Platform-neutral feature introspection is available via
   `GetRuntimeCapabilities`; macOS non-CGO builds report CoreGraphics capture,
   display bounds, and Screen Recording permission state without prompting.
+- Linux/X11 non-CGO builds provide a Pure-Go XGB/XTEST keyboard and pointer
+  backend with live readiness probes, text/Unicode, smooth movement/drag,
+  scrolling, pointer location, explicit state errors, and deterministic
+  cleanup/reconnect. It is selected only for X11-primary sessions and never as
+  an implicit Xwayland fallback from Wayland.
 - Non-CGO `CaptureImg`/`CaptureScreen`, their Go-bitmap/string variants, and
   pixel-color queries use the hardened screenshot portal on Wayland and the
   Pure-Go screenshot backend on X11/Windows; unsupported targets fail explicitly.
@@ -92,7 +97,10 @@ Window backend support matrix (current):
     fractional scale, transforms, portal consent, and fallback.
     `[new vs robotgo-pro]`
   - 5. Selectively port useful Pure-Go backends with behavioral parity tests,
-    backend introspection, and benchmarks before changing defaults.
+    backend introspection, and benchmarks before changing defaults. Linux/X11
+    input is implemented and covered by a non-skipping multi-layout Xvfb/XTEST
+    CI test; protecting its remote check, native-vs-Pure-Go benchmark evidence,
+    and any default switch remain open.
   - 6. Publish versioned compatibility data and expand diagnostics with
     protocol versions, permissions, and actionable remediation.
   - 7. Promote race/vet and native leak/sanitizer checks to blocking release
@@ -108,7 +116,7 @@ Window backend support matrix (current):
   - `GetLinuxCapabilities` reports hook/event status explicitly.
 
 - Screen Capture:
-  - The blocking hermetic matrix now covers positive/negative output origins,
+  - A non-skipping hermetic CI matrix now covers positive/negative output origins,
     fractional scaling, clipped/overflowing regions, and all eight transforms
     across native screencopy and PipeWire mapping.
   - Validate the same scale/transform and region-crop behavior on real wlroots,
@@ -121,8 +129,9 @@ Window backend support matrix (current):
   - Validate the persistent ScreenCast/PipeWire stream path and repeated-frame
     behavior across GNOME/KDE/wlroots portal backends.
 - Keyboard Input:
-  - Add Unicode typing via xkbcommon compose/keysyms.
-  - Verify modifier synchronization and layout handling under various layouts.
+  - Add native Wayland Unicode typing via xkbcommon compose/keysyms.
+  - Verify native Wayland modifier synchronization and layout handling under
+    various layouts.
 - Window APIs:
   - Extend compositor-backed move/resize/activate/topmost/minimize/title
     behavior while preserving explicit `ErrNotSupported` elsewhere.
@@ -140,14 +149,25 @@ Window backend support matrix (current):
 - Build/Tooling:
   - Document pkg-config deps and `wayland-scanner` generation steps; ensure protocol headers are vendored.
   - Keep build tags consistent (`linux,wayland` for native capture and `linux,portal` for explicit portal package path).
-  - Non-CGO builds compile with explicit unsupported stubs; selectively port
-    and harden upstream Pure-Go backends before enabling them as defaults.
+  - Non-CGO builds keep explicit unsupported stubs for unavailable operations
+    while supported capture, portal, and Linux/X11 input paths report their real
+    capabilities. Harden additional Pure-Go backends selectively before
+    enabling any of them as defaults.
 - CI/Testing:
-  - Keep the current headless Weston, screencopy, portal, and non-CGO jobs
-    blocking.
+  - Keep the current headless Weston, screencopy, portal, and non-CGO CI
+    commands green; eliminating unexpected hermetic skips and adding branch
+    protection remain open.
+  - Keep the non-CGO Xvfb/XTEST input test on a configured `us,de` keymap in
+    Linux CI; missing `DISPLAY` or XTEST must fail the matrix leg rather than
+    skip, and the resulting remote check still needs branch protection.
+  - Extract the Pure-Go X11 core into a race-testable package and design a
+    scoped or crash-safe lifecycle for its server-global keyboard scratch map.
   - Provision the existing dedicated GNOME, KDE, and wlroots runtime workflow.
-  - Keep the new blocking race/vet jobs green; add leak/sanitizer and
+  - Keep the race/vet CI jobs green and protect them; add leak/sanitizer and
     bounds-across-outputs gates.
 - Examples/Docs:
   - Add backend selection flags in examples (dmabuf, wl_shm, portal).
+  - Keep `examples/purego_x11_input` side-effect-free by default; live
+    readiness checks and global input must remain behind its explicit `-act`
+    flag.
   - Publish a versioned support matrix and troubleshooting guide.

--- a/examples/key/main.go
+++ b/examples/key/main.go
@@ -20,7 +20,7 @@ import (
 func typeStr() {
 	// typing "Hello World"
 	robotgo.TypeStr("Hello World!", 0, 1)
-	robotgo.KeySleep = 100
+	setKeyDelay(100)
 	robotgo.TypeStr("だんしゃり")
 
 	robotgo.TypeStr("Hi galaxy, hi stars, hi MT.Rainier, hi sea. こんにちは世界.")
@@ -45,7 +45,7 @@ func keyTap() {
 	if err := robotgo.KeyTap(robotgo.Enter); err != nil {
 		fmt.Println(err)
 	}
-	robotgo.KeySleep = 200
+	setKeyDelay(200)
 	if err := robotgo.KeyTap("a"); err != nil {
 		fmt.Println(err)
 	}
@@ -99,6 +99,14 @@ func keyTap() {
 	}
 	if err := robotgo.KeyTap("a", "control"); err != nil {
 		fmt.Println(err)
+	}
+}
+
+func setKeyDelay(delay int) {
+	config := robotgo.GetRuntimeConfig()
+	config.KeyDelay = delay
+	if err := robotgo.SetRuntimeConfig(config); err != nil {
+		fmt.Println("SetRuntimeConfig error:", err)
 	}
 }
 

--- a/examples/mouse/main.go
+++ b/examples/mouse/main.go
@@ -19,7 +19,11 @@ import (
 )
 
 func move() {
-	robotgo.MouseSleep = 100
+	config := robotgo.GetRuntimeConfig()
+	config.MouseDelay = 100
+	if err := robotgo.SetRuntimeConfig(config); err != nil {
+		fmt.Println("SetRuntimeConfig error:", err)
+	}
 	robotgo.Move(100, 200)
 	robotgo.MoveRelative(10, -200)
 

--- a/examples/purego_x11_input/main.go
+++ b/examples/purego_x11_input/main.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/marang/robotgo"
+)
+
+const (
+	maximumDemoTextRunes = 256
+	abortDelay           = 3 * time.Second
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() (runErr error) {
+	act := flag.Bool("act", false, "explicitly allow the requested global desktop actions")
+	move := flag.String("move", "", "move the pointer to x,y (requires -act)")
+	key := flag.String("key", "", "tap one key in the focused window (requires -act)")
+	text := flag.String("text", "", "type up to 256 runes in the focused window (requires -act)")
+	settle := flag.Duration("settle", 2*time.Second, "keep X11 scratch mappings alive after keyboard input; increase for delayed targets")
+	flag.Parse()
+	abortContext, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stopSignals()
+
+	keyboardInputStarted := false
+	info := robotgo.GetRuntimeBackendInfo()
+	capabilities := robotgo.GetRuntimeCapabilities()
+	defer func() {
+		if keyboardInputStarted {
+			fmt.Fprintf(os.Stderr,
+				"Keeping X11 keyboard mappings available for %s before verified cleanup; increase -settle for delayed target clients.\n",
+				*settle,
+			)
+			time.Sleep(*settle)
+		}
+		runErr = errors.Join(runErr, robotgo.CloseMainDisplayE())
+	}()
+	printCapability("keyboard", capabilities.Keyboard)
+	printCapability("mouse", capabilities.Mouse)
+	fmt.Printf("runtime: implementation=%s cgo=%t platform=%s/%s display=%s\n",
+		info.BuildImplementation, info.CGOEnabled, info.GOOS, info.GOARCH, info.DisplayServer)
+
+	requested := *move != "" || *key != "" || *text != ""
+	if !requested {
+		fmt.Println("inspection only: no desktop action requested")
+		return nil
+	}
+	if !*act {
+		return fmt.Errorf("no action performed: add -act after reviewing the requested global input")
+	}
+	if (*key != "" || *text != "") && *settle <= 0 {
+		return fmt.Errorf("-settle must be positive when keyboard input is requested")
+	}
+	if err := validateRuntime(info, capabilities, *move, *key, *text); err != nil {
+		return fmt.Errorf("cannot run input demo: %w", err)
+	}
+	if *move != "" {
+		if err := robotgo.MouseReady(); err != nil {
+			return fmt.Errorf("pointer backend is not ready: %w", err)
+		}
+	}
+	if *key != "" || *text != "" {
+		if err := robotgo.KeyboardReady(); err != nil {
+			return fmt.Errorf("keyboard backend is not ready: %w", err)
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "WARNING: XTEST input is global; key/text input goes to the currently focused window.")
+	fmt.Fprintf(os.Stderr, "Press Ctrl+C within %s to abort.\n", abortDelay)
+	abortTimer := time.NewTimer(abortDelay)
+	defer abortTimer.Stop()
+	select {
+	case <-abortTimer.C:
+	case <-abortContext.Done():
+		return errors.New("input demo aborted before global action")
+	}
+
+	if *move != "" {
+		if abortContext.Err() != nil {
+			return errors.New("input demo aborted before pointer action")
+		}
+		x, y, err := parsePoint(*move)
+		if err != nil {
+			return err
+		}
+		if err := robotgo.MoveE(x, y); err != nil {
+			return fmt.Errorf("move pointer: %w", err)
+		}
+	}
+	if *key != "" {
+		if abortContext.Err() != nil {
+			return errors.New("input demo aborted before keyboard action")
+		}
+		keyboardInputStarted = true
+		if err := robotgo.KeyTap(*key); err != nil {
+			return fmt.Errorf("tap key: %w", err)
+		}
+	}
+	if *text != "" {
+		if abortContext.Err() != nil {
+			return errors.New("input demo aborted before text action")
+		}
+		keyboardInputStarted = true
+		if err := robotgo.TypeStrE(*text); err != nil {
+			return fmt.Errorf("type text: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateRuntime(info robotgo.RuntimeBackendInfo, capabilities robotgo.RuntimeCapabilities, move, key, text string) error {
+	if runtime.GOOS != "linux" || info.GOOS != "linux" {
+		return fmt.Errorf("Pure-Go X11 input requires Linux")
+	}
+	if info.CGOEnabled {
+		return fmt.Errorf("this example targets a CGO_ENABLED=0 build")
+	}
+	if info.DisplayServer != robotgo.DisplayServerX11 {
+		return fmt.Errorf("an X11-primary session is required; got %q", info.DisplayServer)
+	}
+	if move != "" && !capabilities.Mouse.Available {
+		return fmt.Errorf("mouse backend %q is unavailable: %s", capabilities.Mouse.Backend, capabilities.Mouse.Reason)
+	}
+	if key != "" || text != "" {
+		if !capabilities.Keyboard.Available {
+			return fmt.Errorf("keyboard backend %q is unavailable: %s", capabilities.Keyboard.Backend, capabilities.Keyboard.Reason)
+		}
+	}
+	if text != "" && utf8.RuneCountInString(text) > maximumDemoTextRunes {
+		return fmt.Errorf("text exceeds the %d-rune demo limit", maximumDemoTextRunes)
+	}
+	return nil
+}
+
+func printCapability(name string, capability robotgo.FeatureCapability) {
+	fmt.Printf("%s: available=%t backend=%s reason=%q notes=%q\n",
+		name, capability.Available, capability.Backend, capability.Reason, capability.Notes)
+}
+
+func parsePoint(value string) (int, int, error) {
+	parts := strings.Split(value, ",")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("move must be formatted as x,y")
+	}
+	x, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse move x coordinate: %w", err)
+	}
+	y, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse move y coordinate: %w", err)
+	}
+	return x, y, nil
+}

--- a/examples/scale/main.go
+++ b/examples/scale/main.go
@@ -23,7 +23,12 @@ func main() {
 		fmt.Println(err)
 	}
 
-	robotgo.Scale = true
+	config := robotgo.GetRuntimeConfig()
+	config.Scale = true
+	if err := robotgo.SetRuntimeConfig(config); err != nil {
+		fmt.Println("SetRuntimeConfig error:", err)
+		return
+	}
 	robotgo.Move(10, 10)
 	robotgo.MoveSmooth(100, 100)
 

--- a/examples/screen/main.go
+++ b/examples/screen/main.go
@@ -52,7 +52,11 @@ func bitmap() error {
 
 	num := robotgo.DisplaysNum()
 	for i := 0; i < num; i++ {
-		robotgo.DisplayID = i
+		config := robotgo.GetRuntimeConfig()
+		config.DisplayID = i
+		if err := robotgo.SetRuntimeConfig(config); err != nil {
+			return fmt.Errorf("set display %d: %w", i, err)
+		}
 		img1, _ := robotgo.CaptureImg()
 		path1 := "save_" + strconv.Itoa(i)
 		if err := robotgo.Save(img1, path1+".png"); err != nil {

--- a/input_backend_default_nocgo.go
+++ b/input_backend_default_nocgo.go
@@ -1,0 +1,7 @@
+//go:build !cgo && !linux
+
+package robotgo
+
+func platformPureGoInputBackend() pureGoInputBackend { return nil }
+
+func closePureGoPlatformInput() error { return nil }

--- a/input_backend_linux_x11_integration_export_test.go
+++ b/input_backend_linux_x11_integration_export_test.go
@@ -1,0 +1,21 @@
+//go:build linux && !cgo && x11integration
+
+package robotgo
+
+import "time"
+
+// SetX11KeyHoldDelayForIntegrationTest extends or removes the short key hold
+// while an external X11 client inspects the server-side mapping.
+func SetX11KeyHoldDelayForIntegrationTest(delay time.Duration) func() {
+	previous := x11KeyHoldDelay
+	x11KeyHoldDelay = delay
+	return func() { x11KeyHoldDelay = previous }
+}
+
+// SetX11BeforeTextTapHookForIntegrationTest installs an adversarial hook after
+// scratch reservation and before the first text key event.
+func SetX11BeforeTextTapHookForIntegrationTest(hook func()) func() {
+	previous := x11BeforeTextTapHook
+	x11BeforeTextTapHook = hook
+	return func() { x11BeforeTextTapHook = previous }
+}

--- a/input_backend_linux_x11_keyboard_nocgo.go
+++ b/input_backend_linux_x11_keyboard_nocgo.go
@@ -1,0 +1,818 @@
+//go:build linux && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgb/xtest"
+)
+
+const (
+	x11KeysymF1 = 0xffbe
+)
+
+var x11KeyHoldDelay = 5 * time.Millisecond
+var x11BeforeTextTapHook func()
+
+var x11ModifierNames = map[string]struct{}{
+	"none": {},
+	"alt":  {}, "lalt": {}, "ralt": {},
+	"cmd": {}, "command": {}, "lcmd": {}, "rcmd": {},
+	"ctrl": {}, "control": {}, "lctrl": {}, "rctrl": {},
+	"shift": {}, "lshift": {}, "rshift": {}, "right_shift": {},
+}
+
+var x11ShiftedSpecialKeys = map[rune]rune{
+	'`': '~', '1': '!', '2': '@', '3': '#', '4': '$', '5': '%',
+	'6': '^', '7': '&', '8': '*', '9': '(', '0': ')', '-': '_',
+	'=': '+', '[': '{', ']': '}', '\\': '|', ';': ':', '\'': '"',
+	',': '<', '.': '>', '/': '?',
+}
+
+type x11ResolvedKey struct {
+	code xproto.Keycode
+}
+
+type x11KeyboardMap struct {
+	minimum    xproto.Keycode
+	perKeycode byte
+	keysyms    []xproto.Keysym
+	modifiers  map[xproto.Keycode]struct{}
+}
+
+type x11ScratchSlot struct {
+	code   xproto.Keycode
+	keysym uint32
+}
+
+type x11HeldKey struct {
+	code      xproto.Keycode
+	modifiers []xproto.Keycode
+}
+
+func (backend *x11InputBackend) KeyboardReady() error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	if err := backend.loadKeyboardMapLocked(); err != nil {
+		return backend.failLocked("load keyboard map", err)
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) loadKeyboardMapLocked() error {
+	setup := xproto.Setup(backend.conn)
+	if setup == nil {
+		return errors.New("missing setup information")
+	}
+	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
+	if count <= 0 || count > math.MaxUint8 {
+		return fmt.Errorf("invalid keycode range %d..%d", setup.MinKeycode, setup.MaxKeycode)
+	}
+	reply, err := xproto.GetKeyboardMapping(backend.conn, setup.MinKeycode, byte(count)).Reply()
+	if err != nil {
+		return err
+	}
+	if reply == nil || reply.KeysymsPerKeycode == 0 {
+		return errors.New("server returned an empty keyboard map")
+	}
+	expected := count * int(reply.KeysymsPerKeycode)
+	if len(reply.Keysyms) < expected {
+		return fmt.Errorf("short keyboard map: got %d keysyms, want at least %d", len(reply.Keysyms), expected)
+	}
+	modifiers, err := backend.modifierKeycodesLocked()
+	if err != nil {
+		return err
+	}
+	keyboard := x11KeyboardMap{
+		minimum:    setup.MinKeycode,
+		perKeycode: reply.KeysymsPerKeycode,
+		keysyms:    append([]xproto.Keysym(nil), reply.Keysyms[:expected]...),
+		modifiers:  modifiers,
+	}
+	if err := backend.updateScratchStateLocked(&keyboard); err != nil {
+		return err
+	}
+	backend.keyboard = keyboard
+	return nil
+}
+
+func (backend *x11InputBackend) modifierKeycodesLocked() (map[xproto.Keycode]struct{}, error) {
+	reply, err := xproto.GetModifierMapping(backend.conn).Reply()
+	if err != nil {
+		return nil, errors.Join(errX11Connection, err)
+	}
+	if reply == nil {
+		return nil, errors.Join(errX11Connection, errors.New("server returned an empty modifier map"))
+	}
+	modifiers := make(map[xproto.Keycode]struct{})
+	for _, code := range reply.Keycodes {
+		if code != 0 {
+			modifiers[code] = struct{}{}
+		}
+	}
+	return modifiers, nil
+}
+
+func (keyboard *x11KeyboardMap) resolve(keysym uint32) (x11ResolvedKey, bool) {
+	per := int(keyboard.perKeycode)
+	if per == 0 {
+		return x11ResolvedKey{}, false
+	}
+	for offset := 0; offset+per <= len(keyboard.keysyms); offset += per {
+		// The core map begins G1L1, G1L2, G2L1, G2L2. Without an XKB state
+		// client, a keycode is unambiguous only when every nonempty group and
+		// level resolves to the same symbol.
+		mapping := keyboard.keysyms[offset : offset+per]
+		if x11MappingOwnedBy(mapping, keysym) {
+			return x11ResolvedKey{
+				code: keyboard.minimum + xproto.Keycode(offset/per),
+			}, true
+		}
+	}
+	return x11ResolvedKey{}, false
+}
+
+func (keyboard *x11KeyboardMap) resolveModifier(keysym uint32) (x11ResolvedKey, bool) {
+	per := int(keyboard.perKeycode)
+	if per == 0 {
+		return x11ResolvedKey{}, false
+	}
+	for offset := 0; offset+per <= len(keyboard.keysyms); offset += per {
+		code := keyboard.minimum + xproto.Keycode(offset/per)
+		if _, modifier := keyboard.modifiers[code]; !modifier {
+			continue
+		}
+		for _, value := range keyboard.keysyms[offset : offset+per] {
+			if uint32(value) == keysym {
+				return x11ResolvedKey{code: code}, true
+			}
+		}
+	}
+	return x11ResolvedKey{}, false
+}
+
+func (keyboard *x11KeyboardMap) mapping(code xproto.Keycode) ([]xproto.Keysym, bool) {
+	per := int(keyboard.perKeycode)
+	index := int(code) - int(keyboard.minimum)
+	if per == 0 || index < 0 {
+		return nil, false
+	}
+	offset := index * per
+	if offset+per > len(keyboard.keysyms) {
+		return nil, false
+	}
+	return keyboard.keysyms[offset : offset+per], true
+}
+
+func x11MappingIs(mapping []xproto.Keysym, keysym uint32) bool {
+	if len(mapping) == 0 {
+		return false
+	}
+	for _, value := range mapping {
+		if uint32(value) != keysym {
+			return false
+		}
+	}
+	return true
+}
+
+func x11MappingOwnedBy(mapping []xproto.Keysym, keysym uint32) bool {
+	if keysym == 0 {
+		return x11MappingIs(mapping, 0)
+	}
+	if len(mapping) == 0 || uint32(mapping[0]) != keysym {
+		return false
+	}
+	for _, value := range mapping[1:] {
+		if value != 0 && uint32(value) != keysym {
+			return false
+		}
+	}
+	return true
+}
+
+func (backend *x11InputBackend) updateScratchStateLocked(keyboard *x11KeyboardMap) error {
+	if !backend.scratchInitialized {
+		per := int(keyboard.perKeycode)
+		for offset := 0; offset+per <= len(keyboard.keysyms); offset += per {
+			code := keyboard.minimum + xproto.Keycode(offset/per)
+			if _, modifier := keyboard.modifiers[code]; modifier {
+				continue
+			}
+			if x11MappingIs(keyboard.keysyms[offset:offset+per], 0) {
+				backend.scratchSlots = append(backend.scratchSlots, x11ScratchSlot{
+					code: code,
+				})
+			}
+		}
+		backend.scratchInitialized = true
+		backend.scratchPerKeycode = keyboard.perKeycode
+		backend.scratchByKeysym = make(map[uint32]xproto.Keycode)
+		return nil
+	}
+	if keyboard.perKeycode != backend.scratchPerKeycode {
+		return fmt.Errorf("X11 keysyms-per-keycode changed from %d to %d while RobotGo owns scratch mappings",
+			backend.scratchPerKeycode, keyboard.perKeycode)
+	}
+	kept := backend.scratchSlots[:0]
+	for _, slot := range backend.scratchSlots {
+		if _, modifier := keyboard.modifiers[slot.code]; modifier {
+			if slot.keysym != 0 {
+				return fmt.Errorf("X11 scratch keycode %d became a modifier while RobotGo owns its mapping", slot.code)
+			}
+			continue
+		}
+		mapping, ok := keyboard.mapping(slot.code)
+		if !ok {
+			return fmt.Errorf("X11 scratch keycode %d disappeared from the keyboard map", slot.code)
+		}
+		if slot.keysym == 0 {
+			if x11MappingIs(mapping, 0) {
+				kept = append(kept, slot)
+			}
+			continue
+		}
+		if !x11MappingOwnedBy(mapping, slot.keysym) {
+			return fmt.Errorf("X11 scratch keycode %d was changed by another client", slot.code)
+		}
+		kept = append(kept, slot)
+	}
+	backend.scratchSlots = kept
+	return nil
+}
+
+func x11ScratchMappingCanRestore(current *xproto.GetKeyboardMappingReply, keysym uint32) (byte, bool, error) {
+	if current == nil || current.KeysymsPerKeycode == 0 {
+		return 0, false, errors.New("server returned an empty scratch-key mapping")
+	}
+	width := int(current.KeysymsPerKeycode)
+	if len(current.Keysyms) < width {
+		return 0, false, fmt.Errorf("server returned %d scratch keysyms, want at least %d", len(current.Keysyms), width)
+	}
+	return current.KeysymsPerKeycode, x11MappingOwnedBy(current.Keysyms[:width], keysym), nil
+}
+
+func (backend *x11InputBackend) restoreScratchMappingsLocked() error {
+	if backend.conn == nil || backend.scratchPerKeycode == 0 {
+		return nil
+	}
+	return backend.withServerGrabLocked(func() error {
+		var restoreErr error
+		var pressed []byte
+		var modifiers map[xproto.Keycode]struct{}
+		stateLoaded := false
+		for index := range backend.scratchSlots {
+			slot := &backend.scratchSlots[index]
+			if slot.keysym == 0 {
+				continue
+			}
+			current, err := xproto.GetKeyboardMapping(backend.conn, slot.code, 1).Reply()
+			if err != nil {
+				restoreErr = errors.Join(restoreErr, errX11Connection,
+					fmt.Errorf("query X11 scratch keycode %d during cleanup: %w", slot.code, err))
+				continue
+			}
+			width, owned, ownershipErr := x11ScratchMappingCanRestore(current, slot.keysym)
+			if ownershipErr != nil {
+				restoreErr = errors.Join(restoreErr, fmt.Errorf("query X11 scratch keycode %d during cleanup: %w", slot.code, ownershipErr))
+				continue
+			}
+			if !owned {
+				// Another client now owns this mapping. Preserve its state rather
+				// than treating intentional non-ownership as a cleanup failure.
+				delete(backend.scratchByKeysym, slot.keysym)
+				slot.keysym = 0
+				continue
+			}
+			if !stateLoaded {
+				pressed, err = backend.pressedKeysLocked()
+				if err != nil {
+					return errors.Join(restoreErr, err)
+				}
+				modifiers, err = backend.modifierKeycodesLocked()
+				if err != nil {
+					return errors.Join(restoreErr, err)
+				}
+				stateLoaded = true
+			}
+			if x11KeycodePressed(pressed, slot.code) {
+				restoreErr = errors.Join(restoreErr, fmt.Errorf(
+					"cannot restore X11 scratch keycode %d while it is pressed; reset the mapping after the key is released", slot.code,
+				))
+				continue
+			}
+			if _, modifier := modifiers[slot.code]; modifier {
+				restoreErr = errors.Join(restoreErr, fmt.Errorf(
+					"cannot restore X11 scratch keycode %d after it became a modifier; reset the mapping after restoring the modifier map", slot.code,
+				))
+				continue
+			}
+			empty := make([]xproto.Keysym, int(width))
+			if err := xproto.ChangeKeyboardMappingChecked(
+				backend.conn, 1, slot.code, width, empty,
+			).Check(); err != nil {
+				restoreErr = errors.Join(restoreErr, errX11Connection,
+					fmt.Errorf("restore X11 scratch keycode %d: %w", slot.code, err))
+				continue
+			}
+			delete(backend.scratchByKeysym, slot.keysym)
+			slot.keysym = 0
+		}
+		return restoreErr
+	})
+}
+
+func x11KeysymForKey(key string) (uint32, error) {
+	if key == "" || !utf8.ValidString(key) {
+		return 0, fmt.Errorf("%w: invalid X11 keyboard key %q", ErrNotSupported, key)
+	}
+	if named, ok := portalNamedKeysyms[strings.ToLower(key)]; ok {
+		return uint32(named), nil
+	}
+	lower := strings.ToLower(key)
+	if strings.HasPrefix(lower, "f") {
+		number, err := strconv.Atoi(strings.TrimPrefix(lower, "f"))
+		if err == nil && number >= 1 && number <= 24 {
+			return x11KeysymF1 + uint32(number-1), nil
+		}
+	}
+	if utf8.RuneCountInString(key) == 1 {
+		value, _ := utf8.DecodeRuneInString(key)
+		keysym, err := portalKeysymForRune(value)
+		return uint32(keysym), err
+	}
+	return 0, fmt.Errorf("%w: X11 keyboard key %q", ErrNotSupported, key)
+}
+
+func (backend *x11InputBackend) sendKeyLocked(code xproto.Keycode, down bool) error {
+	eventType := byte(xproto.KeyRelease)
+	if down {
+		eventType = byte(xproto.KeyPress)
+	}
+	if err := xtest.FakeInputChecked(backend.conn, eventType, byte(code), 0, backend.root, 0, 0, 0).Check(); err != nil {
+		return errors.Join(errX11Connection, err)
+	}
+	return nil
+}
+
+func appendUniqueKeycode(codes []xproto.Keycode, code xproto.Keycode) []xproto.Keycode {
+	if code == 0 {
+		return codes
+	}
+	for _, existing := range codes {
+		if existing == code {
+			return codes
+		}
+	}
+	return append(codes, code)
+}
+
+func (backend *x11InputBackend) modifierCodesLocked(names []string) ([]xproto.Keycode, error) {
+	codes := make([]xproto.Keycode, 0, len(names)+2)
+	for _, name := range names {
+		if strings.EqualFold(name, "none") {
+			continue
+		}
+		keysym, err := x11KeysymForKey(name)
+		if err != nil {
+			return nil, err
+		}
+		modifier, ok := backend.keyboard.resolveModifier(keysym)
+		if !ok {
+			return nil, fmt.Errorf("%w: modifier %q is absent from the active X11 keymap", ErrNotSupported, name)
+		}
+		codes = appendUniqueKeycode(codes, modifier.code)
+	}
+	return codes, nil
+}
+
+func (backend *x11InputBackend) reserveScratchMappingsLocked(keysyms []uint32) error {
+	return backend.withServerGrabLocked(func() error {
+		// Refresh after grabbing the server. Another client may have claimed an
+		// originally empty keycode before this transaction; never overwrite it.
+		if err := backend.loadKeyboardMapLocked(); err != nil {
+			return errors.Join(errX11KeyboardMap, err)
+		}
+		return backend.reserveScratchMappingsUnderGrabLocked(keysyms)
+	})
+}
+
+func (backend *x11InputBackend) reserveScratchMappingsUnderGrabLocked(keysyms []uint32) error {
+	pressed, err := backend.pressedKeysLocked()
+	if err != nil {
+		return err
+	}
+	if err := backend.validateScratchCapacityLocked(keysyms, pressed); err != nil {
+		return err
+	}
+	for _, keysym := range keysyms {
+		if _, assigned := backend.scratchByKeysym[keysym]; assigned {
+			continue
+		}
+		if _, err := backend.assignScratchMappingLocked(keysym, pressed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) validateScratchCapacityLocked(keysyms []uint32, pressed []byte) error {
+	missing := make(map[uint32]struct{}, len(keysyms))
+	for _, keysym := range keysyms {
+		if _, assigned := backend.scratchByKeysym[keysym]; !assigned {
+			missing[keysym] = struct{}{}
+		}
+	}
+	available := 0
+	for _, slot := range backend.scratchSlots {
+		if slot.keysym == 0 && !x11KeycodePressed(pressed, slot.code) {
+			available++
+		}
+	}
+	if len(missing) > available {
+		return fmt.Errorf("%w: X11 keyboard input requires %d new stable scratch keycodes, but only %d are available; call CloseMainDisplayE after the target has processed prior keyboard input to reset the pool",
+			ErrNotSupported, len(missing), available)
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) assignScratchMappingLocked(keysym uint32, pressed []byte) (xproto.Keycode, error) {
+	if code, assigned := backend.scratchByKeysym[keysym]; assigned {
+		return code, nil
+	}
+	for index := range backend.scratchSlots {
+		slot := &backend.scratchSlots[index]
+		if slot.keysym != 0 || x11KeycodePressed(pressed, slot.code) {
+			continue
+		}
+		replacement := make([]xproto.Keysym, int(backend.keyboard.perKeycode))
+		for column := range replacement {
+			replacement[column] = xproto.Keysym(keysym)
+		}
+		if err := xproto.ChangeKeyboardMappingChecked(
+			backend.conn, 1, slot.code, backend.keyboard.perKeycode, replacement,
+		).Check(); err != nil {
+			return 0, errors.Join(errX11Connection, err)
+		}
+		slot.keysym = keysym
+		backend.scratchByKeysym[keysym] = slot.code
+		mapping, ok := backend.keyboard.mapping(slot.code)
+		if !ok {
+			return 0, errors.Join(errX11Connection, fmt.Errorf("assigned X11 scratch keycode %d disappeared", slot.code))
+		}
+		copy(mapping, replacement)
+		return slot.code, nil
+	}
+	return 0, fmt.Errorf("%w: no stable X11 scratch keycode is available", ErrNotSupported)
+}
+
+// prepareKeysymUnderGrabLocked must run while this X client owns the server
+// grab and after loadKeyboardMapLocked refreshed the global keymap.
+func (backend *x11InputBackend) prepareKeysymUnderGrabLocked(keysym uint32, allowScratch, forceScratch bool) (x11ResolvedKey, error) {
+	if !forceScratch {
+		if resolved, ok := backend.keyboard.resolve(keysym); ok {
+			return resolved, nil
+		}
+	}
+	if !allowScratch {
+		return x11ResolvedKey{}, fmt.Errorf("%w: keysym %#x has no unambiguous mapping in the active X11 keymap", ErrNotSupported, keysym)
+	}
+	if err := backend.reserveScratchMappingsUnderGrabLocked([]uint32{keysym}); err != nil {
+		return x11ResolvedKey{}, err
+	}
+	return x11ResolvedKey{code: backend.scratchByKeysym[keysym]}, nil
+}
+
+func x11LiteralKey(key string) bool {
+	if !utf8.ValidString(key) {
+		return false
+	}
+	if _, named := portalNamedKeysyms[strings.ToLower(key)]; named {
+		return false
+	}
+	if utf8.RuneCountInString(key) != 1 {
+		return false
+	}
+	_, size := utf8.DecodeRuneInString(key)
+	return size > 0
+}
+
+func validateX11KeyEvent(event pureGoKeyEvent) error {
+	if !event.Tap && event.Down && x11LiteralKey(event.Key) {
+		return fmt.Errorf("%w: Pure-Go X11 cannot safely hold literal keys across XKB layout groups; use KeyTap, KeyPress, or a named key", ErrNotSupported)
+	}
+	for _, modifier := range event.Modifiers {
+		if _, supported := x11ModifierNames[strings.ToLower(modifier)]; !supported {
+			return fmt.Errorf("%w: Pure-Go X11 modifier %q is not a supported modifier key", ErrNotSupported, modifier)
+		}
+	}
+	return nil
+}
+
+func x11EventKeysym(event pureGoKeyEvent) (uint32, error) {
+	key := event.Key
+	if x11LiteralKey(key) && x11EventHasShift(event.Modifiers) {
+		value, _ := utf8.DecodeRuneInString(key)
+		if shifted, ok := x11ShiftedSpecialKeys[value]; ok {
+			value = shifted
+		} else {
+			value = unicode.ToUpper(value)
+		}
+		key = string(value)
+	}
+	return x11KeysymForKey(key)
+}
+
+func x11EventHasShift(modifiers []string) bool {
+	for _, modifier := range modifiers {
+		switch strings.ToLower(modifier) {
+		case "shift", "lshift", "rshift", "right_shift":
+			return true
+		}
+	}
+	return false
+}
+
+func (backend *x11InputBackend) pressedKeysLocked() ([]byte, error) {
+	reply, err := xproto.QueryKeymap(backend.conn).Reply()
+	if err != nil {
+		return nil, errors.Join(errX11Connection, err)
+	}
+	if reply == nil || len(reply.Keys) != 32 {
+		return nil, errors.Join(errX11Connection, errors.New("X11 returned an invalid pressed-key map"))
+	}
+	return reply.Keys, nil
+}
+
+func x11KeycodePressed(keys []byte, code xproto.Keycode) bool {
+	index := int(code) / 8
+	return index < len(keys) && keys[index]&(1<<uint(code%8)) != 0
+}
+
+func (backend *x11InputBackend) acquireModifierLocked(code xproto.Keycode, pressed []byte) (bool, error) {
+	if backend.keyRefs == nil {
+		backend.keyRefs = make(map[xproto.Keycode]int)
+	}
+	if backend.keyRefs[code] > 0 {
+		backend.keyRefs[code]++
+		return true, nil
+	}
+	if x11KeycodePressed(pressed, code) {
+		return false, nil
+	}
+	if err := backend.sendKeyLocked(code, true); err != nil {
+		return false, err
+	}
+	backend.keyRefs[code] = 1
+	backend.keyOrder = append(backend.keyOrder, code)
+	return true, nil
+}
+
+func (backend *x11InputBackend) acquireMainKeyLocked(code xproto.Keycode, pressed []byte) error {
+	if backend.keyRefs[code] > 0 || x11KeycodePressed(pressed, code) {
+		return fmt.Errorf("robotgo: X11 keycode %d is already held; refusing to alter foreign input state", code)
+	}
+	if err := backend.sendKeyLocked(code, true); err != nil {
+		return err
+	}
+	if backend.keyRefs == nil {
+		backend.keyRefs = make(map[xproto.Keycode]int)
+	}
+	backend.keyRefs[code] = 1
+	backend.keyOrder = append(backend.keyOrder, code)
+	return nil
+}
+
+func (backend *x11InputBackend) releaseOwnedKeyLocked(code xproto.Keycode) error {
+	refs := backend.keyRefs[code]
+	if refs <= 0 {
+		return nil
+	}
+	if refs > 1 {
+		backend.keyRefs[code] = refs - 1
+		return nil
+	}
+	if err := backend.sendKeyLocked(code, false); err != nil {
+		return err
+	}
+	delete(backend.keyRefs, code)
+	backend.keyOrder = removeX11Keycode(backend.keyOrder, code)
+	return nil
+}
+
+func removeX11Keycode(codes []xproto.Keycode, code xproto.Keycode) []xproto.Keycode {
+	for index := len(codes) - 1; index >= 0; index-- {
+		if codes[index] != code {
+			continue
+		}
+		copy(codes[index:], codes[index+1:])
+		codes[len(codes)-1] = 0
+		return codes[:len(codes)-1]
+	}
+	return codes
+}
+
+func (backend *x11InputBackend) releaseOwnedModifiersLocked(codes []xproto.Keycode) error {
+	var releaseErr error
+	for index := len(codes) - 1; index >= 0; index-- {
+		releaseErr = errors.Join(releaseErr, backend.releaseOwnedKeyLocked(codes[index]))
+	}
+	return releaseErr
+}
+
+func (backend *x11InputBackend) acquireModifiersLocked(codes []xproto.Keycode, pressed []byte) ([]xproto.Keycode, error) {
+	owned := make([]xproto.Keycode, 0, len(codes))
+	for _, code := range codes {
+		acquired, err := backend.acquireModifierLocked(code, pressed)
+		if err != nil {
+			return nil, errors.Join(err, backend.releaseOwnedModifiersLocked(owned))
+		}
+		if acquired {
+			owned = append(owned, code)
+		}
+	}
+	return owned, nil
+}
+
+func (backend *x11InputBackend) tapResolvedLocked(resolved x11ResolvedKey, modifierCodes []xproto.Keycode) error {
+	pressed, err := backend.pressedKeysLocked()
+	if err != nil {
+		return err
+	}
+	ownedModifiers, err := backend.acquireModifiersLocked(modifierCodes, pressed)
+	if err != nil {
+		return err
+	}
+	mainDown := backend.acquireMainKeyLocked(resolved.code, pressed)
+	var mainUp error
+	if mainDown == nil {
+		time.Sleep(x11KeyHoldDelay)
+		mainUp = backend.releaseOwnedKeyLocked(resolved.code)
+	}
+	return errors.Join(mainDown, mainUp, backend.releaseOwnedModifiersLocked(ownedModifiers))
+}
+
+func (backend *x11InputBackend) tapKeysymLocked(keysym uint32, modifiers []string, allowScratch, forceScratch bool) error {
+	return backend.withServerGrabLocked(func() error {
+		if err := backend.loadKeyboardMapLocked(); err != nil {
+			return errors.Join(errX11KeyboardMap, err)
+		}
+		modifierCodes, err := backend.modifierCodesLocked(modifiers)
+		if err != nil {
+			return err
+		}
+		resolved, err := backend.prepareKeysymUnderGrabLocked(keysym, allowScratch, forceScratch)
+		if err != nil {
+			return err
+		}
+		return backend.tapResolvedLocked(resolved, modifierCodes)
+	})
+}
+
+func (backend *x11InputBackend) toggleDownResolvedLocked(keysym uint32, resolved x11ResolvedKey, modifierCodes []xproto.Keycode) error {
+	if backend.heldKeys != nil {
+		if _, held := backend.heldKeys[keysym]; held {
+			return nil
+		}
+	}
+	pressed, err := backend.pressedKeysLocked()
+	if err != nil {
+		return err
+	}
+	ownedModifiers, err := backend.acquireModifiersLocked(modifierCodes, pressed)
+	if err != nil {
+		return err
+	}
+	if err := backend.acquireMainKeyLocked(resolved.code, pressed); err != nil {
+		return errors.Join(err, backend.releaseOwnedModifiersLocked(ownedModifiers))
+	}
+	if backend.heldKeys == nil {
+		backend.heldKeys = make(map[uint32]x11HeldKey)
+	}
+	backend.heldKeys[keysym] = x11HeldKey{code: resolved.code, modifiers: ownedModifiers}
+	return nil
+}
+
+func (backend *x11InputBackend) toggleDownKeysymLocked(keysym uint32, modifiers []string) error {
+	return backend.withServerGrabLocked(func() error {
+		if err := backend.loadKeyboardMapLocked(); err != nil {
+			return errors.Join(errX11KeyboardMap, err)
+		}
+		modifierCodes, err := backend.modifierCodesLocked(modifiers)
+		if err != nil {
+			return err
+		}
+		resolved, err := backend.prepareKeysymUnderGrabLocked(keysym, false, false)
+		if err != nil {
+			return err
+		}
+		return backend.toggleDownResolvedLocked(keysym, resolved, modifierCodes)
+	})
+}
+
+func (backend *x11InputBackend) toggleUpLocked(keysym uint32) error {
+	held, ok := backend.heldKeys[keysym]
+	if !ok {
+		return fmt.Errorf("robotgo: X11 key %#x is not held by this RobotGo backend", keysym)
+	}
+	err := errors.Join(
+		backend.releaseOwnedKeyLocked(held.code),
+		backend.releaseOwnedModifiersLocked(held.modifiers),
+	)
+	if err == nil {
+		delete(backend.heldKeys, keysym)
+	}
+	return err
+}
+
+func (backend *x11InputBackend) Key(event pureGoKeyEvent) (err error) {
+	if event.PID != 0 {
+		return fmt.Errorf("%w: Pure-Go X11 input cannot target a process", ErrNotSupported)
+	}
+	if err := validateX11KeyEvent(event); err != nil {
+		return err
+	}
+	keysym, err := x11EventKeysym(event)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	if !event.Tap && !event.Down {
+		err = backend.withServerGrabLocked(func() error { return backend.toggleUpLocked(keysym) })
+		if errors.Is(err, errX11Connection) {
+			err = errors.Join(err, backend.closeLocked())
+		}
+		return err
+	}
+	if event.Tap {
+		err = backend.tapKeysymLocked(keysym, event.Modifiers, true, x11LiteralKey(event.Key))
+	} else {
+		err = backend.toggleDownKeysymLocked(keysym, event.Modifiers)
+	}
+	if errors.Is(err, errX11Connection) || errors.Is(err, errX11KeyboardMap) {
+		return backend.failLocked("inject keyboard input", err)
+	}
+	return err
+}
+
+func (backend *x11InputBackend) Text(event pureGoTextEvent) (err error) {
+	if event.PID != 0 {
+		return fmt.Errorf("%w: Pure-Go X11 input cannot target a process", ErrNotSupported)
+	}
+	if event.Delay < 0 {
+		return errors.New("robotgo: text delay must be non-negative")
+	}
+	if !utf8.ValidString(event.Text) {
+		return errors.New("robotgo: text is not valid UTF-8")
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	keysyms := make([]uint32, 0, utf8.RuneCountInString(event.Text))
+	for _, value := range event.Text {
+		keysym, keysymErr := portalKeysymForRune(value)
+		if keysymErr != nil {
+			return keysymErr
+		}
+		keysyms = append(keysyms, uint32(keysym))
+	}
+	if reserveErr := backend.reserveScratchMappingsLocked(keysyms); reserveErr != nil {
+		if errors.Is(reserveErr, errX11Connection) || errors.Is(reserveErr, errX11KeyboardMap) {
+			return backend.failLocked("prepare Unicode keyboard mappings", reserveErr)
+		}
+		return reserveErr
+	}
+	if x11BeforeTextTapHook != nil {
+		x11BeforeTextTapHook()
+	}
+	for _, keysym := range keysyms {
+		tapErr := backend.tapKeysymLocked(keysym, nil, true, true)
+		if tapErr != nil {
+			err = tapErr
+			if errors.Is(tapErr, errX11Connection) || errors.Is(tapErr, errX11KeyboardMap) {
+				err = errors.Join(err, backend.closeLocked())
+			}
+			return err
+		}
+		MilliSleep(event.Delay)
+	}
+	return nil
+}

--- a/input_backend_linux_x11_nocgo.go
+++ b/input_backend_linux_x11_nocgo.go
@@ -1,0 +1,284 @@
+//go:build linux && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgb/xtest"
+)
+
+const (
+	x11XTestMajor = 2
+	x11XTestMinor = 2
+)
+
+var (
+	errX11Connection  = errors.New("X11 connection failure")
+	errX11KeyboardMap = errors.New("X11 keyboard mapping failure")
+)
+
+// x11InputBackend owns one lazily opened X connection. Its mutex covers whole
+// high-level transactions, including the stable scratch-keymap pool.
+type x11InputBackend struct {
+	mu             sync.Mutex
+	conn           *xgb.Conn
+	display        string
+	root           xproto.Window
+	keyboard       x11KeyboardMap
+	events         <-chan struct{}
+	heldKeys       map[uint32]x11HeldKey
+	keyRefs        map[xproto.Keycode]int
+	keyOrder       []xproto.Keycode
+	buttons        map[byte]struct{}
+	buttonOrder    []byte
+	cleanupPending bool
+
+	scratchInitialized bool
+	scratchPerKeycode  byte
+	scratchSlots       []x11ScratchSlot
+	scratchByKeysym    map[uint32]xproto.Keycode
+
+	eventMu         sync.Mutex
+	eventGeneration uint64
+	eventErr        error
+}
+
+var linuxX11Input = &x11InputBackend{}
+
+func platformPureGoInputBackend() pureGoInputBackend {
+	if DetectDisplayServer() != DisplayServerX11 {
+		return nil
+	}
+	return linuxX11Input
+}
+
+func closePureGoPlatformInput() error { return linuxX11Input.Close() }
+
+func (*x11InputBackend) Name() string { return featureBackendPureGoX11 }
+
+func (backend *x11InputBackend) sessionReady() error {
+	if DetectDisplayServer() != DisplayServerX11 {
+		return fmt.Errorf("%w: Pure-Go X11 input requires DISPLAY without an active Wayland session", ErrNotSupported)
+	}
+	if pureGoX11EnvironmentConflict() {
+		return fmt.Errorf("%w: %s selects Wayland while DISPLAY selects X11", ErrNotSupported, envXDGSessionType)
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) openLocked() error {
+	if err := backend.sessionReady(); err != nil {
+		if backend.conn != nil {
+			err = errors.Join(err, backend.closeLocked())
+		}
+		return err
+	}
+	display := os.Getenv(envDisplay)
+	if display == "" {
+		return fmt.Errorf("%w: %s is unset", ErrNotSupported, envDisplay)
+	}
+	if backend.conn != nil {
+		if backend.cleanupPending {
+			return errors.New("robotgo: previous X11 cleanup is incomplete; release conflicting input state and retry CloseMainDisplayE")
+		}
+		if backend.display != display {
+			if err := backend.closeLocked(); err != nil {
+				return fmt.Errorf("robotgo: clean up previous X11 display: %w", err)
+			}
+		} else {
+			if err := backend.eventDrainErrorLocked(); err != nil {
+				return errors.Join(
+					fmt.Errorf("robotgo: X11 connection is unhealthy: %w", err),
+					backend.closeLocked(),
+				)
+			}
+			return nil
+		}
+	}
+	connection, err := xgb.NewConnDisplay(display)
+	if err != nil {
+		return fmt.Errorf("robotgo: connect to X11 display %q: %w", display, err)
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			connection.Close()
+		}
+	}()
+	if err := xtest.Init(connection); err != nil {
+		return fmt.Errorf("%w: XTEST extension is unavailable: %v", ErrNotSupported, err)
+	}
+	version, err := xtest.GetVersion(connection, x11XTestMajor, x11XTestMinor).Reply()
+	if err != nil {
+		return fmt.Errorf("robotgo: query XTEST version: %w", err)
+	}
+	if !x11XTestVersionSupported(version) {
+		if version == nil {
+			return fmt.Errorf("%w: XTEST returned no version", ErrNotSupported)
+		}
+		return fmt.Errorf("%w: XTEST %d.%d is older than required %d.%d",
+			ErrNotSupported, version.MajorVersion, version.MinorVersion, x11XTestMajor, x11XTestMinor)
+	}
+	setup := xproto.Setup(connection)
+	if setup == nil {
+		return errors.New("robotgo: X11 returned no setup information")
+	}
+	screen := setup.DefaultScreen(connection)
+	if screen == nil || screen.Root == 0 {
+		return errors.New("robotgo: X11 returned no default root window")
+	}
+	backend.conn = connection
+	backend.display = display
+	backend.root = screen.Root
+	backend.keyboard = x11KeyboardMap{}
+	backend.startEventDrainLocked(connection)
+	closeOnError = false
+	return nil
+}
+
+func x11XTestVersionSupported(version *xtest.GetVersionReply) bool {
+	if version == nil {
+		return false
+	}
+	return version.MajorVersion > x11XTestMajor ||
+		version.MajorVersion == x11XTestMajor && version.MinorVersion >= x11XTestMinor
+}
+
+func (backend *x11InputBackend) startEventDrainLocked(connection *xgb.Conn) {
+	backend.eventMu.Lock()
+	backend.eventGeneration++
+	generation := backend.eventGeneration
+	backend.eventErr = nil
+	backend.eventMu.Unlock()
+	done := make(chan struct{})
+	backend.events = done
+	go func() {
+		defer close(done)
+		for {
+			event, eventErr := connection.WaitForEvent()
+			if event == nil && eventErr == nil {
+				return
+			}
+			if eventErr != nil {
+				backend.eventMu.Lock()
+				if backend.eventGeneration == generation {
+					backend.eventErr = errors.Join(backend.eventErr, eventErr)
+				}
+				backend.eventMu.Unlock()
+			}
+		}
+	}()
+}
+
+func (backend *x11InputBackend) eventDrainErrorLocked() error {
+	if backend.events != nil {
+		select {
+		case <-backend.events:
+			return errors.New("X11 connection event drain stopped")
+		default:
+		}
+	}
+	backend.eventMu.Lock()
+	defer backend.eventMu.Unlock()
+	return backend.eventErr
+}
+
+func (backend *x11InputBackend) withServerGrabLocked(operation func() error) (err error) {
+	if backend.conn == nil {
+		return errors.Join(errX11Connection, errors.New("X11 connection is closed"))
+	}
+	if grabErr := xproto.GrabServerChecked(backend.conn).Check(); grabErr != nil {
+		return errors.Join(errX11Connection, grabErr)
+	}
+	defer func() {
+		if ungrabErr := xproto.UngrabServerChecked(backend.conn).Check(); ungrabErr != nil {
+			// Connection health takes precedence over the operation result: the
+			// caller must discard a connection whose server-grab state is unknown.
+			err = errors.Join(err, errX11Connection, ungrabErr)
+		}
+	}()
+	return operation()
+}
+
+func (backend *x11InputBackend) closeLocked() error {
+	var cleanupErr error
+	if backend.conn != nil {
+		cleanupErr = errors.Join(
+			backend.withServerGrabLocked(backend.releaseOwnedInputLocked),
+			backend.restoreScratchMappingsLocked(),
+		)
+		if cleanupErr != nil && !errors.Is(cleanupErr, errX11Connection) {
+			backend.cleanupPending = true
+			return cleanupErr
+		}
+		backend.conn.Close()
+	}
+	backend.conn = nil
+	backend.display = ""
+	backend.root = 0
+	backend.keyboard = x11KeyboardMap{}
+	backend.events = nil
+	backend.heldKeys = nil
+	backend.keyRefs = nil
+	backend.keyOrder = nil
+	backend.buttons = nil
+	backend.buttonOrder = nil
+	backend.cleanupPending = false
+	backend.scratchInitialized = false
+	backend.scratchPerKeycode = 0
+	backend.scratchSlots = nil
+	backend.scratchByKeysym = nil
+	return cleanupErr
+}
+
+func (backend *x11InputBackend) releaseOwnedInputLocked() error {
+	var releaseErr error
+	for index := len(backend.keyOrder) - 1; index >= 0; index-- {
+		code := backend.keyOrder[index]
+		if backend.keyRefs[code] > 0 {
+			if err := backend.sendKeyLocked(code, false); err != nil {
+				releaseErr = errors.Join(releaseErr, err)
+				continue
+			}
+			delete(backend.keyRefs, code)
+			backend.keyOrder = removeX11Keycode(backend.keyOrder, code)
+		}
+	}
+	for keysym, held := range backend.heldKeys {
+		if backend.keyRefs[held.code] == 0 {
+			delete(backend.heldKeys, keysym)
+		}
+	}
+	for index := len(backend.buttonOrder) - 1; index >= 0; index-- {
+		button := backend.buttonOrder[index]
+		if _, held := backend.buttons[button]; held {
+			if err := backend.sendButtonLocked(button, false); err != nil {
+				releaseErr = errors.Join(releaseErr, err)
+				continue
+			}
+			delete(backend.buttons, button)
+			backend.buttonOrder = removeX11Button(backend.buttonOrder, button)
+		}
+	}
+	return releaseErr
+}
+
+func (backend *x11InputBackend) Close() error {
+	backend.mu.Lock()
+	err := backend.closeLocked()
+	backend.mu.Unlock()
+	return err
+}
+
+func (backend *x11InputBackend) failLocked(action string, err error) error {
+	return errors.Join(
+		fmt.Errorf("robotgo: X11 %s: %w", action, err),
+		backend.closeLocked(),
+	)
+}

--- a/input_backend_linux_x11_nocgo_test.go
+++ b/input_backend_linux_x11_nocgo_test.go
@@ -1,0 +1,368 @@
+//go:build linux && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgb/xtest"
+)
+
+func TestX11KeyboardMapResolvesActiveLayoutLevels(t *testing.T) {
+	keyboard := x11KeyboardMap{
+		minimum:    8,
+		perKeycode: 6,
+		modifiers:  map[xproto.Keycode]struct{}{11: {}},
+		keysyms: []xproto.Keysym{
+			'a', 'A', 0x010003b1, 0x01000391, '@', '#',
+			0xffe1, 0, 0xffe1, 0, 0, 0,
+			0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0,
+		},
+	}
+	tests := []struct {
+		keysym uint32
+		want   x11ResolvedKey
+	}{
+		{keysym: 0xffe1, want: x11ResolvedKey{code: 9}},
+	}
+	for _, test := range tests {
+		got, ok := keyboard.resolve(test.keysym)
+		if !ok || got != test.want {
+			t.Fatalf("resolve(%#x) = (%+v,%v), want (%+v,true)", test.keysym, got, ok, test.want)
+		}
+	}
+	for _, ambiguous := range []uint32{'a', 'A', 0x010003b1, '@'} {
+		if got, ok := keyboard.resolve(ambiguous); ok {
+			t.Fatalf("resolve(%#x) = %+v, want no unsafe core-map guess", ambiguous, got)
+		}
+	}
+	backend := &x11InputBackend{}
+	if err := backend.updateScratchStateLocked(&keyboard); err != nil {
+		t.Fatalf("initialize scratch state: %v", err)
+	}
+	if len(backend.scratchSlots) != 1 || backend.scratchSlots[0].code != 10 {
+		t.Fatalf("scratch slots = %+v, want only non-modifier keycode 10", backend.scratchSlots)
+	}
+	keyboard.modifiers[10] = struct{}{}
+	if err := backend.updateScratchStateLocked(&keyboard); err != nil {
+		t.Fatalf("drop newly assigned modifier from unused scratch pool: %v", err)
+	}
+	if len(backend.scratchSlots) != 0 {
+		t.Fatalf("modifier keycode remained in scratch pool: %+v", backend.scratchSlots)
+	}
+}
+
+func TestX11ModifierResolutionRequiresModifierMapMembership(t *testing.T) {
+	keyboard := x11KeyboardMap{
+		minimum:    8,
+		perKeycode: 2,
+		keysyms: []xproto.Keysym{
+			0xffe3, 0, // Control_L-shaped key that is not a modifier.
+			0xffe3, 0xffe7, // Actual Control modifier with a second symbol.
+		},
+		modifiers: map[xproto.Keycode]struct{}{9: {}},
+	}
+	got, ok := keyboard.resolveModifier(0xffe3)
+	if !ok || got.code != 9 {
+		t.Fatalf("resolveModifier(Control_L) = (%+v,%t), want keycode 9", got, ok)
+	}
+	delete(keyboard.modifiers, 9)
+	if got, ok := keyboard.resolveModifier(0xffe3); ok {
+		t.Fatalf("resolveModifier without modifier-map membership = %+v, want no match", got)
+	}
+}
+
+func TestX11ScratchCapacityFailsBeforeMapping(t *testing.T) {
+	backend := &x11InputBackend{
+		scratchInitialized: true,
+		scratchPerKeycode:  2,
+		scratchSlots:       []x11ScratchSlot{{code: 10}},
+		scratchByKeysym:    make(map[uint32]xproto.Keycode),
+	}
+	err := backend.validateScratchCapacityLocked([]uint32{'a', 'b'}, nil)
+	if !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("scratch capacity error = %v, want ErrNotSupported", err)
+	}
+	if backend.scratchSlots[0].keysym != 0 || len(backend.scratchByKeysym) != 0 {
+		t.Fatalf("capacity failure mutated scratch state: slots=%+v mappings=%v", backend.scratchSlots, backend.scratchByKeysym)
+	}
+}
+
+func TestX11ScratchCapacityExcludesPressedEmptyKeycodes(t *testing.T) {
+	backend := &x11InputBackend{
+		scratchInitialized: true,
+		scratchPerKeycode:  2,
+		scratchSlots:       []x11ScratchSlot{{code: 10}},
+		scratchByKeysym:    make(map[uint32]xproto.Keycode),
+	}
+	pressed := make([]byte, 32)
+	pressed[10/8] |= 1 << uint(10%8)
+	if err := backend.validateScratchCapacityLocked([]uint32{'a'}, pressed); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("pressed scratch capacity error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestX11ScratchCleanupUsesCurrentMappingWidth(t *testing.T) {
+	const keysym = uint32(0x010020ac)
+	current := &xproto.GetKeyboardMappingReply{
+		KeysymsPerKeycode: 3,
+		Keysyms: []xproto.Keysym{
+			xproto.Keysym(keysym), xproto.Keysym(keysym), xproto.Keysym(keysym),
+		},
+	}
+	width, owned, err := x11ScratchMappingCanRestore(current, keysym)
+	if err != nil || !owned || width != 3 {
+		t.Fatalf("restore plan = (width=%d owned=%t err=%v), want (3,true,nil)", width, owned, err)
+	}
+	current.Keysyms[2] = 'x'
+	if _, owned, err := x11ScratchMappingCanRestore(current, keysym); err != nil || owned {
+		t.Fatalf("foreign restore plan = (owned=%t err=%v), want (false,nil)", owned, err)
+	}
+}
+
+func TestX11ScratchOwnershipRecognizesServerCanonicalization(t *testing.T) {
+	keysym := uint32(0x010020ac)
+	for _, test := range []struct {
+		mapping []xproto.Keysym
+		want    bool
+	}{
+		{mapping: []xproto.Keysym{xproto.Keysym(keysym), xproto.Keysym(keysym), 0}, want: true},
+		{mapping: []xproto.Keysym{xproto.Keysym(keysym)}, want: true},
+		{mapping: []xproto.Keysym{0, 0}},
+		{mapping: []xproto.Keysym{xproto.Keysym(keysym), 'x'}},
+	} {
+		if got := x11MappingOwnedBy(test.mapping, keysym); got != test.want {
+			t.Fatalf("x11MappingOwnedBy(%v,%#x) = %t, want %t", test.mapping, keysym, got, test.want)
+		}
+	}
+}
+
+func TestX11ScratchOwnershipRejectsModifierReassignment(t *testing.T) {
+	const keysym = uint32(0x010020ac)
+	backend := &x11InputBackend{
+		scratchInitialized: true,
+		scratchPerKeycode:  2,
+		scratchSlots:       []x11ScratchSlot{{code: 10, keysym: keysym}},
+		scratchByKeysym:    map[uint32]xproto.Keycode{keysym: 10},
+	}
+	keyboard := x11KeyboardMap{
+		minimum:    10,
+		perKeycode: 2,
+		keysyms:    []xproto.Keysym{xproto.Keysym(keysym), xproto.Keysym(keysym)},
+		modifiers:  map[xproto.Keycode]struct{}{10: {}},
+	}
+	if err := backend.updateScratchStateLocked(&keyboard); err == nil {
+		t.Fatal("owned scratch keycode becoming a modifier unexpectedly succeeded")
+	}
+}
+
+func TestX11VersionAndLiteralContracts(t *testing.T) {
+	for _, test := range []struct {
+		version *xtest.GetVersionReply
+		want    bool
+	}{
+		{version: nil},
+		{version: &xtest.GetVersionReply{MajorVersion: 2, MinorVersion: 1}},
+		{version: &xtest.GetVersionReply{MajorVersion: 2, MinorVersion: 2}, want: true},
+		{version: &xtest.GetVersionReply{MajorVersion: 3}, want: true},
+	} {
+		if got := x11XTestVersionSupported(test.version); got != test.want {
+			t.Fatalf("x11XTestVersionSupported(%+v) = %t, want %t", test.version, got, test.want)
+		}
+	}
+	for key, want := range map[string]bool{"a": true, "€": true, "enter": false, "F12": false} {
+		if got := x11LiteralKey(key); got != want {
+			t.Fatalf("x11LiteralKey(%q) = %t, want %t", key, got, want)
+		}
+	}
+	if _, err := x11Coordinate(math.MaxInt16 + 1); err == nil || errors.Is(err, ErrNotSupported) {
+		t.Fatalf("coordinate validation error = %v, want non-ErrNotSupported", err)
+	}
+	if _, err := x11MouseButton("invalid"); err == nil || errors.Is(err, ErrNotSupported) {
+		t.Fatalf("button validation error = %v, want non-ErrNotSupported", err)
+	}
+	if err := validateX11KeyEvent(pureGoKeyEvent{Key: "a", Down: true}); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("persistent literal key validation = %v, want ErrNotSupported", err)
+	}
+	for _, event := range []pureGoKeyEvent{
+		{Key: "a", Tap: true},
+		{Key: "shift", Down: true},
+		{Key: "a", Down: false},
+		{Key: "enter", Tap: true, Modifiers: []string{"ctrl", "right_shift", "NONE"}},
+	} {
+		if err := validateX11KeyEvent(event); err != nil {
+			t.Fatalf("validateX11KeyEvent(%+v) = %v, want nil", event, err)
+		}
+	}
+	if err := validateX11KeyEvent(pureGoKeyEvent{Key: "enter", Tap: true, Modifiers: []string{"y"}}); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("literal modifier validation = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestX11KeysymResolutionPreservesCaseAndNamedKeys(t *testing.T) {
+	tests := []struct {
+		key  string
+		want uint32
+	}{
+		{key: "A", want: 'A'},
+		{key: "a", want: 'a'},
+		{key: "enter", want: 0xff0d},
+		{key: "F24", want: x11KeysymF1 + 23},
+		{key: "€", want: 0x010020ac},
+	}
+	for _, test := range tests {
+		got, err := x11KeysymForKey(test.key)
+		if err != nil || got != test.want {
+			t.Fatalf("x11KeysymForKey(%q) = (%#x,%v), want (%#x,nil)", test.key, got, err, test.want)
+		}
+	}
+	for _, key := range []string{"", "not-a-key", string([]byte{0xff})} {
+		if _, err := x11KeysymForKey(key); err == nil {
+			t.Fatalf("x11KeysymForKey(%q) unexpectedly succeeded", key)
+		}
+	}
+}
+
+func TestX11EventKeysymAppliesExplicitShiftToLiteralKeys(t *testing.T) {
+	for _, test := range []struct {
+		key       string
+		modifiers []string
+		want      uint32
+	}{
+		{key: "a", modifiers: []string{"shift"}, want: 'A'},
+		{key: "1", modifiers: []string{"right_shift"}, want: '!'},
+		{key: "+", modifiers: []string{"shift"}, want: '+'},
+		{key: "a", modifiers: []string{"ctrl"}, want: 'a'},
+		{key: "enter", modifiers: []string{"shift"}, want: 0xff0d},
+	} {
+		got, err := x11EventKeysym(pureGoKeyEvent{Key: test.key, Modifiers: test.modifiers, Tap: true})
+		if err != nil || got != test.want {
+			t.Fatalf("x11EventKeysym(%q,%v) = (%#x,%v), want (%#x,nil)",
+				test.key, test.modifiers, got, err, test.want)
+		}
+	}
+}
+
+func TestX11PointerArgumentsAreStrictlyBounded(t *testing.T) {
+	for _, value := range []int{math.MinInt16, 0, math.MaxInt16} {
+		if got, err := x11Coordinate(value); err != nil || int(got) != value {
+			t.Fatalf("x11Coordinate(%d) = (%d,%v)", value, got, err)
+		}
+	}
+	for _, value := range []int{math.MinInt16 - 1, math.MaxInt16 + 1} {
+		if _, err := x11Coordinate(value); err == nil {
+			t.Fatalf("x11Coordinate(%d) unexpectedly succeeded", value)
+		}
+	}
+	for value, want := range map[int]uint64{-1000: 1000, 0: 0, 1000: 1000} {
+		if got, err := x11ScrollSteps(value); err != nil || got != want {
+			t.Fatalf("x11ScrollSteps(%d) = (%d,%v), want (%d,nil)", value, got, err, want)
+		}
+	}
+	for _, value := range []int{-1001, 1001, math.MinInt, math.MaxInt} {
+		if _, err := x11ScrollSteps(value); err == nil {
+			t.Fatalf("x11ScrollSteps(%d) unexpectedly succeeded", value)
+		}
+	}
+}
+
+func TestX11MouseButtonRejectsUnknownNames(t *testing.T) {
+	tests := map[string]byte{
+		"": x11ButtonLeft, "left": x11ButtonLeft, "center": x11ButtonMiddle,
+		"middle": x11ButtonMiddle, "right": x11ButtonRight,
+		"wheelUp": x11ButtonWheelUp, "wheelDown": x11ButtonWheelDown,
+		"wheelLeft": x11ButtonWheelLeft, "wheelRight": x11ButtonWheelRight,
+	}
+	for name, want := range tests {
+		got, err := x11MouseButton(name)
+		if err != nil || got != want {
+			t.Fatalf("x11MouseButton(%q) = (%d,%v), want (%d,nil)", name, got, err, want)
+		}
+	}
+	if _, err := x11MouseButton("primary"); err == nil {
+		t.Fatal("unknown X11 mouse button unexpectedly succeeded")
+	}
+	for _, button := range []byte{x11ButtonLeft, x11ButtonMiddle, x11ButtonRight, x11ButtonWheelUp, x11ButtonWheelDown} {
+		if !x11ButtonStateObservable(button) {
+			t.Fatalf("button %d state unexpectedly unobservable", button)
+		}
+	}
+	for _, button := range []byte{x11ButtonWheelLeft, x11ButtonWheelRight} {
+		if x11ButtonStateObservable(button) {
+			t.Fatalf("button %d state unexpectedly observable", button)
+		}
+	}
+}
+
+func TestX11BackendResolverNeverUsesX11InWaylandSession(t *testing.T) {
+	t.Setenv("DISPLAY", ":99")
+	t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+	if backend := platformPureGoInputBackend(); backend != nil {
+		t.Fatalf("Wayland session selected X11 backend %q", backend.Name())
+	}
+	t.Setenv("WAYLAND_DISPLAY", "")
+	if backend := platformPureGoInputBackend(); backend == nil || backend.Name() != featureBackendPureGoX11 {
+		t.Fatalf("X11 session backend = %#v, want %q", backend, featureBackendPureGoX11)
+	}
+}
+
+func TestX11CapabilityInspectionDoesNotWaitForBackendMutex(t *testing.T) {
+	t.Setenv(envWaylandDisplay, "")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envXDGSessionType, "x11")
+	linuxX11Input.mu.Lock()
+	done := make(chan RuntimeCapabilities, 1)
+	go func() { done <- GetRuntimeCapabilities() }()
+	select {
+	case capabilities := <-done:
+		linuxX11Input.mu.Unlock()
+		if !capabilities.Keyboard.Available || !capabilities.Mouse.Available {
+			t.Fatalf("X11 capabilities = keyboard %+v, mouse %+v", capabilities.Keyboard, capabilities.Mouse)
+		}
+	case <-time.After(250 * time.Millisecond):
+		linuxX11Input.mu.Unlock()
+		<-done
+		t.Fatal("capability inspection waited for the persistent X11 backend mutex")
+	}
+}
+
+func TestX11CapabilityInspectionDoesNotCleanUpDeselectedBackend(t *testing.T) {
+	t.Setenv(envWaylandDisplay, "wayland-test")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	linuxX11Input.mu.Lock()
+	done := make(chan RuntimeCapabilities, 1)
+	go func() { done <- GetRuntimeCapabilities() }()
+	select {
+	case capabilities := <-done:
+		linuxX11Input.mu.Unlock()
+		if capabilities.Keyboard.Backend == featureBackendPureGoX11 ||
+			capabilities.Mouse.Backend == featureBackendPureGoX11 {
+			t.Fatalf("Wayland capabilities selected Pure-Go X11: %+v", capabilities)
+		}
+	case <-time.After(250 * time.Millisecond):
+		linuxX11Input.mu.Unlock()
+		<-done
+		t.Fatal("capability inspection tried to clean up the deselected X11 backend")
+	}
+}
+
+func TestX11CapabilityInspectionRejectsSessionConflictWithoutProbe(t *testing.T) {
+	t.Setenv(envWaylandDisplay, "")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	capabilities := GetRuntimeCapabilities()
+	for name, capability := range map[string]FeatureCapability{
+		"keyboard": capabilities.Keyboard,
+		"mouse":    capabilities.Mouse,
+	} {
+		if capability.Available || capability.Backend != featureBackendPureGoX11 {
+			t.Fatalf("%s conflict capability = %+v", name, capability)
+		}
+	}
+}

--- a/input_backend_linux_x11_pointer_nocgo.go
+++ b/input_backend_linux_x11_pointer_nocgo.go
@@ -1,0 +1,544 @@
+//go:build linux && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgb/xtest"
+)
+
+const (
+	x11DoubleClickGap     = 200 * time.Millisecond
+	x11MaximumSmoothDelay = 10_000
+	x11MaximumScrollSteps = 1_000
+	x11RelativeMotion     = 1
+)
+
+const (
+	x11ButtonLeft       byte = 1
+	x11ButtonMiddle     byte = 2
+	x11ButtonRight      byte = 3
+	x11ButtonWheelUp    byte = 4
+	x11ButtonWheelDown  byte = 5
+	x11ButtonWheelLeft  byte = 6
+	x11ButtonWheelRight byte = 7
+)
+
+func (backend *x11InputBackend) MouseReady() error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	if _, err := backend.pointerStateLocked(); err != nil {
+		return backend.failLocked("query pointer", err)
+	}
+	return nil
+}
+
+func x11MouseButton(name string) (byte, error) {
+	switch name {
+	case "", "left":
+		return x11ButtonLeft, nil
+	case "center", "middle":
+		return x11ButtonMiddle, nil
+	case "right":
+		return x11ButtonRight, nil
+	case "wheelUp":
+		return x11ButtonWheelUp, nil
+	case "wheelDown":
+		return x11ButtonWheelDown, nil
+	case "wheelLeft":
+		return x11ButtonWheelLeft, nil
+	case "wheelRight":
+		return x11ButtonWheelRight, nil
+	default:
+		return 0, fmt.Errorf("robotgo: invalid X11 pointer button %q", name)
+	}
+}
+
+func x11Coordinate(value int) (int16, error) {
+	if value < math.MinInt16 || value > math.MaxInt16 {
+		return 0, fmt.Errorf("robotgo: X11 coordinate %d is outside [%d,%d]", value, math.MinInt16, math.MaxInt16)
+	}
+	return int16(value), nil
+}
+
+func x11Coordinates(x, y int) (int16, int16, error) {
+	xCoordinate, err := x11Coordinate(x)
+	if err != nil {
+		return 0, 0, err
+	}
+	yCoordinate, err := x11Coordinate(y)
+	if err != nil {
+		return 0, 0, err
+	}
+	return xCoordinate, yCoordinate, nil
+}
+
+func (backend *x11InputBackend) sendButtonLocked(button byte, down bool) error {
+	eventType := byte(xproto.ButtonRelease)
+	if down {
+		eventType = byte(xproto.ButtonPress)
+	}
+	if err := xtest.FakeInputChecked(backend.conn, eventType, button, 0, backend.root, 0, 0, 0).Check(); err != nil {
+		return errors.Join(errX11Connection, err)
+	}
+	return nil
+}
+
+func x11ButtonMask(button byte) uint16 {
+	switch button {
+	case x11ButtonLeft:
+		return xproto.ButtonMask1
+	case x11ButtonMiddle:
+		return xproto.ButtonMask2
+	case x11ButtonRight:
+		return xproto.ButtonMask3
+	case x11ButtonWheelUp:
+		return xproto.ButtonMask4
+	case x11ButtonWheelDown:
+		return xproto.ButtonMask5
+	default:
+		return 0
+	}
+}
+
+func x11ButtonStateObservable(button byte) bool {
+	return x11ButtonMask(button) != 0
+}
+
+func (backend *x11InputBackend) acquireButtonLocked(button byte, pointerMask uint16) error {
+	if _, held := backend.buttons[button]; held {
+		return fmt.Errorf("robotgo: X11 button %d is already held by this RobotGo backend", button)
+	}
+	if mask := x11ButtonMask(button); mask != 0 && pointerMask&mask != 0 {
+		return fmt.Errorf("robotgo: X11 button %d is already held; refusing to alter foreign input state", button)
+	}
+	if err := backend.sendButtonLocked(button, true); err != nil {
+		return err
+	}
+	if backend.buttons == nil {
+		backend.buttons = make(map[byte]struct{})
+	}
+	backend.buttons[button] = struct{}{}
+	backend.buttonOrder = append(backend.buttonOrder, button)
+	return nil
+}
+
+func (backend *x11InputBackend) releaseOwnedButtonLocked(button byte) error {
+	if _, held := backend.buttons[button]; !held {
+		return fmt.Errorf("robotgo: X11 button %d is not held by this RobotGo backend", button)
+	}
+	if err := backend.sendButtonLocked(button, false); err != nil {
+		return err
+	}
+	delete(backend.buttons, button)
+	backend.buttonOrder = removeX11Button(backend.buttonOrder, button)
+	return nil
+}
+
+func removeX11Button(buttons []byte, button byte) []byte {
+	for index := len(buttons) - 1; index >= 0; index-- {
+		if buttons[index] != button {
+			continue
+		}
+		copy(buttons[index:], buttons[index+1:])
+		buttons[len(buttons)-1] = 0
+		return buttons[:len(buttons)-1]
+	}
+	return buttons
+}
+
+func (backend *x11InputBackend) moveLocked(x, y int) error {
+	xCoordinate, yCoordinate, err := x11Coordinates(x, y)
+	if err != nil {
+		return err
+	}
+	if err := xtest.FakeInputChecked(
+		backend.conn, byte(xproto.MotionNotify), 0, 0, backend.root,
+		xCoordinate, yCoordinate, 0,
+	).Check(); err != nil {
+		return errors.Join(errX11Connection, err)
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) moveRelativeLocked(x, y int) error {
+	xDelta, yDelta, err := x11Coordinates(x, y)
+	if err != nil {
+		return err
+	}
+	if err := xtest.FakeInputChecked(
+		backend.conn, byte(xproto.MotionNotify), x11RelativeMotion, 0,
+		xproto.Window(0), xDelta, yDelta, 0,
+	).Check(); err != nil {
+		return errors.Join(errX11Connection, err)
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) MoveAbsolute(x, y int, _ []int) error {
+	if _, _, err := x11Coordinates(x, y); err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	if err := backend.moveLocked(x, y); err != nil {
+		return backend.failLocked("move pointer", err)
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) pointerStateLocked() (*xproto.QueryPointerReply, error) {
+	reply, err := xproto.QueryPointer(backend.conn, backend.root).Reply()
+	if err != nil {
+		return nil, errors.Join(errX11Connection, err)
+	}
+	if reply == nil {
+		return nil, errors.Join(errX11Connection, errors.New("server returned no pointer reply"))
+	}
+	return reply, nil
+}
+
+func (backend *x11InputBackend) pointerLocationLocked() (int, int, error) {
+	reply, err := backend.pointerStateLocked()
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(reply.RootX), int(reply.RootY), nil
+}
+
+func (backend *x11InputBackend) MoveRelative(x, y int) error {
+	if _, _, err := x11Coordinates(x, y); err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	if err := backend.moveRelativeLocked(x, y); err != nil {
+		return backend.failLocked("move pointer relatively", err)
+	}
+	return nil
+}
+
+type x11SmoothMovePlan struct {
+	relative         bool
+	startX, startY   int
+	targetX, targetY int
+	steps            int
+	delay            time.Duration
+}
+
+func validateX11SmoothMove(x, y int, lowDelay, highDelay float64) error {
+	if !validSmoothDelayRange(lowDelay, highDelay) || highDelay > x11MaximumSmoothDelay {
+		return fmt.Errorf("robotgo: invalid X11 smooth-move delay range %g..%g ms", lowDelay, highDelay)
+	}
+	if _, _, err := x11Coordinates(x, y); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) planSmoothMoveLocked(x, y int, relative bool, lowDelay, highDelay float64) (x11SmoothMovePlan, error) {
+	plan := x11SmoothMovePlan{relative: relative, targetX: x, targetY: y}
+	if !relative {
+		startX, startY, err := backend.pointerLocationLocked()
+		if err != nil {
+			return x11SmoothMovePlan{}, err
+		}
+		plan.startX, plan.startY = startX, startY
+	}
+	distance := math.Hypot(float64(plan.targetX-plan.startX), float64(plan.targetY-plan.startY))
+	steps := int(math.Ceil(distance / 8))
+	if steps < 1 {
+		steps = 1
+	}
+	if steps > 240 {
+		steps = 240
+	}
+	plan.steps = steps
+	plan.delay = time.Duration((lowDelay + highDelay) / 2 * float64(time.Millisecond))
+	return plan, nil
+}
+
+func (backend *x11InputBackend) executeSmoothMoveLocked(plan x11SmoothMovePlan) error {
+	lastX, lastY := plan.startX, plan.startY
+	for step := 1; step <= plan.steps; step++ {
+		progress := float64(step) / float64(plan.steps)
+		if progress < 0.5 {
+			progress = 4 * progress * progress * progress
+		} else {
+			inverse := -2*progress + 2
+			progress = 1 - inverse*inverse*inverse/2
+		}
+		currentX := int(math.Round(float64(plan.startX) + float64(plan.targetX-plan.startX)*progress))
+		currentY := int(math.Round(float64(plan.startY) + float64(plan.targetY-plan.startY)*progress))
+		if currentX == lastX && currentY == lastY && step != plan.steps {
+			continue
+		}
+		var err error
+		if plan.relative {
+			err = backend.moveRelativeLocked(currentX-lastX, currentY-lastY)
+		} else {
+			err = backend.moveLocked(currentX, currentY)
+		}
+		if err != nil {
+			return err
+		}
+		lastX, lastY = currentX, currentY
+		if plan.delay > 0 && step != plan.steps {
+			time.Sleep(plan.delay)
+		}
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error {
+	if err := validateX11SmoothMove(x, y, lowDelay, highDelay); err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	plan, err := backend.planSmoothMoveLocked(x, y, relative, lowDelay, highDelay)
+	if err != nil {
+		return backend.failLocked("plan smooth pointer move", err)
+	}
+	if err := backend.executeSmoothMoveLocked(plan); err != nil {
+		return backend.failLocked("move pointer smoothly", err)
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
+	if err := validateX11SmoothMove(x, y, lowDelay, highDelay); err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	plan, err := backend.planSmoothMoveLocked(x, y, false, lowDelay, highDelay)
+	if err != nil {
+		return backend.failLocked("plan smooth pointer drag", err)
+	}
+	downErr := backend.acquireButtonTransactionLocked(x11ButtonLeft)
+	if downErr != nil && !errors.Is(downErr, errX11Connection) {
+		return downErr
+	}
+	if downErr == nil {
+		time.Sleep(50 * time.Millisecond)
+	}
+	moveErr := downErr
+	if downErr == nil {
+		moveErr = backend.executeSmoothMoveLocked(plan)
+	}
+	var upErr error
+	if downErr == nil {
+		upErr = backend.releaseButtonTransactionLocked(x11ButtonLeft)
+	}
+	eventErr := errors.Join(moveErr, upErr)
+	if eventErr != nil {
+		return backend.failLocked("drag pointer smoothly", eventErr)
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) Location() (int, int, error) {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return 0, 0, err
+	}
+	x, y, err := backend.pointerLocationLocked()
+	if err != nil {
+		return 0, 0, backend.failLocked("query pointer location", err)
+	}
+	return x, y, nil
+}
+
+func (backend *x11InputBackend) Click(name string, double bool) error {
+	button, err := x11MouseButton(name)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	clicks := 1
+	if double {
+		clicks = 2
+	}
+	var eventErr error
+	for click := 0; click < clicks; click++ {
+		clickErr := backend.clickButtonTransactionLocked(button)
+		eventErr = errors.Join(eventErr, clickErr)
+		if clickErr != nil {
+			break
+		}
+		if click+1 < clicks {
+			time.Sleep(x11DoubleClickGap)
+		}
+	}
+	if eventErr != nil {
+		if !errors.Is(eventErr, errX11Connection) {
+			return eventErr
+		}
+		return backend.failLocked("click pointer", eventErr)
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) Toggle(name string, down bool) error {
+	button, err := x11MouseButton(name)
+	if err != nil {
+		return err
+	}
+	if !x11ButtonStateObservable(button) {
+		return fmt.Errorf("%w: Pure-Go X11 cannot safely own button %d because core X11 exposes state only for buttons 1-5", ErrNotSupported, button)
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	var eventErr error
+	if down {
+		eventErr = backend.acquireButtonTransactionLocked(button)
+	} else {
+		eventErr = backend.releaseButtonTransactionLocked(button)
+	}
+	if eventErr != nil {
+		if !errors.Is(eventErr, errX11Connection) {
+			return eventErr
+		}
+		return backend.failLocked("toggle pointer button", eventErr)
+	}
+	return nil
+}
+
+func x11ScrollSteps(value int) (uint64, error) {
+	var steps uint64
+	if value < 0 {
+		steps = uint64(-(value + 1)) + 1
+	} else {
+		steps = uint64(value)
+	}
+	if steps > x11MaximumScrollSteps {
+		return 0, fmt.Errorf("robotgo: Pure-Go X11 scroll magnitude %d exceeds the per-axis limit %d", steps, x11MaximumScrollSteps)
+	}
+	return steps, nil
+}
+
+func (backend *x11InputBackend) scrollWheelLocked(button byte, count uint64) error {
+	for step := uint64(0); step < count; step++ {
+		if err := backend.pulseButtonTransactionLocked(button); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) pulseButtonTransactionLocked(button byte) error {
+	return backend.withServerGrabLocked(func() error {
+		pointer, err := backend.pointerStateLocked()
+		if err != nil {
+			return err
+		}
+		if err := backend.acquireButtonLocked(button, pointer.Mask); err != nil {
+			return err
+		}
+		return backend.releaseOwnedButtonLocked(button)
+	})
+}
+
+func (backend *x11InputBackend) Scroll(x, y int) error {
+	xSteps, err := x11ScrollSteps(x)
+	if err != nil {
+		return err
+	}
+	ySteps, err := x11ScrollSteps(y)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.openLocked(); err != nil {
+		return err
+	}
+	if x != 0 {
+		button := x11ButtonWheelLeft
+		if x < 0 {
+			button = x11ButtonWheelRight
+		}
+		if err := backend.scrollWheelLocked(button, xSteps); err != nil {
+			if errors.Is(err, errX11Connection) {
+				return backend.failLocked("scroll pointer horizontally", err)
+			}
+			return err
+		}
+	}
+	if y != 0 {
+		button := x11ButtonWheelUp
+		if y < 0 {
+			button = x11ButtonWheelDown
+		}
+		if err := backend.scrollWheelLocked(button, ySteps); err != nil {
+			if errors.Is(err, errX11Connection) {
+				return backend.failLocked("scroll pointer vertically", err)
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (backend *x11InputBackend) acquireButtonTransactionLocked(button byte) error {
+	return backend.withServerGrabLocked(func() error {
+		pointer, err := backend.pointerStateLocked()
+		if err != nil {
+			return err
+		}
+		return backend.acquireButtonLocked(button, pointer.Mask)
+	})
+}
+
+func (backend *x11InputBackend) releaseButtonTransactionLocked(button byte) error {
+	return backend.withServerGrabLocked(func() error {
+		return backend.releaseOwnedButtonLocked(button)
+	})
+}
+
+func (backend *x11InputBackend) clickButtonTransactionLocked(button byte) error {
+	return backend.withServerGrabLocked(func() error {
+		pointer, err := backend.pointerStateLocked()
+		if err != nil {
+			return err
+		}
+		downErr := backend.acquireButtonLocked(button, pointer.Mask)
+		if downErr == nil {
+			time.Sleep(x11KeyHoldDelay)
+		}
+		var upErr error
+		if downErr == nil {
+			upErr = backend.releaseOwnedButtonLocked(button)
+		}
+		return errors.Join(downErr, upErr)
+	})
+}

--- a/input_backend_nocgo.go
+++ b/input_backend_nocgo.go
@@ -1,0 +1,86 @@
+//go:build !cgo
+
+package robotgo
+
+import "fmt"
+
+// pureGoKeyEvent is the normalized keyboard contract used by non-CGO
+// platform backends. A tap owns the complete press/release transaction; a
+// toggle changes only the requested state.
+type pureGoKeyEvent struct {
+	Key       string
+	Modifiers []string
+	PID       int
+	Down      bool
+	Tap       bool
+}
+
+// pureGoTextEvent describes one UTF-8 text transaction. Delay is applied
+// between runes and PID zero targets the active application.
+type pureGoTextEvent struct {
+	Text  string
+	PID   int
+	Delay int
+}
+
+// pureGoInputBackend keeps platform-specific input below one explicit,
+// error-returning boundary. Implementations must serialize composite events so
+// modifiers, double clicks, and temporary keymap changes cannot interleave.
+type pureGoInputBackend interface {
+	Name() string
+	KeyboardReady() error
+	MouseReady() error
+	Key(pureGoKeyEvent) error
+	Text(pureGoTextEvent) error
+	MoveAbsolute(x, y int, displayID []int) error
+	MoveRelative(x, y int) error
+	MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error
+	DragSmooth(x, y int, lowDelay, highDelay float64) error
+	Location() (int, int, error)
+	Click(button string, double bool) error
+	Toggle(button string, down bool) error
+	Scroll(x, y int) error
+	Close() error
+}
+
+var resolvePureGoInputBackend = platformPureGoInputBackend
+
+func withPureGoInputBackend(operation func(pureGoInputBackend) error) (bool, error) {
+	backend := resolvePureGoInputBackend()
+	if backend == nil {
+		if err := closePureGoPlatformInput(); err != nil {
+			return true, fmt.Errorf("robotgo: clean up deselected Pure-Go input backend: %w", err)
+		}
+		return false, nil
+	}
+	return true, operation(backend)
+}
+
+func pureGoInputCapabilities() (keyboard, mouse FeatureCapability) {
+	backend := resolvePureGoInputBackend()
+	if backend == nil {
+		return FeatureCapability{}, FeatureCapability{}
+	}
+	backendName := backend.Name()
+	keyboard = FeatureCapability{
+		Available: true,
+		Backend:   backendName,
+		Reason:    "Pure-Go keyboard backend is selected; runtime access is not probed",
+		Notes:     "call KeyboardReady for a live backend check; capability inspection does not open a display connection",
+	}
+	mouse = FeatureCapability{
+		Available: true,
+		Backend:   backendName,
+		Reason:    "Pure-Go pointer backend is selected; runtime access is not probed",
+		Notes:     "call MouseReady for a live backend check; capability inspection does not open a display connection",
+	}
+	if backendName == featureBackendPureGoX11 {
+		keyboard.Notes += "; key taps and text may use server-global scratch keycodes: call CloseMainDisplayE after targets process all prior keyboard input; abnormal termination can leave mappings behind"
+		if pureGoX11EnvironmentConflict() {
+			reason := envXDGSessionType + " selects Wayland while DISPLAY selects X11"
+			keyboard.Available, keyboard.Reason = false, reason
+			mouse.Available, mouse.Reason = false, reason
+		}
+	}
+	return keyboard, mouse
+}

--- a/input_backend_nocgo_test.go
+++ b/input_backend_nocgo_test.go
@@ -1,0 +1,289 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+)
+
+type fakePureGoInputBackend struct {
+	calls        []string
+	location     Point
+	keyboardErr  error
+	mouseErr     error
+	operationErr error
+}
+
+func (*fakePureGoInputBackend) Name() string { return "pure-go-test-input" }
+
+func (backend *fakePureGoInputBackend) record(format string, args ...interface{}) error {
+	backend.calls = append(backend.calls, fmt.Sprintf(format, args...))
+	return backend.operationErr
+}
+
+func (backend *fakePureGoInputBackend) KeyboardReady() error {
+	backend.calls = append(backend.calls, "keyboard-ready")
+	return backend.keyboardErr
+}
+
+func (backend *fakePureGoInputBackend) MouseReady() error {
+	backend.calls = append(backend.calls, "mouse-ready")
+	return backend.mouseErr
+}
+
+func (backend *fakePureGoInputBackend) Key(event pureGoKeyEvent) error {
+	return backend.record("key:%s:%v:%d:%t:%t", event.Key, event.Modifiers, event.PID, event.Down, event.Tap)
+}
+
+func (backend *fakePureGoInputBackend) Text(event pureGoTextEvent) error {
+	return backend.record("text:%s:%d:%d", event.Text, event.PID, event.Delay)
+}
+
+func (backend *fakePureGoInputBackend) MoveAbsolute(x, y int, displayID []int) error {
+	return backend.record("move:%d:%d:%v", x, y, displayID)
+}
+
+func (backend *fakePureGoInputBackend) MoveRelative(x, y int) error {
+	return backend.record("relative:%d:%d", x, y)
+}
+
+func (backend *fakePureGoInputBackend) MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error {
+	return backend.record("smooth:%d:%d:%t:%g:%g", x, y, relative, lowDelay, highDelay)
+}
+
+func (backend *fakePureGoInputBackend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
+	return backend.record("drag:%d:%d:%g:%g", x, y, lowDelay, highDelay)
+}
+
+func (backend *fakePureGoInputBackend) Location() (int, int, error) {
+	backend.calls = append(backend.calls, "location")
+	return backend.location.X, backend.location.Y, backend.operationErr
+}
+
+func (backend *fakePureGoInputBackend) Click(button string, double bool) error {
+	return backend.record("click:%s:%t", button, double)
+}
+
+func (backend *fakePureGoInputBackend) Toggle(button string, down bool) error {
+	return backend.record("toggle:%s:%t", button, down)
+}
+
+func (backend *fakePureGoInputBackend) Scroll(x, y int) error {
+	return backend.record("scroll:%d:%d", x, y)
+}
+
+func (backend *fakePureGoInputBackend) Close() error {
+	backend.calls = append(backend.calls, "close")
+	return backend.operationErr
+}
+
+func installFakePureGoInputBackend(t *testing.T, backend pureGoInputBackend) {
+	t.Helper()
+	previous := resolvePureGoInputBackend
+	resolvePureGoInputBackend = func() pureGoInputBackend { return backend }
+	t.Cleanup(func() { resolvePureGoInputBackend = previous })
+}
+
+func zeroInputDelays(t *testing.T) {
+	t.Helper()
+	previous := GetRuntimeConfig()
+	config := previous
+	config.MouseDelay = 0
+	config.KeyDelay = 0
+	if err := SetRuntimeConfig(config); err != nil {
+		t.Fatalf("SetRuntimeConfig: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := SetRuntimeConfig(previous); err != nil {
+			t.Errorf("restore runtime config: %v", err)
+		}
+	})
+}
+
+func TestNonCGOInputDispatchUsesSelectedPlatformBackend(t *testing.T) {
+	backend := &fakePureGoInputBackend{location: Point{X: -12, Y: 34}}
+	installFakePureGoInputBackend(t, backend)
+	zeroInputDelays(t)
+
+	if err := KeyboardReady(); err != nil {
+		t.Fatalf("KeyboardReady: %v", err)
+	}
+	if err := MouseReady(); err != nil {
+		t.Fatalf("MouseReady: %v", err)
+	}
+	if err := KeyTap("a", "ctrl"); err != nil {
+		t.Fatalf("KeyTap: %v", err)
+	}
+	if err := KeyTap("A", "ctrl"); err != nil {
+		t.Fatalf("uppercase KeyTap: %v", err)
+	}
+	if err := KeyTap("+"); err != nil {
+		t.Fatalf("special-symbol KeyTap: %v", err)
+	}
+	if err := KeyPress("b", []string{"shift"}); err != nil {
+		t.Fatalf("KeyPress: %v", err)
+	}
+	if err := KeyToggle("c", "up", "alt"); err != nil {
+		t.Fatalf("KeyToggle: %v", err)
+	}
+	if err := KeyDown("d", 0, []string{"ctrl"}); err != nil {
+		t.Fatalf("KeyDown: %v", err)
+	}
+	if err := KeyUp("d", []string{"ctrl"}, 0); err != nil {
+		t.Fatalf("KeyUp: %v", err)
+	}
+	if err := TypeStrE("text", 0, 7); err != nil {
+		t.Fatalf("TypeStrE: %v", err)
+	}
+	if err := UnicodeTypeE('€'); err != nil {
+		t.Fatalf("UnicodeTypeE: %v", err)
+	}
+	if err := MoveE(10, 20, 2); err != nil {
+		t.Fatalf("MoveE: %v", err)
+	}
+	if err := MoveRelativeE(-3, 4); err != nil {
+		t.Fatalf("MoveRelativeE: %v", err)
+	}
+	if !MoveSmooth(30, 40, 1.0, 2.0, 0) {
+		t.Fatal("MoveSmooth returned false")
+	}
+	MoveSmoothRelative(3, -2, 1.0, 2.0, 0)
+	DragSmooth(50, 60, 1.0, 2.0, 0)
+	if err := ClickE("right", true); err != nil {
+		t.Fatalf("ClickE: %v", err)
+	}
+	if err := Toggle("center", "up"); err != nil {
+		t.Fatalf("Toggle: %v", err)
+	}
+	if err := ScrollE(1, -2, 0); err != nil {
+		t.Fatalf("ScrollE: %v", err)
+	}
+	x, y, err := LocationE()
+	if err != nil || x != -12 || y != 34 {
+		t.Fatalf("LocationE = (%d,%d,%v), want (-12,34,nil)", x, y, err)
+	}
+
+	want := []string{
+		"keyboard-ready",
+		"mouse-ready",
+		"key:a:[ctrl]:0:true:true",
+		"key:A:[ctrl shift]:0:true:true",
+		"key:+:[shift]:0:true:true",
+		"key:b:[shift]:0:true:true",
+		"key:c:[alt]:0:false:false",
+		"key:d:[ctrl]:0:true:false",
+		"key:d:[ctrl]:0:false:false",
+		"text:text:0:7",
+		"text:€:0:0",
+		"move:10:20:[2]",
+		"relative:-3:4",
+		"smooth:30:40:false:1:2",
+		"smooth:3:-2:true:1:2",
+		"drag:50:60:1:2",
+		"click:right:true",
+		"toggle:center:false",
+		"scroll:1:-2",
+		"location",
+	}
+	if !reflect.DeepEqual(backend.calls, want) {
+		t.Fatalf("backend calls = %#v, want %#v", backend.calls, want)
+	}
+}
+
+func TestNonCGOKeyArgumentsRejectMultipleProcessIDs(t *testing.T) {
+	backend := &fakePureGoInputBackend{}
+	installFakePureGoInputBackend(t, backend)
+	if err := KeyTap("a", 1, 2); err == nil {
+		t.Fatal("KeyTap accepted multiple process IDs")
+	}
+	if len(backend.calls) != 0 {
+		t.Fatalf("invalid key arguments reached backend: %#v", backend.calls)
+	}
+}
+
+func TestNonCGOSmoothMoveRejectsInvalidLegacyArguments(t *testing.T) {
+	backend := &fakePureGoInputBackend{}
+	installFakePureGoInputBackend(t, backend)
+	for _, args := range [][]interface{}{
+		{1, 2},
+		{3.0, 2.0},
+		{1.0, 2.0, -1},
+		{math.NaN(), 2.0},
+		{1.0, math.Inf(1)},
+	} {
+		if MoveSmooth(1, 2, args...) {
+			t.Fatalf("MoveSmooth accepted invalid args %#v", args)
+		}
+	}
+	if len(backend.calls) != 0 {
+		t.Fatalf("invalid smooth move reached backend: %#v", backend.calls)
+	}
+}
+
+func TestNonCGOInputDispatchPreservesBackendErrors(t *testing.T) {
+	wantErr := errors.New("backend injection failed")
+	backend := &fakePureGoInputBackend{operationErr: wantErr}
+	installFakePureGoInputBackend(t, backend)
+	zeroInputDelays(t)
+	if err := KeyTap("a"); !errors.Is(err, wantErr) {
+		t.Fatalf("KeyTap error = %v, want %v", err, wantErr)
+	}
+	if err := MoveE(1, 2); !errors.Is(err, wantErr) {
+		t.Fatalf("MoveE error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestPureGoInputCapabilitiesDoNotPerformLiveProbes(t *testing.T) {
+	keyboardErr := errors.New("keyboard unavailable")
+	backend := &fakePureGoInputBackend{keyboardErr: keyboardErr}
+	installFakePureGoInputBackend(t, backend)
+	keyboard, mouse := pureGoInputCapabilities()
+	if !keyboard.Available || keyboard.Backend != backend.Name() {
+		t.Fatalf("keyboard capability = %+v", keyboard)
+	}
+	if !mouse.Available || mouse.Backend != backend.Name() {
+		t.Fatalf("mouse capability = %+v", mouse)
+	}
+	if len(backend.calls) != 0 {
+		t.Fatalf("capability inspection performed live backend calls: %v", backend.calls)
+	}
+}
+
+func TestUnicodeTypeRejectsInvalidScalarBeforeDispatch(t *testing.T) {
+	backend := &fakePureGoInputBackend{}
+	installFakePureGoInputBackend(t, backend)
+	for _, value := range []uint32{0xd800, 0x110000} {
+		if err := UnicodeTypeE(value); err == nil {
+			t.Fatalf("UnicodeTypeE(%#x) unexpectedly succeeded", value)
+		}
+	}
+	if len(backend.calls) != 0 {
+		t.Fatalf("invalid Unicode reached backend: %#v", backend.calls)
+	}
+}
+
+func TestTypeStrRejectsInvalidInputBeforeDispatch(t *testing.T) {
+	backend := &fakePureGoInputBackend{}
+	installFakePureGoInputBackend(t, backend)
+	for _, test := range []struct {
+		name string
+		text string
+		args []int
+	}{
+		{name: "negative delay", text: "text", args: []int{0, -1}},
+		{name: "invalid UTF-8", text: string([]byte{0xff})},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := TypeStrE(test.text, test.args...); err == nil {
+				t.Fatal("invalid text input unexpectedly succeeded")
+			}
+		})
+	}
+	if len(backend.calls) != 0 {
+		t.Fatalf("invalid text input reached backend: %#v", backend.calls)
+	}
+}

--- a/input_validation.go
+++ b/input_validation.go
@@ -1,0 +1,171 @@
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+func uppercaseSingleRuneKey(key string) bool {
+	if !utf8.ValidString(key) {
+		return false
+	}
+	value, size := utf8.DecodeRuneInString(key)
+	return size == len(key) && unicode.IsUpper(value)
+}
+
+func validateKeyArgument(key string) error {
+	if _, err := portalKeysymForKey(key); err != nil {
+		return fmt.Errorf("robotgo: invalid keyboard key %q", key)
+	}
+	return nil
+}
+
+func parseKeyArguments(args []interface{}, toggle bool) (pid int, down bool, modifiers []string, err error) {
+	down = true
+	pidSet := false
+	for _, arg := range args {
+		switch value := arg.(type) {
+		case string:
+			modifiers = append(modifiers, value)
+		case []string:
+			modifiers = append(modifiers, value...)
+		case int:
+			if pidSet {
+				return 0, false, nil, errors.New("robotgo: multiple process IDs in key arguments")
+			}
+			pid = value
+			pidSet = true
+		default:
+			return 0, false, nil, fmt.Errorf("robotgo: key argument must be a modifier string, modifier slice, or process ID, got %T", arg)
+		}
+	}
+	if toggle && len(modifiers) > 0 {
+		switch strings.ToLower(modifiers[0]) {
+		case "down":
+			modifiers = modifiers[1:]
+		case "up":
+			down = false
+			modifiers = modifiers[1:]
+		}
+	}
+	return pid, down, modifiers, nil
+}
+
+func normalizeKeyModifiers(modifiers []string) ([]string, error) {
+	result := make([]string, len(modifiers))
+	for index, modifier := range modifiers {
+		normalized := strings.ToLower(modifier)
+		switch normalized {
+		case "none",
+			"alt", "lalt", "ralt",
+			"cmd", "command", "lcmd", "rcmd",
+			"ctrl", "control", "lctrl", "rctrl",
+			"shift", "lshift", "rshift", "right_shift":
+			result[index] = normalized
+		default:
+			return nil, fmt.Errorf("robotgo: unsupported key modifier %q", modifier)
+		}
+	}
+	return result, nil
+}
+
+func parseSmoothMoveArguments(args []interface{}) (lowDelay, highDelay float64, extraDelay int, ok bool) {
+	lowDelay, highDelay, extraDelay = 1, 3, 1
+	switch len(args) {
+	case 0:
+		return lowDelay, highDelay, extraDelay, true
+	case 2, 3:
+	default:
+		return 0, 0, 0, false
+	}
+	var lowOK, highOK bool
+	lowDelay, lowOK = args[0].(float64)
+	highDelay, highOK = args[1].(float64)
+	if !lowOK || !highOK {
+		return 0, 0, 0, false
+	}
+	if len(args) == 3 {
+		var delayOK bool
+		extraDelay, delayOK = args[2].(int)
+		if !delayOK {
+			return 0, 0, 0, false
+		}
+	}
+	if !validSmoothDelayRange(lowDelay, highDelay) || extraDelay < 0 {
+		return 0, 0, 0, false
+	}
+	return lowDelay, highDelay, extraDelay, true
+}
+
+func validSmoothDelayRange(lowDelay, highDelay float64) bool {
+	return !math.IsNaN(lowDelay) && !math.IsNaN(highDelay) &&
+		!math.IsInf(lowDelay, 0) && !math.IsInf(highDelay, 0) &&
+		lowDelay >= 0 && highDelay >= lowDelay
+}
+
+func validateUnicodeScalar(value uint32) error {
+	if value > 0x10ffff || value >= 0xd800 && value <= 0xdfff {
+		return fmt.Errorf("robotgo: invalid Unicode code point U+%X", value)
+	}
+	return nil
+}
+
+func parseTextInput(text string, args []int) (pid, delay int, err error) {
+	if len(args) > 3 {
+		return 0, 0, fmt.Errorf("robotgo: text input accepts at most pid, delay, and X11 delay, got %d arguments", len(args))
+	}
+	if !utf8.ValidString(text) {
+		return 0, 0, errors.New("robotgo: text is not valid UTF-8")
+	}
+	if len(args) > 0 {
+		pid = args[0]
+	}
+	if len(args) > 1 {
+		delay = args[1]
+		if delay < 0 {
+			return 0, 0, errors.New("robotgo: text delay must be non-negative")
+		}
+	}
+	if len(args) > 2 && args[2] < 0 {
+		return 0, 0, errors.New("robotgo: X11 text delay must be non-negative")
+	}
+	return pid, delay, nil
+}
+
+func parseScrollDelay(args []int) (int, error) {
+	if len(args) > 1 {
+		return 0, fmt.Errorf("robotgo: scroll accepts at most one delay argument, got %d", len(args))
+	}
+	delay := 10
+	if len(args) == 1 {
+		delay = args[0]
+	}
+	if delay < 0 {
+		return 0, errors.New("robotgo: scroll delay must be non-negative")
+	}
+	return delay, nil
+}
+
+func parseScrollDirection(args []interface{}) (string, error) {
+	if len(args) > 1 {
+		return "", fmt.Errorf("robotgo: scroll direction accepts at most one argument, got %d", len(args))
+	}
+	direction := "down"
+	if len(args) == 1 {
+		value, ok := args[0].(string)
+		if !ok {
+			return "", fmt.Errorf("robotgo: scroll direction must be a string, got %T", args[0])
+		}
+		direction = value
+	}
+	switch direction {
+	case "up", "down", "left", "right":
+		return direction, nil
+	default:
+		return "", fmt.Errorf("robotgo: unknown scroll direction %q", direction)
+	}
+}

--- a/input_validation_cgo_test.go
+++ b/input_validation_cgo_test.go
@@ -1,0 +1,42 @@
+//go:build cgo
+
+package robotgo
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestInvalidMouseArgumentsDoNotWaitForWaylandBackendLock(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Wayland mouse serialization is Linux-specific")
+	}
+	t.Setenv("WAYLAND_DISPLAY", "robotgo-validation-test")
+	t.Setenv("DISPLAY", "")
+
+	for _, test := range []struct {
+		name string
+		call func() error
+	}{
+		{name: "click", call: func() error { return ClickE("invalid") }},
+		{name: "toggle", call: func() error { return Toggle("invalid") }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			waylandMouseMu.Lock()
+			done := make(chan error, 1)
+			go func() { done <- test.call() }()
+			select {
+			case err := <-done:
+				waylandMouseMu.Unlock()
+				if err == nil {
+					t.Fatal("invalid arguments unexpectedly succeeded")
+				}
+			case <-time.After(250 * time.Millisecond):
+				waylandMouseMu.Unlock()
+				<-done
+				t.Fatal("invalid arguments waited for the Wayland backend lock")
+			}
+		})
+	}
+}

--- a/input_validation_test.go
+++ b/input_validation_test.go
@@ -1,0 +1,202 @@
+package robotgo
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+)
+
+var _ func() error = CloseMainDisplayE
+
+func TestKeyArgumentParsingIsBuildIndependent(t *testing.T) {
+	pid, down, modifiers, err := parseKeyArguments(
+		[]interface{}{[]string{"CTRL"}, 42, "shift"}, false,
+	)
+	if err != nil || pid != 42 || !down || !reflect.DeepEqual(modifiers, []string{"CTRL", "shift"}) {
+		t.Fatalf("parseKeyArguments(tap) = (%d,%t,%v,%v)", pid, down, modifiers, err)
+	}
+	pid, down, modifiers, err = parseKeyArguments(
+		[]interface{}{[]string{"UP", "alt"}, 7}, true,
+	)
+	if err != nil || pid != 7 || down || !reflect.DeepEqual(modifiers, []string{"alt"}) {
+		t.Fatalf("parseKeyArguments(toggle) = (%d,%t,%v,%v)", pid, down, modifiers, err)
+	}
+	for _, args := range [][]interface{}{
+		{1, 2},
+		{struct{}{}},
+	} {
+		if _, _, _, err := parseKeyArguments(args, false); err == nil {
+			t.Fatalf("parseKeyArguments(%v) unexpectedly succeeded", args)
+		}
+	}
+	if got, err := normalizeKeyModifiers([]string{"CTRL", "right_shift", "NONE"}); err != nil ||
+		!reflect.DeepEqual(got, []string{"ctrl", "right_shift", "none"}) {
+		t.Fatalf("normalizeKeyModifiers(valid) = (%v,%v)", got, err)
+	}
+	if _, err := normalizeKeyModifiers([]string{"not-a-modifier"}); err == nil {
+		t.Fatal("normalizeKeyModifiers accepted an unknown modifier")
+	}
+}
+
+func TestUppercaseShiftDetectionOnlyAppliesToSingleRuneKeys(t *testing.T) {
+	for _, test := range []struct {
+		key  string
+		want bool
+	}{
+		{key: "A", want: true},
+		{key: "Ä", want: true},
+		{key: "a"},
+		{key: "Enter"},
+		{key: ""},
+		{key: string([]byte{0xff})},
+	} {
+		if got := uppercaseSingleRuneKey(test.key); got != test.want {
+			t.Fatalf("uppercaseSingleRuneKey(%q) = %t, want %t", test.key, got, test.want)
+		}
+	}
+}
+
+func TestParseSmoothMoveArgumentsIsStrict(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []interface{}
+		ok   bool
+	}{
+		{name: "defaults", ok: true},
+		{name: "range", args: []interface{}{1.0, 2.0}, ok: true},
+		{name: "range and delay", args: []interface{}{1.0, 2.0, 3}, ok: true},
+		{name: "one argument", args: []interface{}{"typo"}},
+		{name: "too many", args: []interface{}{1.0, 2.0, 3, 4}},
+		{name: "wrong range types", args: []interface{}{1, 2}},
+		{name: "wrong delay type", args: []interface{}{1.0, 2.0, 3.0}},
+		{name: "descending range", args: []interface{}{2.0, 1.0}},
+		{name: "negative delay", args: []interface{}{1.0, 2.0, -1}},
+		{name: "NaN", args: []interface{}{math.NaN(), 2.0}},
+		{name: "infinity", args: []interface{}{1.0, math.Inf(1)}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, _, ok := parseSmoothMoveArguments(test.args)
+			if ok != test.ok {
+				t.Fatalf("parseSmoothMoveArguments(%#v) ok = %t, want %t", test.args, ok, test.ok)
+			}
+		})
+	}
+}
+
+func TestTextAndUnicodeValidationIsBuildIndependent(t *testing.T) {
+	for _, value := range []uint32{0xd800, 0x110000} {
+		if err := validateUnicodeScalar(value); err == nil {
+			t.Fatalf("validateUnicodeScalar(%#x) unexpectedly succeeded", value)
+		}
+	}
+	if err := validateUnicodeScalar('€'); err != nil {
+		t.Fatalf("validateUnicodeScalar(valid) = %v", err)
+	}
+	for _, test := range []struct {
+		text string
+		args []int
+	}{
+		{text: string([]byte{0xff})},
+		{text: "text", args: []int{0, -1}},
+		{text: "text", args: []int{0, 0, -1}},
+		{text: "text", args: []int{0, 0, 0, 0}},
+	} {
+		if _, _, err := parseTextInput(test.text, test.args); err == nil {
+			t.Fatalf("parseTextInput(%q,%v) unexpectedly succeeded", test.text, test.args)
+		}
+	}
+	if pid, delay, err := parseTextInput("text", []int{17, 3, 7}); err != nil || pid != 17 || delay != 3 {
+		t.Fatalf("parseTextInput(valid) = (%d,%d,%v), want (17,3,nil)", pid, delay, err)
+	}
+}
+
+func TestParseScrollDelayIsStrict(t *testing.T) {
+	for _, test := range []struct {
+		args []int
+		want int
+		ok   bool
+	}{
+		{want: 10, ok: true},
+		{args: []int{3}, want: 3, ok: true},
+		{args: []int{-1}},
+		{args: []int{1, 2}},
+	} {
+		got, err := parseScrollDelay(test.args)
+		if (err == nil) != test.ok || test.ok && got != test.want {
+			t.Fatalf("parseScrollDelay(%v) = (%d,%v), want (%d,ok=%t)", test.args, got, err, test.want, test.ok)
+		}
+	}
+}
+
+func TestParseScrollDirectionIsBuildIndependent(t *testing.T) {
+	for _, test := range []struct {
+		args []interface{}
+		want string
+		ok   bool
+	}{
+		{want: "down", ok: true},
+		{args: []interface{}{"up"}, want: "up", ok: true},
+		{args: []interface{}{7}},
+		{args: []interface{}{"diagonal"}},
+		{args: []interface{}{"up", "extra"}},
+	} {
+		got, err := parseScrollDirection(test.args)
+		if (err == nil) != test.ok || test.ok && got != test.want {
+			t.Fatalf("parseScrollDirection(%v) = (%q,%v), want (%q,ok=%t)", test.args, got, err, test.want, test.ok)
+		}
+	}
+	ScrollDir(1, 7)
+	ScrollDir(1, "diagonal")
+	ScrollDir(1, "up", "extra")
+}
+
+func TestMalformedSmoothMoveDoesNotReachPlatform(t *testing.T) {
+	if MoveSmooth(10, 10, "typo") {
+		t.Fatal("MoveSmooth accepted one malformed argument")
+	}
+	if MoveSmooth(10, 10, 1.0, 2.0, 3, "extra") {
+		t.Fatal("MoveSmooth accepted surplus arguments")
+	}
+}
+
+func TestPublicInputValidationRunsBeforeBackendSelection(t *testing.T) {
+	for _, call := range []func() error{
+		func() error { return KeyTap("") },
+		func() error { return KeyToggle("not-a-key") },
+	} {
+		if err := call(); err == nil || errors.Is(err, ErrNotSupported) {
+			t.Fatalf("invalid key error = %v, want a backend-independent argument error", err)
+		}
+	}
+	if err := UnicodeTypeE(0x110000); err == nil {
+		t.Fatal("UnicodeTypeE accepted an out-of-range code point")
+	}
+	if err := TypeStrE(string([]byte{0xff})); err == nil {
+		t.Fatal("TypeStrE accepted invalid UTF-8")
+	}
+	if err := TypeStrE("text", 0, -1); err == nil {
+		t.Fatal("TypeStrE accepted a negative delay")
+	}
+	if err := TypeStrE("text", 0, 0, 0, 0); err == nil {
+		t.Fatal("TypeStrE accepted surplus arguments")
+	}
+	if err := ScrollE(0, 0, -1); err == nil {
+		t.Fatal("ScrollE accepted a negative delay")
+	}
+	if err := ScrollE(0, 0, 1, 2); err == nil {
+		t.Fatal("ScrollE accepted surplus arguments")
+	}
+}
+
+func TestUTF8SingleRuneKeyUsesExplicitBackendContract(t *testing.T) {
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", "")
+	t.Setenv("XDG_SESSION_TYPE", "")
+	if err := validateKeyArgument("é"); err != nil {
+		t.Fatalf("UTF-8 single rune should be a valid key argument: %v", err)
+	}
+	if err := KeyTap("é"); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("KeyTap UTF-8 error = %v, want explicit ErrNotSupported without a capable backend", err)
+	}
+}

--- a/key.go
+++ b/key.go
@@ -19,13 +19,10 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"math/rand"
-	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
-	"unicode"
 	"unsafe"
 
 	"github.com/marang/robotgo/clipboard"
@@ -435,7 +432,7 @@ func closeWaylandKeyboard() { C.robotgo_wayland_keyboard_close() }
 
 func checkKeyCodes(k string) (key C.MMKeyCode, err error) {
 	if k == "" {
-		return
+		return C.K_NOT_A_KEY, errInvalidKeyFlag
 	}
 
 	if len(k) == 1 {
@@ -456,86 +453,62 @@ func checkKeyCodes(k string) (key C.MMKeyCode, err error) {
 			err = errInvalidKeyFlag
 			return
 		}
+		return key, nil
 	}
-	return
+	return C.K_NOT_A_KEY, errInvalidKeyFlag
 }
 
-func checkKeyFlags(f string) (flags C.MMKeyFlags) {
+func checkKeyFlags(f string) (C.MMKeyFlags, error) {
 	m := map[string]C.MMKeyFlags{
-		"alt":    C.MOD_ALT,
-		"ralt":   C.MOD_ALT,
-		"lalt":   C.MOD_ALT,
-		"cmd":    C.MOD_META,
-		"rcmd":   C.MOD_META,
-		"lcmd":   C.MOD_META,
-		"ctrl":   C.MOD_CONTROL,
-		Control:  C.MOD_CONTROL,
-		"rctrl":  C.MOD_CONTROL,
-		"lctrl":  C.MOD_CONTROL,
-		"shift":  C.MOD_SHIFT,
-		"rshift": C.MOD_SHIFT,
-		"lshift": C.MOD_SHIFT,
-		"none":   C.MOD_NONE,
+		"alt":         C.MOD_ALT,
+		"ralt":        C.MOD_ALT,
+		"lalt":        C.MOD_ALT,
+		"cmd":         C.MOD_META,
+		"command":     C.MOD_META,
+		"rcmd":        C.MOD_META,
+		"lcmd":        C.MOD_META,
+		"ctrl":        C.MOD_CONTROL,
+		Control:       C.MOD_CONTROL,
+		"rctrl":       C.MOD_CONTROL,
+		"lctrl":       C.MOD_CONTROL,
+		"shift":       C.MOD_SHIFT,
+		"rshift":      C.MOD_SHIFT,
+		"lshift":      C.MOD_SHIFT,
+		"right_shift": C.MOD_SHIFT,
+		"none":        C.MOD_NONE,
 	}
 
-	if v, ok := m[f]; ok {
-		return v
+	if value, ok := m[strings.ToLower(f)]; ok {
+		return value, nil
 	}
-	return
+	return C.MOD_NONE, fmt.Errorf("robotgo: unsupported key modifier %q", f)
 }
 
-func getFlagsFromValue(value []string) (flags C.MMKeyFlags) {
+func getFlagsFromValue(value []string) (flags C.MMKeyFlags, err error) {
 	if len(value) <= 0 {
-		return
+		return flags, nil
 	}
 
-	for i := 0; i < len(value); i++ {
-		var f C.MMKeyFlags = C.MOD_NONE
-
-		f = checkKeyFlags(value[i])
+	for _, modifier := range value {
+		f, flagErr := checkKeyFlags(modifier)
+		if flagErr != nil {
+			return C.MOD_NONE, flagErr
+		}
 		flags = (C.MMKeyFlags)(flags | f)
 	}
 
-	return
-}
-
-func portalKeysyms(key string, modifiers []string) (int32, []int32, error) {
-	mainKey, err := checkKeyCodes(key)
-	if err != nil {
-		return 0, nil, err
-	}
-	if mainKey == C.K_NOT_A_KEY || mainKey == 0 {
-		return 0, nil, errInvalidKeyFlag
-	}
-	portalModifiers := make([]int32, 0, len(modifiers))
-	seen := make(map[int32]struct{}, len(modifiers))
-	for _, modifier := range modifiers {
-		if modifier == "none" {
-			continue
-		}
-		code, err := checkKeyCodes(modifier)
-		if err != nil {
-			return 0, nil, err
-		}
-		if code == C.K_NOT_A_KEY || code == 0 {
-			return 0, nil, errInvalidKeyFlag
-		}
-		keysym := int32(code)
-		if _, duplicate := seen[keysym]; duplicate {
-			continue
-		}
-		seen[keysym] = struct{}{}
-		portalModifiers = append(portalModifiers, keysym)
-	}
-	return int32(mainKey), portalModifiers, nil
+	return flags, nil
 }
 
 func tryPortalKey(key string, modifiers []string, pid int, down bool, tap bool) (bool, error) {
+	if runtime.GOOS != "linux" || DetectDisplayServer() != DisplayServerWayland {
+		return false, nil
+	}
 	return withRemoteDesktopInput(inputportal.DeviceKeyboard, func(session remoteDesktopInputSession) error {
 		if pid != 0 {
 			return fmt.Errorf("%w: RemoteDesktop portal input cannot target a process", ErrNotSupported)
 		}
-		mainKey, portalModifiers, err := portalKeysyms(key, modifiers)
+		mainKey, portalModifiers, err := portalKeysymsPure(key, modifiers)
 		if err != nil {
 			return err
 		}
@@ -544,6 +517,10 @@ func tryPortalKey(key string, modifiers []string, pid int, down bool, tap bool) 
 }
 
 func keyTaps(k string, keyArr []string, pid int) error {
+	flags, err := getFlagsFromValue(keyArr)
+	if err != nil {
+		return err
+	}
 	unlock := lockWaylandKeyboard()
 	defer unlock()
 	if nativeErr := ensureWaylandKeyboardReady(); nativeErr != nil {
@@ -555,31 +532,26 @@ func keyTaps(k string, keyArr []string, pid int) error {
 		}
 		return nativeErr
 	}
-	flags := getFlagsFromValue(keyArr)
 	key, err := checkKeyCodes(k)
 	if err != nil {
-		return err
+		if used, portalErr := tryPortalKey(k, keyArr, pid, true, true); used {
+			if portalErr == nil {
+				MilliSleep(currentKeyDelay())
+			}
+			return portalErr
+		}
+		return fmt.Errorf("%w: native keyboard backend cannot map key %q; use TypeStrE or UnicodeTypeE for text", ErrNotSupported, k)
 	}
-
 	tapKeyCode(key, flags, C.uintptr(pid))
 	MilliSleep(currentKeyDelay())
 	return nil
 }
 
-func getKeyDown(keyArr []string) (bool, []string) {
-	if len(keyArr) <= 0 {
-		keyArr = append(keyArr, "down")
-	}
-
-	down := keyArr[0] != "up"
-
-	if keyArr[0] == "up" || keyArr[0] == "down" {
-		keyArr = keyArr[1:]
-	}
-	return down, keyArr
-}
-
 func keyTogglesB(k string, down bool, keyArr []string, pid int) error {
+	flags, err := getFlagsFromValue(keyArr)
+	if err != nil {
+		return err
+	}
 	unlock := lockWaylandKeyboard()
 	defer unlock()
 	if nativeErr := ensureWaylandKeyboardReady(); nativeErr != nil {
@@ -591,20 +563,19 @@ func keyTogglesB(k string, down bool, keyArr []string, pid int) error {
 		}
 		return nativeErr
 	}
-	flags := getFlagsFromValue(keyArr)
 	key, err := checkKeyCodes(k)
 	if err != nil {
-		return err
+		if used, portalErr := tryPortalKey(k, keyArr, pid, down, false); used {
+			if portalErr == nil {
+				MilliSleep(currentKeyDelay())
+			}
+			return portalErr
+		}
+		return fmt.Errorf("%w: native keyboard backend cannot map key %q; use TypeStrE or UnicodeTypeE for text", ErrNotSupported, k)
 	}
-
 	C.toggleKeyCode(key, C.bool(down), flags, C.uintptr(pid))
 	MilliSleep(currentKeyDelay())
 	return nil
-}
-
-func keyToggles(k string, keyArr []string, pid int) error {
-	down, keyArr1 := getKeyDown(keyArr)
-	return keyTogglesB(k, down, keyArr1, pid)
 }
 
 /*
@@ -653,8 +624,8 @@ func toErr(str *C.char) error {
 	return errors.New(gstr)
 }
 
-func appendShift(key string, len1 int, args ...interface{}) (string, []interface{}) {
-	if len(key) > 0 && unicode.IsUpper([]rune(key)[0]) {
+func appendShift(key string, args ...interface{}) (string, []interface{}) {
+	if uppercaseSingleRuneKey(key) {
 		args = append(args, "shift")
 	}
 
@@ -662,9 +633,7 @@ func appendShift(key string, len1 int, args ...interface{}) (string, []interface
 	if spec := CurrentSpecialTable(); spec != nil {
 		if v, ok := spec[key]; ok {
 			key = v
-			if len(args) <= len1 {
-				args = append(args, "shift")
-			}
+			args = append(args, "shift")
 			return key, args
 		}
 	}
@@ -688,52 +657,19 @@ func appendShift(key string, len1 int, args ...interface{}) (string, []interface
 //
 //	robotgo.KeyTap("k", pid int)
 func KeyTap(key string, args ...interface{}) error {
-	var keyArr []string
-	key, args = appendShift(key, 0, args...)
-
-	pid := 0
-	if len(args) > 0 {
-		if reflect.TypeOf(args[0]) == reflect.TypeOf(keyArr) {
-			keyArr = append(keyArr, args[0].([]string)...)
-			values, err := toStringsE(args[1:])
-			if err != nil {
-				return err
-			}
-			keyArr = append(keyArr, values...)
-		} else {
-			if reflect.TypeOf(args[0]) == reflect.TypeOf(pid) {
-				pid = args[0].(int)
-				values, err := toStringsE(args[1:])
-				if err != nil {
-					return err
-				}
-				keyArr = values
-			} else {
-				values, err := toStringsE(args)
-				if err != nil {
-					return err
-				}
-				keyArr = values
-			}
-		}
+	key, args = appendShift(key, args...)
+	pid, _, keyArr, err := parseKeyArguments(args, false)
+	if err != nil {
+		return err
 	}
-
+	keyArr, err = normalizeKeyModifiers(keyArr)
+	if err != nil {
+		return err
+	}
+	if err := validateKeyArgument(key); err != nil {
+		return err
+	}
 	return keyTaps(key, keyArr, pid)
-}
-
-func getToggleArgs(args ...interface{}) (pid int, keyArr []string, err error) {
-	if len(args) > 0 && reflect.TypeOf(args[0]) == reflect.TypeOf(pid) {
-		pid = args[0].(int)
-		keyArr, err = toStringsE(args[1:])
-	} else if len(args) > 0 && reflect.TypeOf(args[0]) == reflect.TypeOf(keyArr) {
-		keyArr = append(keyArr, args[0].([]string)...)
-		var values []string
-		values, err = toStringsE(args[1:])
-		keyArr = append(keyArr, values...)
-	} else {
-		keyArr, err = toStringsE(args)
-	}
-	return
 }
 
 // KeyToggle toggles the keyboard, if there not have args default is "down"
@@ -750,23 +686,25 @@ func getToggleArgs(args ...interface{}) (pid int, keyArr []string, err error) {
 //	robotgo.KeyToggle("a", "up", "alt", "cmd")
 //	robotgo.KeyToggle("k", pid int)
 func KeyToggle(key string, args ...interface{}) error {
-	key, args = appendShift(key, 1, args...)
-	pid, keyArr, err := getToggleArgs(args...)
+	key, args = appendShift(key, args...)
+	pid, down, keyArr, err := parseKeyArguments(args, true)
 	if err != nil {
 		return err
 	}
-	return keyToggles(key, keyArr, pid)
+	keyArr, err = normalizeKeyModifiers(keyArr)
+	if err != nil {
+		return err
+	}
+	if err := validateKeyArgument(key); err != nil {
+		return err
+	}
+	return keyTogglesB(key, down, keyArr, pid)
 }
 
-// KeyPress press key string
+// KeyPress presses and releases a key as one backend transaction. It is
+// equivalent to KeyTap.
 func KeyPress(key string, args ...interface{}) error {
-	err := KeyDown(key, args...)
-	if err != nil {
-		return err
-	}
-
-	MilliSleep(1 + rand.Intn(3))
-	return KeyUp(key, args...)
+	return KeyTap(key, args...)
 }
 
 // KeyDown press down a key
@@ -812,6 +750,9 @@ func UnicodeType(str uint32, args ...int) {
 // UnicodeTypeE types one Unicode code point and reports backend availability
 // errors.
 func UnicodeTypeE(str uint32, args ...int) error {
+	if err := validateUnicodeScalar(str); err != nil {
+		return err
+	}
 	unlock := lockWaylandKeyboard()
 	defer unlock()
 	if nativeErr := ensureWaylandKeyboardReady(); nativeErr != nil {
@@ -888,6 +829,9 @@ func TypeStr(str string, args ...int) {
 
 // TypeStrE sends a UTF-8 string and reports backend or key injection errors.
 func TypeStrE(str string, args ...int) error {
+	if _, _, err := parseTextInput(str, args); err != nil {
+		return err
+	}
 	unlock := lockWaylandKeyboard()
 	defer unlock()
 	if nativeErr := ensureWaylandKeyboardReady(); nativeErr != nil {

--- a/key_argument_parity_linux_test.go
+++ b/key_argument_parity_linux_test.go
@@ -1,0 +1,88 @@
+//go:build linux
+
+package robotgo
+
+import (
+	"reflect"
+	"testing"
+
+	inputportal "github.com/marang/robotgo/input/portal"
+)
+
+func TestKeyArgumentAndValidationParityThroughPortalFallback(t *testing.T) {
+	t.Setenv("WAYLAND_DISPLAY", "robotgo-key-parity-test")
+	t.Setenv("DISPLAY", "")
+	session := installFakeHighLevelPortalSession(t, inputportal.DeviceKeyboard)
+	previous := GetRuntimeConfig()
+	config := previous
+	config.KeyDelay = 0
+	if err := SetRuntimeConfig(config); err != nil {
+		t.Fatalf("disable key delay: %v", err)
+	}
+	t.Cleanup(func() { _ = SetRuntimeConfig(previous) })
+
+	if err := KeyDown("d", 0, []string{"CTRL"}); err != nil {
+		t.Fatalf("KeyDown with mixed argument forms: %v", err)
+	}
+	if err := KeyUp("d", []string{"ctrl"}, 0); err != nil {
+		t.Fatalf("KeyUp with mixed argument forms: %v", err)
+	}
+	if err := KeyPress("+", 0, "CTRL"); err != nil {
+		t.Fatalf("KeyPress with shifted special key: %v", err)
+	}
+	if err := KeyPress("Enter", 0); err != nil {
+		t.Fatalf("KeyPress with mixed-case named key: %v", err)
+	}
+	if err := KeyPress("numpad_0", 0); err != nil {
+		t.Fatalf("KeyPress with legacy numpad alias: %v", err)
+	}
+	if err := KeyPress("é", 0); err != nil {
+		t.Fatalf("KeyPress with a UTF-8 single rune: %v", err)
+	}
+	if err := KeyDown("Ä", 0); err != nil {
+		t.Fatalf("KeyDown with an uppercase UTF-8 single rune: %v", err)
+	}
+	if err := KeyUp("Ä", 0); err != nil {
+		t.Fatalf("KeyUp with an uppercase UTF-8 single rune: %v", err)
+	}
+	events, _ := session.snapshot()
+	want := []string{
+		"keysym:65507:true",
+		"keysym:100:true",
+		"keysym:100:false",
+		"keysym:65507:false",
+		"keysym:65507:true",
+		"keysym:65505:true",
+		"keysym:61:true",
+		"keysym:61:false",
+		"keysym:65505:false",
+		"keysym:65507:false",
+		"keysym:65293:true",
+		"keysym:65293:false",
+		"keysym:65456:true",
+		"keysym:65456:false",
+		"keysym:233:true",
+		"keysym:233:false",
+		"keysym:65505:true",
+		"keysym:228:true",
+		"keysym:228:false",
+		"keysym:65505:false",
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("key events = %v, want %v", events, want)
+	}
+
+	for _, call := range []func() error{
+		func() error { return KeyTap("") },
+		func() error { return KeyTap("not-a-key") },
+		func() error { return KeyTap("enter", "not-a-modifier") },
+	} {
+		if err := call(); err == nil {
+			t.Fatal("invalid key input unexpectedly succeeded")
+		}
+	}
+	after, _ := session.snapshot()
+	if !reflect.DeepEqual(after, want) {
+		t.Fatalf("invalid key input produced portal events: before=%v after=%v", want, after)
+	}
+}

--- a/key_constants_test.go
+++ b/key_constants_test.go
@@ -26,7 +26,7 @@ func TestUpstreamKeyConstants(t *testing.T) {
 	if _, ok := keyNames[PauseBreak]; !ok {
 		t.Fatalf("keyNames missing %q", PauseBreak)
 	}
-	if got := checkKeyFlags(Control); got == 0 {
-		t.Fatalf("checkKeyFlags(%q) returned no modifier", Control)
+	if got, err := checkKeyFlags(Control); err != nil || got == 0 {
+		t.Fatalf("checkKeyFlags(%q) = (%d,%v), want a modifier", Control, got, err)
 	}
 }

--- a/legacy_args.go
+++ b/legacy_args.go
@@ -2,7 +2,19 @@ package robotgo
 
 import "fmt"
 
+func validateMouseButtonName(name string) error {
+	switch name {
+	case "", "left", "center", "middle", "right", "wheelDown", "wheelUp", "wheelLeft", "wheelRight":
+		return nil
+	default:
+		return fmt.Errorf("robotgo: unknown mouse button %q", name)
+	}
+}
+
 func parseClickArguments(args []interface{}) (name string, double bool, err error) {
+	if len(args) > 2 {
+		return "", false, fmt.Errorf("robotgo: click accepts at most a button and double-click flag, got %d arguments", len(args))
+	}
 	name = "left"
 	if len(args) > 0 {
 		value, ok := args[0].(string)
@@ -10,6 +22,9 @@ func parseClickArguments(args []interface{}) (name string, double bool, err erro
 			return "", false, fmt.Errorf("robotgo: mouse button must be a string, got %T", args[0])
 		}
 		name = value
+	}
+	if err := validateMouseButtonName(name); err != nil {
+		return "", false, err
 	}
 	if len(args) > 1 {
 		value, ok := args[1].(bool)
@@ -22,6 +37,9 @@ func parseClickArguments(args []interface{}) (name string, double bool, err erro
 }
 
 func parseToggleArguments(args []interface{}) (name string, down bool, err error) {
+	if len(args) > 2 {
+		return "", false, fmt.Errorf("robotgo: toggle accepts at most a button and state, got %d arguments", len(args))
+	}
 	name, down = "left", true
 	if len(args) > 0 {
 		value, ok := args[0].(string)
@@ -30,12 +48,22 @@ func parseToggleArguments(args []interface{}) (name string, down bool, err error
 		}
 		name = value
 	}
+	if err := validateMouseButtonName(name); err != nil {
+		return "", false, err
+	}
 	if len(args) > 1 {
 		value, ok := args[1].(string)
 		if !ok {
 			return "", false, fmt.Errorf("robotgo: mouse state must be a string, got %T", args[1])
 		}
-		down = value != "up"
+		switch value {
+		case "down":
+			down = true
+		case "up":
+			down = false
+		default:
+			return "", false, fmt.Errorf("robotgo: mouse state must be %q or %q, got %q", "down", "up", value)
+		}
 	}
 	return name, down, nil
 }

--- a/legacy_args_test.go
+++ b/legacy_args_test.go
@@ -9,8 +9,12 @@ func TestErrorReturningInputAPIsRejectInvalidArgumentTypes(t *testing.T) {
 	}{
 		{name: "click button", call: func() error { return ClickE(1) }},
 		{name: "click flag", call: func() error { return ClickE("left", "double") }},
+		{name: "click button name", call: func() error { return ClickE("typo") }},
+		{name: "click arity", call: func() error { return ClickE("left", false, "extra") }},
 		{name: "toggle button", call: func() error { return Toggle(false) }},
 		{name: "toggle state", call: func() error { return Toggle("left", true) }},
+		{name: "toggle button name", call: func() error { return Toggle("typo") }},
+		{name: "toggle arity", call: func() error { return Toggle("left", "down", "extra") }},
 		{name: "key modifier", call: func() error { return KeyTap("a", struct{}{}) }},
 		{name: "key toggle modifier", call: func() error { return KeyToggle("a", struct{}{}) }},
 	}
@@ -20,5 +24,13 @@ func TestErrorReturningInputAPIsRejectInvalidArgumentTypes(t *testing.T) {
 				t.Fatal("invalid argument type unexpectedly accepted")
 			}
 		})
+	}
+}
+
+func TestParseToggleArgumentsRejectsUnknownState(t *testing.T) {
+	for _, state := range []string{"", "pressed", "UP"} {
+		if _, _, err := parseToggleArguments([]interface{}{"left", state}); err == nil {
+			t.Fatalf("parseToggleArguments accepted state %q", state)
+		}
 	}
 }

--- a/remote_desktop_input.go
+++ b/remote_desktop_input.go
@@ -82,8 +82,10 @@ var (
 	remoteDesktopInputOperation sync.Mutex
 	remoteDesktopInputPending   struct {
 		sync.Mutex
-		start   *remoteDesktopPendingStart
-		closing int
+		start            *remoteDesktopPendingStart
+		operationContext context.Context
+		operationCancel  context.CancelFunc
+		closing          int
 	}
 	remoteDesktopInputState struct {
 		sync.RWMutex
@@ -218,6 +220,9 @@ func CloseRemoteDesktopInput() error {
 	if remoteDesktopInputPending.start != nil {
 		remoteDesktopInputPending.start.cancel()
 	}
+	if remoteDesktopInputPending.operationCancel != nil {
+		remoteDesktopInputPending.operationCancel()
+	}
 	remoteDesktopInputPending.Unlock()
 
 	remoteDesktopInputOperation.Lock()
@@ -248,6 +253,11 @@ func CloseRemoteDesktopInput() error {
 }
 
 func withRemoteDesktopInput(device inputportal.DeviceType, fn func(remoteDesktopInputSession) error) (bool, error) {
+	// A high-level input operation is one transaction. Serialize it with session
+	// replacement/close so modifier sequences and double clicks cannot interleave
+	// or lose their backend halfway through cleanup.
+	remoteDesktopInputOperation.Lock()
+	defer remoteDesktopInputOperation.Unlock()
 	remoteDesktopInputState.RLock()
 	session := remoteDesktopInputState.session
 	remoteDesktopInputState.RUnlock()
@@ -262,13 +272,79 @@ func withRemoteDesktopInput(device inputportal.DeviceType, fn func(remoteDesktop
 	if session.Devices()&device == 0 {
 		return true, fmt.Errorf("%w: required=%d granted=%d", inputportal.ErrDeviceNotGranted, device, session.Devices())
 	}
+	operationContext, cancelCause := context.WithCancelCause(context.Background())
+	cancel := func() { cancelCause(context.Canceled) }
+	watchDone := make(chan struct{})
+	remoteDesktopInputPending.Lock()
+	if remoteDesktopInputPending.closing > 0 {
+		remoteDesktopInputPending.Unlock()
+		close(watchDone)
+		cancel()
+		return true, context.Canceled
+	}
+	remoteDesktopInputPending.operationContext = operationContext
+	remoteDesktopInputPending.operationCancel = cancel
+	remoteDesktopInputPending.Unlock()
+	go func() {
+		select {
+		case <-session.Closed():
+			cancelCause(inputportal.ErrClosed)
+		case <-watchDone:
+		}
+	}()
+	defer func() {
+		close(watchDone)
+		cancel()
+		remoteDesktopInputPending.Lock()
+		if remoteDesktopInputPending.operationCancel != nil {
+			remoteDesktopInputPending.operationContext = nil
+			remoteDesktopInputPending.operationCancel = nil
+		}
+		remoteDesktopInputPending.Unlock()
+	}()
 	return true, fn(session)
 }
 
 func remoteDesktopEvent(fn func(context.Context) error) error {
-	ctx, cancel := context.WithTimeout(context.Background(), remoteDesktopEventTimeout)
+	remoteDesktopInputPending.Lock()
+	parent := remoteDesktopInputPending.operationContext
+	remoteDesktopInputPending.Unlock()
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, remoteDesktopEventTimeout)
 	defer cancel()
-	return fn(ctx)
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	err := fn(ctx)
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	return err
+}
+
+func remoteDesktopSleep(milliseconds int) error {
+	remoteDesktopInputPending.Lock()
+	ctx := remoteDesktopInputPending.operationContext
+	remoteDesktopInputPending.Unlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	if milliseconds <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(time.Duration(milliseconds) * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
 }
 
 func finishRemoteDesktopMouseEvent(err error, extraDelay int) error {
@@ -352,7 +428,7 @@ func portalPointerButton(name string) (int32, error) {
 		return 0x110, nil
 	case "right":
 		return 0x111, nil
-	case "center":
+	case "center", "middle":
 		return 0x112, nil
 	default:
 		return 0, fmt.Errorf("%w: portal pointer button %q", ErrNotSupported, name)
@@ -389,7 +465,9 @@ func tryRemoteDesktopClick(name string, double bool) (bool, error) {
 				return err
 			}
 			if double && i == 0 {
-				MilliSleep(200)
+				if err := remoteDesktopSleep(200); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -470,7 +548,9 @@ func tryRemoteDesktopText(text string, args []int) (bool, error) {
 			}); err != nil {
 				return err
 			}
-			MilliSleep(delay)
+			if err := remoteDesktopSleep(delay); err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/remote_desktop_input_nocgo_test.go
+++ b/remote_desktop_input_nocgo_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestNonCGOHighLevelPortalInput(t *testing.T) {
+	t.Setenv(envWaylandDisplay, "robotgo-test-wayland")
+	t.Setenv(envDisplay, "")
 	oldMouseSleep, oldKeySleep := MouseSleep, KeySleep
 	MouseSleep, KeySleep = 23, 0
 	t.Cleanup(func() { MouseSleep, KeySleep = oldMouseSleep, oldKeySleep })

--- a/remote_desktop_input_test.go
+++ b/remote_desktop_input_test.go
@@ -8,9 +8,323 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	inputportal "github.com/marang/robotgo/input/portal"
 )
+
+func TestPortalPointerButtonAliases(t *testing.T) {
+	center, err := portalPointerButton("center")
+	if err != nil {
+		t.Fatalf("portalPointerButton(center): %v", err)
+	}
+	middle, err := portalPointerButton("middle")
+	if err != nil || middle != center {
+		t.Fatalf("portalPointerButton(middle) = (%#x,%v), want (%#x,nil)", middle, err, center)
+	}
+}
+
+func TestRemoteDesktopInputSerializesHighLevelTransactions(t *testing.T) {
+	installFakeHighLevelPortalSession(t, inputportal.DeviceKeyboard)
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{}, 1)
+	t.Cleanup(func() {
+		select {
+		case releaseFirst <- struct{}{}:
+		default:
+		}
+	})
+	secondAttempted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	firstDone := make(chan struct{})
+	secondDone := make(chan struct{})
+
+	go func() {
+		defer close(firstDone)
+		_, _ = withRemoteDesktopInput(inputportal.DeviceKeyboard, func(remoteDesktopInputSession) error {
+			close(firstStarted)
+			<-releaseFirst
+			return nil
+		})
+	}()
+	<-firstStarted
+	go func() {
+		defer close(secondDone)
+		close(secondAttempted)
+		_, _ = withRemoteDesktopInput(inputportal.DeviceKeyboard, func(remoteDesktopInputSession) error {
+			close(secondStarted)
+			return nil
+		})
+	}()
+	<-secondAttempted
+
+	select {
+	case <-secondStarted:
+		t.Fatal("second RemoteDesktop transaction interleaved with the first")
+	case <-time.After(50 * time.Millisecond):
+	}
+	releaseFirst <- struct{}{}
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("first RemoteDesktop transaction did not finish")
+	}
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second RemoteDesktop transaction did not start after release")
+	}
+	<-secondDone
+}
+
+func TestCloseRemoteDesktopInputCancelsActiveTransaction(t *testing.T) {
+	base := &fakeHighLevelPortalSession{devices: inputportal.DeviceKeyboard}
+	started := make(chan struct{})
+	session := &blockingRemoteDesktopSession{fakeHighLevelPortalSession: base, started: started}
+	remoteDesktopInputState.Lock()
+	previous := remoteDesktopInputState.session
+	previousPermission := remoteDesktopInputState.permission
+	previousReason := remoteDesktopInputState.reason
+	remoteDesktopInputState.session = session
+	remoteDesktopInputState.Unlock()
+	t.Cleanup(func() {
+		remoteDesktopInputState.Lock()
+		remoteDesktopInputState.session = previous
+		remoteDesktopInputState.permission = previousPermission
+		remoteDesktopInputState.reason = previousReason
+		remoteDesktopInputState.Unlock()
+	})
+
+	operationDone := make(chan error, 1)
+	go func() {
+		_, err := withRemoteDesktopInput(inputportal.DeviceKeyboard, func(active remoteDesktopInputSession) error {
+			return remoteDesktopEvent(func(ctx context.Context) error {
+				return active.KeyboardKeysym(ctx, 'a', true)
+			})
+		})
+		operationDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("RemoteDesktop transaction did not start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- CloseRemoteDesktopInput() }()
+	select {
+	case err := <-operationDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("active transaction error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CloseRemoteDesktopInput did not cancel the active transaction")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("CloseRemoteDesktopInput error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CloseRemoteDesktopInput did not finish after cancellation")
+	}
+	if _, closed := base.snapshot(); closed != 1 {
+		t.Fatalf("session close count = %d, want 1", closed)
+	}
+}
+
+func TestCloseRemoteDesktopInputCancelsCompositeEventSleeps(t *testing.T) {
+	tests := []struct {
+		name    string
+		devices inputportal.DeviceType
+		start   func() (bool, error)
+	}{
+		{
+			name:    "double click gap",
+			devices: inputportal.DevicePointer,
+			start:   func() (bool, error) { return tryRemoteDesktopClick("left", true) },
+		},
+		{
+			name:    "text rune delay",
+			devices: inputportal.DeviceKeyboard,
+			start:   func() (bool, error) { return tryRemoteDesktopText("ab", []int{0, 500}) },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session := installFakeHighLevelPortalSession(t, test.devices)
+			type result struct {
+				used bool
+				err  error
+			}
+			done := make(chan result, 1)
+			go func() {
+				used, err := test.start()
+				done <- result{used: used, err: err}
+			}()
+			deadline := time.Now().Add(time.Second)
+			for {
+				events, _ := session.snapshot()
+				if len(events) >= 2 {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("composite RemoteDesktop operation did not reach its cancellable sleep")
+				}
+				time.Sleep(time.Millisecond)
+			}
+			if err := CloseRemoteDesktopInput(); err != nil {
+				t.Fatalf("CloseRemoteDesktopInput: %v", err)
+			}
+			select {
+			case got := <-done:
+				if !got.used || !errors.Is(got.err, context.Canceled) {
+					t.Fatalf("composite operation = (used=%t, err=%v), want cancellation", got.used, got.err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("composite RemoteDesktop operation did not stop after Close")
+			}
+			events, _ := session.snapshot()
+			if len(events) != 2 {
+				t.Fatalf("events after cancellation = %v, want only the first press/release pair", events)
+			}
+		})
+	}
+}
+
+func TestExternalPortalCloseCancelsCompositeRemoteDesktopSleep(t *testing.T) {
+	session := installFakeHighLevelPortalSession(t, inputportal.DeviceKeyboard)
+	session.done = make(chan struct{})
+	type result struct {
+		used bool
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		used, err := tryRemoteDesktopText("ab", []int{0, 60_000})
+		done <- result{used: used, err: err}
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		events, _ := session.snapshot()
+		if len(events) >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("RemoteDesktop text did not reach its cancellable sleep")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(session.done)
+	select {
+	case got := <-done:
+		if !got.used || !errors.Is(got.err, inputportal.ErrClosed) {
+			t.Fatalf("externally closed operation = (used=%t err=%v), want ErrClosed", got.used, got.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("external portal close did not cancel the composite operation")
+	}
+	events, _ := session.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("events after external close = %v, want only first key press/release", events)
+	}
+}
+
+type blockingRemoteDesktopSession struct {
+	*fakeHighLevelPortalSession
+	once    sync.Once
+	started chan struct{}
+}
+
+type contextIgnoringRemoteDesktopSession struct {
+	*fakeHighLevelPortalSession
+	once    sync.Once
+	started chan struct{}
+	release chan struct{}
+}
+
+func (session *contextIgnoringRemoteDesktopSession) KeyboardKeysym(_ context.Context, keysym int32, pressed bool) error {
+	if err := session.record("keysym:%d:%t", keysym, pressed); err != nil {
+		return err
+	}
+	session.once.Do(func() {
+		close(session.started)
+		<-session.release
+	})
+	return nil
+}
+
+func TestCloseStopsCompositeOperationWhenSessionIgnoresContext(t *testing.T) {
+	base := installFakeHighLevelPortalSession(t, inputportal.DeviceKeyboard)
+	session := &contextIgnoringRemoteDesktopSession{
+		fakeHighLevelPortalSession: base,
+		started:                    make(chan struct{}),
+		release:                    make(chan struct{}),
+	}
+	remoteDesktopInputState.Lock()
+	remoteDesktopInputState.session = session
+	remoteDesktopInputState.Unlock()
+	t.Cleanup(func() {
+		remoteDesktopInputState.Lock()
+		if remoteDesktopInputState.session == session {
+			remoteDesktopInputState.session = base
+		}
+		remoteDesktopInputState.Unlock()
+	})
+
+	operationDone := make(chan error, 1)
+	go func() {
+		_, err := tryRemoteDesktopText("ab", []int{0, 0})
+		operationDone <- err
+	}()
+	select {
+	case <-session.started:
+	case <-time.After(time.Second):
+		t.Fatal("context-ignoring RemoteDesktop operation did not start")
+	}
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- CloseRemoteDesktopInput() }()
+	deadline := time.Now().Add(time.Second)
+	for {
+		remoteDesktopInputPending.Lock()
+		ctx := remoteDesktopInputPending.operationContext
+		remoteDesktopInputPending.Unlock()
+		if ctx != nil && context.Cause(ctx) != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("CloseRemoteDesktopInput did not cancel the operation context")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(session.release)
+	select {
+	case err := <-operationDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("context-ignoring operation error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("context-ignoring operation continued after cancellation")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("CloseRemoteDesktopInput: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CloseRemoteDesktopInput did not finish")
+	}
+	events, _ := base.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events after cancellation = %v, want only the in-flight event", events)
+	}
+}
+
+func (session *blockingRemoteDesktopSession) KeyboardKeysym(ctx context.Context, _ int32, _ bool) error {
+	session.once.Do(func() { close(session.started) })
+	<-ctx.Done()
+	return ctx.Err()
+}
 
 type fakeHighLevelPortalSession struct {
 	mu           sync.Mutex

--- a/remote_desktop_keys.go
+++ b/remote_desktop_keys.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 )
 
@@ -47,6 +46,17 @@ var portalNamedKeysyms = map[string]int32{
 	"num7":              0xffb7,
 	"num8":              0xffb8,
 	"num9":              0xffb9,
+	"numpad_0":          0xffb0,
+	"numpad_1":          0xffb1,
+	"numpad_2":          0xffb2,
+	"numpad_3":          0xffb3,
+	"numpad_4":          0xffb4,
+	"numpad_5":          0xffb5,
+	"numpad_6":          0xffb6,
+	"numpad_7":          0xffb7,
+	"numpad_8":          0xffb8,
+	"numpad_9":          0xffb9,
+	"numpad_lock":       0xff7f,
 	"num_equal":         0xffbd,
 	"num_clear":         0xff0b,
 	"shift":             0xffe1,
@@ -110,7 +120,7 @@ func portalKeysymForKey(key string) (int32, error) {
 }
 
 func normalizePortalKey(key string, modifiers []string) (string, []string) {
-	if value, _ := utf8.DecodeRuneInString(key); value != utf8.RuneError && unicode.IsUpper(value) {
+	if uppercaseSingleRuneKey(key) {
 		key = strings.ToLower(key)
 		modifiers = append(modifiers, "shift")
 	}

--- a/robotgo.go
+++ b/robotgo.go
@@ -1526,9 +1526,15 @@ func GetXDisplayName() string {
 	return gname
 }
 
-// CloseMainDisplay close the main X11 display
-func CloseMainDisplay() {
+// CloseMainDisplay closes the main display and ignores cleanup errors for
+// compatibility. Prefer CloseMainDisplayE in new code.
+func CloseMainDisplay() { _ = CloseMainDisplayE() }
+
+// CloseMainDisplayE closes the native main display. Native CGO cleanup does not
+// currently expose an error result.
+func CloseMainDisplayE() error {
 	C.close_main_display()
+	return nil
 }
 
 // Deprecated: use the ScaledF(),
@@ -1554,6 +1560,7 @@ func CheckMouse(btn string) C.MMMouseButton {
 	m1 := map[string]C.MMMouseButton{
 		"left":       C.LEFT_BUTTON,
 		"center":     C.CENTER_BUTTON,
+		"middle":     C.CENTER_BUTTON,
 		"right":      C.RIGHT_BUTTON,
 		"wheelDown":  C.WheelDown,
 		"wheelUp":    C.WheelUp,
@@ -1693,6 +1700,9 @@ func Drag(x, y int, args ...string) {
 //
 //	robotgo.DragSmooth(10, 10)
 func DragSmooth(x, y int, args ...interface{}) {
+	if _, _, _, ok := parseSmoothMoveArguments(args); !ok {
+		return
+	}
 	if err := Toggle("left"); err != nil {
 		return
 	}
@@ -1713,6 +1723,10 @@ func DragSmooth(x, y int, args ...interface{}) {
 //	robotgo.MoveSmooth(10, 10)
 //	robotgo.MoveSmooth(10, 10, 1.0, 2.0)
 func MoveSmooth(x, y int, args ...interface{}) bool {
+	lowDelay, highDelay, mouseDelay, ok := parseSmoothMoveArguments(args)
+	if !ok {
+		return false
+	}
 	unlock := lockWaylandMouse()
 	defer unlock()
 	if err := ensureWaylandMouseReady(); err != nil {
@@ -1727,23 +1741,8 @@ func MoveSmooth(x, y int, args ...interface{}) bool {
 	cx := C.int32_t(x)
 	cy := C.int32_t(y)
 
-	var (
-		mouseDelay = 1
-		low        C.double
-		high       C.double
-	)
-
-	if len(args) > 2 {
-		mouseDelay = args[2].(int)
-	}
-
-	if len(args) > 1 {
-		low = C.double(args[0].(float64))
-		high = C.double(args[1].(float64))
-	} else {
-		low = 1.0
-		high = 3.0
-	}
+	low := C.double(lowDelay)
+	high := C.double(highDelay)
 
 	cbool := C.smoothlyMoveMouse(C.MMPointInt32Make(cx, cy), low, high)
 	MilliSleep(currentMouseDelay() + mouseDelay)
@@ -1789,6 +1788,9 @@ func MoveRelativeE(x, y int) error {
 
 // MoveSmoothRelative move mouse smooth with relative
 func MoveSmoothRelative(x, y int, args ...interface{}) {
+	if _, _, _, ok := parseSmoothMoveArguments(args); !ok {
+		return
+	}
 	mx, my := MoveArgs(x, y)
 	MoveSmooth(mx, my, args...)
 }
@@ -1833,12 +1835,12 @@ func Click(args ...interface{}) {
 
 // ClickE clicks a mouse button and reports backend availability errors.
 func ClickE(args ...interface{}) error {
-	unlock := lockWaylandMouse()
-	defer unlock()
 	name, double, err := parseClickArguments(args)
 	if err != nil {
 		return err
 	}
+	unlock := lockWaylandMouse()
+	defer unlock()
 	button := CheckMouse(name)
 	if nativeErr := ensureWaylandMouseReady(); nativeErr != nil {
 		used, err := tryRemoteDesktopClick(name, double)
@@ -1891,12 +1893,12 @@ func MovesClick(x, y int, args ...interface{}) {
 //	robotgo.Toggle("left") // default is down
 //	robotgo.Toggle("left", "up")
 func Toggle(key ...interface{}) error {
-	unlock := lockWaylandMouse()
-	defer unlock()
 	name, down, err := parseToggleArguments(key)
 	if err != nil {
 		return err
 	}
+	unlock := lockWaylandMouse()
+	defer unlock()
 	button := CheckMouse(name)
 	if nativeErr := ensureWaylandMouseReady(); nativeErr != nil {
 		used, err := tryRemoteDesktopToggle(name, down)
@@ -1939,12 +1941,12 @@ func Scroll(x, y int, args ...int) {
 
 // ScrollE scrolls the mouse and reports backend availability errors.
 func ScrollE(x, y int, args ...int) error {
+	msDelay, validationErr := parseScrollDelay(args)
+	if validationErr != nil {
+		return validationErr
+	}
 	unlock := lockWaylandMouse()
 	defer unlock()
-	var msDelay = 10
-	if len(args) > 0 {
-		msDelay = args[0]
-	}
 	if nativeErr := ensureWaylandMouseReady(); nativeErr != nil {
 		used, err := tryRemoteDesktopScroll(x, y)
 		if used {
@@ -1969,9 +1971,9 @@ func ScrollE(x, y int, args ...int) error {
 //	robotgo.ScrollDir(10, "down")
 //	robotgo.ScrollDir(10, "up")
 func ScrollDir(x int, direction ...interface{}) {
-	d := "down"
-	if len(direction) > 0 {
-		d = direction[0].(string)
+	d, err := parseScrollDirection(direction)
+	if err != nil {
+		return
 	}
 
 	if d == "down" {

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -40,6 +40,11 @@ const (
 	DisplayServerUnknown DisplayServer = "unknown"
 )
 
+const (
+	envWaylandDisplay = "WAYLAND_DISPLAY"
+	envDisplay        = "DISPLAY"
+)
+
 type FeatureCapability struct {
 	Available bool
 	Fallback  bool
@@ -125,10 +130,10 @@ type CBitmap = *Bitmap
 func GetVersion() string { return Version }
 
 func DetectDisplayServer() DisplayServer {
-	if os.Getenv("WAYLAND_DISPLAY") != "" {
+	if os.Getenv(envWaylandDisplay) != "" {
 		return DisplayServerWayland
 	}
-	if os.Getenv("DISPLAY") != "" {
+	if os.Getenv(envDisplay) != "" {
 		return DisplayServerX11
 	}
 	return DisplayServerUnknown
@@ -210,21 +215,23 @@ func GetLinuxCapabilities() LinuxCapabilities {
 			}
 		}
 	}
-	if runtime.GOOS == "linux" && ds == DisplayServerX11 && !captureOverridden {
+	if runtime.GOOS == "linux" && ds == DisplayServerX11 {
 		compiled := pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH)
 		conflict := pureGoX11EnvironmentConflict()
-		capabilities.Capture = FeatureCapability{
-			Available: compiled && !conflict,
-			Backend:   featureBackendPureGoX11,
-			Reason:    "Pure-Go X11 screenshot backend is selected; runtime access is not probed",
-			Notes:     "runtime X server access is validated when capture starts",
-		}
-		if !compiled {
-			capabilities.Capture.Reason = fmt.Sprintf("Pure-Go X11 capture is not compiled for %s/%s", runtime.GOOS, runtime.GOARCH)
-			capabilities.Capture.Notes = ErrNotSupported.Error()
-		} else if conflict {
-			capabilities.Capture.Reason = envXDGSessionType + " selects Wayland while DISPLAY selects X11"
-			capabilities.Capture.Notes = "capture refuses the screenshot dependency's implicit portal fallback"
+		if !captureOverridden {
+			capabilities.Capture = FeatureCapability{
+				Available: compiled && !conflict,
+				Backend:   featureBackendPureGoX11,
+				Reason:    "Pure-Go X11 screenshot backend is selected; runtime access is not probed",
+				Notes:     "runtime X server access is validated when capture starts",
+			}
+			if !compiled {
+				capabilities.Capture.Reason = fmt.Sprintf("Pure-Go X11 capture is not compiled for %s/%s", runtime.GOOS, runtime.GOARCH)
+				capabilities.Capture.Notes = ErrNotSupported.Error()
+			} else if conflict {
+				capabilities.Capture.Reason = envXDGSessionType + " selects Wayland while DISPLAY selects X11"
+				capabilities.Capture.Notes = "capture refuses the screenshot dependency's implicit portal fallback"
+			}
 		}
 		capabilities.Bounds = FeatureCapability{
 			Available: compiled && !conflict,
@@ -238,6 +245,13 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		} else if conflict {
 			capabilities.Bounds.Reason = envXDGSessionType + " selects Wayland while DISPLAY selects X11"
 			capabilities.Bounds.Notes = "bounds refuse the screenshot dependency's implicit portal fallback"
+		}
+		keyboard, mouse := pureGoInputCapabilities()
+		if keyboard.Backend != "" {
+			capabilities.Keyboard = keyboard
+		}
+		if mouse.Backend != "" {
+			capabilities.Mouse = mouse
 		}
 	}
 	return capabilities
@@ -326,13 +340,38 @@ const (
 	Cmd            = "cmd"
 )
 
-// KeyTap taps a key through an explicitly authorized RemoteDesktop session.
+// KeyTap taps a key through the selected Pure-Go platform backend or an
+// explicitly authorized RemoteDesktop session.
 func KeyTap(key string, args ...interface{}) error {
-	pid, _, modifiers, err := parsePortalKeyArgs(args, false)
+	pid, _, modifiers, err := parseKeyArguments(args, false)
 	if err != nil {
 		return err
 	}
-	used, err := withRemoteDesktopInput(inputportal.DeviceKeyboard, func(session remoteDesktopInputSession) error {
+	modifiers, err = normalizeKeyModifiers(modifiers)
+	if err != nil {
+		return err
+	}
+	if err := validateKeyArgument(key); err != nil {
+		return err
+	}
+	_, platformModifiers := normalizePortalKey(key, append([]string(nil), modifiers...))
+	platformModifiers, err = normalizeKeyModifiers(platformModifiers)
+	if err != nil {
+		return err
+	}
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.Key(pureGoKeyEvent{
+			Key: key, Modifiers: platformModifiers, PID: pid,
+			Down: true, Tap: true,
+		})
+	})
+	if used {
+		if err == nil {
+			MilliSleep(currentKeyDelay())
+		}
+		return err
+	}
+	used, err = withRemoteDesktopInput(inputportal.DeviceKeyboard, func(session remoteDesktopInputSession) error {
 		if pid != 0 {
 			return fmt.Errorf("%w: RemoteDesktop portal input cannot target a process", ErrNotSupported)
 		}
@@ -351,39 +390,38 @@ func KeyTap(key string, args ...interface{}) error {
 	return err
 }
 
-func parsePortalKeyArgs(args []interface{}, toggle bool) (pid int, down bool, modifiers []string, err error) {
-	down = true
-	if len(args) == 0 {
-		return pid, down, nil, nil
-	}
-	if values, ok := args[0].([]string); ok {
-		modifiers = append(modifiers, values...)
-		args = args[1:]
-	} else if value, ok := args[0].(int); ok {
-		pid = value
-		args = args[1:]
-	}
-	for _, arg := range args {
-		value, ok := arg.(string)
-		if !ok {
-			return 0, false, nil, fmt.Errorf("robotgo: key modifier must be a string, got %T", arg)
-		}
-		modifiers = append(modifiers, value)
-	}
-	if toggle && len(modifiers) > 0 && (modifiers[0] == "up" || modifiers[0] == "down") {
-		down = modifiers[0] == "down"
-		modifiers = modifiers[1:]
-	}
-	return pid, down, modifiers, nil
-}
-
-// KeyToggle changes a key state through an authorized RemoteDesktop session.
+// KeyToggle changes a key state through the selected Pure-Go platform backend
+// or an authorized RemoteDesktop session.
 func KeyToggle(key string, args ...interface{}) error {
-	pid, down, modifiers, err := parsePortalKeyArgs(args, true)
+	pid, down, modifiers, err := parseKeyArguments(args, true)
 	if err != nil {
 		return err
 	}
-	used, err := withRemoteDesktopInput(inputportal.DeviceKeyboard, func(session remoteDesktopInputSession) error {
+	modifiers, err = normalizeKeyModifiers(modifiers)
+	if err != nil {
+		return err
+	}
+	if err := validateKeyArgument(key); err != nil {
+		return err
+	}
+	_, platformModifiers := normalizePortalKey(key, append([]string(nil), modifiers...))
+	platformModifiers, err = normalizeKeyModifiers(platformModifiers)
+	if err != nil {
+		return err
+	}
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.Key(pureGoKeyEvent{
+			Key: key, Modifiers: platformModifiers, PID: pid,
+			Down: down,
+		})
+	})
+	if used {
+		if err == nil {
+			MilliSleep(currentKeyDelay())
+		}
+		return err
+	}
+	used, err = withRemoteDesktopInput(inputportal.DeviceKeyboard, func(session remoteDesktopInputSession) error {
 		if pid != 0 {
 			return fmt.Errorf("%w: RemoteDesktop portal input cannot target a process", ErrNotSupported)
 		}
@@ -402,26 +440,45 @@ func KeyToggle(key string, args ...interface{}) error {
 	return err
 }
 
-// KeyDown presses a key through an authorized RemoteDesktop session.
+// KeyDown presses a key through the selected Pure-Go platform backend or an
+// authorized RemoteDesktop session.
 func KeyDown(key string, args ...interface{}) error { return KeyToggle(key, args...) }
 
-// KeyUp releases a key through an authorized RemoteDesktop session.
+// KeyUp releases a key through the selected Pure-Go platform backend or an
+// authorized RemoteDesktop session.
 func KeyUp(key string, args ...interface{}) error {
 	return KeyToggle(key, append([]interface{}{"up"}, args...)...)
 }
 
-// KeyPress presses and releases a key through an authorized RemoteDesktop session.
+// KeyPress presses and releases a key as one backend transaction. It is
+// equivalent to KeyTap.
 func KeyPress(key string, args ...interface{}) error {
-	if err := KeyDown(key, args...); err != nil {
+	return KeyTap(key, args...)
+}
+func KeyboardReady() error {
+	if used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.KeyboardReady()
+	}); used {
 		return err
 	}
-	MilliSleep(2)
-	return KeyUp(key, args...)
+	return RemoteDesktopInputReady(RemoteDesktopKeyboard)
 }
-func KeyboardReady() error                  { return RemoteDesktopInputReady(RemoteDesktopKeyboard) }
 func UnicodeType(value uint32, args ...int) { _ = UnicodeTypeE(value, args...) }
 func UnicodeTypeE(value uint32, args ...int) error {
-	used, err := tryRemoteDesktopUnicode(rune(value), args)
+	if err := validateUnicodeScalar(value); err != nil {
+		return err
+	}
+	pid := 0
+	if len(args) > 0 {
+		pid = args[0]
+	}
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.Text(pureGoTextEvent{Text: string(rune(value)), PID: pid})
+	})
+	if used {
+		return err
+	}
+	used, err = tryRemoteDesktopUnicode(rune(value), args)
 	if !used {
 		return ErrNotSupported
 	}
@@ -429,7 +486,16 @@ func UnicodeTypeE(value uint32, args ...int) error {
 }
 func TypeStr(text string, args ...int) { _ = TypeStrE(text, args...) }
 func TypeStrE(text string, args ...int) error {
-	used, err := tryRemoteDesktopText(text, args)
+	pid, delay, validationErr := parseTextInput(text, args)
+	if validationErr != nil {
+		return validationErr
+	}
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.Text(pureGoTextEvent{Text: text, PID: pid, Delay: delay})
+	})
+	if !used {
+		used, err = tryRemoteDesktopText(text, args)
+	}
 	if !used {
 		return ErrNotSupported
 	}
@@ -453,7 +519,13 @@ func CharCodeAt(s string, n int) rune {
 
 func Move(x, y int, displayID ...int) { _ = MoveE(x, y, displayID...) }
 func MoveE(x, y int, displayID ...int) error {
-	used, err := tryRemoteDesktopMoveAbsolute(x, y, displayID)
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.MoveAbsolute(x, y, append([]int(nil), displayID...))
+	})
+	if used {
+		return finishNonCGOMouseEvent(err, 0)
+	}
+	used, err = tryRemoteDesktopMoveAbsolute(x, y, displayID)
 	if !used {
 		return ErrNotSupported
 	}
@@ -461,22 +533,72 @@ func MoveE(x, y int, displayID ...int) error {
 }
 func MoveRelative(x, y int) { _ = MoveRelativeE(x, y) }
 func MoveRelativeE(x, y int) error {
-	used, err := tryRemoteDesktopMoveRelative(x, y)
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.MoveRelative(x, y)
+	})
+	if used {
+		return finishNonCGOMouseEvent(err, 0)
+	}
+	used, err = tryRemoteDesktopMoveRelative(x, y)
 	if !used {
 		return ErrNotSupported
 	}
 	return finishRemoteDesktopMouseEvent(err, 0)
 }
-func MoveSmooth(int, int, ...interface{}) bool    { return false }
-func MoveSmoothRelative(int, int, ...interface{}) {}
-func DragSmooth(int, int, ...interface{})         {}
-func Click(args ...interface{})                   { _ = ClickE(args...) }
+
+func MoveSmooth(x, y int, args ...interface{}) bool {
+	lowDelay, highDelay, extraDelay, ok := parseSmoothMoveArguments(args)
+	if !ok {
+		return false
+	}
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.MoveSmooth(x, y, false, lowDelay, highDelay)
+	})
+	if !used || err != nil {
+		return false
+	}
+	MilliSleep(currentMouseDelay() + extraDelay)
+	return true
+}
+
+func MoveSmoothRelative(x, y int, args ...interface{}) {
+	lowDelay, highDelay, extraDelay, ok := parseSmoothMoveArguments(args)
+	if !ok {
+		return
+	}
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.MoveSmooth(x, y, true, lowDelay, highDelay)
+	})
+	if used && err == nil {
+		MilliSleep(currentMouseDelay() + extraDelay)
+	}
+}
+
+func DragSmooth(x, y int, args ...interface{}) {
+	lowDelay, highDelay, extraDelay, ok := parseSmoothMoveArguments(args)
+	if !ok {
+		return
+	}
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.DragSmooth(x, y, lowDelay, highDelay)
+	})
+	if used && err == nil {
+		MilliSleep(currentMouseDelay() + extraDelay)
+	}
+}
+func Click(args ...interface{}) { _ = ClickE(args...) }
 func ClickE(args ...interface{}) error {
 	name, double, err := parseClickArguments(args)
 	if err != nil {
 		return err
 	}
-	used, err := tryRemoteDesktopClick(name, double)
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.Click(name, double)
+	})
+	if used {
+		return finishNonCGOMouseEvent(err, 0)
+	}
+	used, err = tryRemoteDesktopClick(name, double)
 	if !used {
 		return ErrNotSupported
 	}
@@ -487,7 +609,13 @@ func Toggle(args ...interface{}) error {
 	if err != nil {
 		return err
 	}
-	used, err := tryRemoteDesktopToggle(name, down)
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.Toggle(name, down)
+	})
+	if used {
+		return err
+	}
+	used, err = tryRemoteDesktopToggle(name, down)
 	if !used {
 		return ErrNotSupported
 	}
@@ -495,21 +623,67 @@ func Toggle(args ...interface{}) error {
 }
 func Scroll(x, y int, args ...int) { _ = ScrollE(x, y, args...) }
 func ScrollE(x, y int, args ...int) error {
-	msDelay := 10
-	if len(args) > 0 {
-		msDelay = args[0]
+	msDelay, validationErr := parseScrollDelay(args)
+	if validationErr != nil {
+		return validationErr
 	}
-	used, err := tryRemoteDesktopScroll(x, y)
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.Scroll(x, y)
+	})
+	if used {
+		return finishNonCGOMouseEvent(err, msDelay)
+	}
+	used, err = tryRemoteDesktopScroll(x, y)
 	if !used {
 		return ErrNotSupported
 	}
 	return finishRemoteDesktopMouseEvent(err, msDelay)
 }
-func ScrollDir(int, ...interface{}) {}
-func Location() (int, int)          { return 0, 0 }
-func LocationE() (int, int, error)  { return 0, 0, ErrNotSupported }
-func MouseReady() error             { return RemoteDesktopInputReady(RemoteDesktopPointer) }
-func CloseWaylandInput()            { _ = CloseRemoteDesktopInput() }
+func ScrollDir(amount int, direction ...interface{}) {
+	name, err := parseScrollDirection(direction)
+	if err != nil {
+		return
+	}
+	switch name {
+	case "down":
+		Scroll(0, -amount)
+	case "up":
+		Scroll(0, amount)
+	case "left":
+		Scroll(amount, 0)
+	case "right":
+		Scroll(-amount, 0)
+	}
+}
+func Location() (int, int) { x, y, _ := LocationE(); return x, y }
+func LocationE() (int, int, error) {
+	var x, y int
+	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		var locationErr error
+		x, y, locationErr = backend.Location()
+		return locationErr
+	})
+	if !used {
+		return 0, 0, ErrNotSupported
+	}
+	return x, y, err
+}
+func MouseReady() error {
+	if used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
+		return backend.MouseReady()
+	}); used {
+		return err
+	}
+	return RemoteDesktopInputReady(RemoteDesktopPointer)
+}
+func CloseWaylandInput() { _ = CloseRemoteDesktopInput() }
+
+func finishNonCGOMouseEvent(err error, extraDelay int) error {
+	if err == nil {
+		MilliSleep(currentMouseDelay() + extraDelay)
+	}
+	return err
+}
 func GetScreenSize() (int, int) {
 	displayID := currentDisplayID()
 	if displayID < 0 {

--- a/robotgo_nocgo_parity.go
+++ b/robotgo_nocgo_parity.go
@@ -23,7 +23,20 @@ func CmdCtrl() string {
 	return "ctrl"
 }
 
-func CloseMainDisplay()            {}
+// CloseMainDisplay closes persistent Pure-Go display/input connections and
+// ignores cleanup errors for compatibility. Prefer CloseMainDisplayE when
+// server-global X11 scratch mappings or owned input state may need restoration.
+func CloseMainDisplay() { _ = CloseMainDisplayE() }
+
+// CloseMainDisplayE closes persistent Pure-Go display/input connections and
+// reports owned-input release or X11 scratch-mapping restoration failures. A
+// later operation reconnects lazily. On Pure-Go X11, key taps and text may use
+// server-global scratch mappings, so call it only after targets have processed
+// all prior keyboard input. Abnormal process termination can leave mappings
+// behind. If cleanup reports a pressed-key or modifier-map conflict, remove
+// that conflict and retry CloseMainDisplayE.
+func CloseMainDisplayE() error { return closePureGoPlatformInput() }
+
 func InvalidateScreenBoundsCache() {}
 func Drag(int, int, ...string)     {}
 func FreeBitmapArr(bits ...CBitmap) {

--- a/runtime_capabilities_nocgo.go
+++ b/runtime_capabilities_nocgo.go
@@ -43,5 +43,12 @@ func runtimeCapabilities() RuntimeCapabilities {
 		return result
 	}
 	result.Capture, result.Bounds = pureGoPlatformCaptureCapabilities()
+	keyboard, mouse := pureGoInputCapabilities()
+	if keyboard.Backend != "" {
+		result.Keyboard = keyboard
+	}
+	if mouse.Backend != "" {
+		result.Mouse = mouse
+	}
 	return result
 }

--- a/runtime_config.go
+++ b/runtime_config.go
@@ -31,31 +31,58 @@ func GetRuntimeConfig() RuntimeConfig {
 // Direct writes to MouseSleep, KeySleep, DisplayID, NotPid, and Scale remain
 // supported for compatibility, but must not race with active operations.
 func SetRuntimeConfig(config RuntimeConfig) error {
+	if err := validateRuntimeConfig(config); err != nil {
+		return err
+	}
+	runtimeConfigMu.Lock()
+	setRuntimeConfigLocked(config)
+	runtimeConfigMu.Unlock()
+	return nil
+}
+
+func validateRuntimeConfig(config RuntimeConfig) error {
 	if config.MouseDelay < 0 || config.KeyDelay < 0 {
 		return fmt.Errorf("robotgo: delays must be non-negative")
 	}
 	if config.DisplayID < -1 {
 		return fmt.Errorf("robotgo: display ID must be -1 or greater")
 	}
-	runtimeConfigMu.Lock()
+	return nil
+}
+
+func setRuntimeConfigLocked(config RuntimeConfig) {
 	MouseSleep = config.MouseDelay
 	KeySleep = config.KeyDelay
 	DisplayID = config.DisplayID
 	NotPid = config.TreatAsHandle
 	Scale = config.Scale
-	runtimeConfigMu.Unlock()
+}
+
+func updateRuntimeConfig(update func(*RuntimeConfig) error) error {
+	runtimeConfigMu.Lock()
+	defer runtimeConfigMu.Unlock()
+	config := RuntimeConfig{
+		MouseDelay: MouseSleep, KeyDelay: KeySleep, DisplayID: DisplayID,
+		TreatAsHandle: NotPid, Scale: Scale,
+	}
+	if err := update(&config); err != nil {
+		return err
+	}
+	if err := validateRuntimeConfig(config); err != nil {
+		return err
+	}
+	setRuntimeConfigLocked(config)
 	return nil
 }
 
-func currentMouseDelay() int     { return GetRuntimeConfig().MouseDelay }
-func currentKeyDelay() int       { return GetRuntimeConfig().KeyDelay }
-func currentDisplayID() int      { return GetRuntimeConfig().DisplayID }
-func currentTreatAsHandle() bool { return GetRuntimeConfig().TreatAsHandle }
-func currentScale() bool         { return GetRuntimeConfig().Scale }
+func currentMouseDelay() int { return GetRuntimeConfig().MouseDelay }
+func currentKeyDelay() int   { return GetRuntimeConfig().KeyDelay }
+func currentDisplayID() int  { return GetRuntimeConfig().DisplayID }
 
 func setInputDelays(keyDelay, mouseDelay int) error {
-	config := GetRuntimeConfig()
-	config.KeyDelay = keyDelay
-	config.MouseDelay = mouseDelay
-	return SetRuntimeConfig(config)
+	return updateRuntimeConfig(func(config *RuntimeConfig) error {
+		config.KeyDelay = keyDelay
+		config.MouseDelay = mouseDelay
+		return nil
+	})
 }

--- a/runtime_config_cgo.go
+++ b/runtime_config_cgo.go
@@ -1,0 +1,6 @@
+//go:build cgo
+
+package robotgo
+
+func currentTreatAsHandle() bool { return GetRuntimeConfig().TreatAsHandle }
+func currentScale() bool         { return GetRuntimeConfig().Scale }

--- a/runtime_config_test.go
+++ b/runtime_config_test.go
@@ -52,3 +52,27 @@ func TestRuntimeConfigRejectsInvalidValuesWithoutMutation(t *testing.T) {
 		}
 	}
 }
+
+func TestInputDelayUpdatePreservesUnrelatedRuntimeConfig(t *testing.T) {
+	previous := GetRuntimeConfig()
+	t.Cleanup(func() {
+		if err := SetRuntimeConfig(previous); err != nil {
+			t.Errorf("restore runtime config: %v", err)
+		}
+	})
+	want := RuntimeConfig{
+		MouseDelay: 1, KeyDelay: 2, DisplayID: 7,
+		TreatAsHandle: true, Scale: true,
+	}
+	if err := SetRuntimeConfig(want); err != nil {
+		t.Fatalf("SetRuntimeConfig: %v", err)
+	}
+	if err := setInputDelays(11, 12); err != nil {
+		t.Fatalf("setInputDelays: %v", err)
+	}
+	want.KeyDelay = 11
+	want.MouseDelay = 12
+	if got := GetRuntimeConfig(); got != want {
+		t.Fatalf("runtime config = %+v, want %+v", got, want)
+	}
+}

--- a/x11_input_integration_test.go
+++ b/x11_input_integration_test.go
@@ -3,9 +3,15 @@
 package robotgo_test
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"reflect"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -18,19 +24,19 @@ import (
 const (
 	x11EventTimeout = 3 * time.Second
 	x11PollInterval = 5 * time.Millisecond
+	x11RequiredEnv  = "ROBOTGO_REQUIRE_X11_INTEGRATION"
 
 	x11WindowX      = 100
 	x11WindowY      = 100
 	x11WindowWidth  = 400
 	x11WindowHeight = 300
 
-	x11ButtonLeft       = 1
-	x11ButtonRight      = 3
-	x11ButtonWheelUp    = 4
-	x11ButtonWheelRight = 6
+	x11ButtonLeft      = 1
+	x11ButtonRight     = 3
+	x11ButtonWheelUp   = 4
+	x11ButtonWheelLeft = 6
 
-	x11KeysymA      = 0x0061
-	x11KeysymZ      = 0x007a
+	x11KeysymEnter  = 0xff0d
 	x11KeysymShiftL = 0xffe1
 	x11KeysymShiftR = 0xffe2
 )
@@ -50,22 +56,22 @@ func newX11InputHarness(t *testing.T) *x11InputHarness {
 	t.Helper()
 	display := os.Getenv("DISPLAY")
 	if display == "" {
-		t.Skip("X11 integration test requires DISPLAY")
+		x11Unavailable(t, "X11 integration test requires DISPLAY")
 	}
 	if os.Getenv("WAYLAND_DISPLAY") != "" {
-		t.Skip("X11 integration test requires an X11-primary session; unset WAYLAND_DISPLAY")
+		x11Unavailable(t, "X11 integration test requires an X11-primary session; unset WAYLAND_DISPLAY")
 	}
 	conn, err := xgb.NewConnDisplay(display)
 	if err != nil {
-		t.Skipf("X11 integration test cannot connect to DISPLAY %q: %v", display, err)
+		x11Unavailable(t, "X11 integration test cannot connect to DISPLAY %q: %v", display, err)
 	}
 	if err := xtest.Init(conn); err != nil {
 		conn.Close()
-		t.Skipf("X11 integration test requires the XTEST extension: %v", err)
+		x11Unavailable(t, "X11 integration test requires the XTEST extension: %v", err)
 	}
 	if _, err := xtest.GetVersion(conn, 2, 2).Reply(); err != nil {
 		conn.Close()
-		t.Skipf("X11 integration test cannot query the XTEST extension: %v", err)
+		x11Unavailable(t, "X11 integration test cannot query the XTEST extension: %v", err)
 	}
 
 	screen := xproto.Setup(conn).DefaultScreen(conn)
@@ -147,8 +153,41 @@ func newX11InputHarness(t *testing.T) *x11InputHarness {
 		_ = xproto.DestroyWindowChecked(conn, windowID).Check()
 		conn.Close()
 	})
-	t.Cleanup(robotgo.CloseMainDisplay)
+	t.Cleanup(func() {
+		if err := robotgo.CloseMainDisplayE(); err != nil {
+			t.Errorf("CloseMainDisplayE cleanup: %v", err)
+		}
+	})
 	return harness
+}
+
+func x11Unavailable(t *testing.T, format string, args ...interface{}) {
+	t.Helper()
+	if os.Getenv(x11RequiredEnv) == "1" {
+		t.Fatalf(format, args...)
+	}
+	t.Skipf(format, args...)
+}
+
+func TestPureGoX11MultiLayoutConfiguration(t *testing.T) {
+	if os.Getenv("DISPLAY") == "" || os.Getenv("WAYLAND_DISPLAY") != "" {
+		x11Unavailable(t, "multi-layout integration test requires an X11-primary DISPLAY")
+	}
+	path, err := exec.LookPath("setxkbmap")
+	if err != nil {
+		x11Unavailable(t, "multi-layout integration test requires setxkbmap: %v", err)
+	}
+	output, err := exec.Command(path, "-query").CombinedOutput()
+	if err != nil {
+		x11Unavailable(t, "query active X11 keymap: %v: %s", err, strings.TrimSpace(string(output)))
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		name, value, found := strings.Cut(line, ":")
+		if found && strings.TrimSpace(name) == "layout" && strings.TrimSpace(value) == "us,de" {
+			return
+		}
+	}
+	x11Unavailable(t, "active X11 keymap is not the required us,de configuration: %s", strings.TrimSpace(string(output)))
 }
 
 func (h *x11InputHarness) drainEvents() {
@@ -179,6 +218,21 @@ func (h *x11InputHarness) waitForEvent(description string, match func(xgb.Event)
 	}
 	h.t.Fatalf("timed out after %s waiting for %s", x11EventTimeout, description)
 	return nil
+}
+
+func (h *x11InputHarness) assertNoMatchingEvent(description string, duration time.Duration, match func(xgb.Event) bool) {
+	h.t.Helper()
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		event, err := h.conn.PollForEvent()
+		if err != nil {
+			h.t.Fatalf("poll while checking for unexpected %s: %v", description, err)
+		}
+		if event != nil && match(event) {
+			h.t.Fatalf("received unexpected %s: %T %+v", description, event, event)
+		}
+		time.Sleep(x11PollInterval)
+	}
 }
 
 func (h *x11InputHarness) waitForKeyPress(description string) xproto.KeyPressEvent {
@@ -230,6 +284,37 @@ func (h *x11InputHarness) queryPointer() (int, int) {
 	return int(reply.RootX), int(reply.RootY)
 }
 
+func (h *x11InputHarness) keyPressed(keycode xproto.Keycode) bool {
+	h.t.Helper()
+	reply, err := xproto.QueryKeymap(h.conn).Reply()
+	if err != nil {
+		h.t.Fatalf("query X11 pressed keys: %v", err)
+	}
+	return reply.Keys[int(keycode)/8]&(1<<uint(keycode%8)) != 0
+}
+
+func (h *x11InputHarness) fakeKey(keycode xproto.Keycode, down bool) {
+	h.t.Helper()
+	eventType := byte(xproto.KeyRelease)
+	if down {
+		eventType = byte(xproto.KeyPress)
+	}
+	if err := xtest.FakeInputChecked(h.conn, eventType, byte(keycode), 0, h.root, 0, 0, 0).Check(); err != nil {
+		h.t.Fatalf("inject independent X11 key state: %v", err)
+	}
+}
+
+func (h *x11InputHarness) fakeButton(button byte, down bool) {
+	h.t.Helper()
+	eventType := byte(xproto.ButtonRelease)
+	if down {
+		eventType = byte(xproto.ButtonPress)
+	}
+	if err := xtest.FakeInputChecked(h.conn, eventType, button, 0, h.root, 0, 0, 0).Check(); err != nil {
+		h.t.Fatalf("inject independent X11 button state: %v", err)
+	}
+}
+
 func (h *x11InputHarness) keysym(keycode xproto.Keycode) xproto.Keysym {
 	h.t.Helper()
 	reply, err := xproto.GetKeyboardMapping(h.conn, keycode, 1).Reply()
@@ -240,6 +325,251 @@ func (h *x11InputHarness) keysym(keycode xproto.Keycode) xproto.Keysym {
 		h.t.Fatalf("X11 keycode %d has no keysyms", keycode)
 	}
 	return reply.Keysyms[0]
+}
+
+func (h *x11InputHarness) keysyms(keycode xproto.Keycode) []xproto.Keysym {
+	h.t.Helper()
+	reply, err := xproto.GetKeyboardMapping(h.conn, keycode, 1).Reply()
+	if err != nil {
+		h.t.Fatalf("query mapping for X11 keycode %d: %v", keycode, err)
+	}
+	return append([]xproto.Keysym(nil), reply.Keysyms...)
+}
+
+func (h *x11InputHarness) findKeycode(keysym uint32) (xproto.Keycode, []xproto.Keysym) {
+	h.t.Helper()
+	setup := xproto.Setup(h.conn)
+	if setup == nil {
+		h.t.Fatal("X11 connection has no setup while finding a keysym")
+	}
+	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
+	reply, err := xproto.GetKeyboardMapping(h.conn, setup.MinKeycode, byte(count)).Reply()
+	if err != nil || reply == nil || reply.KeysymsPerKeycode == 0 {
+		h.t.Fatalf("query X11 keymap while finding keysym %#x: reply=%+v err=%v", keysym, reply, err)
+	}
+	per := int(reply.KeysymsPerKeycode)
+	for offset := 0; offset+per <= len(reply.Keysyms); offset += per {
+		for _, value := range reply.Keysyms[offset : offset+per] {
+			if uint32(value) == keysym {
+				mapping := append([]xproto.Keysym(nil), reply.Keysyms[offset:offset+per]...)
+				return setup.MinKeycode + xproto.Keycode(offset/per), mapping
+			}
+		}
+	}
+	h.t.Fatalf("X11 keymap does not contain keysym %#x", keysym)
+	return 0, nil
+}
+
+func (h *x11InputHarness) findEmptyNonModifierKeycode() (xproto.Keycode, []xproto.Keysym) {
+	h.t.Helper()
+	setup := xproto.Setup(h.conn)
+	if setup == nil {
+		h.t.Fatal("X11 connection has no setup while finding an empty keycode")
+	}
+	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
+	reply, err := xproto.GetKeyboardMapping(h.conn, setup.MinKeycode, byte(count)).Reply()
+	if err != nil || reply == nil || reply.KeysymsPerKeycode == 0 {
+		h.t.Fatalf("query X11 keymap while finding empty keycode: reply=%+v err=%v", reply, err)
+	}
+	modifierReply, err := xproto.GetModifierMapping(h.conn).Reply()
+	if err != nil || modifierReply == nil {
+		h.t.Fatalf("query X11 modifier map while finding empty keycode: reply=%+v err=%v", modifierReply, err)
+	}
+	modifiers := make(map[xproto.Keycode]struct{})
+	for _, code := range modifierReply.Keycodes {
+		if code != 0 {
+			modifiers[code] = struct{}{}
+		}
+	}
+	per := int(reply.KeysymsPerKeycode)
+	for offset := 0; offset+per <= len(reply.Keysyms); offset += per {
+		code := setup.MinKeycode + xproto.Keycode(offset/per)
+		if _, modifier := modifiers[code]; modifier {
+			continue
+		}
+		mapping := reply.Keysyms[offset : offset+per]
+		empty := true
+		for _, keysym := range mapping {
+			if keysym != 0 {
+				empty = false
+				break
+			}
+		}
+		if empty {
+			return code, append([]xproto.Keysym(nil), mapping...)
+		}
+	}
+	h.t.Fatal("X11 keymap has no empty non-modifier keycode")
+	return 0, nil
+}
+
+func (h *x11InputHarness) modifierMapping() (byte, []xproto.Keycode) {
+	h.t.Helper()
+	reply, err := xproto.GetModifierMapping(h.conn).Reply()
+	if err != nil || reply == nil || reply.KeycodesPerModifier == 0 {
+		h.t.Fatalf("query X11 modifier map: reply=%+v err=%v", reply, err)
+	}
+	return reply.KeycodesPerModifier, append([]xproto.Keycode(nil), reply.Keycodes...)
+}
+
+func (h *x11InputHarness) setModifierMapping(per byte, keycodes []xproto.Keycode) {
+	h.t.Helper()
+	reply, err := xproto.SetModifierMapping(h.conn, per, keycodes).Reply()
+	if err != nil || reply == nil || reply.Status != xproto.MappingStatusSuccess {
+		h.t.Fatalf("set X11 modifier map: reply=%+v err=%v", reply, err)
+	}
+}
+
+func (h *x11InputHarness) keymapContains(keysym uint32) bool {
+	h.t.Helper()
+	setup := xproto.Setup(h.conn)
+	if setup == nil {
+		h.t.Fatal("X11 connection has no setup while scanning the keymap")
+	}
+	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
+	reply, err := xproto.GetKeyboardMapping(h.conn, setup.MinKeycode, byte(count)).Reply()
+	if err != nil || reply == nil {
+		h.t.Fatalf("scan X11 keymap: reply=%+v err=%v", reply, err)
+	}
+	for _, value := range reply.Keysyms {
+		if uint32(value) == keysym {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *x11InputHarness) rootChildren() map[xproto.Window]struct{} {
+	h.t.Helper()
+	reply, err := xproto.QueryTree(h.conn, h.root).Reply()
+	if err != nil {
+		h.t.Fatalf("query X11 root children: %v", err)
+	}
+	children := make(map[xproto.Window]struct{}, len(reply.Children))
+	for _, child := range reply.Children {
+		children[child] = struct{}{}
+	}
+	return children
+}
+
+func (h *x11InputHarness) waitForNewRootChild(previous map[xproto.Window]struct{}) xproto.Window {
+	h.t.Helper()
+	deadline := time.Now().Add(x11EventTimeout)
+	for time.Now().Before(deadline) {
+		for child := range h.rootChildren() {
+			if _, existed := previous[child]; !existed {
+				return child
+			}
+		}
+		time.Sleep(x11PollInterval)
+	}
+	h.t.Fatalf("timed out after %s waiting for XKB oracle window", x11EventTimeout)
+	return 0
+}
+
+func startXKBOracle(t *testing.T, harness *x11InputHarness) (xproto.Window, <-chan string, *os.Process) {
+	t.Helper()
+	path, err := exec.LookPath("xkbcli")
+	if err != nil {
+		x11Unavailable(t, "X11 text integration requires xkbcli: %v", err)
+	}
+	stdbufPath, err := exec.LookPath("stdbuf")
+	if err != nil {
+		x11Unavailable(t, "X11 text integration requires stdbuf: %v", err)
+	}
+	previousChildren := harness.rootChildren()
+	command := exec.Command(stdbufPath, "-oL", path, "interactive-x11", "--uniline")
+	command.Env = os.Environ()
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatalf("create xkbcli stdout pipe: %v", err)
+	}
+	command.Stderr = io.Discard
+	if err := command.Start(); err != nil {
+		x11Unavailable(t, "start xkbcli X11 oracle: %v", err)
+	}
+	lines := make(chan string, 32)
+	go func() {
+		defer close(lines)
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			lines <- scanner.Text()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = command.Process.Signal(syscall.SIGCONT)
+		_ = command.Process.Kill()
+		_ = command.Wait()
+	})
+	window := harness.waitForNewRootChild(previousChildren)
+	if err := xproto.SetInputFocusChecked(
+		harness.conn, xproto.InputFocusPointerRoot, window, xproto.TimeCurrentTime,
+	).Check(); err != nil {
+		t.Fatalf("focus xkbcli oracle window: %v", err)
+	}
+	harness.conn.Sync()
+	return window, lines, command.Process
+}
+
+func waitForProcessStopped(t *testing.T, process *os.Process) {
+	t.Helper()
+	statusPath := fmt.Sprintf("/proc/%d/status", process.Pid)
+	deadline := time.Now().Add(x11EventTimeout)
+	for time.Now().Before(deadline) {
+		status, err := os.ReadFile(statusPath)
+		if err != nil {
+			t.Fatalf("read XKB oracle process status: %v", err)
+		}
+		if strings.Contains(string(status), "\nState:\tT") {
+			return
+		}
+		time.Sleep(x11PollInterval)
+	}
+	t.Fatalf("XKB oracle process %d did not stop", process.Pid)
+}
+
+func waitForXKBOracleText(t *testing.T, lines <-chan string, count int) []rune {
+	t.Helper()
+	result := make([]rune, 0, count)
+	observed := make([]string, 0, count*2)
+	deadline := time.NewTimer(x11EventTimeout)
+	defer deadline.Stop()
+	for len(result) < count {
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				t.Fatalf("xkbcli oracle exited after text %q", string(result))
+			}
+			observed = append(observed, line)
+			if !strings.Contains(line, "down") {
+				continue
+			}
+			const unicodeMarker = "unicode [ "
+			unicodeIndex := strings.Index(line, unicodeMarker)
+			if unicodeIndex < 0 {
+				continue
+			}
+			unicodeText := line[unicodeIndex+len(unicodeMarker):]
+			end := strings.Index(unicodeText, " ]")
+			if end < 0 {
+				continue
+			}
+			unicodeText = strings.TrimSpace(unicodeText[:end])
+			if strings.HasPrefix(unicodeText, "U+") {
+				var value uint32
+				if _, err := fmt.Sscanf(unicodeText, "U+%X", &value); err == nil {
+					result = append(result, rune(value))
+				}
+				continue
+			}
+			if values := []rune(unicodeText); len(values) == 1 {
+				result = append(result, values[0])
+			}
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for %d XKB characters; got %q from lines %q", count, string(result), observed)
+		}
+	}
+	return result
 }
 
 func TestPureGoX11Capabilities(t *testing.T) {
@@ -276,6 +606,9 @@ func TestPureGoX11Capabilities(t *testing.T) {
 
 func TestPureGoX11PointerInput(t *testing.T) {
 	harness := newX11InputHarness(t)
+	if err := robotgo.Toggle("wheelLeft", "down"); !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("persistent horizontal-wheel toggle error = %v, want ErrNotSupported", err)
+	}
 	const targetX, targetY = 180, 170
 	if err := robotgo.MoveE(targetX, targetY); err != nil {
 		t.Fatalf("MoveE: %v", err)
@@ -295,6 +628,26 @@ func TestPureGoX11PointerInput(t *testing.T) {
 		return ok && int(motion.RootX) == targetX+deltaX && int(motion.RootY) == targetY+deltaY
 	})
 	assertPointerLocation(t, harness, targetX+deltaX, targetY+deltaY)
+
+	const smoothX, smoothY = 260, 240
+	if !robotgo.MoveSmooth(smoothX, smoothY, 0.0, 0.0, 0) {
+		t.Fatal("MoveSmooth returned false")
+	}
+	harness.waitForEvent("final smooth pointer motion", func(event xgb.Event) bool {
+		motion, ok := event.(xproto.MotionNotifyEvent)
+		return ok && int(motion.RootX) == smoothX && int(motion.RootY) == smoothY
+	})
+	assertPointerLocation(t, harness, smoothX, smoothY)
+
+	const dragX, dragY = 300, 270
+	robotgo.DragSmooth(dragX, dragY, 0.0, 0.0, 0)
+	if got, want := harness.waitForButtonEvents(2), []x11ButtonEvent{
+		{pressed: true, button: x11ButtonLeft},
+		{button: x11ButtonLeft},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("drag button events = %+v, want %+v", got, want)
+	}
+	assertPointerLocation(t, harness, dragX, dragY)
 
 	if err := robotgo.ClickE("left"); err != nil {
 		t.Fatalf("ClickE: %v", err)
@@ -324,18 +677,34 @@ func TestPureGoX11PointerInput(t *testing.T) {
 		t.Fatalf("ScrollE: %v", err)
 	}
 	if got, want := harness.waitForButtonEvents(4), []x11ButtonEvent{
-		{pressed: true, button: x11ButtonWheelRight},
-		{button: x11ButtonWheelRight},
+		{pressed: true, button: x11ButtonWheelLeft},
+		{button: x11ButtonWheelLeft},
 		{pressed: true, button: x11ButtonWheelUp},
 		{button: x11ButtonWheelUp},
 	}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("scroll events = %+v, want %+v", got, want)
 	}
+	if err := robotgo.Toggle("wheelUp", "down"); err != nil {
+		t.Fatalf("hold wheel button before ScrollE: %v", err)
+	}
+	harness.waitForButtonEvents(1)
+	if err := robotgo.ScrollE(0, 1, 0); err == nil || errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("ScrollE over RobotGo-held wheel button error = %v, want state error", err)
+	}
+	if reply, err := xproto.QueryPointer(harness.conn, harness.root).Reply(); err != nil {
+		t.Fatalf("query owned wheel-button state: %v", err)
+	} else if reply.Mask&xproto.ButtonMask4 == 0 {
+		t.Fatal("ScrollE released the RobotGo-held wheel button")
+	}
+	if err := robotgo.Toggle("wheelUp", "up"); err != nil {
+		t.Fatalf("release held wheel button after ScrollE: %v", err)
+	}
+	harness.waitForButtonEvents(1)
 }
 
 func TestPureGoX11KeyboardInput(t *testing.T) {
 	harness := newX11InputHarness(t)
-	if err := robotgo.KeyTap("a"); err != nil {
+	if err := robotgo.KeyTap("enter"); err != nil {
 		t.Fatalf("KeyTap: %v", err)
 	}
 	press := harness.waitForKeyPress("KeyTap press")
@@ -343,9 +712,21 @@ func TestPureGoX11KeyboardInput(t *testing.T) {
 	if press.Detail != release.Detail {
 		t.Fatalf("KeyTap keycodes differ: press=%d release=%d", press.Detail, release.Detail)
 	}
-	if got := harness.keysym(press.Detail); got != x11KeysymA {
-		t.Fatalf("KeyTap keysym = %#x, want %#x (a)", got, x11KeysymA)
+	if got := harness.keysym(press.Detail); got != x11KeysymEnter {
+		t.Fatalf("KeyTap keysym = %#x, want %#x (Enter)", got, x11KeysymEnter)
 	}
+
+	if err := robotgo.KeyTap("A", "ctrl"); err != nil {
+		t.Fatalf("uppercase KeyTap with modifier: %v", err)
+	}
+	uppercase := harness.waitForEvent("uppercase KeyTap main press", func(event xgb.Event) bool {
+		press, ok := event.(xproto.KeyPressEvent)
+		return ok && uint32(harness.keysym(press.Detail)) == 'A'
+	}).(xproto.KeyPressEvent)
+	if want := uint16(xproto.ModMaskControl | xproto.ModMaskShift); uppercase.State&want != want {
+		t.Fatalf("uppercase KeyTap state = %#x, want Ctrl+Shift bits %#x", uppercase.State, want)
+	}
+	harness.drainEvents()
 
 	if err := robotgo.KeyToggle("shift", "down"); err != nil {
 		t.Fatalf("KeyToggle shift down: %v", err)
@@ -362,25 +743,614 @@ func TestPureGoX11KeyboardInput(t *testing.T) {
 	if shiftRelease.Detail != shiftPress.Detail {
 		t.Fatalf("shift keycodes differ: press=%d release=%d", shiftPress.Detail, shiftRelease.Detail)
 	}
-
-	if err := robotgo.TypeStrE("az"); err != nil {
-		t.Fatalf("TypeStrE: %v", err)
+	if err := robotgo.KeyToggle("a", "down"); !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("persistent literal KeyToggle error = %v, want ErrNotSupported", err)
 	}
-	for index, want := range []xproto.Keysym{x11KeysymA, x11KeysymZ} {
+	if err := robotgo.KeyTap("enter", "y"); err == nil || errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("literal modifier KeyTap error = %v, want argument-validation error", err)
+	}
+
+	restoreDelay := robotgo.SetX11KeyHoldDelayForIntegrationTest(150 * time.Millisecond)
+	defer restoreDelay()
+	text := "Aä€😀"
+	typeDone := make(chan error, 1)
+	go func() { typeDone <- robotgo.TypeStrE(text) }()
+	var scratchCode xproto.Keycode
+	scratchCodes := make(map[xproto.Keycode]struct{})
+	for index, value := range []rune(text) {
 		press := harness.waitForKeyPress(fmt.Sprintf("TypeStrE character %d press", index))
+		scratchCode = press.Detail
+		scratchCodes[press.Detail] = struct{}{}
+		want := x11KeysymForRune(value)
+		for column, got := range harness.keysyms(press.Detail) {
+			if column < 4 && uint32(got) != want {
+				t.Fatalf("TypeStrE character %d column %d keysym = %#x, want %#x", index, column, got, want)
+			}
+			if column >= 4 && got != 0 && uint32(got) != want {
+				t.Fatalf("TypeStrE character %d column %d has unexpected keysym %#x", index, column, got)
+			}
+		}
 		release := harness.waitForKeyRelease(fmt.Sprintf("TypeStrE character %d release", index))
 		if press.Detail != release.Detail {
 			t.Fatalf("TypeStrE character %d keycodes differ: press=%d release=%d", index, press.Detail, release.Detail)
 		}
-		if got := harness.keysym(press.Detail); got != want {
-			t.Fatalf("TypeStrE character %d keysym = %#x, want %#x", index, got, want)
+	}
+	if err := <-typeDone; err != nil {
+		t.Fatalf("TypeStrE: %v", err)
+	}
+	if got, want := uint32(harness.keysym(scratchCode)), x11KeysymForRune('😀'); got != want {
+		t.Fatalf("stable Unicode key mapping = %#x, want %#x before cleanup", got, want)
+	}
+	modifierMap, err := xproto.GetModifierMapping(harness.conn).Reply()
+	if err != nil || modifierMap == nil {
+		t.Fatalf("query modifier map after Unicode input: reply=%+v err=%v", modifierMap, err)
+	}
+	for _, code := range modifierMap.Keycodes {
+		if _, scratch := scratchCodes[code]; scratch && code != 0 {
+			t.Fatalf("Unicode scratch keycode %d is also present in the X11 modifier map", code)
 		}
+	}
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE after Unicode input: %v", err)
+	}
+	if got := harness.keysym(scratchCode); got != 0 {
+		t.Fatalf("Unicode key mapping was not restored by CloseMainDisplay: keysym=%#x", got)
+	}
+}
+
+func TestPureGoX11TextReachesDelayedXKBClient(t *testing.T) {
+	harness := newX11InputHarness(t)
+	_, lines, process := startXKBOracle(t, harness)
+	if err := process.Signal(syscall.SIGSTOP); err != nil {
+		t.Fatalf("stop XKB oracle: %v", err)
+	}
+	waitForProcessStopped(t, process)
+	// The oracle must process MappingNotify and key events only after the
+	// RobotGo transaction finishes; this catches mappings whose lifetime is too
+	// short for a delayed target client.
+	const text = "Aä€😀"
+	if err := robotgo.TypeStrE(text); err != nil {
+		t.Fatalf("TypeStrE while XKB oracle is stopped: %v", err)
+	}
+	if err := process.Signal(syscall.SIGCONT); err != nil {
+		t.Fatalf("resume XKB oracle: %v", err)
+	}
+	if got := string(waitForXKBOracleText(t, lines, len([]rune(text)))); got != text {
+		t.Fatalf("XKB oracle text = %q, want %q", got, text)
+	}
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE after delayed XKB input: %v", err)
+	}
+}
+
+func TestPureGoX11ExplicitShiftReachesXKBClient(t *testing.T) {
+	harness := newX11InputHarness(t)
+	_, lines, _ := startXKBOracle(t, harness)
+	for _, test := range []struct {
+		key       string
+		modifiers []interface{}
+		want      rune
+	}{
+		{key: "a", modifiers: []interface{}{"shift"}, want: 'A'},
+		{key: "1", modifiers: []interface{}{"right_shift"}, want: '!'},
+		{key: "+", want: '+'},
+	} {
+		if err := robotgo.KeyTap(test.key, test.modifiers...); err != nil {
+			t.Fatalf("KeyTap(%q,%v): %v", test.key, test.modifiers, err)
+		}
+		if got := waitForXKBOracleText(t, lines, 1); len(got) != 1 || got[0] != test.want {
+			t.Fatalf("XKB oracle KeyTap(%q,%v) = %q, want %q", test.key, test.modifiers, string(got), string(test.want))
+		}
+	}
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE after shifted literal input: %v", err)
+	}
+}
+
+func TestPureGoX11ScratchReservationSkipsPressedEmptyKeycode(t *testing.T) {
+	harness := newX11InputHarness(t)
+	heldCode, original := harness.findEmptyNonModifierKeycode()
+	harness.fakeKey(heldCode, true)
+	harness.waitForKeyPress("foreign press on empty keycode")
+	held := true
+	t.Cleanup(func() {
+		if held {
+			harness.fakeKey(heldCode, false)
+		}
+		_ = xproto.ChangeKeyboardMappingChecked(
+			harness.conn, 1, heldCode, byte(len(original)), original,
+		).Check()
+	})
+	typeDone := make(chan error, 1)
+	go func() { typeDone <- robotgo.TypeStrE("😀") }()
+	press := harness.waitForKeyPress("text press with foreign empty keycode held")
+	harness.waitForKeyRelease("text release with foreign empty keycode held")
+	if err := <-typeDone; err != nil {
+		t.Fatalf("TypeStrE with a pressed empty keycode: %v", err)
+	}
+	if press.Detail == heldCode {
+		t.Fatalf("text reused foreign-held empty keycode %d", heldCode)
+	}
+	for column, keysym := range harness.keysyms(heldCode) {
+		if keysym != 0 {
+			t.Fatalf("foreign-held keycode %d column %d was mapped to %#x", heldCode, column, keysym)
+		}
+	}
+	if !harness.keyPressed(heldCode) {
+		t.Fatal("text input released the foreign-held empty keycode")
+	}
+	harness.fakeKey(heldCode, false)
+	held = false
+	harness.waitForKeyRelease("foreign empty-keycode release")
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE after pressed scratch exclusion: %v", err)
+	}
+}
+
+func TestPureGoX11ScratchCleanupCanRetryAfterForeignRelease(t *testing.T) {
+	harness := newX11InputHarness(t)
+	typeDone := make(chan error, 1)
+	go func() { typeDone <- robotgo.TypeStrE("😀") }()
+	press := harness.waitForKeyPress("scratch press before cleanup conflict")
+	harness.waitForKeyRelease("scratch release before cleanup conflict")
+	if err := <-typeDone; err != nil {
+		t.Fatalf("TypeStrE before cleanup conflict: %v", err)
+	}
+	harness.fakeKey(press.Detail, true)
+	harness.waitForKeyPress("foreign scratch-code press")
+	foreignHeld := true
+	t.Cleanup(func() {
+		if foreignHeld {
+			harness.fakeKey(press.Detail, false)
+		}
+	})
+	if err := robotgo.CloseMainDisplayE(); err == nil {
+		t.Fatal("CloseMainDisplayE restored a foreign-held scratch keycode")
+	}
+	if got, want := uint32(harness.keysym(press.Detail)), x11KeysymForRune('😀'); got != want {
+		t.Fatalf("mapping after rejected cleanup = %#x, want %#x", got, want)
+	}
+	harness.fakeKey(press.Detail, false)
+	foreignHeld = false
+	harness.waitForKeyRelease("foreign scratch-code release")
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("retry CloseMainDisplayE after foreign release: %v", err)
+	}
+	if got := harness.keysym(press.Detail); got != 0 {
+		t.Fatalf("retry cleanup left scratch mapping %#x", got)
+	}
+}
+
+func TestPureGoX11RejectsNonModifierBeforeScratchMutation(t *testing.T) {
+	harness := newX11InputHarness(t)
+	per, original := harness.modifierMapping()
+	cleared := make([]xproto.Keycode, len(original))
+	harness.setModifierMapping(per, cleared)
+	restored := false
+	t.Cleanup(func() {
+		if !restored {
+			harness.setModifierMapping(per, original)
+		}
+	})
+	const value = '😀'
+	if err := robotgo.KeyTap(string(value), "ctrl"); !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("KeyTap with a keysym that is not in the modifier map = %v, want ErrNotSupported", err)
+	}
+	if harness.keymapContains(x11KeysymForRune(value)) {
+		t.Fatal("failed modifier preflight still installed a Unicode scratch mapping")
+	}
+	harness.assertNoMatchingEvent("key input after modifier preflight failure", 100*time.Millisecond, func(event xgb.Event) bool {
+		_, pressed := event.(xproto.KeyPressEvent)
+		return pressed
+	})
+	harness.setModifierMapping(per, original)
+	restored = true
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE after modifier preflight failure: %v", err)
+	}
+}
+
+func TestPureGoX11ScratchCleanupCanRetryAfterModifierRestore(t *testing.T) {
+	harness := newX11InputHarness(t)
+	typeDone := make(chan error, 1)
+	go func() { typeDone <- robotgo.TypeStrE("😀") }()
+	press := harness.waitForKeyPress("scratch press before modifier conflict")
+	harness.waitForKeyRelease("scratch release before modifier conflict")
+	if err := <-typeDone; err != nil {
+		t.Fatalf("TypeStrE before modifier cleanup conflict: %v", err)
+	}
+	per, original := harness.modifierMapping()
+	modified := append([]xproto.Keycode(nil), original...)
+	inserted := false
+	for index, code := range modified {
+		if code == 0 {
+			modified[index] = press.Detail
+			inserted = true
+			break
+		}
+	}
+	if !inserted {
+		t.Fatal("X11 modifier map has no empty slot for cleanup-conflict test")
+	}
+	harness.setModifierMapping(per, modified)
+	restored := false
+	t.Cleanup(func() {
+		if !restored {
+			harness.setModifierMapping(per, original)
+		}
+	})
+	if err := robotgo.CloseMainDisplayE(); err == nil {
+		t.Fatal("CloseMainDisplayE restored a scratch keycode that became a modifier")
+	}
+	if got, want := uint32(harness.keysym(press.Detail)), x11KeysymForRune('😀'); got != want {
+		t.Fatalf("mapping after modifier cleanup conflict = %#x, want %#x", got, want)
+	}
+	harness.setModifierMapping(per, original)
+	restored = true
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("retry CloseMainDisplayE after modifier restore: %v", err)
+	}
+	if got := harness.keysym(press.Detail); got != 0 {
+		t.Fatalf("retry cleanup left modifier-conflicted scratch mapping %#x", got)
+	}
+}
+
+func TestPureGoX11TextCapacityFailsBeforeInput(t *testing.T) {
+	harness := newX11InputHarness(t)
+	var text strings.Builder
+	for value := rune(0x400); value < 0x500; value++ {
+		text.WriteRune(value)
+	}
+	if err := robotgo.TypeStrE(text.String()); !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("oversized distinct-text error = %v, want ErrNotSupported", err)
+	}
+	harness.assertNoMatchingEvent("partial key input after scratch-capacity failure", 100*time.Millisecond, func(event xgb.Event) bool {
+		_, pressed := event.(xproto.KeyPressEvent)
+		return pressed
+	})
+}
+
+func TestPureGoX11RejectsScratchReplacementBeforeTextTap(t *testing.T) {
+	harness := newX11InputHarness(t)
+	const value = '😀'
+	keysym := x11KeysymForRune(value)
+	var scratchCode xproto.Keycode
+	var empty []xproto.Keysym
+	restoreHook := robotgo.SetX11BeforeTextTapHookForIntegrationTest(func() {
+		code, mapping := harness.findKeycode(keysym)
+		scratchCode = code
+		empty = make([]xproto.Keysym, len(mapping))
+		foreign := make([]xproto.Keysym, len(mapping))
+		for index := range foreign {
+			foreign[index] = 'z'
+		}
+		if err := xproto.ChangeKeyboardMappingChecked(
+			harness.conn, 1, code, byte(len(foreign)), foreign,
+		).Check(); err != nil {
+			t.Fatalf("replace scratch mapping before text tap: %v", err)
+		}
+	})
+	defer restoreHook()
+	t.Cleanup(func() {
+		if scratchCode != 0 {
+			_ = xproto.ChangeKeyboardMappingChecked(
+				harness.conn, 1, scratchCode, byte(len(empty)), empty,
+			).Check()
+		}
+	})
+	if err := robotgo.TypeStrE(string(value)); err == nil || errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("TypeStrE after foreign scratch replacement error = %v, want ownership error", err)
+	}
+	harness.assertNoMatchingEvent("key input from a stale scratch mapping", 100*time.Millisecond, func(event xgb.Event) bool {
+		_, pressed := event.(xproto.KeyPressEvent)
+		return pressed
+	})
+	if got := harness.keysym(scratchCode); got != 'z' {
+		t.Fatalf("cleanup overwrote adversarial scratch replacement with keysym %#x", got)
+	}
+}
+
+func TestPureGoX11ClosePreservesForeignScratchReplacement(t *testing.T) {
+	harness := newX11InputHarness(t)
+	restoreDelay := robotgo.SetX11KeyHoldDelayForIntegrationTest(150 * time.Millisecond)
+	defer restoreDelay()
+	typeDone := make(chan error, 1)
+	go func() { typeDone <- robotgo.TypeStrE("😀") }()
+	press := harness.waitForKeyPress("scratch ownership key press")
+	harness.waitForKeyRelease("scratch ownership key release")
+	if err := <-typeDone; err != nil {
+		t.Fatalf("TypeStrE before foreign scratch replacement: %v", err)
+	}
+	current := harness.keysyms(press.Detail)
+	foreign := make([]xproto.Keysym, len(current))
+	for index := range foreign {
+		foreign[index] = 'z'
+	}
+	empty := make([]xproto.Keysym, len(current))
+	t.Cleanup(func() {
+		_ = xproto.ChangeKeyboardMappingChecked(
+			harness.conn, 1, press.Detail, byte(len(empty)), empty,
+		).Check()
+	})
+	if err := xproto.ChangeKeyboardMappingChecked(
+		harness.conn, 1, press.Detail, byte(len(foreign)), foreign,
+	).Check(); err != nil {
+		t.Fatalf("install foreign scratch replacement: %v", err)
+	}
+	harness.fakeKey(press.Detail, true)
+	harness.waitForKeyPress("foreign replacement press")
+	foreignHeld := true
+	t.Cleanup(func() {
+		if foreignHeld {
+			harness.fakeKey(press.Detail, false)
+		}
+	})
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE after pressed foreign replacement: %v", err)
+	}
+	if got := harness.keysym(press.Detail); got != 'z' {
+		t.Fatalf("CloseMainDisplay overwrote foreign scratch mapping with keysym %#x", got)
+	}
+	if !harness.keyPressed(press.Detail) {
+		t.Fatal("CloseMainDisplay released a pressed foreign scratch replacement")
+	}
+	harness.fakeKey(press.Detail, false)
+	foreignHeld = false
+	harness.waitForKeyRelease("foreign replacement release")
+}
+
+func TestPureGoX11ClosePreservesForeignModifierScratchReplacement(t *testing.T) {
+	harness := newX11InputHarness(t)
+	typeDone := make(chan error, 1)
+	go func() { typeDone <- robotgo.TypeStrE("😀") }()
+	press := harness.waitForKeyPress("scratch press before foreign modifier replacement")
+	harness.waitForKeyRelease("scratch release before foreign modifier replacement")
+	if err := <-typeDone; err != nil {
+		t.Fatalf("TypeStrE before foreign modifier replacement: %v", err)
+	}
+	current := harness.keysyms(press.Detail)
+	foreign := make([]xproto.Keysym, len(current))
+	for index := range foreign {
+		foreign[index] = 'z'
+	}
+	empty := make([]xproto.Keysym, len(current))
+	t.Cleanup(func() {
+		_ = xproto.ChangeKeyboardMappingChecked(
+			harness.conn, 1, press.Detail, byte(len(empty)), empty,
+		).Check()
+	})
+	if err := xproto.ChangeKeyboardMappingChecked(
+		harness.conn, 1, press.Detail, byte(len(foreign)), foreign,
+	).Check(); err != nil {
+		t.Fatalf("install foreign modifier scratch replacement: %v", err)
+	}
+	per, original := harness.modifierMapping()
+	modified := append([]xproto.Keycode(nil), original...)
+	inserted := false
+	for index, code := range modified {
+		if code == 0 {
+			modified[index] = press.Detail
+			inserted = true
+			break
+		}
+	}
+	if !inserted {
+		t.Fatal("X11 modifier map has no empty slot for foreign replacement test")
+	}
+	harness.setModifierMapping(per, modified)
+	restored := false
+	t.Cleanup(func() {
+		if !restored {
+			harness.setModifierMapping(per, original)
+		}
+	})
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE after foreign modifier replacement: %v", err)
+	}
+	if got := harness.keysym(press.Detail); got != 'z' {
+		t.Fatalf("CloseMainDisplay overwrote foreign modifier mapping with keysym %#x", got)
+	}
+	harness.setModifierMapping(per, original)
+	restored = true
+}
+
+func TestPureGoX11PreservesForeignInputState(t *testing.T) {
+	harness := newX11InputHarness(t)
+	if err := robotgo.KeyToggle("shift", "down"); err != nil {
+		t.Fatalf("discover shift keycode: %v", err)
+	}
+	shift := harness.waitForKeyPress("RobotGo shift press").Detail
+	if err := robotgo.KeyToggle("shift", "up"); err != nil {
+		t.Fatalf("release RobotGo shift: %v", err)
+	}
+	harness.waitForKeyRelease("RobotGo shift release")
+
+	harness.fakeKey(shift, true)
+	harness.waitForKeyPress("independent shift press")
+	if err := robotgo.KeyTap("enter", "shift"); err != nil {
+		t.Fatalf("KeyTap with foreign Shift: %v", err)
+	}
+	harness.waitForKeyPress("Enter press with foreign Shift")
+	harness.waitForKeyRelease("Enter release with foreign Shift")
+	if !harness.keyPressed(shift) {
+		t.Fatal("RobotGo released a Shift key held by another X11 client")
+	}
+	harness.fakeKey(shift, false)
+	harness.waitForKeyRelease("independent shift release")
+
+	harness.fakeButton(x11ButtonRight, true)
+	harness.waitForButtonEvents(1)
+	err := robotgo.ClickE("right")
+	if err == nil || errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("ClickE over foreign-held button error = %v, want state error", err)
+	}
+	if reply, queryErr := xproto.QueryPointer(harness.conn, harness.root).Reply(); queryErr != nil {
+		t.Fatalf("query foreign button state: %v", queryErr)
+	} else if reply.Mask&xproto.ButtonMask3 == 0 {
+		t.Fatal("RobotGo released a pointer button held by another X11 client")
+	}
+	harness.fakeButton(x11ButtonRight, false)
+	harness.waitForButtonEvents(1)
+
+	harness.fakeButton(x11ButtonWheelUp, true)
+	harness.waitForButtonEvents(1)
+	if err := robotgo.ScrollE(0, 1, 0); err == nil || errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("ScrollE over foreign-held wheel button error = %v, want state error", err)
+	}
+	if reply, queryErr := xproto.QueryPointer(harness.conn, harness.root).Reply(); queryErr != nil {
+		t.Fatalf("query foreign wheel-button state: %v", queryErr)
+	} else if reply.Mask&xproto.ButtonMask4 == 0 {
+		t.Fatal("ScrollE released a wheel button held by another X11 client")
+	}
+	harness.fakeButton(x11ButtonWheelUp, false)
+	harness.waitForButtonEvents(1)
+
+	doubleClickDone := make(chan error, 1)
+	go func() { doubleClickDone <- robotgo.ClickE("right", true) }()
+	if got, want := harness.waitForButtonEvents(2), []x11ButtonEvent{
+		{pressed: true, button: x11ButtonRight},
+		{button: x11ButtonRight},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("first half of double click = %+v, want %+v", got, want)
+	}
+	harness.fakeButton(x11ButtonRight, true)
+	harness.waitForButtonEvents(1)
+	if err := <-doubleClickDone; err == nil || errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("double click over newly foreign-held button error = %v, want state error", err)
+	}
+	if reply, queryErr := xproto.QueryPointer(harness.conn, harness.root).Reply(); queryErr != nil {
+		t.Fatalf("query button state after rejected double click: %v", queryErr)
+	} else if reply.Mask&xproto.ButtonMask3 == 0 {
+		t.Fatal("second half of double click released a newly foreign-held button")
+	}
+	harness.fakeButton(x11ButtonRight, false)
+	harness.waitForButtonEvents(1)
+}
+
+func x11KeysymForRune(value rune) uint32 {
+	if value >= 0x20 && value <= 0x7e || value >= 0xa0 && value <= 0xff {
+		return uint32(value)
+	}
+	return 0x01000000 | uint32(value)
+}
+
+func TestPureGoX11EventDrainDoesNotStall(t *testing.T) {
+	if os.Getenv("DISPLAY") == "" || os.Getenv("WAYLAND_DISPLAY") != "" {
+		x11Unavailable(t, "X11 event-drain integration test requires an X11-primary DISPLAY")
+	}
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("initial CloseMainDisplayE: %v", err)
+	}
+	if err := robotgo.KeyboardReady(); err != nil {
+		x11Unavailable(t, "X11 keyboard backend is unavailable: %v", err)
+	}
+	emitter, err := xgb.NewConnDisplay(os.Getenv("DISPLAY"))
+	if err != nil {
+		x11Unavailable(t, "connect X11 MappingNotify emitter: %v", err)
+	}
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for {
+			event, eventErr := emitter.WaitForEvent()
+			if event == nil && eventErr == nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		emitter.Close()
+		select {
+		case <-drainDone:
+		case <-time.After(time.Second):
+			t.Error("MappingNotify emitter drain did not stop")
+		}
+	})
+	setup := xproto.Setup(emitter)
+	if setup == nil {
+		t.Fatal("MappingNotify emitter has no X11 setup")
+	}
+	mapping, err := xproto.GetKeyboardMapping(emitter, setup.MinKeycode, 1).Reply()
+	if err != nil || mapping == nil || mapping.KeysymsPerKeycode == 0 {
+		t.Fatalf("query mapping used for event-drain stress: reply=%+v err=%v", mapping, err)
+	}
+	for range 6001 {
+		xproto.ChangeKeyboardMapping(
+			emitter, 1, setup.MinKeycode, mapping.KeysymsPerKeycode, mapping.Keysyms,
+		)
+	}
+	emitter.Sync()
+
+	readyDone := make(chan error, 1)
+	go func() { readyDone <- robotgo.KeyboardReady() }()
+	select {
+	case err := <-readyDone:
+		if err != nil {
+			t.Fatalf("keyboard readiness after MappingNotify stress failed: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("X11 input stalled after filling the XGB event buffer")
+	}
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- robotgo.CloseMainDisplayE()
+	}()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("CloseMainDisplayE after event stress: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CloseMainDisplay stalled after long Unicode input")
 	}
 }
 
 func TestPureGoX11CloseMainDisplayReconnects(t *testing.T) {
 	harness := newX11InputHarness(t)
-	robotgo.CloseMainDisplay()
+	if err := robotgo.KeyTap("shift"); err != nil {
+		t.Fatalf("KeyTap before held-key cleanup test: %v", err)
+	}
+	harness.waitForKeyPress("historical key press")
+	harness.waitForKeyRelease("historical key release")
+	if err := robotgo.KeyToggle("shift", "down"); err != nil {
+		t.Fatalf("KeyToggle before CloseMainDisplay: %v", err)
+	}
+	heldKey := harness.waitForKeyPress("held key before CloseMainDisplay").Detail
+	if err := robotgo.KeyTap("shift"); err == nil || errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("KeyTap over RobotGo-held key error = %v, want state error", err)
+	}
+	if !harness.keyPressed(heldKey) {
+		t.Fatal("failed KeyTap released an existing RobotGo-held key")
+	}
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE owned-key cleanup: %v", err)
+	}
+	if release := harness.waitForKeyRelease("owned key cleanup on CloseMainDisplay"); release.Detail != heldKey {
+		t.Fatalf("CloseMainDisplay released keycode %d, want %d", release.Detail, heldKey)
+	}
+	harness.assertNoMatchingEvent("duplicate owned key release", 100*time.Millisecond, func(event xgb.Event) bool {
+		release, ok := event.(xproto.KeyReleaseEvent)
+		return ok && release.Detail == heldKey
+	})
+
+	if err := robotgo.ClickE("right"); err != nil {
+		t.Fatalf("ClickE before held-button cleanup test: %v", err)
+	}
+	harness.waitForButtonEvents(2)
+	if err := robotgo.Toggle("right", "down"); err != nil {
+		t.Fatalf("Toggle before CloseMainDisplay: %v", err)
+	}
+	harness.waitForButtonEvents(1)
+	if err := robotgo.CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE owned-button cleanup: %v", err)
+	}
+	if got, want := harness.waitForButtonEvents(1), []x11ButtonEvent{{button: x11ButtonRight}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("CloseMainDisplay button cleanup = %+v, want %+v", got, want)
+	}
+	harness.assertNoMatchingEvent("duplicate owned button release", 100*time.Millisecond, func(event xgb.Event) bool {
+		release, ok := event.(xproto.ButtonReleaseEvent)
+		return ok && release.Detail == x11ButtonRight
+	})
 
 	if err := robotgo.KeyboardReady(); err != nil {
 		t.Fatalf("KeyboardReady after CloseMainDisplay: %v", err)
@@ -405,6 +1375,37 @@ func TestPureGoX11CloseMainDisplayReconnects(t *testing.T) {
 	release := harness.waitForKeyRelease("key release after reconnect")
 	if press.Detail != release.Detail {
 		t.Fatalf("reconnected KeyTap keycodes differ: press=%d release=%d", press.Detail, release.Detail)
+	}
+}
+
+func TestPureGoX11SessionSwitchReleasesOwnedInput(t *testing.T) {
+	harness := newX11InputHarness(t)
+	if err := robotgo.KeyToggle("shift", "down"); err != nil {
+		t.Fatalf("hold key before session switch: %v", err)
+	}
+	heldKey := harness.waitForKeyPress("held key before session switch").Detail
+	if err := robotgo.Toggle("right", "down"); err != nil {
+		t.Fatalf("hold button before session switch: %v", err)
+	}
+	harness.waitForButtonEvents(1)
+
+	t.Setenv("WAYLAND_DISPLAY", "robotgo-test-wayland")
+	if err := robotgo.KeyboardReady(); err == nil {
+		t.Fatal("KeyboardReady unexpectedly accepted a switched Wayland session")
+	}
+	if release := harness.waitForKeyRelease("owned key cleanup after session switch"); release.Detail != heldKey {
+		t.Fatalf("session switch released keycode %d, want %d", release.Detail, heldKey)
+	}
+	if got, want := harness.waitForButtonEvents(1), []x11ButtonEvent{{button: x11ButtonRight}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("session-switch button cleanup = %+v, want %+v", got, want)
+	}
+	if harness.keyPressed(heldKey) {
+		t.Fatal("session switch left a RobotGo-owned key held on the old X server")
+	}
+	if reply, err := xproto.QueryPointer(harness.conn, harness.root).Reply(); err != nil {
+		t.Fatalf("query pointer after session switch: %v", err)
+	} else if reply.Mask&xproto.ButtonMask3 != 0 {
+		t.Fatal("session switch left a RobotGo-owned button held on the old X server")
 	}
 }
 

--- a/x11_input_integration_test.go
+++ b/x11_input_integration_test.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"reflect"
@@ -452,19 +451,41 @@ func (h *x11InputHarness) rootChildren() map[xproto.Window]struct{} {
 	return children
 }
 
-func (h *x11InputHarness) waitForNewRootChild(previous map[xproto.Window]struct{}) xproto.Window {
+func (h *x11InputHarness) waitForNewRootChild(
+	previous map[xproto.Window]struct{}, processDone <-chan error, stderr *strings.Builder,
+) xproto.Window {
 	h.t.Helper()
-	deadline := time.Now().Add(x11EventTimeout)
-	for time.Now().Before(deadline) {
+	ticker := time.NewTicker(x11PollInterval)
+	defer ticker.Stop()
+	deadline := time.NewTimer(x11EventTimeout)
+	defer deadline.Stop()
+	for {
 		for child := range h.rootChildren() {
 			if _, existed := previous[child]; !existed {
 				return child
 			}
 		}
-		time.Sleep(x11PollInterval)
+		select {
+		case err := <-processDone:
+			detail := strings.TrimSpace(stderr.String())
+			if detail == "" {
+				detail = "no stderr output"
+			}
+			h.t.Fatalf("XKB oracle exited before creating a window: %v (%s)", err, detail)
+		case <-ticker.C:
+		case <-deadline.C:
+			h.t.Fatalf("timed out after %s waiting for XKB oracle window", x11EventTimeout)
+		}
 	}
-	h.t.Fatalf("timed out after %s waiting for XKB oracle window", x11EventTimeout)
-	return 0
+}
+
+func xkbOracleArgs(path string) []string {
+	args := []string{"interactive-x11"}
+	help, _ := exec.Command(path, "interactive-x11", "--help").CombinedOutput()
+	if strings.Contains(string(help), "--uniline") {
+		args = append(args, "--uniline")
+	}
+	return args
 }
 
 func startXKBOracle(t *testing.T, harness *x11InputHarness) (xproto.Window, <-chan string, *os.Process) {
@@ -478,30 +499,65 @@ func startXKBOracle(t *testing.T, harness *x11InputHarness) (xproto.Window, <-ch
 		x11Unavailable(t, "X11 text integration requires stdbuf: %v", err)
 	}
 	previousChildren := harness.rootChildren()
-	command := exec.Command(stdbufPath, "-oL", path, "interactive-x11", "--uniline")
+	commandArgs := append([]string{"-oL", path}, xkbOracleArgs(path)...)
+	command := exec.Command(stdbufPath, commandArgs...)
 	command.Env = os.Environ()
 	stdout, err := command.StdoutPipe()
 	if err != nil {
 		t.Fatalf("create xkbcli stdout pipe: %v", err)
 	}
-	command.Stderr = io.Discard
+	var stderr strings.Builder
+	command.Stderr = &stderr
 	if err := command.Start(); err != nil {
 		x11Unavailable(t, "start xkbcli X11 oracle: %v", err)
 	}
 	lines := make(chan string, 32)
+	stopLines := make(chan struct{})
+	scanDone := make(chan error, 1)
 	go func() {
 		defer close(lines)
 		scanner := bufio.NewScanner(stdout)
+		discard := false
 		for scanner.Scan() {
-			lines <- scanner.Text()
+			if !discard {
+				select {
+				case <-stopLines:
+					discard = true
+				default:
+				}
+			}
+			if discard {
+				continue
+			}
+			select {
+			case lines <- scanner.Text():
+			case <-stopLines:
+				discard = true
+			}
 		}
+		scanDone <- scanner.Err()
+	}()
+	processDone := make(chan error, 1)
+	go func() {
+		scanErr := <-scanDone
+		waitErr := command.Wait()
+		if scanErr != nil {
+			waitErr = errors.Join(waitErr, fmt.Errorf("read xkbcli stdout: %w", scanErr))
+		}
+		processDone <- waitErr
+		close(processDone)
 	}()
 	t.Cleanup(func() {
 		_ = command.Process.Signal(syscall.SIGCONT)
+		close(stopLines)
 		_ = command.Process.Kill()
-		_ = command.Wait()
+		select {
+		case <-processDone:
+		case <-time.After(x11EventTimeout):
+			t.Errorf("XKB oracle process %d did not exit during cleanup", command.Process.Pid)
+		}
 	})
-	window := harness.waitForNewRootChild(previousChildren)
+	window := harness.waitForNewRootChild(previousChildren, processDone, &stderr)
 	if err := xproto.SetInputFocusChecked(
 		harness.conn, xproto.InputFocusPointerRoot, window, xproto.TimeCurrentTime,
 	).Check(); err != nil {
@@ -541,7 +597,12 @@ func waitForXKBOracleText(t *testing.T, lines <-chan string, count int) []rune {
 				t.Fatalf("xkbcli oracle exited after text %q", string(result))
 			}
 			observed = append(observed, line)
-			if !strings.Contains(line, "down") {
+			// Older xkbcli releases only report key presses and have no event-type
+			// field. Newer releases report both directions, so keep only down.
+			if !strings.Contains(line, "down") && !strings.Contains(line, "keycode [") {
+				continue
+			}
+			if strings.Contains(line, "up") && !strings.Contains(line, "down") {
 				continue
 			}
 			const unicodeMarker = "unicode [ "

--- a/x11_input_integration_test.go
+++ b/x11_input_integration_test.go
@@ -1,0 +1,423 @@
+//go:build linux && !cgo && x11integration
+
+package robotgo_test
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgb/xtest"
+	"github.com/marang/robotgo"
+)
+
+const (
+	x11EventTimeout = 3 * time.Second
+	x11PollInterval = 5 * time.Millisecond
+
+	x11WindowX      = 100
+	x11WindowY      = 100
+	x11WindowWidth  = 400
+	x11WindowHeight = 300
+
+	x11ButtonLeft       = 1
+	x11ButtonRight      = 3
+	x11ButtonWheelUp    = 4
+	x11ButtonWheelRight = 6
+
+	x11KeysymA      = 0x0061
+	x11KeysymZ      = 0x007a
+	x11KeysymShiftL = 0xffe1
+	x11KeysymShiftR = 0xffe2
+)
+
+type x11InputHarness struct {
+	t    *testing.T
+	conn *xgb.Conn
+	root xproto.Window
+}
+
+type x11ButtonEvent struct {
+	pressed bool
+	button  xproto.Button
+}
+
+func newX11InputHarness(t *testing.T) *x11InputHarness {
+	t.Helper()
+	display := os.Getenv("DISPLAY")
+	if display == "" {
+		t.Skip("X11 integration test requires DISPLAY")
+	}
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		t.Skip("X11 integration test requires an X11-primary session; unset WAYLAND_DISPLAY")
+	}
+	conn, err := xgb.NewConnDisplay(display)
+	if err != nil {
+		t.Skipf("X11 integration test cannot connect to DISPLAY %q: %v", display, err)
+	}
+	if err := xtest.Init(conn); err != nil {
+		conn.Close()
+		t.Skipf("X11 integration test requires the XTEST extension: %v", err)
+	}
+	if _, err := xtest.GetVersion(conn, 2, 2).Reply(); err != nil {
+		conn.Close()
+		t.Skipf("X11 integration test cannot query the XTEST extension: %v", err)
+	}
+
+	screen := xproto.Setup(conn).DefaultScreen(conn)
+	if screen == nil {
+		conn.Close()
+		t.Fatal("X11 connection has no default screen")
+	}
+	windowID, err := xproto.NewWindowId(conn)
+	if err != nil {
+		conn.Close()
+		t.Fatalf("allocate X11 test window: %v", err)
+	}
+	eventMask := uint32(
+		xproto.EventMaskKeyPress |
+			xproto.EventMaskKeyRelease |
+			xproto.EventMaskButtonPress |
+			xproto.EventMaskButtonRelease |
+			xproto.EventMaskPointerMotion |
+			xproto.EventMaskStructureNotify,
+	)
+	if err := xproto.CreateWindowChecked(
+		conn,
+		screen.RootDepth,
+		windowID,
+		screen.Root,
+		x11WindowX,
+		x11WindowY,
+		x11WindowWidth,
+		x11WindowHeight,
+		0,
+		xproto.WindowClassInputOutput,
+		screen.RootVisual,
+		xproto.CwBackPixel|xproto.CwEventMask,
+		[]uint32{screen.BlackPixel, eventMask},
+	).Check(); err != nil {
+		conn.Close()
+		t.Fatalf("create X11 test window: %v", err)
+	}
+	if err := xproto.MapWindowChecked(conn, windowID).Check(); err != nil {
+		conn.Close()
+		t.Fatalf("map X11 test window: %v", err)
+	}
+	deadline := time.Now().Add(x11EventTimeout)
+	mapped := false
+	for time.Now().Before(deadline) {
+		event, err := conn.PollForEvent()
+		if err != nil {
+			conn.Close()
+			t.Fatalf("wait for X11 test window to map: %v", err)
+		}
+		if notify, ok := event.(xproto.MapNotifyEvent); ok && notify.Window == windowID {
+			mapped = true
+			break
+		}
+		time.Sleep(x11PollInterval)
+	}
+	if !mapped {
+		conn.Close()
+		t.Fatalf("X11 test window did not map within %s", x11EventTimeout)
+	}
+	if err := xproto.SetInputFocusChecked(
+		conn,
+		xproto.InputFocusPointerRoot,
+		windowID,
+		xproto.TimeCurrentTime,
+	).Check(); err != nil {
+		conn.Close()
+		t.Fatalf("focus X11 test window: %v", err)
+	}
+	conn.Sync()
+
+	harness := &x11InputHarness{
+		t:    t,
+		conn: conn,
+		root: screen.Root,
+	}
+	harness.drainEvents()
+	t.Cleanup(func() {
+		_ = xproto.DestroyWindowChecked(conn, windowID).Check()
+		conn.Close()
+	})
+	t.Cleanup(robotgo.CloseMainDisplay)
+	return harness
+}
+
+func (h *x11InputHarness) drainEvents() {
+	h.t.Helper()
+	for {
+		event, err := h.conn.PollForEvent()
+		if err != nil {
+			h.t.Fatalf("drain X11 events: %v", err)
+		}
+		if event == nil {
+			return
+		}
+	}
+}
+
+func (h *x11InputHarness) waitForEvent(description string, match func(xgb.Event) bool) xgb.Event {
+	h.t.Helper()
+	deadline := time.Now().Add(x11EventTimeout)
+	for time.Now().Before(deadline) {
+		event, err := h.conn.PollForEvent()
+		if err != nil {
+			h.t.Fatalf("poll for %s: %v", description, err)
+		}
+		if event != nil && match(event) {
+			return event
+		}
+		time.Sleep(x11PollInterval)
+	}
+	h.t.Fatalf("timed out after %s waiting for %s", x11EventTimeout, description)
+	return nil
+}
+
+func (h *x11InputHarness) waitForKeyPress(description string) xproto.KeyPressEvent {
+	h.t.Helper()
+	event := h.waitForEvent(description, func(event xgb.Event) bool {
+		_, ok := event.(xproto.KeyPressEvent)
+		return ok
+	})
+	return event.(xproto.KeyPressEvent)
+}
+
+func (h *x11InputHarness) waitForKeyRelease(description string) xproto.KeyReleaseEvent {
+	h.t.Helper()
+	event := h.waitForEvent(description, func(event xgb.Event) bool {
+		_, ok := event.(xproto.KeyReleaseEvent)
+		return ok
+	})
+	return event.(xproto.KeyReleaseEvent)
+}
+
+func (h *x11InputHarness) waitForButtonEvents(count int) []x11ButtonEvent {
+	h.t.Helper()
+	events := make([]x11ButtonEvent, 0, count)
+	for len(events) < count {
+		event := h.waitForEvent("X11 button event", func(event xgb.Event) bool {
+			switch event.(type) {
+			case xproto.ButtonPressEvent, xproto.ButtonReleaseEvent:
+				return true
+			default:
+				return false
+			}
+		})
+		switch value := event.(type) {
+		case xproto.ButtonPressEvent:
+			events = append(events, x11ButtonEvent{pressed: true, button: value.Detail})
+		case xproto.ButtonReleaseEvent:
+			events = append(events, x11ButtonEvent{button: value.Detail})
+		}
+	}
+	return events
+}
+
+func (h *x11InputHarness) queryPointer() (int, int) {
+	h.t.Helper()
+	reply, err := xproto.QueryPointer(h.conn, h.root).Reply()
+	if err != nil {
+		h.t.Fatalf("query X11 pointer: %v", err)
+	}
+	return int(reply.RootX), int(reply.RootY)
+}
+
+func (h *x11InputHarness) keysym(keycode xproto.Keycode) xproto.Keysym {
+	h.t.Helper()
+	reply, err := xproto.GetKeyboardMapping(h.conn, keycode, 1).Reply()
+	if err != nil {
+		h.t.Fatalf("query mapping for X11 keycode %d: %v", keycode, err)
+	}
+	if len(reply.Keysyms) == 0 {
+		h.t.Fatalf("X11 keycode %d has no keysyms", keycode)
+	}
+	return reply.Keysyms[0]
+}
+
+func TestPureGoX11Capabilities(t *testing.T) {
+	newX11InputHarness(t)
+
+	capabilities := robotgo.GetRuntimeCapabilities()
+	if capabilities.Runtime.CGOEnabled {
+		t.Fatal("X11 integration suite must run with CGO_ENABLED=0")
+	}
+	if capabilities.Runtime.BuildImplementation != robotgo.RuntimeImplementationPureGo {
+		t.Fatalf("build implementation = %q, want %q", capabilities.Runtime.BuildImplementation, robotgo.RuntimeImplementationPureGo)
+	}
+	if capabilities.Runtime.DisplayServer != robotgo.DisplayServerX11 {
+		t.Fatalf("display server = %q, want %q", capabilities.Runtime.DisplayServer, robotgo.DisplayServerX11)
+	}
+	for name, capability := range map[string]robotgo.FeatureCapability{
+		"keyboard": capabilities.Keyboard,
+		"mouse":    capabilities.Mouse,
+	} {
+		if !capability.Available {
+			t.Errorf("%s capability unavailable: reason=%q notes=%q", name, capability.Reason, capability.Notes)
+		}
+		if capability.Backend != "pure-go-x11" {
+			t.Errorf("%s backend = %q, want pure-go-x11", name, capability.Backend)
+		}
+	}
+	if err := robotgo.KeyboardReady(); err != nil {
+		t.Errorf("KeyboardReady: %v", err)
+	}
+	if err := robotgo.MouseReady(); err != nil {
+		t.Errorf("MouseReady: %v", err)
+	}
+}
+
+func TestPureGoX11PointerInput(t *testing.T) {
+	harness := newX11InputHarness(t)
+	const targetX, targetY = 180, 170
+	if err := robotgo.MoveE(targetX, targetY); err != nil {
+		t.Fatalf("MoveE: %v", err)
+	}
+	harness.waitForEvent("absolute pointer motion", func(event xgb.Event) bool {
+		motion, ok := event.(xproto.MotionNotifyEvent)
+		return ok && int(motion.RootX) == targetX && int(motion.RootY) == targetY
+	})
+	assertPointerLocation(t, harness, targetX, targetY)
+
+	const deltaX, deltaY = 17, 13
+	if err := robotgo.MoveRelativeE(deltaX, deltaY); err != nil {
+		t.Fatalf("MoveRelativeE: %v", err)
+	}
+	harness.waitForEvent("relative pointer motion", func(event xgb.Event) bool {
+		motion, ok := event.(xproto.MotionNotifyEvent)
+		return ok && int(motion.RootX) == targetX+deltaX && int(motion.RootY) == targetY+deltaY
+	})
+	assertPointerLocation(t, harness, targetX+deltaX, targetY+deltaY)
+
+	if err := robotgo.ClickE("left"); err != nil {
+		t.Fatalf("ClickE: %v", err)
+	}
+	if got, want := harness.waitForButtonEvents(2), []x11ButtonEvent{
+		{pressed: true, button: x11ButtonLeft},
+		{button: x11ButtonLeft},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("left-click events = %+v, want %+v", got, want)
+	}
+
+	if err := robotgo.Toggle("right", "down"); err != nil {
+		t.Fatalf("Toggle right down: %v", err)
+	}
+	t.Cleanup(func() { _ = robotgo.Toggle("right", "up") })
+	if got, want := harness.waitForButtonEvents(1), []x11ButtonEvent{{pressed: true, button: x11ButtonRight}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("right-button down events = %+v, want %+v", got, want)
+	}
+	if err := robotgo.Toggle("right", "up"); err != nil {
+		t.Fatalf("Toggle right up: %v", err)
+	}
+	if got, want := harness.waitForButtonEvents(1), []x11ButtonEvent{{button: x11ButtonRight}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("right-button up events = %+v, want %+v", got, want)
+	}
+
+	if err := robotgo.ScrollE(1, 1, 0); err != nil {
+		t.Fatalf("ScrollE: %v", err)
+	}
+	if got, want := harness.waitForButtonEvents(4), []x11ButtonEvent{
+		{pressed: true, button: x11ButtonWheelRight},
+		{button: x11ButtonWheelRight},
+		{pressed: true, button: x11ButtonWheelUp},
+		{button: x11ButtonWheelUp},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("scroll events = %+v, want %+v", got, want)
+	}
+}
+
+func TestPureGoX11KeyboardInput(t *testing.T) {
+	harness := newX11InputHarness(t)
+	if err := robotgo.KeyTap("a"); err != nil {
+		t.Fatalf("KeyTap: %v", err)
+	}
+	press := harness.waitForKeyPress("KeyTap press")
+	release := harness.waitForKeyRelease("KeyTap release")
+	if press.Detail != release.Detail {
+		t.Fatalf("KeyTap keycodes differ: press=%d release=%d", press.Detail, release.Detail)
+	}
+	if got := harness.keysym(press.Detail); got != x11KeysymA {
+		t.Fatalf("KeyTap keysym = %#x, want %#x (a)", got, x11KeysymA)
+	}
+
+	if err := robotgo.KeyToggle("shift", "down"); err != nil {
+		t.Fatalf("KeyToggle shift down: %v", err)
+	}
+	t.Cleanup(func() { _ = robotgo.KeyToggle("shift", "up") })
+	shiftPress := harness.waitForKeyPress("shift press")
+	if got := harness.keysym(shiftPress.Detail); got != x11KeysymShiftL && got != x11KeysymShiftR {
+		t.Fatalf("shift key keysym = %#x, want %#x or %#x", got, x11KeysymShiftL, x11KeysymShiftR)
+	}
+	if err := robotgo.KeyToggle("shift", "up"); err != nil {
+		t.Fatalf("KeyToggle shift up: %v", err)
+	}
+	shiftRelease := harness.waitForKeyRelease("shift release")
+	if shiftRelease.Detail != shiftPress.Detail {
+		t.Fatalf("shift keycodes differ: press=%d release=%d", shiftPress.Detail, shiftRelease.Detail)
+	}
+
+	if err := robotgo.TypeStrE("az"); err != nil {
+		t.Fatalf("TypeStrE: %v", err)
+	}
+	for index, want := range []xproto.Keysym{x11KeysymA, x11KeysymZ} {
+		press := harness.waitForKeyPress(fmt.Sprintf("TypeStrE character %d press", index))
+		release := harness.waitForKeyRelease(fmt.Sprintf("TypeStrE character %d release", index))
+		if press.Detail != release.Detail {
+			t.Fatalf("TypeStrE character %d keycodes differ: press=%d release=%d", index, press.Detail, release.Detail)
+		}
+		if got := harness.keysym(press.Detail); got != want {
+			t.Fatalf("TypeStrE character %d keysym = %#x, want %#x", index, got, want)
+		}
+	}
+}
+
+func TestPureGoX11CloseMainDisplayReconnects(t *testing.T) {
+	harness := newX11InputHarness(t)
+	robotgo.CloseMainDisplay()
+
+	if err := robotgo.KeyboardReady(); err != nil {
+		t.Fatalf("KeyboardReady after CloseMainDisplay: %v", err)
+	}
+	if err := robotgo.MouseReady(); err != nil {
+		t.Fatalf("MouseReady after CloseMainDisplay: %v", err)
+	}
+	const targetX, targetY = 230, 210
+	if err := robotgo.MoveE(targetX, targetY); err != nil {
+		t.Fatalf("MoveE after CloseMainDisplay: %v", err)
+	}
+	harness.waitForEvent("pointer motion after reconnect", func(event xgb.Event) bool {
+		motion, ok := event.(xproto.MotionNotifyEvent)
+		return ok && int(motion.RootX) == targetX && int(motion.RootY) == targetY
+	})
+	assertPointerLocation(t, harness, targetX, targetY)
+
+	if err := robotgo.KeyTap("a"); err != nil {
+		t.Fatalf("KeyTap after CloseMainDisplay: %v", err)
+	}
+	press := harness.waitForKeyPress("key press after reconnect")
+	release := harness.waitForKeyRelease("key release after reconnect")
+	if press.Detail != release.Detail {
+		t.Fatalf("reconnected KeyTap keycodes differ: press=%d release=%d", press.Detail, release.Detail)
+	}
+}
+
+func assertPointerLocation(t *testing.T, harness *x11InputHarness, wantX, wantY int) {
+	t.Helper()
+	x, y, err := robotgo.LocationE()
+	if err != nil {
+		t.Fatalf("LocationE: %v", err)
+	}
+	if x != wantX || y != wantY {
+		t.Errorf("LocationE = (%d, %d), want (%d, %d)", x, y, wantX, wantY)
+	}
+	if x, y := harness.queryPointer(); x != wantX || y != wantY {
+		t.Errorf("independent X11 pointer query = (%d, %d), want (%d, %d)", x, y, wantX, wantY)
+	}
+}


### PR DESCRIPTION
## What changed

- add a Pure-Go Linux/X11 XGB/XTEST backend for mouse, keyboard, text/Unicode, smooth movement, drag, scroll, readiness probes, and explicit cleanup
- harden shared input validation, RemoteDesktop transaction cancellation/serialization, runtime configuration, and CGO/non-CGO parity
- add required multi-layout Xvfb/XKB integration coverage, Non-CGO lint, capability reporting, docs, and a safe opt-in example

## Why

CGO-disabled Linux/X11 builds previously had capture support but no useful native input backend. This adds explicit, observable X11 input without weakening Wayland-first selection or silently falling back through Xwayland.

## Behavior and risk

- Pure-Go X11 is selected only for X11-primary sessions.
- Server-global scratch key mappings are bounded, ownership-checked, restored through `CloseMainDisplayE`, and documented; abnormal termination remains an explicit roadmap limitation.
- Foreign key/button/mapping state is preserved where core X11 exposes it.
- Unsupported operations and conflicts return actionable errors.

## Validation

- default and `CGO_ENABLED=0` test suites
- race detector and CGO/non-CGO vet
- CGO, non-CGO, and tagged integration lint
- real Xvfb/XTEST/XKB integration with `us,de`
- Portal and Wayland tagged suites
- Windows, macOS, Linux arm64/386 compile matrix
- `actionlint`, `go mod tidy -diff`, and `git diff --check`