### PR TITLE
feat(x11): add crash-safe Pure-Go input guardian

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,6 +54,8 @@ jobs:
             libgbm-dev libdrm-dev
       - name: Run race detector
         run: go test -race ./...
+      - name: Stress race-testable Pure-Go X11 core
+        run: go test -race -count=20 -timeout=2m ./internal/x11input
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -161,6 +163,7 @@ jobs:
                 TestPureGoX11PointerInput \
                 TestPureGoX11KeyboardInput \
                 TestPureGoX11TextReachesDelayedXKBClient \
+                TestPureGoX11CrashRestoresScratchAndOwnedInput \
                 TestPureGoX11ExplicitShiftReachesXKBClient \
                 TestPureGoX11ScratchReservationSkipsPressedEmptyKeycode \
                 TestPureGoX11ScratchCleanupCanRetryAfterForeignRelease \

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture and display bounds with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
-| Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds plus XTEST mouse, keyboard, text/Unicode, pointer-location, smooth-move/drag, scroll, and live readiness probes |
+| Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds plus XTEST mouse, keyboard, text/Unicode, pointer-location, smooth-move/drag, vertical scroll, and live readiness probes; horizontal scroll is explicitly unsupported |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |
 | Other supported platforms without CGO | `CGO_ENABLED=0` | Pure-Go capture works on macOS and Windows; Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
 
@@ -288,8 +288,9 @@ movement/drag, scroll, pointer location, and live
 1,000 steps per axis. XTEST input is global; process-target (`pid`) arguments
 are rejected explicitly.
 Single-character keys are tap-only; persistent key state requires a named key.
-Persistent pointer-button toggles are limited to core X11 buttons 1–5; use
-`ScrollE` for wheel input.
+Persistent pointer-button toggles are limited to core X11 buttons 1–5. Pure-Go
+X11 supports vertical `ScrollE`; horizontal scrolling returns
+`ErrNotSupported` because core XTEST button 6/7 state is not observable safely.
 `GetRuntimeCapabilities` reports the selected `pure-go-x11` backend.
 Key taps without an unambiguous active mapping and text use a bounded pool of
 originally unmapped X11 keycodes so delayed XKB clients still decode input
@@ -297,9 +298,42 @@ correctly. If one connection exhausts that server-dependent pool of distinct
 symbols, the operation fails before injecting more input. Call
 `CloseMainDisplayE` only after targets have processed all prior keyboard input
 to restore the mappings, verify cleanup, and reset the pool. Place that call in
-a scope whose lifetime includes any delayed target processing. These mappings
-are server-global: omitting cleanup or terminating abnormally can leave the
-formerly unused keycodes mapped until the X11 keymap is reset. A later RobotGo
+a scope whose lifetime includes any delayed target processing.
+
+These mappings are server-global, so the Pure-Go backend owns its X11
+connection in a separate, re-executed guardian process. If the application
+process exits unexpectedly or receives `SIGKILL`, control-socket EOF makes the
+guardian run a bounded, conditional cleanup: it releases RobotGo-owned
+keys/buttons, allows up to two seconds for already delivered text events, and
+restores a scratch before-image only while the current mapping still exactly
+matches RobotGo's recorded final image and that keycode is neither pressed nor
+a modifier. A different final image is treated as another client's state and
+is preserved. X11 cannot reveal an ABA change where another client changes a
+mapping and later puts back the exact same image, so that case is inherently
+indistinguishable from RobotGo's ownership.
+
+Guardian startup requires Linux procfs to expose `/proc/self/exe` and the
+sandbox/service policy to permit re-executing the current program and using
+Linux abstract Unix sockets. The parent accepts only the authenticated socket
+peer whose kernel credentials match the helper it started; no control file
+descriptor is inherited through the re-exec initialization phase. Re-exec can
+still repeat dependency initializers that run before RobotGo's guardian
+initializer. Those initializers must not block or terminate the helper; if they
+prevent its authenticated handshake, startup fails before an X11 input
+connection is exposed. Failure is explicit, the failed helper is reaped, and
+there is no silent in-process X11 fallback. Crash cleanup also requires the
+guardian and X server to remain alive and responsive. A
+simultaneous guardian/container/host kill, X-server loss, or an X11 transport
+that remains blocked beyond the cleanup deadline cannot be restored
+synchronously. Request dispatch and cleanup are deadline-bounded; on a blocked
+transport the guardian initiates connection close and exits, while the parent
+kills and reaps a helper that misses its final exit deadline.
+
+Explicit `CloseMainDisplayE` remains the deterministic path because it reports
+actionable cleanup/transport errors and lets callers choose when even
+arbitrarily delayed target clients have finished processing input. A foreign
+mapping replacement is deliberately relinquished without being reported as a
+cleanup failure because overwriting it would be unsafe. A later RobotGo
 operation reconnects lazily. In a Wayland-primary session the backend remains
 disabled, even when `DISPLAY` points to Xwayland.
 If cleanup reports that a scratch keycode is pressed or became a modifier,
@@ -585,11 +619,14 @@ contract and benchmark smoke to native CGO and Pure-Go binaries. It also proves
 that native readiness rejects a reachable X server with XTEST disabled. Missing
 X11 runtime support fails instead of skipping; see
 [the testing guide](TEST.md#x11integration-native-and-pure-go-x11-input) for
-the exact commands and prerequisites. The
+the exact commands and prerequisites. The crash proof additionally inspects
+`/proc/<pid>/task/<tid>/children` under a Linux child subreaper to verify that
+the reported guardian is the exact child that exits and is reaped. The
 [versioned decision-grade comparison](docs/performance/data/x11-2026-07-16-d5fd51c/summary.md)
 retains native CGO as the X11 default and Pure-Go as the supported CGO-disabled
-backend. Protecting the resulting remote checks remains a roadmap exit
-criterion.
+backend. That sample predates the guardian IPC layer; it remains the
+default-selection record, not a current guardian performance measurement.
+Protecting the resulting remote checks remains a roadmap exit criterion.
 
 Wayland and portal code has additional tagged suites:
 
@@ -619,10 +656,11 @@ Real Wayland input results are tracked in the
 The active product slice remains selective Phase 3 Pure-Go hardening. The
 Linux/X11 evaluation is complete: shared behavior is blocking CI,
 decision-grade evidence is versioned, and native CGO remains the default while
-Pure-Go supports CGO-disabled builds. Race-testable Pure-Go internals,
-crash-safe Unicode scratch cleanup, protected remote checks, and further
-backend evaluations remain. Real GNOME/KDE/wlroots validation is an independent
-Wayland release gate.
+Pure-Go supports CGO-disabled builds. The Pure-Go X11 core is race-testable and
+its separate guardian performs bounded, claim-checked cleanup after an
+application-process crash. Protecting remote checks and evaluating further
+backends remain. Real GNOME/KDE/wlroots validation is an independent Wayland
+release gate.
 
 ## Upstream and attribution
 

--- a/TEST.md
+++ b/TEST.md
@@ -82,7 +82,7 @@ must be new, empty, or contain its valid evidence sentinel. The run starts with
 a complete status only after all behavior and benchmark checks pass. Only a
 clean detached snapshot with at least five balanced cycles and a duration of at
 least `500ms`, expressed as integer milliseconds, seconds, minutes, or hours,
-is marked decision-grade. It also requires 11 matching benchmark
+is marked decision-grade. It also requires 10 matching benchmark
 names in both outputs, the expected sample count, and `ns/op`, `B/op`, and
 `allocs/op` for every result. The generated summary identifies the commit and
 measurement setup and labels CI smoke data as report-only. Use full results for
@@ -314,6 +314,12 @@ Purpose:
 - Preservation of keys and pointer buttons held by another X11 client
 - Event-drain stress coverage plus deterministic owned-input release,
   error-reporting `CloseMainDisplayE`, mapping restoration, and lazy reconnect
+- A real application-process `SIGKILL` test: a separately re-executed workload
+  leaves Unicode scratch state plus a held key/button behind, while the
+  surviving Pure-Go guardian must restore the canonical core map, modifier map,
+  XKB description, key state, pointer state, and button mask. The emergency
+  test cleanup is claim-bounded: it restores only an exact unchanged scratch
+  final image that is unpressed and absent from the modifier map
 - Side-effect-free capability selection plus explicit readiness probes against
   the live X server
 - Adversarial replacement of a reserved mapping before injection; the default
@@ -339,6 +345,14 @@ CGO_ENABLED=0 ROBOTGO_REQUIRE_X11_INTEGRATION=1 \
   '
 ```
 
+The extracted core is also exercised with the Linux race detector in a normal
+CGO-enabled test process; the production backend remains a `CGO_ENABLED=0`
+implementation:
+
+```bash
+go test -race -count=20 -timeout=2m ./internal/x11input
+```
+
 Native missing-XTEST contract:
 
 ```bash
@@ -361,8 +375,17 @@ Prerequisites:
 - CGO-enabled builds need X11/XTest development files; the deep Pure-Go suite
   uses `CGO_ENABLED=0`
 - An X11 server with XTEST 2.2 or newer
-- `xvfb`, `xauth`, `setxkbmap` (Debian/Ubuntu package `x11-xkb-utils`),
-  `xkbcli` (`libxkbcommon-tools`), and `stdbuf` (`coreutils`)
+- `xvfb`, `xauth`, `setxkbmap` and `xkbcomp` (Debian/Ubuntu package
+  `x11-xkb-utils`), `xkbcli` (`libxkbcommon-tools`), and `stdbuf` (`coreutils`)
+- A mounted, readable Linux procfs with an executable `/proc/self/exe`; the
+  runtime sandbox/service must permit re-executing the current test/program,
+  Linux abstract Unix sockets, and `SO_PEERCRED` peer verification. Dependency
+  initializers that run before RobotGo's guardian initializer must not block or
+  terminate the re-executed helper
+- The crash proof additionally needs Linux child-subreaper support and readable
+  `/proc/<pid>/task/<tid>/children` files so it can verify the exact guardian
+  child is adopted, exits successfully, and is reaped. Normal guardian runtime
+  cleanup does not inspect that child-listing file
 
 Without `ROBOTGO_REQUIRE_X11_INTEGRATION=1`, the normal suite skips cleanly when
 `DISPLAY` or XTEST is unavailable. Linux CI sets that variable, configures both
@@ -371,6 +394,17 @@ The explicit missing-XTEST test is the exception: it requires a reachable X
 server and expects the XTEST probe to fail. The tagged suite verifies the active
 `us,de` layout itself; the default non-CGO unit suite separately proves that a
 Wayland-primary session never selects this backend through implicit Xwayland.
+The crash contract covers termination of the application process while its
+guardian and X server continue running and respond within the bounded cleanup
+deadline. Scratch restoration requires the current mapping to equal the exact
+recorded final image and the keycode to be unpressed and non-modifier. Foreign
+final images are preserved; an ABA change that returns to the same exact image
+cannot be detected by the X11 protocol. A simultaneous guardian/container/host
+kill, X-server loss, or pathologically blocked X11 transport cannot provide
+synchronous restoration. Normal dispatch and cleanup have independent
+deadlines; the parent kills and reaps a helper that does not exit afterward.
+Explicit `CloseMainDisplayE` reports actionable cleanup/transport failures;
+intentionally preserving a foreign replacement is not itself an error.
 
 ## Useful Environment Variables
 

--- a/docs/performance/x11-native-vs-purego.md
+++ b/docs/performance/x11-native-vs-purego.md
@@ -12,7 +12,9 @@ Both binaries must pass the same black-box test against one isolated Xvfb:
   keyboard/pointer readiness
 - 640x480 capture bounds, known black/white pixels, and `BackendX11`
 - absolute/relative pointer movement plus independent location observation
-- click, persistent button, and horizontal/vertical scroll event order
+- click, persistent button, vertical-scroll event order, and the
+  backend-specific horizontal-scroll contract (native delivery; explicit
+  Pure-Go unsupported error)
 - named-key press/release and canonical `Ctrl down, key down, key up, Ctrl up`
 - ASCII text received by an independent XKB client
 - byte-identical keyboard and modifier maps after cleanup
@@ -32,7 +34,13 @@ cleanup conflicts, reconnect, and event-drain stress.
 ## Reproduce
 
 Install a C compiler, X11/XTest development files, `git`, `xvfb`, `xauth`,
-`setxkbmap`, `xkbcli`, and coreutils (`stdbuf` and `tee`), then run:
+`setxkbmap`, `xkbcomp`, `xkbcli`, and coreutils (`stdbuf` and `tee`), then run:
+
+The crash-recovery contract also requires executable Linux procfs
+(`/proc/self/exe` and readable `/proc/<pid>/task/<tid>/children`), Linux
+abstract Unix sockets with `SO_PEERCRED`, and child-subreaper support. See the
+[X11 integration prerequisites](../../TEST.md#x11integration-native-and-pure-go-x11-input)
+for the complete runtime contract.
 
 ```bash
 scripts/benchmark-x11-backends.sh /tmp/robotgo-x11-backend-evidence
@@ -60,7 +68,7 @@ script-owned, protected by a sentinel, and locked against concurrent writers;
 a non-empty foreign directory is never modified. Only a clean detached snapshot
 with at least five balanced cycles and a duration of at least `500ms`, expressed
 as integer milliseconds, seconds, minutes, or hours, is marked decision-grade.
-The comparison requires 11 matching benchmark names in both
+The current comparison requires 10 matching benchmark names in both
 outputs, the expected sample count, and all three metrics (`ns/op`, `B/op`,
 `allocs/op`). CI uses one iteration only to catch broken benchmark paths; its
 self-contained summary is explicitly report-only and never fails on
@@ -92,20 +100,31 @@ is stored with its raw output, behavior logs, metadata, and completion record in
 implementations passed the complete shared contract and their exact
 backend-specific safety manifests.
 
+The table below is historical evidence for that exact commit. The current
+Pure-Go backend subsequently moved its X11 connection into a re-executed
+guardian and moved its state machine into a race-testable internal package.
+Those changes close the targeted application-process-crash gap but add IPC, so
+the stored measurements must not be presented as guardian-path performance.
+
 | Criterion | Evidence | Decision impact |
 |---|---|---|
 | Capture | Pure-Go/native median latency ratio `3.493x`; 115 versus 2 Go allocations per operation | Native has a material throughput and allocation advantage |
 | Stateful buttons and keys | Pure-Go/native median latency ratios `1.395x` for button toggles, `1.347x` for key toggles, and `1.627x` for key presses | Native remains preferable for common input sequences |
-| Scroll | Pure-Go/native median latency ratios `2.017x` horizontal and `2.083x` vertical | Native remains preferable |
+| Scroll at sampled commit | Pure-Go/native median latency ratios `2.017x` horizontal and `2.083x` vertical; the current shared comparison retains vertical only because Pure-Go now rejects unobservable horizontal button state explicitly | Native remains preferable; do not present the historical horizontal number as current supported behavior |
 | Pointer queries and moves | Location is effectively equal at `1.016x`; Pure-Go absolute and relative move ratios are `0.565x` and `0.398x` | Pure-Go has a real pointer-movement advantage, but not enough to outweigh the broader default-path costs |
 | Delayed click and ASCII text | Ratios are `1.016x` and `1.012x`; configured user-visible delays dominate | No meaningful default-selection signal |
 | Build and Unicode behavior | Pure-Go removes the C/Xlib build dependency and retains managed Unicode scratch mappings; native avoids server-global temporary mappings | Keep Pure-Go useful and supported for CGO-disabled builds |
-| Lifecycle risk | Pure-Go scratch mappings are conflict-aware, but abnormal process termination still lacks a scoped or crash-safe cleanup mechanism | Do not make Pure-Go the general default yet |
+| Lifecycle risk at sampled commit | Pure-Go scratch mappings were conflict-aware, but abnormal process termination still lacked a scoped or crash-safe cleanup mechanism | Do not use this historical sample to claim guardian crash behavior or performance |
 
 **Decision:** retain native CGO as the Linux/X11 default when CGO is enabled.
 Keep the Pure-Go X11 backend as the supported CGO-disabled implementation. This
 is not a rejection of Pure-Go: it already wins pointer-movement latency and
 build portability, while native currently wins capture, most input operations,
-allocation cost, and crash-isolation of Unicode handling. Revisit the decision
-after the scratch-map lifecycle is crash-safe, the Pure-Go core is race-testable,
-and a new decision-grade sample passes the same contract.
+and allocation cost. Native also avoids server-global Unicode mappings
+entirely; the Pure-Go guardian now restores those mappings after a targeted
+application-process kill while it and a responsive X server survive. Its
+cleanup is deadline-bounded and restores only an exact unchanged, unpressed,
+non-modifier final image; foreign final images are preserved, while an
+exact-image ABA replacement is not observable in X11. Revisit the default only
+after a new decision-grade sample measures the guardian path and passes the
+same behavioral, race, and crash-recovery contracts.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -35,7 +35,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in branch | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Confirm all required jobs after the branch is pushed and protect them |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | X11 evaluation complete; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; versioned decision-grade evidence; explicit decision to retain native CGO as the X11 default; three-OS CI; non-skipping multi-layout Xvfb input tests | Protect the remote CI checks, make the Pure-Go X11 core race-testable and its scratch-map lifecycle crash-safe, then assess further backends selectively |
+| 3. Pure-Go | X11 hardening complete; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; versioned decision-grade evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; three-OS CI; non-skipping multi-layout Xvfb input tests | Protect the remote CI checks, collect current guardian performance evidence, then assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -157,23 +157,35 @@ reproducible balanced benchmark script records raw observations, medians,
 quartiles, ratios, metadata, and runs a report-only CI smoke. The versioned
 decision-grade sample retains native CGO as the Linux/X11 default: Pure-Go wins
 pointer-movement latency and build portability, while native wins capture, most
-input operations, allocations, and Unicode crash isolation. The comparison also
-exposed and fixed native
+input operations and allocations. At the measured revision, native also had
+stronger Unicode crash isolation; the later Pure-Go guardian closes the targeted
+application-process-kill gap without changing that historical performance
+sample. The comparison also exposed and fixed native
 modifier-release ordering and unsafe server-global Unicode mapping. Native X11
 now preflights complete text and modified keys before injection. Its Xlib
 display, capture, input, readiness, replacement, and close paths share a locked
 configured-display lifecycle; separate XGB connections use the same configured
 target and close deterministically. Live readiness requires XTEST 2.2 and has a
 dedicated negative CI contract. The Pure-Go backend retains its broader,
-explicitly managed Unicode mapping support.
-
-The non-CGO backend itself cannot currently run under Go's CGO-dependent Linux
-race detector; its concurrency stress tests remain mandatory while extracting
-the X11 core into a race-testable internal package is tracked. A scoped
-keyboard-input lifecycle (or equivalent crash-safe cleanup strategy) is also
-still needed to eliminate the server-global scratch-mapping risk after abnormal
-process termination. Those tasks and selective evaluation of additional
-backends keep the broader Phase 3 partial.
+explicitly managed Unicode mapping support. Its stateful X11 implementation now
+lives in a Linux internal package that is built by the normal CGO-enabled race
+job as well as the production non-CGO adapter. A separate Pure-Go guardian owns
+the live X11 connection through a randomly named, token-authenticated Linux
+abstract Unix socket whose peer PID/UID the parent verifies. No live control FD
+crosses the re-exec initialization phase. The guardian detects application death
+through control-socket EOF, bounds normal request dispatch independently from
+cleanup, and the parent kills and reaps a helper that misses its exit deadline.
+Cleanup releases RobotGo-owned input and
+restores a verified scratch before-image only when the exact recorded final
+image remains, the keycode is unpressed, and it is not a modifier. Foreign final
+images are preserved; X11 cannot identify an ABA replacement that returns to
+the same exact image. The blocking Xvfb contract sends a real `SIGKILL` to the
+application workload and compares core, modifier, XKB, key, pointer, and button
+state. The guarantee requires the guardian and responsive X server to survive;
+guardian/host loss or a transport blocked beyond the cleanup deadline still
+needs later reconciliation. Protecting the remote checks, refreshing
+performance evidence for the guardian path, and selectively evaluating
+additional backends keep the broader Phase 3 partial.
 
 Exit criteria:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -104,8 +104,14 @@ Window backend support matrix (current):
     configured-display lifecycle/target, live XTEST readiness, and an XTEST-disabled negative
     contract. A versioned decision-grade sample retains native CGO as the X11
     default while keeping Pure-Go supported for CGO-disabled builds. Protecting
-    the checks, making the Pure-Go core race-testable and its scratch-map
-    lifecycle crash-safe, and evaluating further backends remain open.
+    the checks, collecting current guardian-path performance evidence, and
+    evaluating further backends remain open. The Pure-Go core is now
+    race-testable, and a separate X11 guardian uses an authenticated abstract
+    Unix socket with kernel-verified peer credentials, bounded request dispatch,
+    and deadline-bounded cleanup after an application-process `SIGKILL`. It
+    releases owned input and restores only an exact unchanged, unpressed,
+    non-modifier scratch claim. Foreign final images are preserved; exact-image
+    ABA replacement is not observable in X11.
   - 6. Publish versioned compatibility data and expand diagnostics with
     protocol versions, permissions, and actionable remediation.
   - 7. Promote race/vet and native leak/sanitizer checks to blocking release
@@ -168,8 +174,10 @@ Window backend support matrix (current):
     smoke green, including the native XTEST-disabled negative contract and
     display-lifecycle stress; the resulting remote checks still need branch
     protection.
-  - Extract the Pure-Go X11 core into a race-testable package and design a
-    scoped or crash-safe lifecycle for its server-global keyboard scratch map.
+  - Keep the extracted Pure-Go X11 core in the blocking race job and its
+    guardian-backed application-`SIGKILL` recovery in the non-skipping Xvfb
+    manifest; guardian/host/X-server loss and X11 transport stalls beyond the
+    cleanup deadline remain outside that scoped guarantee.
   - Provision the existing dedicated GNOME, KDE, and wlroots runtime workflow.
   - Keep the race/vet CI jobs green and protect them; add leak/sanitizer and
     bounds-across-outputs gates.

--- a/input_backend_linux_x11_integration_export_test.go
+++ b/input_backend_linux_x11_integration_export_test.go
@@ -7,15 +7,16 @@ import "time"
 // SetX11KeyHoldDelayForIntegrationTest extends or removes the short key hold
 // while an external X11 client inspects the server-side mapping.
 func SetX11KeyHoldDelayForIntegrationTest(delay time.Duration) func() {
-	previous := x11KeyHoldDelay
-	x11KeyHoldDelay = delay
-	return func() { x11KeyHoldDelay = previous }
+	return linuxX11Input.core.SetKeyHoldDelayForIntegrationTest(delay)
 }
 
 // SetX11BeforeTextTapHookForIntegrationTest installs an adversarial hook after
 // scratch reservation and before the first text key event.
 func SetX11BeforeTextTapHookForIntegrationTest(hook func()) func() {
-	previous := x11BeforeTextTapHook
-	x11BeforeTextTapHook = hook
-	return func() { x11BeforeTextTapHook = previous }
+	return linuxX11Input.core.SetBeforeTextTapHookForIntegrationTest(hook)
+}
+
+// X11GuardianPIDForIntegrationTest returns the live Pure-Go X11 guardian PID.
+func X11GuardianPIDForIntegrationTest() (int, bool) {
+	return linuxX11Input.core.GuardianPIDForIntegrationTest()
 }

--- a/input_backend_linux_x11_nocgo.go
+++ b/input_backend_linux_x11_nocgo.go
@@ -6,50 +6,55 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
 
-	"github.com/jezek/xgb"
-	"github.com/jezek/xgb/xproto"
-	"github.com/jezek/xgb/xtest"
+	"github.com/marang/robotgo/internal/x11input"
 )
 
-const (
-	x11XTestMajor = 2
-	x11XTestMinor = 2
-)
+const x11KeysymF1 = 0xffbe
 
-var (
-	errX11Connection  = errors.New("X11 connection failure")
-	errX11KeyboardMap = errors.New("X11 keyboard mapping failure")
-)
-
-// x11InputBackend owns one lazily opened X connection. Its mutex covers whole
-// high-level transactions, including the stable scratch-keymap pool.
-type x11InputBackend struct {
-	mu             sync.Mutex
-	conn           *xgb.Conn
-	display        string
-	root           xproto.Window
-	keyboard       x11KeyboardMap
-	events         <-chan struct{}
-	heldKeys       map[uint32]x11HeldKey
-	keyRefs        map[xproto.Keycode]int
-	keyOrder       []xproto.Keycode
-	buttons        map[byte]struct{}
-	buttonOrder    []byte
-	cleanupPending bool
-
-	scratchInitialized bool
-	scratchPerKeycode  byte
-	scratchSlots       []x11ScratchSlot
-	scratchByKeysym    map[uint32]xproto.Keycode
-
-	eventMu         sync.Mutex
-	eventGeneration uint64
-	eventErr        error
+var x11ModifierNames = map[string]struct{}{
+	"none": {},
+	"alt":  {}, "lalt": {}, "ralt": {},
+	"cmd": {}, "command": {}, "lcmd": {}, "rcmd": {},
+	"ctrl": {}, "control": {}, "lctrl": {}, "rctrl": {},
+	"shift": {}, "lshift": {}, "rshift": {}, "right_shift": {},
 }
 
-var linuxX11Input = &x11InputBackend{}
+var x11ShiftedSpecialKeys = map[rune]rune{
+	'`': '~', '1': '!', '2': '@', '3': '#', '4': '$', '5': '%',
+	'6': '^', '7': '&', '8': '*', '9': '(', '0': ')', '-': '_',
+	'=': '+', '[': '{', ']': '}', '\\': '|', ';': ':', '\'': '"',
+	',': '<', '.': '>', '/': '?',
+}
+
+type x11InputBackend struct {
+	core *x11input.Backend
+}
+
+var linuxX11Input = &x11InputBackend{core: x11input.New(x11input.Config{
+	ResolveDisplay: resolvePureGoX11Display,
+	Dialer:         x11input.NewGuardianDialer(x11input.GuardianOptions{}),
+	KeyHoldDelay:   5 * time.Millisecond,
+})}
+
+func resolvePureGoX11Display() (string, error) {
+	if DetectDisplayServer() != DisplayServerX11 {
+		return "", fmt.Errorf("%w: Pure-Go X11 input requires DISPLAY without an active Wayland session", ErrNotSupported)
+	}
+	if pureGoX11EnvironmentConflict() {
+		return "", fmt.Errorf("%w: %s selects Wayland while DISPLAY selects X11", ErrNotSupported, envXDGSessionType)
+	}
+	display := os.Getenv(envDisplay)
+	if display == "" {
+		return "", fmt.Errorf("%w: %s is unset", ErrNotSupported, envDisplay)
+	}
+	return display, nil
+}
 
 func platformPureGoInputBackend() pureGoInputBackend {
 	if DetectDisplayServer() != DisplayServerX11 {
@@ -62,223 +67,215 @@ func closePureGoPlatformInput() error { return linuxX11Input.Close() }
 
 func (*x11InputBackend) Name() string { return featureBackendPureGoX11 }
 
-func (backend *x11InputBackend) sessionReady() error {
-	if DetectDisplayServer() != DisplayServerX11 {
-		return fmt.Errorf("%w: Pure-Go X11 input requires DISPLAY without an active Wayland session", ErrNotSupported)
-	}
-	if pureGoX11EnvironmentConflict() {
-		return fmt.Errorf("%w: %s selects Wayland while DISPLAY selects X11", ErrNotSupported, envXDGSessionType)
-	}
-	return nil
-}
-
-func (backend *x11InputBackend) openLocked() error {
-	if err := backend.sessionReady(); err != nil {
-		if backend.conn != nil {
-			err = errors.Join(err, backend.closeLocked())
-		}
+func translatePureGoX11Error(err error) error {
+	if err == nil || !errors.Is(err, x11input.ErrUnsupported) {
 		return err
 	}
-	display := os.Getenv(envDisplay)
-	if display == "" {
-		return fmt.Errorf("%w: %s is unset", ErrNotSupported, envDisplay)
+	return fmt.Errorf("%w: %w", ErrNotSupported, err)
+}
+
+func (backend *x11InputBackend) KeyboardReady() error {
+	return translatePureGoX11Error(backend.core.KeyboardReady())
+}
+
+func (backend *x11InputBackend) MouseReady() error {
+	return translatePureGoX11Error(backend.core.MouseReady())
+}
+
+func x11KeysymForKey(key string) (uint32, error) {
+	if key == "" || !utf8.ValidString(key) {
+		return 0, fmt.Errorf("%w: invalid X11 keyboard key %q", ErrNotSupported, key)
 	}
-	if backend.conn != nil {
-		if backend.cleanupPending {
-			return errors.New("robotgo: previous X11 cleanup is incomplete; release conflicting input state and retry CloseMainDisplayE")
+	if named, ok := portalNamedKeysyms[strings.ToLower(key)]; ok {
+		return uint32(named), nil
+	}
+	lower := strings.ToLower(key)
+	if strings.HasPrefix(lower, "f") {
+		number, err := strconv.Atoi(strings.TrimPrefix(lower, "f"))
+		if err == nil && number >= 1 && number <= 24 {
+			return x11KeysymF1 + uint32(number-1), nil
 		}
-		if backend.display != display {
-			if err := backend.closeLocked(); err != nil {
-				return fmt.Errorf("robotgo: clean up previous X11 display: %w", err)
-			}
-		} else {
-			if err := backend.eventDrainErrorLocked(); err != nil {
-				return errors.Join(
-					fmt.Errorf("robotgo: X11 connection is unhealthy: %w", err),
-					backend.closeLocked(),
-				)
-			}
-			return nil
+	}
+	if utf8.RuneCountInString(key) == 1 {
+		value, _ := utf8.DecodeRuneInString(key)
+		keysym, err := portalKeysymForRune(value)
+		return uint32(keysym), err
+	}
+	return 0, fmt.Errorf("%w: X11 keyboard key %q", ErrNotSupported, key)
+}
+
+func x11LiteralKey(key string) bool {
+	if !utf8.ValidString(key) {
+		return false
+	}
+	if _, named := portalNamedKeysyms[strings.ToLower(key)]; named {
+		return false
+	}
+	return utf8.RuneCountInString(key) == 1
+}
+
+func validateX11KeyEvent(event pureGoKeyEvent) error {
+	if !event.Tap && event.Down && x11LiteralKey(event.Key) {
+		return fmt.Errorf("%w: Pure-Go X11 cannot safely hold literal keys across XKB layout groups; use KeyTap, KeyPress, or a named key", ErrNotSupported)
+	}
+	for _, modifier := range event.Modifiers {
+		if _, supported := x11ModifierNames[strings.ToLower(modifier)]; !supported {
+			return fmt.Errorf("%w: Pure-Go X11 modifier %q is not a supported modifier key", ErrNotSupported, modifier)
 		}
 	}
-	connection, err := xgb.NewConnDisplay(display)
-	if err != nil {
-		return fmt.Errorf("robotgo: connect to X11 display %q: %w", display, err)
-	}
-	closeOnError := true
-	defer func() {
-		if closeOnError {
-			connection.Close()
-		}
-	}()
-	if err := xtest.Init(connection); err != nil {
-		return fmt.Errorf("%w: XTEST extension is unavailable: %v", ErrNotSupported, err)
-	}
-	version, err := xtest.GetVersion(connection, x11XTestMajor, x11XTestMinor).Reply()
-	if err != nil {
-		return fmt.Errorf("robotgo: query XTEST version: %w", err)
-	}
-	if !x11XTestVersionSupported(version) {
-		if version == nil {
-			return fmt.Errorf("%w: XTEST returned no version", ErrNotSupported)
-		}
-		return fmt.Errorf("%w: XTEST %d.%d is older than required %d.%d",
-			ErrNotSupported, version.MajorVersion, version.MinorVersion, x11XTestMajor, x11XTestMinor)
-	}
-	setup := xproto.Setup(connection)
-	if setup == nil {
-		return errors.New("robotgo: X11 returned no setup information")
-	}
-	screen := setup.DefaultScreen(connection)
-	if screen == nil || screen.Root == 0 {
-		return errors.New("robotgo: X11 returned no default root window")
-	}
-	backend.conn = connection
-	backend.display = display
-	backend.root = screen.Root
-	backend.keyboard = x11KeyboardMap{}
-	backend.startEventDrainLocked(connection)
-	closeOnError = false
 	return nil
 }
 
-func x11XTestVersionSupported(version *xtest.GetVersionReply) bool {
-	if version == nil {
-		return false
+func x11EventKeysym(event pureGoKeyEvent) (uint32, error) {
+	key := event.Key
+	if x11LiteralKey(key) && x11EventHasShift(event.Modifiers) {
+		value, _ := utf8.DecodeRuneInString(key)
+		if shifted, ok := x11ShiftedSpecialKeys[value]; ok {
+			value = shifted
+		} else {
+			value = unicode.ToUpper(value)
+		}
+		key = string(value)
 	}
-	return version.MajorVersion > x11XTestMajor ||
-		version.MajorVersion == x11XTestMajor && version.MinorVersion >= x11XTestMinor
+	return x11KeysymForKey(key)
 }
 
-func (backend *x11InputBackend) startEventDrainLocked(connection *xgb.Conn) {
-	backend.eventMu.Lock()
-	backend.eventGeneration++
-	generation := backend.eventGeneration
-	backend.eventErr = nil
-	backend.eventMu.Unlock()
-	done := make(chan struct{})
-	backend.events = done
-	go func() {
-		defer close(done)
-		for {
-			event, eventErr := connection.WaitForEvent()
-			if event == nil && eventErr == nil {
-				return
-			}
-			if eventErr != nil {
-				backend.eventMu.Lock()
-				if backend.eventGeneration == generation {
-					backend.eventErr = errors.Join(backend.eventErr, eventErr)
-				}
-				backend.eventMu.Unlock()
-			}
+func x11EventHasShift(modifiers []string) bool {
+	for _, modifier := range modifiers {
+		switch strings.ToLower(modifier) {
+		case "shift", "lshift", "rshift", "right_shift":
+			return true
 		}
-	}()
+	}
+	return false
 }
 
-func (backend *x11InputBackend) eventDrainErrorLocked() error {
-	if backend.events != nil {
-		select {
-		case <-backend.events:
-			return errors.New("X11 connection event drain stopped")
-		default:
+func x11ModifierKeysyms(modifiers []string) ([]uint32, error) {
+	result := make([]uint32, 0, len(modifiers))
+	for _, modifier := range modifiers {
+		if strings.EqualFold(modifier, "none") {
+			continue
 		}
+		keysym, err := x11KeysymForKey(modifier)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, keysym)
 	}
-	backend.eventMu.Lock()
-	defer backend.eventMu.Unlock()
-	return backend.eventErr
+	return result, nil
 }
 
-func (backend *x11InputBackend) withServerGrabLocked(operation func() error) (err error) {
-	if backend.conn == nil {
-		return errors.Join(errX11Connection, errors.New("X11 connection is closed"))
+func (backend *x11InputBackend) Key(event pureGoKeyEvent) error {
+	if event.PID != 0 {
+		return fmt.Errorf("%w: Pure-Go X11 input cannot target a process", ErrNotSupported)
 	}
-	if grabErr := xproto.GrabServerChecked(backend.conn).Check(); grabErr != nil {
-		return errors.Join(errX11Connection, grabErr)
+	if err := validateX11KeyEvent(event); err != nil {
+		return err
 	}
-	defer func() {
-		if ungrabErr := xproto.UngrabServerChecked(backend.conn).Check(); ungrabErr != nil {
-			// Connection health takes precedence over the operation result: the
-			// caller must discard a connection whose server-grab state is unknown.
-			err = errors.Join(err, errX11Connection, ungrabErr)
-		}
-	}()
-	return operation()
+	keysym, err := x11EventKeysym(event)
+	if err != nil {
+		return err
+	}
+	modifiers, err := x11ModifierKeysyms(event.Modifiers)
+	if err != nil {
+		return err
+	}
+	return translatePureGoX11Error(backend.core.Key(x11input.KeyEvent{
+		Keysym:       keysym,
+		Modifiers:    modifiers,
+		Down:         event.Down,
+		Tap:          event.Tap,
+		AllowScratch: event.Tap,
+		ForceScratch: event.Tap && x11LiteralKey(event.Key),
+	}))
 }
 
-func (backend *x11InputBackend) closeLocked() error {
-	var cleanupErr error
-	if backend.conn != nil {
-		cleanupErr = errors.Join(
-			backend.withServerGrabLocked(backend.releaseOwnedInputLocked),
-			backend.restoreScratchMappingsLocked(),
-		)
-		if cleanupErr != nil && !errors.Is(cleanupErr, errX11Connection) {
-			backend.cleanupPending = true
-			return cleanupErr
-		}
-		backend.conn.Close()
+func (backend *x11InputBackend) Text(event pureGoTextEvent) error {
+	if event.PID != 0 {
+		return fmt.Errorf("%w: Pure-Go X11 input cannot target a process", ErrNotSupported)
 	}
-	backend.conn = nil
-	backend.display = ""
-	backend.root = 0
-	backend.keyboard = x11KeyboardMap{}
-	backend.events = nil
-	backend.heldKeys = nil
-	backend.keyRefs = nil
-	backend.keyOrder = nil
-	backend.buttons = nil
-	backend.buttonOrder = nil
-	backend.cleanupPending = false
-	backend.scratchInitialized = false
-	backend.scratchPerKeycode = 0
-	backend.scratchSlots = nil
-	backend.scratchByKeysym = nil
-	return cleanupErr
+	if event.Delay < 0 {
+		return errors.New("robotgo: text delay must be non-negative")
+	}
+	if !utf8.ValidString(event.Text) {
+		return errors.New("robotgo: text is not valid UTF-8")
+	}
+	keysyms := make([]uint32, 0, utf8.RuneCountInString(event.Text))
+	for _, value := range event.Text {
+		keysym, err := portalKeysymForRune(value)
+		if err != nil {
+			return err
+		}
+		keysyms = append(keysyms, uint32(keysym))
+	}
+	return translatePureGoX11Error(backend.core.Text(x11input.TextEvent{
+		Keysyms: keysyms,
+		Delay:   time.Duration(event.Delay) * time.Millisecond,
+	}))
 }
 
-func (backend *x11InputBackend) releaseOwnedInputLocked() error {
-	var releaseErr error
-	for index := len(backend.keyOrder) - 1; index >= 0; index-- {
-		code := backend.keyOrder[index]
-		if backend.keyRefs[code] > 0 {
-			if err := backend.sendKeyLocked(code, false); err != nil {
-				releaseErr = errors.Join(releaseErr, err)
-				continue
-			}
-			delete(backend.keyRefs, code)
-			backend.keyOrder = removeX11Keycode(backend.keyOrder, code)
-		}
+func x11MouseButton(name string) (x11input.Button, error) {
+	switch name {
+	case "", "left":
+		return x11input.ButtonLeft, nil
+	case "center", "middle":
+		return x11input.ButtonMiddle, nil
+	case "right":
+		return x11input.ButtonRight, nil
+	case "wheelUp":
+		return x11input.ButtonWheelUp, nil
+	case "wheelDown":
+		return x11input.ButtonWheelDown, nil
+	case "wheelLeft":
+		return x11input.ButtonWheelLeft, nil
+	case "wheelRight":
+		return x11input.ButtonWheelRight, nil
+	default:
+		return 0, fmt.Errorf("robotgo: invalid X11 pointer button %q", name)
 	}
-	for keysym, held := range backend.heldKeys {
-		if backend.keyRefs[held.code] == 0 {
-			delete(backend.heldKeys, keysym)
-		}
+}
+
+func (backend *x11InputBackend) MoveAbsolute(x, y int, displayID []int) error {
+	return translatePureGoX11Error(backend.core.MoveAbsolute(x, y, displayID))
+}
+
+func (backend *x11InputBackend) MoveRelative(x, y int) error {
+	return translatePureGoX11Error(backend.core.MoveRelative(x, y))
+}
+
+func (backend *x11InputBackend) MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error {
+	return translatePureGoX11Error(backend.core.MoveSmooth(x, y, relative, lowDelay, highDelay))
+}
+
+func (backend *x11InputBackend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
+	return translatePureGoX11Error(backend.core.DragSmooth(x, y, lowDelay, highDelay))
+}
+
+func (backend *x11InputBackend) Location() (int, int, error) {
+	x, y, err := backend.core.Location()
+	return x, y, translatePureGoX11Error(err)
+}
+
+func (backend *x11InputBackend) Click(name string, double bool) error {
+	button, err := x11MouseButton(name)
+	if err != nil {
+		return err
 	}
-	for index := len(backend.buttonOrder) - 1; index >= 0; index-- {
-		button := backend.buttonOrder[index]
-		if _, held := backend.buttons[button]; held {
-			if err := backend.sendButtonLocked(button, false); err != nil {
-				releaseErr = errors.Join(releaseErr, err)
-				continue
-			}
-			delete(backend.buttons, button)
-			backend.buttonOrder = removeX11Button(backend.buttonOrder, button)
-		}
+	return translatePureGoX11Error(backend.core.Click(button, double))
+}
+
+func (backend *x11InputBackend) Toggle(name string, down bool) error {
+	button, err := x11MouseButton(name)
+	if err != nil {
+		return err
 	}
-	return releaseErr
+	return translatePureGoX11Error(backend.core.Toggle(button, down))
+}
+
+func (backend *x11InputBackend) Scroll(x, y int) error {
+	return translatePureGoX11Error(backend.core.Scroll(x, y))
 }
 
 func (backend *x11InputBackend) Close() error {
-	backend.mu.Lock()
-	err := backend.closeLocked()
-	backend.mu.Unlock()
-	return err
-}
-
-func (backend *x11InputBackend) failLocked(action string, err error) error {
-	return errors.Join(
-		fmt.Errorf("robotgo: X11 %s: %w", action, err),
-		backend.closeLocked(),
-	)
+	return translatePureGoX11Error(backend.core.Close())
 }

--- a/input_backend_linux_x11_nocgo_test.go
+++ b/input_backend_linux_x11_nocgo_test.go
@@ -4,187 +4,27 @@ package robotgo
 
 import (
 	"errors"
-	"math"
 	"testing"
-	"time"
 
-	"github.com/jezek/xgb/xproto"
-	"github.com/jezek/xgb/xtest"
+	"github.com/marang/robotgo/internal/x11input"
 )
 
-func TestX11KeyboardMapResolvesActiveLayoutLevels(t *testing.T) {
-	keyboard := x11KeyboardMap{
-		minimum:    8,
-		perKeycode: 6,
-		modifiers:  map[xproto.Keycode]struct{}{11: {}},
-		keysyms: []xproto.Keysym{
-			'a', 'A', 0x010003b1, 0x01000391, '@', '#',
-			0xffe1, 0, 0xffe1, 0, 0, 0,
-			0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0,
-		},
-	}
-	tests := []struct {
-		keysym uint32
-		want   x11ResolvedKey
-	}{
-		{keysym: 0xffe1, want: x11ResolvedKey{code: 9}},
-	}
-	for _, test := range tests {
-		got, ok := keyboard.resolve(test.keysym)
-		if !ok || got != test.want {
-			t.Fatalf("resolve(%#x) = (%+v,%v), want (%+v,true)", test.keysym, got, ok, test.want)
-		}
-	}
-	for _, ambiguous := range []uint32{'a', 'A', 0x010003b1, '@'} {
-		if got, ok := keyboard.resolve(ambiguous); ok {
-			t.Fatalf("resolve(%#x) = %+v, want no unsafe core-map guess", ambiguous, got)
-		}
-	}
-	backend := &x11InputBackend{}
-	if err := backend.updateScratchStateLocked(&keyboard); err != nil {
-		t.Fatalf("initialize scratch state: %v", err)
-	}
-	if len(backend.scratchSlots) != 1 || backend.scratchSlots[0].code != 10 {
-		t.Fatalf("scratch slots = %+v, want only non-modifier keycode 10", backend.scratchSlots)
-	}
-	keyboard.modifiers[10] = struct{}{}
-	if err := backend.updateScratchStateLocked(&keyboard); err != nil {
-		t.Fatalf("drop newly assigned modifier from unused scratch pool: %v", err)
-	}
-	if len(backend.scratchSlots) != 0 {
-		t.Fatalf("modifier keycode remained in scratch pool: %+v", backend.scratchSlots)
-	}
-}
-
-func TestX11ModifierResolutionRequiresModifierMapMembership(t *testing.T) {
-	keyboard := x11KeyboardMap{
-		minimum:    8,
-		perKeycode: 2,
-		keysyms: []xproto.Keysym{
-			0xffe3, 0, // Control_L-shaped key that is not a modifier.
-			0xffe3, 0xffe7, // Actual Control modifier with a second symbol.
-		},
-		modifiers: map[xproto.Keycode]struct{}{9: {}},
-	}
-	got, ok := keyboard.resolveModifier(0xffe3)
-	if !ok || got.code != 9 {
-		t.Fatalf("resolveModifier(Control_L) = (%+v,%t), want keycode 9", got, ok)
-	}
-	delete(keyboard.modifiers, 9)
-	if got, ok := keyboard.resolveModifier(0xffe3); ok {
-		t.Fatalf("resolveModifier without modifier-map membership = %+v, want no match", got)
-	}
-}
-
-func TestX11ScratchCapacityFailsBeforeMapping(t *testing.T) {
-	backend := &x11InputBackend{
-		scratchInitialized: true,
-		scratchPerKeycode:  2,
-		scratchSlots:       []x11ScratchSlot{{code: 10}},
-		scratchByKeysym:    make(map[uint32]xproto.Keycode),
-	}
-	err := backend.validateScratchCapacityLocked([]uint32{'a', 'b'}, nil)
+func TestTranslatePureGoX11ErrorPreservesJoinedCauses(t *testing.T) {
+	cause := errors.New("specific X11 failure")
+	err := translatePureGoX11Error(errors.Join(x11input.ErrUnsupported, cause))
 	if !errors.Is(err, ErrNotSupported) {
-		t.Fatalf("scratch capacity error = %v, want ErrNotSupported", err)
+		t.Fatalf("translated error = %v, want ErrNotSupported", err)
 	}
-	if backend.scratchSlots[0].keysym != 0 || len(backend.scratchByKeysym) != 0 {
-		t.Fatalf("capacity failure mutated scratch state: slots=%+v mappings=%v", backend.scratchSlots, backend.scratchByKeysym)
-	}
-}
-
-func TestX11ScratchCapacityExcludesPressedEmptyKeycodes(t *testing.T) {
-	backend := &x11InputBackend{
-		scratchInitialized: true,
-		scratchPerKeycode:  2,
-		scratchSlots:       []x11ScratchSlot{{code: 10}},
-		scratchByKeysym:    make(map[uint32]xproto.Keycode),
-	}
-	pressed := make([]byte, 32)
-	pressed[10/8] |= 1 << uint(10%8)
-	if err := backend.validateScratchCapacityLocked([]uint32{'a'}, pressed); !errors.Is(err, ErrNotSupported) {
-		t.Fatalf("pressed scratch capacity error = %v, want ErrNotSupported", err)
+	if !errors.Is(err, x11input.ErrUnsupported) || !errors.Is(err, cause) {
+		t.Fatalf("translated error lost joined causes: %v", err)
 	}
 }
 
-func TestX11ScratchCleanupUsesCurrentMappingWidth(t *testing.T) {
-	const keysym = uint32(0x010020ac)
-	current := &xproto.GetKeyboardMappingReply{
-		KeysymsPerKeycode: 3,
-		Keysyms: []xproto.Keysym{
-			xproto.Keysym(keysym), xproto.Keysym(keysym), xproto.Keysym(keysym),
-		},
-	}
-	width, owned, err := x11ScratchMappingCanRestore(current, keysym)
-	if err != nil || !owned || width != 3 {
-		t.Fatalf("restore plan = (width=%d owned=%t err=%v), want (3,true,nil)", width, owned, err)
-	}
-	current.Keysyms[2] = 'x'
-	if _, owned, err := x11ScratchMappingCanRestore(current, keysym); err != nil || owned {
-		t.Fatalf("foreign restore plan = (owned=%t err=%v), want (false,nil)", owned, err)
-	}
-}
-
-func TestX11ScratchOwnershipRecognizesServerCanonicalization(t *testing.T) {
-	keysym := uint32(0x010020ac)
-	for _, test := range []struct {
-		mapping []xproto.Keysym
-		want    bool
-	}{
-		{mapping: []xproto.Keysym{xproto.Keysym(keysym), xproto.Keysym(keysym), 0}, want: true},
-		{mapping: []xproto.Keysym{xproto.Keysym(keysym)}, want: true},
-		{mapping: []xproto.Keysym{0, 0}},
-		{mapping: []xproto.Keysym{xproto.Keysym(keysym), 'x'}},
-	} {
-		if got := x11MappingOwnedBy(test.mapping, keysym); got != test.want {
-			t.Fatalf("x11MappingOwnedBy(%v,%#x) = %t, want %t", test.mapping, keysym, got, test.want)
-		}
-	}
-}
-
-func TestX11ScratchOwnershipRejectsModifierReassignment(t *testing.T) {
-	const keysym = uint32(0x010020ac)
-	backend := &x11InputBackend{
-		scratchInitialized: true,
-		scratchPerKeycode:  2,
-		scratchSlots:       []x11ScratchSlot{{code: 10, keysym: keysym}},
-		scratchByKeysym:    map[uint32]xproto.Keycode{keysym: 10},
-	}
-	keyboard := x11KeyboardMap{
-		minimum:    10,
-		perKeycode: 2,
-		keysyms:    []xproto.Keysym{xproto.Keysym(keysym), xproto.Keysym(keysym)},
-		modifiers:  map[xproto.Keycode]struct{}{10: {}},
-	}
-	if err := backend.updateScratchStateLocked(&keyboard); err == nil {
-		t.Fatal("owned scratch keycode becoming a modifier unexpectedly succeeded")
-	}
-}
-
-func TestX11VersionAndLiteralContracts(t *testing.T) {
-	for _, test := range []struct {
-		version *xtest.GetVersionReply
-		want    bool
-	}{
-		{version: nil},
-		{version: &xtest.GetVersionReply{MajorVersion: 2, MinorVersion: 1}},
-		{version: &xtest.GetVersionReply{MajorVersion: 2, MinorVersion: 2}, want: true},
-		{version: &xtest.GetVersionReply{MajorVersion: 3}, want: true},
-	} {
-		if got := x11XTestVersionSupported(test.version); got != test.want {
-			t.Fatalf("x11XTestVersionSupported(%+v) = %t, want %t", test.version, got, test.want)
-		}
-	}
+func TestX11LiteralAndModifierContracts(t *testing.T) {
 	for key, want := range map[string]bool{"a": true, "€": true, "enter": false, "F12": false} {
 		if got := x11LiteralKey(key); got != want {
 			t.Fatalf("x11LiteralKey(%q) = %t, want %t", key, got, want)
 		}
-	}
-	if _, err := x11Coordinate(math.MaxInt16 + 1); err == nil || errors.Is(err, ErrNotSupported) {
-		t.Fatalf("coordinate validation error = %v, want non-ErrNotSupported", err)
-	}
-	if _, err := x11MouseButton("invalid"); err == nil || errors.Is(err, ErrNotSupported) {
-		t.Fatalf("button validation error = %v, want non-ErrNotSupported", err)
 	}
 	if err := validateX11KeyEvent(pureGoKeyEvent{Key: "a", Down: true}); !errors.Is(err, ErrNotSupported) {
 		t.Fatalf("persistent literal key validation = %v, want ErrNotSupported", err)
@@ -242,41 +82,15 @@ func TestX11EventKeysymAppliesExplicitShiftToLiteralKeys(t *testing.T) {
 	} {
 		got, err := x11EventKeysym(pureGoKeyEvent{Key: test.key, Modifiers: test.modifiers, Tap: true})
 		if err != nil || got != test.want {
-			t.Fatalf("x11EventKeysym(%q,%v) = (%#x,%v), want (%#x,nil)",
-				test.key, test.modifiers, got, err, test.want)
-		}
-	}
-}
-
-func TestX11PointerArgumentsAreStrictlyBounded(t *testing.T) {
-	for _, value := range []int{math.MinInt16, 0, math.MaxInt16} {
-		if got, err := x11Coordinate(value); err != nil || int(got) != value {
-			t.Fatalf("x11Coordinate(%d) = (%d,%v)", value, got, err)
-		}
-	}
-	for _, value := range []int{math.MinInt16 - 1, math.MaxInt16 + 1} {
-		if _, err := x11Coordinate(value); err == nil {
-			t.Fatalf("x11Coordinate(%d) unexpectedly succeeded", value)
-		}
-	}
-	for value, want := range map[int]uint64{-1000: 1000, 0: 0, 1000: 1000} {
-		if got, err := x11ScrollSteps(value); err != nil || got != want {
-			t.Fatalf("x11ScrollSteps(%d) = (%d,%v), want (%d,nil)", value, got, err, want)
-		}
-	}
-	for _, value := range []int{-1001, 1001, math.MinInt, math.MaxInt} {
-		if _, err := x11ScrollSteps(value); err == nil {
-			t.Fatalf("x11ScrollSteps(%d) unexpectedly succeeded", value)
+			t.Fatalf("x11EventKeysym(%q,%v) = (%#x,%v), want (%#x,nil)", test.key, test.modifiers, got, err, test.want)
 		}
 	}
 }
 
 func TestX11MouseButtonRejectsUnknownNames(t *testing.T) {
 	tests := map[string]byte{
-		"": x11ButtonLeft, "left": x11ButtonLeft, "center": x11ButtonMiddle,
-		"middle": x11ButtonMiddle, "right": x11ButtonRight,
-		"wheelUp": x11ButtonWheelUp, "wheelDown": x11ButtonWheelDown,
-		"wheelLeft": x11ButtonWheelLeft, "wheelRight": x11ButtonWheelRight,
+		"": 1, "left": 1, "center": 2, "middle": 2, "right": 3,
+		"wheelUp": 4, "wheelDown": 5, "wheelLeft": 6, "wheelRight": 7,
 	}
 	for name, want := range tests {
 		got, err := x11MouseButton(name)
@@ -287,68 +101,27 @@ func TestX11MouseButtonRejectsUnknownNames(t *testing.T) {
 	if _, err := x11MouseButton("primary"); err == nil {
 		t.Fatal("unknown X11 mouse button unexpectedly succeeded")
 	}
-	for _, button := range []byte{x11ButtonLeft, x11ButtonMiddle, x11ButtonRight, x11ButtonWheelUp, x11ButtonWheelDown} {
-		if !x11ButtonStateObservable(button) {
-			t.Fatalf("button %d state unexpectedly unobservable", button)
-		}
-	}
-	for _, button := range []byte{x11ButtonWheelLeft, x11ButtonWheelRight} {
-		if x11ButtonStateObservable(button) {
-			t.Fatalf("button %d state unexpectedly observable", button)
-		}
-	}
 }
 
 func TestX11BackendResolverNeverUsesX11InWaylandSession(t *testing.T) {
-	t.Setenv("DISPLAY", ":99")
-	t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envWaylandDisplay, "wayland-test")
 	if backend := platformPureGoInputBackend(); backend != nil {
 		t.Fatalf("Wayland session selected X11 backend %q", backend.Name())
 	}
-	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv(envWaylandDisplay, "")
 	if backend := platformPureGoInputBackend(); backend == nil || backend.Name() != featureBackendPureGoX11 {
 		t.Fatalf("X11 session backend = %#v, want %q", backend, featureBackendPureGoX11)
 	}
 }
 
-func TestX11CapabilityInspectionDoesNotWaitForBackendMutex(t *testing.T) {
+func TestX11CapabilityInspectionDoesNotProbeDisplay(t *testing.T) {
 	t.Setenv(envWaylandDisplay, "")
-	t.Setenv(envDisplay, ":99")
+	t.Setenv(envDisplay, ":robotgo-definitely-unreachable")
 	t.Setenv(envXDGSessionType, "x11")
-	linuxX11Input.mu.Lock()
-	done := make(chan RuntimeCapabilities, 1)
-	go func() { done <- GetRuntimeCapabilities() }()
-	select {
-	case capabilities := <-done:
-		linuxX11Input.mu.Unlock()
-		if !capabilities.Keyboard.Available || !capabilities.Mouse.Available {
-			t.Fatalf("X11 capabilities = keyboard %+v, mouse %+v", capabilities.Keyboard, capabilities.Mouse)
-		}
-	case <-time.After(250 * time.Millisecond):
-		linuxX11Input.mu.Unlock()
-		<-done
-		t.Fatal("capability inspection waited for the persistent X11 backend mutex")
-	}
-}
-
-func TestX11CapabilityInspectionDoesNotCleanUpDeselectedBackend(t *testing.T) {
-	t.Setenv(envWaylandDisplay, "wayland-test")
-	t.Setenv(envDisplay, ":99")
-	t.Setenv(envXDGSessionType, sessionTypeWayland)
-	linuxX11Input.mu.Lock()
-	done := make(chan RuntimeCapabilities, 1)
-	go func() { done <- GetRuntimeCapabilities() }()
-	select {
-	case capabilities := <-done:
-		linuxX11Input.mu.Unlock()
-		if capabilities.Keyboard.Backend == featureBackendPureGoX11 ||
-			capabilities.Mouse.Backend == featureBackendPureGoX11 {
-			t.Fatalf("Wayland capabilities selected Pure-Go X11: %+v", capabilities)
-		}
-	case <-time.After(250 * time.Millisecond):
-		linuxX11Input.mu.Unlock()
-		<-done
-		t.Fatal("capability inspection tried to clean up the deselected X11 backend")
+	capabilities := GetRuntimeCapabilities()
+	if !capabilities.Keyboard.Available || !capabilities.Mouse.Available {
+		t.Fatalf("X11 capabilities = keyboard %+v, mouse %+v", capabilities.Keyboard, capabilities.Mouse)
 	}
 }
 

--- a/input_backend_nocgo.go
+++ b/input_backend_nocgo.go
@@ -75,7 +75,8 @@ func pureGoInputCapabilities() (keyboard, mouse FeatureCapability) {
 		Notes:     "call MouseReady for a live backend check; capability inspection does not open a display connection",
 	}
 	if backendName == featureBackendPureGoX11 {
-		keyboard.Notes += "; key taps and text may use server-global scratch keycodes: call CloseMainDisplayE after targets process all prior keyboard input; abnormal termination can leave mappings behind"
+		keyboard.Notes += "; key taps and text may use server-global scratch keycodes: call CloseMainDisplayE after targets process all prior keyboard input; a separate Pure-Go guardian performs bounded crash cleanup and restores only exact unchanged, unpressed, non-modifier scratch claims"
+		mouse.Notes += "; vertical scrolling is supported; horizontal scrolling returns ErrNotSupported because core XTEST button 6/7 state is not safely observable"
 		if pureGoX11EnvironmentConflict() {
 			reason := envXDGSessionType + " selects Wayland while DISPLAY selects X11"
 			keyboard.Available, keyboard.Reason = false, reason

--- a/internal/x11input/backend_linux.go
+++ b/internal/x11input/backend_linux.go
@@ -1,0 +1,279 @@
+//go:build linux
+
+package x11input
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jezek/xgb/xproto"
+)
+
+const (
+	x11XTestMajor = 2
+	x11XTestMinor = 2
+)
+
+var (
+	// ErrUnsupported identifies X11/XTEST capabilities the core cannot provide.
+	// The public adapter translates it to robotgo.ErrNotSupported.
+	ErrUnsupported    = errors.New("X11 input operation is not supported")
+	errX11Connection  = errors.New("X11 connection failure")
+	errX11KeyboardMap = errors.New("X11 keyboard mapping failure")
+)
+
+// Backend owns one lazily opened X connection. Its mutex covers whole
+// high-level transactions, including the stable scratch-keymap pool.
+type Backend struct {
+	mu             sync.Mutex
+	conn           Connection
+	config         Config
+	display        string
+	root           xproto.Window
+	keyboard       x11KeyboardMap
+	events         <-chan struct{}
+	heldKeys       map[uint32]x11HeldKey
+	keyRefs        map[xproto.Keycode]int
+	keyOrder       []xproto.Keycode
+	buttons        map[byte]struct{}
+	buttonOrder    []byte
+	cleanupPending bool
+
+	scratchInitialized bool
+	scratchPerKeycode  byte
+	scratchSlots       []x11ScratchSlot
+	scratchByKeysym    map[uint32]xproto.Keycode
+
+	eventMu         sync.Mutex
+	eventGeneration uint64
+	eventErr        error
+	beforeTextTap   func()
+}
+
+// New creates an independently owned, lazily connected X11 input backend.
+func New(config Config) *Backend {
+	if config.Dialer == nil {
+		config.Dialer = xgbDialer{}
+	}
+	if config.KeyHoldDelay == 0 {
+		config.KeyHoldDelay = 5 * time.Millisecond
+	}
+	if config.Sleep == nil {
+		config.Sleep = time.Sleep
+	}
+	return &Backend{config: config}
+}
+
+func (backend *Backend) openLocked() (err error) {
+	if backend.config.ResolveDisplay == nil {
+		return fmt.Errorf("%w: no X11 display resolver configured", ErrUnsupported)
+	}
+	display, err := backend.config.ResolveDisplay()
+	if err != nil {
+		if backend.conn != nil {
+			err = errors.Join(err, backend.closeLocked())
+		}
+		return err
+	}
+	if display == "" {
+		return fmt.Errorf("%w: X11 display is unset", ErrUnsupported)
+	}
+	if backend.conn != nil {
+		if backend.cleanupPending {
+			return errors.New("robotgo: previous X11 cleanup is incomplete; release conflicting input state and retry CloseMainDisplayE")
+		}
+		if backend.display != display {
+			if err := backend.closeLocked(); err != nil {
+				return fmt.Errorf("robotgo: clean up previous X11 display: %w", err)
+			}
+		} else {
+			if err := backend.eventDrainErrorLocked(); err != nil {
+				return errors.Join(
+					fmt.Errorf("robotgo: X11 connection is unhealthy: %w", err),
+					backend.closeLocked(),
+				)
+			}
+			return nil
+		}
+	}
+	connection, err := backend.config.Dialer.Dial(display)
+	if err != nil {
+		return fmt.Errorf("robotgo: connect to X11 display %q: %w", display, err)
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			err = errors.Join(err, connection.Close())
+		}
+	}()
+	if err := connection.InitXTest(); err != nil {
+		return fmt.Errorf("%w: XTEST extension is unavailable: %w", ErrUnsupported, err)
+	}
+	version, err := connection.XTestVersion(x11XTestMajor, x11XTestMinor)
+	if err != nil {
+		return fmt.Errorf("robotgo: query XTEST version: %w", err)
+	}
+	if !x11XTestVersionSupported(version) {
+		if !version.Valid {
+			return fmt.Errorf("%w: XTEST returned no version", ErrUnsupported)
+		}
+		return fmt.Errorf("%w: XTEST %d.%d is older than required %d.%d",
+			ErrUnsupported, version.Major, version.Minor, x11XTestMajor, x11XTestMinor)
+	}
+	setup, err := connection.Setup()
+	if err != nil {
+		return fmt.Errorf("robotgo: query X11 setup: %w", err)
+	}
+	backend.conn = connection
+	backend.display = display
+	backend.root = setup.Root
+	backend.keyboard = x11KeyboardMap{}
+	backend.startEventDrainLocked(connection)
+	closeOnError = false
+	return nil
+}
+
+func x11XTestVersionSupported(version XTestVersion) bool {
+	return version.Valid && (version.Major > x11XTestMajor ||
+		version.Major == x11XTestMajor && version.Minor >= x11XTestMinor)
+}
+
+func (backend *Backend) startEventDrainLocked(connection Connection) {
+	backend.eventMu.Lock()
+	backend.eventGeneration++
+	generation := backend.eventGeneration
+	backend.eventErr = nil
+	backend.eventMu.Unlock()
+	done := make(chan struct{})
+	backend.events = done
+	go func() {
+		defer close(done)
+		for {
+			open, eventErr := connection.WaitForEvent()
+			if !open && eventErr == nil {
+				return
+			}
+			if eventErr != nil {
+				backend.eventMu.Lock()
+				if backend.eventGeneration == generation {
+					backend.eventErr = errors.Join(backend.eventErr, eventErr)
+				}
+				backend.eventMu.Unlock()
+			}
+		}
+	}()
+}
+
+func (backend *Backend) eventDrainErrorLocked() error {
+	stopped := false
+	if backend.events != nil {
+		select {
+		case <-backend.events:
+			stopped = true
+		default:
+		}
+	}
+	backend.eventMu.Lock()
+	eventErr := backend.eventErr
+	backend.eventMu.Unlock()
+	if stopped {
+		return errors.Join(errors.New("X11 connection event drain stopped"), eventErr)
+	}
+	return eventErr
+}
+
+func (backend *Backend) withServerGrabLocked(operation func() error) (err error) {
+	if backend.conn == nil {
+		return errors.Join(errX11Connection, errors.New("X11 connection is closed"))
+	}
+	if grabErr := backend.conn.GrabServer(); grabErr != nil {
+		return errors.Join(errX11Connection, grabErr)
+	}
+	defer func() {
+		if ungrabErr := backend.conn.UngrabServer(); ungrabErr != nil {
+			// Connection health takes precedence over the operation result: the
+			// caller must discard a connection whose server-grab state is unknown.
+			err = errors.Join(err, errX11Connection, ungrabErr)
+		}
+	}()
+	return operation()
+}
+
+func (backend *Backend) closeLocked() error {
+	var cleanupErr error
+	if backend.conn != nil {
+		cleanupErr = errors.Join(
+			backend.withServerGrabLocked(backend.releaseOwnedInputLocked),
+			backend.restoreScratchMappingsLocked(),
+		)
+		if cleanupErr != nil && !errors.Is(cleanupErr, errX11Connection) {
+			backend.cleanupPending = true
+			return cleanupErr
+		}
+		cleanupErr = errors.Join(cleanupErr, backend.conn.Close())
+	}
+	backend.conn = nil
+	backend.display = ""
+	backend.root = 0
+	backend.keyboard = x11KeyboardMap{}
+	backend.events = nil
+	backend.heldKeys = nil
+	backend.keyRefs = nil
+	backend.keyOrder = nil
+	backend.buttons = nil
+	backend.buttonOrder = nil
+	backend.cleanupPending = false
+	backend.scratchInitialized = false
+	backend.scratchPerKeycode = 0
+	backend.scratchSlots = nil
+	backend.scratchByKeysym = nil
+	return cleanupErr
+}
+
+func (backend *Backend) releaseOwnedInputLocked() error {
+	var releaseErr error
+	for index := len(backend.keyOrder) - 1; index >= 0; index-- {
+		code := backend.keyOrder[index]
+		if backend.keyRefs[code] > 0 {
+			if err := backend.sendKeyLocked(code, false); err != nil {
+				releaseErr = errors.Join(releaseErr, err)
+				continue
+			}
+			delete(backend.keyRefs, code)
+			backend.keyOrder = removeX11Keycode(backend.keyOrder, code)
+		}
+	}
+	for keysym, held := range backend.heldKeys {
+		if backend.keyRefs[held.code] == 0 {
+			delete(backend.heldKeys, keysym)
+		}
+	}
+	for index := len(backend.buttonOrder) - 1; index >= 0; index-- {
+		button := backend.buttonOrder[index]
+		if _, held := backend.buttons[button]; held {
+			if err := backend.sendButtonLocked(button, false); err != nil {
+				releaseErr = errors.Join(releaseErr, err)
+				continue
+			}
+			delete(backend.buttons, button)
+			backend.buttonOrder = removeX11Button(backend.buttonOrder, button)
+		}
+	}
+	return releaseErr
+}
+
+func (backend *Backend) Close() error {
+	backend.mu.Lock()
+	err := backend.closeLocked()
+	backend.mu.Unlock()
+	return err
+}
+
+func (backend *Backend) failLocked(action string, err error) error {
+	return errors.Join(
+		fmt.Errorf("robotgo: X11 %s: %w", action, err),
+		backend.closeLocked(),
+	)
+}

--- a/internal/x11input/backend_test.go
+++ b/internal/x11input/backend_test.go
@@ -1,0 +1,760 @@
+//go:build linux
+
+package x11input
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jezek/xgb/xproto"
+)
+
+type fakeX11Server struct {
+	mu           sync.Mutex
+	setup        Setup
+	perKeycode   byte
+	keysyms      []xproto.Keysym
+	modifiers    []xproto.Keycode
+	pressed      []byte
+	pointer      PointerState
+	buttons      map[byte]bool
+	connections  []*fakeX11Connection
+	setupErr     error
+	initErr      error
+	versionErr   error
+	grabErr      error
+	ungrabErr    error
+	mappingErr   error
+	modifierErr  error
+	changeErr    error
+	pressedErr   error
+	pointerErr   error
+	fakeInputErr error
+	closeErr     error
+}
+
+func newFakeX11Server() *fakeX11Server {
+	return &fakeX11Server{
+		setup:      Setup{Root: 1, MinKeycode: 8, MaxKeycode: 15},
+		perKeycode: 2,
+		keysyms: []xproto.Keysym{
+			0xff0d, 0, // 8: Enter
+			0xffe1, 0, // 9: Shift_L
+			0, 0, // 10-15: scratch candidates
+			0, 0,
+			0, 0,
+			0, 0,
+			0, 0,
+			0, 0,
+		},
+		modifiers: []xproto.Keycode{9},
+		pressed:   make([]byte, 32),
+		buttons:   make(map[byte]bool),
+	}
+}
+
+type fakeX11Dialer struct{ server *fakeX11Server }
+
+func (dialer fakeX11Dialer) Dial(string) (Connection, error) {
+	connection := &fakeX11Connection{server: dialer.server, closed: make(chan struct{})}
+	dialer.server.mu.Lock()
+	dialer.server.connections = append(dialer.server.connections, connection)
+	dialer.server.mu.Unlock()
+	return connection, nil
+}
+
+type fakeX11Connection struct {
+	server    *fakeX11Server
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+func (connection *fakeX11Connection) Close() error {
+	connection.closeOnce.Do(func() { close(connection.closed) })
+	connection.server.mu.Lock()
+	defer connection.server.mu.Unlock()
+	return connection.server.closeErr
+}
+
+func (connection *fakeX11Connection) WaitForEvent() (bool, error) {
+	<-connection.closed
+	return false, nil
+}
+
+func (connection *fakeX11Connection) Setup() (Setup, error) {
+	connection.server.mu.Lock()
+	defer connection.server.mu.Unlock()
+	return connection.server.setup, connection.server.setupErr
+}
+
+func (connection *fakeX11Connection) InitXTest() error {
+	connection.server.mu.Lock()
+	defer connection.server.mu.Unlock()
+	return connection.server.initErr
+}
+
+func (connection *fakeX11Connection) XTestVersion(byte, uint16) (XTestVersion, error) {
+	connection.server.mu.Lock()
+	defer connection.server.mu.Unlock()
+	return XTestVersion{Major: 2, Minor: 2, Valid: true}, connection.server.versionErr
+}
+
+func (connection *fakeX11Connection) GrabServer() error {
+	connection.server.mu.Lock()
+	defer connection.server.mu.Unlock()
+	return connection.server.grabErr
+}
+
+func (connection *fakeX11Connection) UngrabServer() error {
+	connection.server.mu.Lock()
+	defer connection.server.mu.Unlock()
+	return connection.server.ungrabErr
+}
+
+func (connection *fakeX11Connection) KeyboardMapping(first xproto.Keycode, count byte) (KeyboardMapping, error) {
+	server := connection.server
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.mappingErr != nil {
+		return KeyboardMapping{}, server.mappingErr
+	}
+	start := (int(first) - int(server.setup.MinKeycode)) * int(server.perKeycode)
+	end := start + int(count)*int(server.perKeycode)
+	if start < 0 || end > len(server.keysyms) {
+		return KeyboardMapping{}, errors.New("fake keyboard-map range is invalid")
+	}
+	return KeyboardMapping{
+		KeysymsPerKeycode: server.perKeycode,
+		Keysyms:           append([]xproto.Keysym(nil), server.keysyms[start:end]...),
+	}, nil
+}
+
+func (connection *fakeX11Connection) ModifierMapping() ([]xproto.Keycode, error) {
+	connection.server.mu.Lock()
+	defer connection.server.mu.Unlock()
+	if connection.server.modifierErr != nil {
+		return nil, connection.server.modifierErr
+	}
+	return append([]xproto.Keycode(nil), connection.server.modifiers...), nil
+}
+
+func (connection *fakeX11Connection) ChangeKeyboardMapping(first xproto.Keycode, per byte, keysyms []xproto.Keysym) error {
+	server := connection.server
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.changeErr != nil {
+		return server.changeErr
+	}
+	if per != server.perKeycode || len(keysyms) != int(per) {
+		return errors.New("fake keyboard-map width mismatch")
+	}
+	start := (int(first) - int(server.setup.MinKeycode)) * int(per)
+	if start < 0 || start+len(keysyms) > len(server.keysyms) {
+		return errors.New("fake keyboard-map change is out of range")
+	}
+	copy(server.keysyms[start:], keysyms)
+	return nil
+}
+
+func (connection *fakeX11Connection) PressedKeys() ([]byte, error) {
+	connection.server.mu.Lock()
+	defer connection.server.mu.Unlock()
+	if connection.server.pressedErr != nil {
+		return nil, connection.server.pressedErr
+	}
+	return append([]byte(nil), connection.server.pressed...), nil
+}
+
+func (connection *fakeX11Connection) QueryPointer(xproto.Window) (PointerState, error) {
+	connection.server.mu.Lock()
+	defer connection.server.mu.Unlock()
+	if connection.server.pointerErr != nil {
+		return PointerState{}, connection.server.pointerErr
+	}
+	state := connection.server.pointer
+	for button, down := range connection.server.buttons {
+		if down {
+			state.Mask |= x11ButtonMask(button)
+		}
+	}
+	return state, nil
+}
+
+func (connection *fakeX11Connection) FakeInput(eventType, detail byte, _ xproto.Window, x, y int16) error {
+	server := connection.server
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.fakeInputErr != nil {
+		return server.fakeInputErr
+	}
+	switch eventType {
+	case byte(xproto.KeyPress), byte(xproto.KeyRelease):
+		index := int(detail) / 8
+		mask := byte(1 << uint(detail%8))
+		if eventType == byte(xproto.KeyPress) {
+			server.pressed[index] |= mask
+		} else {
+			server.pressed[index] &^= mask
+		}
+	case byte(xproto.ButtonPress):
+		server.buttons[detail] = true
+	case byte(xproto.ButtonRelease):
+		delete(server.buttons, detail)
+	case byte(xproto.MotionNotify):
+		if detail == x11RelativeMotion {
+			server.pointer.RootX += x
+			server.pointer.RootY += y
+		} else {
+			server.pointer.RootX = x
+			server.pointer.RootY = y
+		}
+	}
+	return nil
+}
+
+func newFakeBackend(server *fakeX11Server, display func() string) *Backend {
+	return New(Config{
+		ResolveDisplay: func() (string, error) { return display(), nil },
+		Dialer:         fakeX11Dialer{server: server},
+		KeyHoldDelay:   time.Nanosecond,
+		Sleep:          func(time.Duration) {},
+	})
+}
+
+func TestKeyboardMapAndScratchContracts(t *testing.T) {
+	keyboard := x11KeyboardMap{
+		minimum:    8,
+		perKeycode: 6,
+		modifiers:  map[xproto.Keycode]struct{}{9: {}},
+		keysyms: []xproto.Keysym{
+			'a', 'A', 0x010003b1, 0x01000391, '@', '#',
+			0xffe1, 0, 0xffe1, 0, 0, 0,
+			0, 0, 0, 0, 0, 0,
+		},
+	}
+	if resolved, ok := keyboard.resolve(0xffe1); !ok || resolved.code != 9 {
+		t.Fatalf("resolve Shift_L = (%+v,%t), want keycode 9", resolved, ok)
+	}
+	for _, ambiguous := range []uint32{'a', 'A', 0x010003b1, '@'} {
+		if resolved, ok := keyboard.resolve(ambiguous); ok {
+			t.Fatalf("resolve(%#x) = %+v, want no unsafe core-map guess", ambiguous, resolved)
+		}
+	}
+	backend := New(Config{})
+	if err := backend.updateScratchStateLocked(&keyboard); err != nil {
+		t.Fatalf("initialize scratch state: %v", err)
+	}
+	if len(backend.scratchSlots) != 1 || backend.scratchSlots[0].code != 10 {
+		t.Fatalf("scratch slots = %+v, want only keycode 10", backend.scratchSlots)
+	}
+}
+
+func TestModifierResolutionRequiresModifierMapMembership(t *testing.T) {
+	keyboard := x11KeyboardMap{
+		minimum:    8,
+		perKeycode: 2,
+		keysyms: []xproto.Keysym{
+			0xffe3, 0,
+			0xffe3, 0xffe7,
+		},
+		modifiers: map[xproto.Keycode]struct{}{9: {}},
+	}
+	resolved, ok := keyboard.resolveModifier(0xffe3)
+	if !ok || resolved.code != 9 {
+		t.Fatalf("resolveModifier(Control_L) = (%+v,%t), want keycode 9", resolved, ok)
+	}
+	delete(keyboard.modifiers, 9)
+	if resolved, ok := keyboard.resolveModifier(0xffe3); ok {
+		t.Fatalf("resolveModifier without modifier-map membership = %+v, want no match", resolved)
+	}
+}
+
+func TestScratchCapacityAndOwnershipAreMutationFreeOnFailure(t *testing.T) {
+	backend := New(Config{})
+	backend.scratchInitialized = true
+	backend.scratchPerKeycode = 2
+	backend.scratchSlots = []x11ScratchSlot{{code: 10}}
+	backend.scratchByKeysym = make(map[uint32]xproto.Keycode)
+	if err := backend.validateScratchCapacityLocked([]uint32{'a', 'b'}, nil); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("capacity error = %v, want ErrUnsupported", err)
+	}
+	if backend.scratchSlots[0].keysym != 0 || len(backend.scratchByKeysym) != 0 {
+		t.Fatalf("capacity failure mutated state: slots=%+v map=%v", backend.scratchSlots, backend.scratchByKeysym)
+	}
+	pressed := make([]byte, 32)
+	pressed[10/8] |= 1 << uint(10%8)
+	if err := backend.validateScratchCapacityLocked([]uint32{'a'}, pressed); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("pressed capacity error = %v, want ErrUnsupported", err)
+	}
+}
+
+func TestScratchRestoreUsesCurrentWidthAndOwnership(t *testing.T) {
+	const keysym = uint32(0x010020ac)
+	current := KeyboardMapping{
+		KeysymsPerKeycode: 3,
+		Keysyms: []xproto.Keysym{
+			xproto.Keysym(keysym), xproto.Keysym(keysym), xproto.Keysym(keysym),
+		},
+	}
+	width, owned, err := x11ScratchMappingCanRestore(current, keysym)
+	if err != nil || !owned || width != 3 {
+		t.Fatalf("restore plan = (%d,%t,%v), want (3,true,nil)", width, owned, err)
+	}
+	current.Keysyms[2] = 'x'
+	if _, owned, err := x11ScratchMappingCanRestore(current, keysym); err != nil || owned {
+		t.Fatalf("foreign restore plan = (owned=%t,err=%v), want false,nil", owned, err)
+	}
+}
+
+func TestScratchOwnershipRecognizesServerCanonicalization(t *testing.T) {
+	const keysym = uint32(0x010020ac)
+	for _, test := range []struct {
+		mapping []xproto.Keysym
+		want    bool
+	}{
+		{mapping: []xproto.Keysym{xproto.Keysym(keysym), xproto.Keysym(keysym), 0}, want: true},
+		{mapping: []xproto.Keysym{xproto.Keysym(keysym)}, want: true},
+		{mapping: []xproto.Keysym{0, 0}},
+		{mapping: []xproto.Keysym{xproto.Keysym(keysym), 'x'}},
+	} {
+		if got := x11MappingOwnedBy(test.mapping, keysym); got != test.want {
+			t.Fatalf("x11MappingOwnedBy(%v,%#x) = %t, want %t", test.mapping, keysym, got, test.want)
+		}
+	}
+}
+
+func TestScratchOwnershipRejectsModifierReassignment(t *testing.T) {
+	const keysym = uint32(0x010020ac)
+	backend := New(Config{})
+	backend.scratchInitialized = true
+	backend.scratchPerKeycode = 2
+	backend.scratchSlots = []x11ScratchSlot{{code: 10, keysym: keysym}}
+	backend.scratchByKeysym = map[uint32]xproto.Keycode{keysym: 10}
+	keyboard := x11KeyboardMap{
+		minimum:    10,
+		perKeycode: 2,
+		keysyms:    []xproto.Keysym{xproto.Keysym(keysym), xproto.Keysym(keysym)},
+		modifiers:  map[xproto.Keycode]struct{}{10: {}},
+	}
+	if err := backend.updateScratchStateLocked(&keyboard); err == nil {
+		t.Fatal("owned scratch keycode becoming a modifier unexpectedly succeeded")
+	}
+}
+
+func TestScratchRefreshFailureLeavesStateExactlyUnchanged(t *testing.T) {
+	const (
+		firstKeysym  = uint32(0x010020ac)
+		secondKeysym = uint32(0x0101f600)
+	)
+	backend := New(Config{})
+	backend.scratchInitialized = true
+	backend.scratchPerKeycode = 2
+	backend.scratchSlots = []x11ScratchSlot{
+		{code: 10},
+		{code: 11, keysym: firstKeysym},
+		{code: 12, keysym: secondKeysym},
+	}
+	backend.scratchByKeysym = map[uint32]xproto.Keycode{
+		firstKeysym:  11,
+		secondKeysym: 12,
+	}
+	originalSlots := append([]x11ScratchSlot(nil), backend.scratchSlots...)
+	originalAssignments := map[uint32]xproto.Keycode{
+		firstKeysym:  11,
+		secondKeysym: 12,
+	}
+	keyboard := x11KeyboardMap{
+		minimum:    10,
+		perKeycode: 2,
+		keysyms: []xproto.Keysym{
+			'x', 'x',
+			xproto.Keysym(firstKeysym), 0,
+			xproto.Keysym(secondKeysym), 'x',
+		},
+		modifiers: make(map[xproto.Keycode]struct{}),
+	}
+	if err := backend.updateScratchStateLocked(&keyboard); err == nil {
+		t.Fatal("foreign scratch replacement unexpectedly succeeded")
+	}
+	if !reflect.DeepEqual(backend.scratchSlots, originalSlots) {
+		t.Fatalf("failed refresh mutated scratch slots: got %+v, want %+v", backend.scratchSlots, originalSlots)
+	}
+	if !reflect.DeepEqual(backend.scratchByKeysym, originalAssignments) {
+		t.Fatalf("failed refresh mutated scratch assignments: got %v, want %v", backend.scratchByKeysym, originalAssignments)
+	}
+}
+
+func TestScratchWidthChangeReinitializesOnlyWithoutClaims(t *testing.T) {
+	backend := New(Config{})
+	backend.scratchInitialized = true
+	backend.scratchPerKeycode = 2
+	backend.scratchSlots = []x11ScratchSlot{{code: 10}}
+	backend.scratchByKeysym = make(map[uint32]xproto.Keycode)
+	keyboard := x11KeyboardMap{
+		minimum:    10,
+		perKeycode: 3,
+		keysyms:    make([]xproto.Keysym, 6),
+		modifiers:  make(map[xproto.Keycode]struct{}),
+	}
+	if err := backend.updateScratchStateLocked(&keyboard); err != nil {
+		t.Fatalf("refresh unclaimed scratch pool after width change: %v", err)
+	}
+	if backend.scratchPerKeycode != 3 || !reflect.DeepEqual(backend.scratchSlots, []x11ScratchSlot{{code: 10}, {code: 11}}) {
+		t.Fatalf("reinitialized scratch state = width %d slots %+v", backend.scratchPerKeycode, backend.scratchSlots)
+	}
+
+	const keysym = uint32(0x010020ac)
+	backend.scratchPerKeycode = 2
+	backend.scratchSlots = []x11ScratchSlot{{code: 10, keysym: keysym}}
+	backend.scratchByKeysym = map[uint32]xproto.Keycode{keysym: 10}
+	originalSlots := append([]x11ScratchSlot(nil), backend.scratchSlots...)
+	if err := backend.updateScratchStateLocked(&keyboard); err == nil {
+		t.Fatal("scratch width change with an owned mapping unexpectedly succeeded")
+	}
+	if backend.scratchPerKeycode != 2 || !reflect.DeepEqual(backend.scratchSlots, originalSlots) || backend.scratchByKeysym[keysym] != 10 {
+		t.Fatalf("rejected width change mutated state: width %d slots %+v map %v", backend.scratchPerKeycode, backend.scratchSlots, backend.scratchByKeysym)
+	}
+}
+
+func TestXTestVersionContract(t *testing.T) {
+	for _, test := range []struct {
+		version XTestVersion
+		want    bool
+	}{
+		{version: XTestVersion{}},
+		{version: XTestVersion{Major: 2, Minor: 1, Valid: true}},
+		{version: XTestVersion{Major: 2, Minor: 2, Valid: true}, want: true},
+		{version: XTestVersion{Major: 3, Valid: true}, want: true},
+	} {
+		if got := x11XTestVersionSupported(test.version); got != test.want {
+			t.Fatalf("x11XTestVersionSupported(%+v) = %t, want %t", test.version, got, test.want)
+		}
+	}
+}
+
+func TestPointerArgumentContracts(t *testing.T) {
+	for _, value := range []int{math.MinInt16, 0, math.MaxInt16} {
+		if got, err := x11Coordinate(value); err != nil || int(got) != value {
+			t.Fatalf("x11Coordinate(%d) = (%d,%v)", value, got, err)
+		}
+	}
+	for _, value := range []int{math.MinInt16 - 1, math.MaxInt16 + 1} {
+		if _, err := x11Coordinate(value); err == nil {
+			t.Fatalf("x11Coordinate(%d) unexpectedly succeeded", value)
+		}
+	}
+	for value, want := range map[int]uint64{-1000: 1000, 0: 0, 1000: 1000} {
+		if got, err := x11ScrollSteps(value); err != nil || got != want {
+			t.Fatalf("x11ScrollSteps(%d) = (%d,%v), want %d,nil", value, got, err, want)
+		}
+	}
+	for _, value := range []int{-1001, 1001, math.MinInt, math.MaxInt} {
+		if _, err := x11ScrollSteps(value); err == nil {
+			t.Fatalf("x11ScrollSteps(%d) unexpectedly succeeded", value)
+		}
+	}
+	for _, button := range []byte{ButtonLeft, ButtonMiddle, ButtonRight, ButtonWheelUp, ButtonWheelDown} {
+		if !x11ButtonStateObservable(button) {
+			t.Fatalf("button %d state unexpectedly unobservable", button)
+		}
+	}
+	for _, button := range []byte{ButtonWheelLeft, ButtonWheelRight} {
+		if x11ButtonStateObservable(button) {
+			t.Fatalf("button %d state unexpectedly observable", button)
+		}
+	}
+}
+
+func TestUnobservableWheelOperationsFailBeforeConnectionOrMutation(t *testing.T) {
+	server := newFakeX11Server()
+	backend := newFakeBackend(server, func() string { return ":fake" })
+	for _, button := range []Button{ButtonWheelLeft, ButtonWheelRight} {
+		if err := backend.Click(button, false); !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("Click(%d) error = %v, want ErrUnsupported", button, err)
+		}
+	}
+	for _, horizontal := range []int{-1, 1} {
+		if err := backend.Scroll(horizontal, 1); !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("Scroll(%d,1) error = %v, want ErrUnsupported", horizontal, err)
+		}
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.connections) != 0 {
+		t.Fatalf("rejected wheel operations opened %d X11 connections", len(server.connections))
+	}
+	if len(server.buttons) != 0 {
+		t.Fatalf("rejected wheel operations changed button state: %v", server.buttons)
+	}
+}
+
+func TestSmoothMovePlanningAndOwnershipOrderHelpers(t *testing.T) {
+	if err := validateX11SmoothMove(1, 2, math.NaN(), 2); err == nil {
+		t.Fatal("NaN smooth-move delay unexpectedly succeeded")
+	}
+	if err := validateX11SmoothMove(1, 2, 3, 2); err == nil {
+		t.Fatal("reversed smooth-move delay unexpectedly succeeded")
+	}
+	if err := validateX11SmoothMove(1, 2, 0, x11MaximumSmoothDelay+1); err == nil {
+		t.Fatal("oversized smooth-move delay unexpectedly succeeded")
+	}
+	keys := []xproto.Keycode{8, 9, 10}
+	keys = removeX11Keycode(keys, 9)
+	if len(keys) != 2 || keys[0] != 8 || keys[1] != 10 {
+		t.Fatalf("removeX11Keycode = %v, want [8 10]", keys)
+	}
+	buttons := []byte{ButtonLeft, ButtonMiddle, ButtonRight}
+	buttons = removeX11Button(buttons, ButtonMiddle)
+	if len(buttons) != 2 || buttons[0] != ButtonLeft || buttons[1] != ButtonRight {
+		t.Fatalf("removeX11Button = %v, want [1 3]", buttons)
+	}
+}
+
+func TestBackendLifecycleRestoresOwnedState(t *testing.T) {
+	server := newFakeX11Server()
+	backend := newFakeBackend(server, func() string { return ":fake" })
+	if err := backend.Key(KeyEvent{Keysym: 0xffe1, Down: true}); err != nil {
+		t.Fatalf("hold key: %v", err)
+	}
+	if err := backend.Toggle(ButtonRight, true); err != nil {
+		t.Fatalf("hold button: %v", err)
+	}
+	if err := backend.Text(TextEvent{Keysyms: []uint32{0x0101f600}}); err != nil {
+		t.Fatalf("install scratch mapping: %v", err)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.buttons) != 0 {
+		t.Fatalf("buttons remained held: %v", server.buttons)
+	}
+	for _, pressed := range server.pressed {
+		if pressed != 0 {
+			t.Fatalf("pressed keys remained after Close: %v", server.pressed)
+		}
+	}
+	for index := 4; index < len(server.keysyms); index++ {
+		if server.keysyms[index] != 0 {
+			t.Fatalf("scratch mapping remained at index %d: %#x", index, server.keysyms[index])
+		}
+	}
+}
+
+func TestBackendPropagatesSynchronousConnectionCloseErrors(t *testing.T) {
+	closeErr := errors.New("verified transport close failed")
+	server := newFakeX11Server()
+	server.closeErr = closeErr
+	backend := newFakeBackend(server, func() string { return ":fake" })
+	if err := backend.KeyboardReady(); err != nil {
+		t.Fatalf("KeyboardReady: %v", err)
+	}
+	if err := backend.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("Close error = %v, want transport close error", err)
+	}
+}
+
+func TestBackendJoinsOpenFailureWithConnectionCloseError(t *testing.T) {
+	initErr := errors.New("XTEST init failed")
+	closeErr := errors.New("failed to close rejected connection")
+	server := newFakeX11Server()
+	server.initErr = initErr
+	server.closeErr = closeErr
+	backend := newFakeBackend(server, func() string { return ":fake" })
+	err := backend.KeyboardReady()
+	if !errors.Is(err, ErrUnsupported) || !errors.Is(err, initErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("KeyboardReady error = %v, want ErrUnsupported, init, and close causes", err)
+	}
+}
+
+func TestBackendStoppedEventDrainPreservesTerminalCause(t *testing.T) {
+	terminalErr := errors.New("terminal X11 transport failure")
+	done := make(chan struct{})
+	close(done)
+	backend := New(Config{})
+	backend.events = done
+	backend.eventMu.Lock()
+	backend.eventErr = terminalErr
+	backend.eventMu.Unlock()
+
+	err := backend.eventDrainErrorLocked()
+	if !errors.Is(err, terminalErr) {
+		t.Fatalf("stopped event-drain error = %v, want terminal cause", err)
+	}
+}
+
+func TestBackendTransportFailuresCloseAndRecover(t *testing.T) {
+	server := newFakeX11Server()
+	backend := newFakeBackend(server, func() string { return ":fake" })
+	inputErr := errors.New("fake XTEST injection failed")
+	server.fakeInputErr = inputErr
+	if err := backend.MoveRelative(1, 1); !errors.Is(err, inputErr) {
+		t.Fatalf("MoveRelative error = %v, want fake input failure", err)
+	}
+	server.mu.Lock()
+	server.fakeInputErr = nil
+	server.mu.Unlock()
+	if err := backend.MoveRelative(1, 1); err != nil {
+		t.Fatalf("MoveRelative after reconnect: %v", err)
+	}
+
+	grabErr := errors.New("fake server grab failed")
+	server.mu.Lock()
+	server.grabErr = grabErr
+	server.mu.Unlock()
+	if err := backend.Click(ButtonLeft, false); !errors.Is(err, grabErr) {
+		t.Fatalf("Click grab error = %v, want fake grab failure", err)
+	}
+	server.mu.Lock()
+	server.grabErr = nil
+	server.mu.Unlock()
+	if err := backend.Click(ButtonLeft, false); err != nil {
+		t.Fatalf("Click after grab recovery: %v", err)
+	}
+
+	ungrabErr := errors.New("fake server ungrab failed")
+	server.mu.Lock()
+	server.ungrabErr = ungrabErr
+	server.mu.Unlock()
+	if err := backend.Click(ButtonLeft, false); !errors.Is(err, ungrabErr) {
+		t.Fatalf("Click ungrab error = %v, want fake ungrab failure", err)
+	}
+	server.mu.Lock()
+	server.ungrabErr = nil
+	server.mu.Unlock()
+	if err := backend.Click(ButtonLeft, false); err != nil {
+		t.Fatalf("Click after ungrab recovery: %v", err)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("final Close: %v", err)
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.buttons) != 0 {
+		t.Fatalf("transport failures left held buttons: %v", server.buttons)
+	}
+	for _, pressed := range server.pressed {
+		if pressed != 0 {
+			t.Fatalf("transport failures left held keys: %v", server.pressed)
+		}
+	}
+}
+
+func TestBackendScratchCleanupFailureCanRetry(t *testing.T) {
+	server := newFakeX11Server()
+	backend := newFakeBackend(server, func() string { return ":fake" })
+	const keysym = uint32(0x0101f600)
+	if err := backend.Text(TextEvent{Keysyms: []uint32{keysym}}); err != nil {
+		t.Fatalf("install scratch mapping: %v", err)
+	}
+	server.mu.Lock()
+	var scratchCode xproto.Keycode
+	for offset := 0; offset < len(server.keysyms); offset += int(server.perKeycode) {
+		if uint32(server.keysyms[offset]) == keysym {
+			scratchCode = server.setup.MinKeycode + xproto.Keycode(offset/int(server.perKeycode))
+			break
+		}
+	}
+	if scratchCode == 0 {
+		server.mu.Unlock()
+		t.Fatal("scratch mapping was not installed")
+	}
+	server.pressed[scratchCode/8] |= 1 << uint(scratchCode%8)
+	server.mu.Unlock()
+	if err := backend.Close(); err == nil {
+		t.Fatal("Close unexpectedly restored a pressed scratch keycode")
+	}
+	server.mu.Lock()
+	server.pressed[scratchCode/8] &^= 1 << uint(scratchCode%8)
+	server.mu.Unlock()
+	if err := backend.Close(); err != nil {
+		t.Fatalf("retry Close after releasing scratch keycode: %v", err)
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	for _, value := range server.keysyms {
+		if uint32(value) == keysym {
+			t.Fatalf("scratch mapping remained after retry: %v", server.keysyms)
+		}
+	}
+}
+
+func TestBackendConcurrentLifecycleIsRaceSafe(t *testing.T) {
+	server := newFakeX11Server()
+	var selected atomic.Uint32
+	backend := newFakeBackend(server, func() string {
+		if selected.Load()%2 == 0 {
+			return ":fake-a"
+		}
+		return ":fake-b"
+	})
+	const workers = 12
+	const iterations = 60
+	var wait sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wait.Add(1)
+		go func(worker int) {
+			defer wait.Done()
+			for iteration := 0; iteration < iterations; iteration++ {
+				selected.Store(uint32(worker + iteration))
+				switch (worker + iteration) % 14 {
+				case 0:
+					_ = backend.KeyboardReady()
+				case 1:
+					_ = backend.MouseReady()
+				case 2:
+					_ = backend.Key(KeyEvent{Keysym: 0xff0d, Tap: true, Modifiers: []uint32{0xffe1}})
+				case 3:
+					_ = backend.Text(TextEvent{Keysyms: []uint32{0x0101f600}})
+				case 4:
+					_ = backend.MoveAbsolute(iteration, worker, nil)
+				case 5:
+					_ = backend.MoveRelative(1, -1)
+				case 6:
+					_ = backend.MoveSmooth(2, 1, true, 0, 0)
+				case 7:
+					_ = backend.DragSmooth(iteration, worker, 0, 0)
+				case 8:
+					_ = backend.Toggle(ButtonRight, true)
+					_ = backend.Toggle(ButtonRight, false)
+				case 9:
+					_ = backend.Key(KeyEvent{Keysym: 0xff0d, Down: true})
+					_ = backend.Key(KeyEvent{Keysym: 0xff0d})
+				case 10:
+					_ = backend.Scroll(0, 1)
+				case 11:
+					_ = backend.Click(ButtonLeft, false)
+				case 12:
+					_, _, _ = backend.Location()
+				case 13:
+					_ = backend.Close()
+				}
+			}
+		}(worker)
+	}
+	wait.Wait()
+	if err := backend.Close(); err != nil {
+		t.Fatalf("final Close: %v", err)
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.buttons) != 0 {
+		t.Fatalf("concurrent lifecycle left held buttons: %v", server.buttons)
+	}
+	for _, pressed := range server.pressed {
+		if pressed != 0 {
+			t.Fatalf("concurrent lifecycle left held keys: %v", server.pressed)
+		}
+	}
+	for index := 4; index < len(server.keysyms); index++ {
+		if server.keysyms[index] != 0 {
+			t.Fatalf("concurrent lifecycle left scratch mapping at index %d: %#x", index, server.keysyms[index])
+		}
+	}
+}

--- a/internal/x11input/guardian_linux.go
+++ b/internal/x11input/guardian_linux.go
@@ -1,0 +1,692 @@
+//go:build linux
+
+package x11input
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/jezek/xgb/xproto"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	guardianEnvironmentToken = "ROBOTGO_INTERNAL_X11_GUARDIAN_TOKEN"
+	guardianReexecArgument   = "--robotgo-internal-x11-guardian"
+	guardianSocketPrefix     = "robotgo-x11-guardian-"
+
+	guardianDefaultStartupTimeout = 5 * time.Second
+	guardianDefaultRequestTimeout = 15 * time.Second
+	guardianDefaultCleanupTimeout = 5 * time.Second
+	guardianDefaultCrashSettle    = 2 * time.Second
+	guardianMaximumDuration       = time.Minute
+	guardianRequestCleanupMargin  = 250 * time.Millisecond
+	guardianMinimumReapTimeout    = 250 * time.Millisecond
+)
+
+// GuardianOptions controls the bounded lifecycle of a Pure-Go X11 guardian.
+// Zero values select conservative defaults. Executable is primarily a test
+// seam; production callers should leave it empty to re-exec /proc/self/exe.
+type GuardianOptions struct {
+	Executable     string
+	StartupTimeout time.Duration
+	RequestTimeout time.Duration
+	CleanupTimeout time.Duration
+	CrashSettle    time.Duration
+}
+
+// GuardianDialer moves ownership of an X11 connection into a re-executed
+// helper over a token-authenticated Linux abstract socket whose kernel peer
+// credentials are verified by the parent. The helper survives a targeted
+// SIGKILL of its parent and restores connection-owned input and keyboard
+// mappings when the control socket closes.
+type GuardianDialer struct {
+	Options GuardianOptions
+}
+
+// NewGuardianDialer returns a Dialer whose X11 connections live in a
+// re-executed guardian process. It never falls back to an in-process XGB
+// connection when guardian startup or authentication fails.
+func NewGuardianDialer(options GuardianOptions) Dialer {
+	return GuardianDialer{Options: options}
+}
+
+type guardianResponse struct {
+	envelope guardianEnvelope
+	err      error
+}
+
+type guardianConnection struct {
+	control io.ReadWriteCloser
+	writer  guardianFramedWriter
+	process *exec.Cmd
+
+	requestTimeout time.Duration
+	cleanupTimeout time.Duration
+
+	mu                sync.Mutex
+	nextID            uint64
+	pending           map[uint64]chan guardianResponse
+	readErr           error
+	controlErr        error
+	terminalEvent     guardianEvent
+	terminalRecorded  bool
+	terminalDelivered bool
+	terminalSignal    chan struct{}
+	terminalOnce      sync.Once
+
+	events chan guardianEvent
+	done   chan struct{}
+
+	finishOnce  sync.Once
+	closeOnce   sync.Once
+	closeErr    error
+	processDone chan error
+}
+
+// Dial starts a guardian and opens the requested display inside that helper.
+func (dialer GuardianDialer) Dial(display string) (Connection, error) {
+	if display == "" {
+		return nil, errors.New("X11 guardian display is empty")
+	}
+	options, err := normalizeGuardianOptions(dialer.Options)
+	if err != nil {
+		return nil, err
+	}
+	token, err := newGuardianToken()
+	if err != nil {
+		return nil, err
+	}
+	listener, err := net.ListenUnix("unix", guardianAbstractSocketAddress(token))
+	if err != nil {
+		return nil, fmt.Errorf("listen on X11 guardian abstract socket: %w", err)
+	}
+	defer func() { _ = listener.Close() }()
+	command := exec.Command(options.Executable, guardianReexecArgument)
+	command.Env = guardianChildEnvironment(os.Environ(), token)
+	if err := command.Start(); err != nil {
+		if options.Executable == "/proc/self/exe" {
+			return nil, fmt.Errorf(
+				"start X11 guardian by re-executing %q (Linux procfs must remain accessible): %w",
+				options.Executable, err,
+			)
+		}
+		return nil, fmt.Errorf("start X11 guardian: %w", err)
+	}
+	control, err := acceptGuardianControl(listener, command, options.StartupTimeout)
+	if err != nil {
+		terminationErr := terminateGuardianCommand(command, options.StartupTimeout, "failed startup")
+		return nil, errors.Join(fmt.Errorf("accept authenticated X11 guardian control connection: %w", err), terminationErr)
+	}
+	connection := newGuardianConnection(control, command, options)
+
+	hello := guardianHelloRequest{
+		Token:              token,
+		Display:            display,
+		RequestTimeoutNano: int64(options.RequestTimeout),
+		CleanupTimeoutNano: int64(options.CleanupTimeout),
+		CrashSettleNano:    int64(options.CrashSettle),
+	}
+	if err := connection.requestWithTimeout(guardianOperationHello, hello, nil, options.StartupTimeout); err != nil {
+		connection.finish(err)
+		terminationErr := connection.terminateStartupProcess(options.StartupTimeout)
+		return nil, errors.Join(
+			fmt.Errorf("initialize X11 guardian: %w", err),
+			terminationErr,
+		)
+	}
+	return connection, nil
+}
+
+func normalizeGuardianOptions(options GuardianOptions) (GuardianOptions, error) {
+	if options.Executable == "" {
+		options.Executable = "/proc/self/exe"
+		if _, err := os.Stat(options.Executable); err != nil {
+			return GuardianOptions{}, fmt.Errorf(
+				"resolve X11 guardian executable %q (Linux procfs must expose /proc/self/exe): %w",
+				options.Executable, err,
+			)
+		}
+	}
+	if options.StartupTimeout == 0 {
+		options.StartupTimeout = guardianDefaultStartupTimeout
+	}
+	if options.RequestTimeout == 0 {
+		options.RequestTimeout = guardianDefaultRequestTimeout
+	}
+	if options.CleanupTimeout == 0 {
+		options.CleanupTimeout = guardianDefaultCleanupTimeout
+	}
+	if options.CrashSettle == 0 {
+		options.CrashSettle = guardianDefaultCrashSettle
+	}
+	for name, duration := range map[string]time.Duration{
+		"startup timeout": options.StartupTimeout,
+		"request timeout": options.RequestTimeout,
+		"cleanup timeout": options.CleanupTimeout,
+		"crash settle":    options.CrashSettle,
+	} {
+		if duration < 0 || duration > guardianMaximumDuration {
+			return GuardianOptions{}, fmt.Errorf("X11 guardian %s %s is outside 0..%s", name, duration, guardianMaximumDuration)
+		}
+	}
+	return options, nil
+}
+
+func newGuardianToken() (string, error) {
+	var token [32]byte
+	if _, err := io.ReadFull(rand.Reader, token[:]); err != nil {
+		return "", fmt.Errorf("create X11 guardian token: %w", err)
+	}
+	return hex.EncodeToString(token[:]), nil
+}
+
+func guardianChildEnvironment(environment []string, token string) []string {
+	clean := make([]string, 0, len(environment)+1)
+	for _, entry := range environment {
+		if hasEnvironmentKey(entry, guardianEnvironmentToken) {
+			continue
+		}
+		clean = append(clean, entry)
+	}
+	return append(clean, guardianEnvironmentToken+"="+token)
+}
+
+func hasEnvironmentKey(entry, key string) bool {
+	return len(entry) > len(key) && entry[:len(key)] == key && entry[len(key)] == '='
+}
+
+func guardianAbstractSocketAddress(token string) *net.UnixAddr {
+	digest := sha256.Sum256([]byte(guardianSocketPrefix + token))
+	return &net.UnixAddr{
+		Name: "\x00" + guardianSocketPrefix + hex.EncodeToString(digest[:]),
+		Net:  "unix",
+	}
+}
+
+func acceptGuardianControl(listener *net.UnixListener, command *exec.Cmd, timeout time.Duration) (*net.UnixConn, error) {
+	if timeout <= 0 {
+		timeout = guardianDefaultStartupTimeout
+	}
+	if err := listener.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, fmt.Errorf("set guardian accept deadline: %w", err)
+	}
+	for {
+		control, err := listener.AcceptUnix()
+		if err != nil {
+			return nil, err
+		}
+		pid, uid, credentialErr := guardianPeerCredentials(control)
+		if credentialErr == nil && command.Process != nil &&
+			pid == command.Process.Pid && uid == uint32(os.Geteuid()) {
+			return control, nil
+		}
+		_ = control.Close()
+		if credentialErr != nil {
+			return nil, fmt.Errorf("inspect guardian peer credentials: %w", credentialErr)
+		}
+	}
+}
+
+func guardianPeerCredentials(control *net.UnixConn) (int, uint32, error) {
+	raw, err := control.SyscallConn()
+	if err != nil {
+		return 0, 0, err
+	}
+	var (
+		credentials *unix.Ucred
+		controlErr  error
+	)
+	if err := raw.Control(func(fd uintptr) {
+		credentials, controlErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	}); err != nil {
+		return 0, 0, err
+	}
+	if controlErr != nil {
+		return 0, 0, controlErr
+	}
+	if credentials == nil || credentials.Pid <= 0 {
+		return 0, 0, errors.New("guardian peer returned invalid credentials")
+	}
+	return int(credentials.Pid), credentials.Uid, nil
+}
+
+func newGuardianConnection(control io.ReadWriteCloser, process *exec.Cmd, options GuardianOptions) *guardianConnection {
+	connection := &guardianConnection{
+		control:        control,
+		writer:         guardianFramedWriter{writer: control},
+		process:        process,
+		requestTimeout: options.RequestTimeout,
+		cleanupTimeout: options.CleanupTimeout,
+		pending:        make(map[uint64]chan guardianResponse),
+		events:         make(chan guardianEvent, 256),
+		done:           make(chan struct{}),
+		terminalSignal: make(chan struct{}),
+		processDone:    make(chan error, 1),
+	}
+	go connection.readFrames()
+	if process != nil {
+		go func() {
+			connection.processDone <- process.Wait()
+			close(connection.processDone)
+		}()
+	} else {
+		close(connection.processDone)
+	}
+	return connection
+}
+
+func (connection *guardianConnection) readFrames() {
+	for {
+		envelope, err := readGuardianEnvelope(connection.control)
+		if err != nil {
+			connection.finish(err)
+			return
+		}
+		switch envelope.Kind {
+		case guardianFrameResponse:
+			connection.mu.Lock()
+			response := connection.pending[envelope.ID]
+			delete(connection.pending, envelope.ID)
+			connection.mu.Unlock()
+			if response != nil {
+				response <- guardianResponse{envelope: envelope}
+			}
+		case guardianFrameEvent:
+			var event guardianEvent
+			if err := decodeGuardianPayload(envelope.Payload, &event); err != nil {
+				connection.finish(err)
+				return
+			}
+			if !event.Open || event.Error != "" {
+				connection.recordTerminalEvent(event)
+				terminalErr := error(io.EOF)
+				if event.Error != "" {
+					terminalErr = errors.New(event.Error)
+				}
+				connection.finish(terminalErr)
+				return
+			}
+			select {
+			case connection.events <- event:
+			default:
+				// Backend consumes events only as a connection-health signal. Dropping
+				// a redundant event cannot lose input or protocol state.
+			}
+		default:
+			connection.finish(fmt.Errorf("unexpected guardian frame kind %q", envelope.Kind))
+			return
+		}
+	}
+}
+
+func (connection *guardianConnection) finish(err error) {
+	connection.finishOnce.Do(func() {
+		if err == nil {
+			err = io.EOF
+		}
+		terminal := guardianEvent{Open: false, Error: err.Error()}
+		connection.recordTerminalEvent(terminal)
+		connection.mu.Lock()
+		connection.readErr = err
+		pending := connection.pending
+		connection.pending = make(map[uint64]chan guardianResponse)
+		connection.mu.Unlock()
+		for _, response := range pending {
+			response <- guardianResponse{err: err}
+		}
+		// Shutdown wakes both the local reader and the guardian peer before Close.
+		var controlErr error
+		if shutdownErr := shutdownGuardianControl(connection.control); shutdownErr != nil {
+			controlErr = shutdownErr
+		}
+		closeErr := connection.control.Close()
+		if closeErr != nil && !errors.Is(closeErr, os.ErrClosed) && !errors.Is(closeErr, net.ErrClosed) {
+			controlErr = errors.Join(controlErr, closeErr)
+		}
+		connection.mu.Lock()
+		connection.controlErr = errors.Join(connection.controlErr, controlErr)
+		connection.mu.Unlock()
+		close(connection.done)
+	})
+}
+
+type guardianSyscallControl interface {
+	SyscallConn() (syscall.RawConn, error)
+}
+
+func shutdownGuardianControl(control io.ReadWriteCloser) error {
+	socket, ok := control.(guardianSyscallControl)
+	if !ok {
+		return nil
+	}
+	raw, err := socket.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("access X11 guardian control socket: %w", err)
+	}
+	var shutdownErr error
+	if err := raw.Control(func(fd uintptr) {
+		shutdownErr = unix.Shutdown(int(fd), unix.SHUT_RDWR)
+	}); err != nil {
+		return fmt.Errorf("access X11 guardian control descriptor: %w", err)
+	}
+	if shutdownErr != nil && !errors.Is(shutdownErr, unix.ENOTCONN) &&
+		!errors.Is(shutdownErr, unix.EINVAL) && !errors.Is(shutdownErr, unix.EBADF) {
+		return fmt.Errorf("shutdown X11 guardian control socket: %w", shutdownErr)
+	}
+	return nil
+}
+
+func (connection *guardianConnection) recordTerminalEvent(event guardianEvent) {
+	connection.terminalOnce.Do(func() {
+		connection.mu.Lock()
+		connection.terminalEvent = event
+		connection.terminalRecorded = true
+		connection.mu.Unlock()
+		close(connection.terminalSignal)
+	})
+}
+
+func (connection *guardianConnection) takeTerminalEvent() (guardianEvent, bool, bool, <-chan struct{}) {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	if connection.terminalRecorded && !connection.terminalDelivered {
+		connection.terminalDelivered = true
+		return connection.terminalEvent, true, false, nil
+	}
+	if connection.terminalDelivered {
+		return guardianEvent{}, false, true, nil
+	}
+	return guardianEvent{}, false, false, connection.terminalSignal
+}
+
+func (connection *guardianConnection) request(operation string, request, response any) error {
+	return connection.requestWithTimeout(
+		operation,
+		request,
+		response,
+		connection.requestTimeout+connection.cleanupTimeout+guardianRequestCleanupMargin,
+	)
+}
+
+func (connection *guardianConnection) requestWithTimeout(operation string, request, response any, timeout time.Duration) error {
+	payload, err := guardianPayload(request)
+	if err != nil {
+		return err
+	}
+	connection.mu.Lock()
+	if connection.readErr != nil {
+		err := connection.readErr
+		connection.mu.Unlock()
+		return err
+	}
+	connection.nextID++
+	id := connection.nextID
+	result := make(chan guardianResponse, 1)
+	connection.pending[id] = result
+	connection.mu.Unlock()
+
+	envelope := guardianEnvelope{
+		Version:   guardianProtocolVersion,
+		Kind:      guardianFrameRequest,
+		ID:        id,
+		Operation: operation,
+		Payload:   payload,
+	}
+	if err := connection.writer.write(envelope); err != nil {
+		connection.removePending(id)
+		connection.finish(err)
+		return err
+	}
+	if timeout <= 0 {
+		timeout = guardianDefaultRequestTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case received := <-result:
+		if received.err != nil {
+			return received.err
+		}
+		if received.envelope.Error != "" {
+			return errors.New(received.envelope.Error)
+		}
+		return decodeGuardianPayload(received.envelope.Payload, response)
+	case <-timer.C:
+		connection.removePending(id)
+		timeoutErr := fmt.Errorf("X11 guardian %s timed out after %s", operation, timeout)
+		// A timed-out state-changing request has an unknowable outcome. Tear down
+		// the control channel so the helper performs its crash-safe cleanup rather
+		// than allowing later requests to continue from ambiguous state.
+		connection.finish(timeoutErr)
+		return timeoutErr
+	}
+}
+
+func (connection *guardianConnection) removePending(id uint64) {
+	connection.mu.Lock()
+	delete(connection.pending, id)
+	connection.mu.Unlock()
+}
+
+func (connection *guardianConnection) WaitForEvent() (bool, error) {
+	for {
+		event, ok, delivered, terminalSignal := connection.takeTerminalEvent()
+		if ok {
+			if event.Error != "" {
+				return event.Open, errors.New(event.Error)
+			}
+			return event.Open, nil
+		} else if delivered {
+			return false, nil
+		}
+		select {
+		case event := <-connection.events:
+			// A terminal frame may have arrived concurrently with this ordinary
+			// event. It takes precedence; ordinary events are health hints and may
+			// be coalesced without losing protocol or input state.
+			if terminal, ok, _, _ := connection.takeTerminalEvent(); ok {
+				if terminal.Error != "" {
+					return terminal.Open, errors.New(terminal.Error)
+				}
+				return terminal.Open, nil
+			}
+			return event.Open, nil
+		case <-terminalSignal:
+			continue
+		case <-connection.done:
+			if terminal, ok, _, _ := connection.takeTerminalEvent(); ok {
+				if terminal.Error != "" {
+					return terminal.Open, errors.New(terminal.Error)
+				}
+				return terminal.Open, nil
+			}
+			return false, nil
+		}
+	}
+}
+
+func (connection *guardianConnection) terminateStartupProcess(timeout time.Duration) error {
+	return connection.terminateProcess(timeout, "failed startup")
+}
+
+func (connection *guardianConnection) terminateProcess(timeout time.Duration, reason string) error {
+	if connection.process == nil || connection.process.Process == nil {
+		return nil
+	}
+	var killErr error
+	killed := false
+	if err := connection.process.Process.Kill(); err == nil {
+		killed = true
+	} else if !errors.Is(err, os.ErrProcessDone) {
+		killErr = fmt.Errorf("kill X11 guardian after %s: %w", reason, err)
+	}
+	reapErr := connection.waitForProcess(timeout)
+	if killed && guardianKilledExit(reapErr) {
+		// A non-success wait status is the expected result of our SIGKILL. Wait
+		// still completed, so the helper was reaped and did not become orphaned.
+		reapErr = nil
+	}
+	if reapErr != nil {
+		reapErr = fmt.Errorf("reap X11 guardian after %s: %w", reason, reapErr)
+	}
+	return errors.Join(killErr, reapErr)
+}
+
+func (connection *guardianConnection) Close() error {
+	connection.closeOnce.Do(func() {
+		requestErr := connection.requestWithTimeout(
+			guardianOperationClose, nil, nil, connection.cleanupTimeout+connection.requestTimeout,
+		)
+		connection.finish(io.EOF)
+		processTimeout := connection.cleanupTimeout + connection.requestTimeout + guardianRequestCleanupMargin
+		processErr := connection.waitForProcess(processTimeout)
+		if processErr != nil {
+			reapTimeout := connection.cleanupTimeout
+			if reapTimeout < guardianMinimumReapTimeout {
+				reapTimeout = guardianMinimumReapTimeout
+			}
+			processErr = errors.Join(processErr, connection.terminateProcess(reapTimeout, "exit timeout"))
+		}
+		connection.mu.Lock()
+		controlErr := connection.controlErr
+		connection.mu.Unlock()
+		connection.closeErr = errors.Join(requestErr, controlErr, processErr)
+	})
+	return connection.closeErr
+}
+
+func terminateGuardianCommand(command *exec.Cmd, timeout time.Duration, reason string) error {
+	if command == nil || command.Process == nil {
+		return nil
+	}
+	done := make(chan error, 1)
+	go func() { done <- command.Wait() }()
+	killErr := command.Process.Kill()
+	killed := killErr == nil
+	if errors.Is(killErr, os.ErrProcessDone) {
+		killErr = nil
+	}
+	if timeout <= 0 {
+		timeout = guardianDefaultStartupTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case waitErr := <-done:
+		if killed && guardianKilledExit(waitErr) {
+			waitErr = nil
+		}
+		return errors.Join(killErr, waitErr)
+	case <-timer.C:
+		return errors.Join(killErr, fmt.Errorf("reap X11 guardian after %s timed out after %s", reason, timeout))
+	}
+}
+
+func guardianKilledExit(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ProcessState == nil {
+		return false
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && status.Signaled() && status.Signal() == syscall.SIGKILL
+}
+
+func (connection *guardianConnection) waitForProcess(timeout time.Duration) error {
+	if connection.process == nil {
+		return nil
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err, open := <-connection.processDone:
+		if !open {
+			return nil
+		}
+		return err
+	case <-timer.C:
+		return fmt.Errorf("X11 guardian process did not exit within %s", timeout)
+	}
+}
+
+func (connection *guardianConnection) Setup() (Setup, error) {
+	var response guardianSetupResponse
+	err := connection.request(guardianOperationSetup, nil, &response)
+	return response.Setup, err
+}
+
+func (connection *guardianConnection) InitXTest() error {
+	return connection.request(guardianOperationInitXTest, nil, nil)
+}
+
+func (connection *guardianConnection) XTestVersion(major byte, minor uint16) (XTestVersion, error) {
+	var response guardianXTestVersionResponse
+	err := connection.request(guardianOperationXTestVersion, guardianXTestVersionRequest{Major: major, Minor: minor}, &response)
+	return response.Version, err
+}
+
+func (connection *guardianConnection) GrabServer() error {
+	return connection.request(guardianOperationGrabServer, nil, nil)
+}
+
+func (connection *guardianConnection) UngrabServer() error {
+	return connection.request(guardianOperationUngrabServer, nil, nil)
+}
+
+func (connection *guardianConnection) KeyboardMapping(first xproto.Keycode, count byte) (KeyboardMapping, error) {
+	var response guardianKeyboardMappingResponse
+	err := connection.request(guardianOperationKeyboardMapping, guardianKeyboardMappingRequest{First: first, Count: count}, &response)
+	return response.Mapping, err
+}
+
+func (connection *guardianConnection) ModifierMapping() ([]xproto.Keycode, error) {
+	var response guardianModifierMappingResponse
+	err := connection.request(guardianOperationModifierMapping, nil, &response)
+	return response.Keycodes, err
+}
+
+func (connection *guardianConnection) ChangeKeyboardMapping(first xproto.Keycode, perKeycode byte, keysyms []xproto.Keysym) error {
+	return connection.request(guardianOperationChangeKeyboardMapping, guardianChangeKeyboardMappingRequest{
+		First: first, PerKeycode: perKeycode, Keysyms: append([]xproto.Keysym(nil), keysyms...),
+	}, nil)
+}
+
+func (connection *guardianConnection) PressedKeys() ([]byte, error) {
+	var response guardianPressedKeysResponse
+	err := connection.request(guardianOperationPressedKeys, nil, &response)
+	return response.Keys, err
+}
+
+func (connection *guardianConnection) QueryPointer(root xproto.Window) (PointerState, error) {
+	var response guardianQueryPointerResponse
+	err := connection.request(guardianOperationQueryPointer, guardianQueryPointerRequest{Root: root}, &response)
+	return response.State, err
+}
+
+func (connection *guardianConnection) FakeInput(eventType, detail byte, root xproto.Window, x, y int16) error {
+	return connection.request(guardianOperationFakeInput, guardianFakeInputRequest{
+		EventType: eventType, Detail: detail, Root: root, X: x, Y: y,
+	}, nil)
+}
+
+func guardianTokenFromEnvironment() (string, bool) {
+	token := os.Getenv(guardianEnvironmentToken)
+	if len(token) != 64 {
+		return "", false
+	}
+	decoded, err := hex.DecodeString(token)
+	if err != nil || len(decoded) != 32 {
+		return "", false
+	}
+	return token, true
+}

--- a/internal/x11input/guardian_linux_test.go
+++ b/internal/x11input/guardian_linux_test.go
@@ -1,0 +1,1481 @@
+//go:build linux
+
+package x11input
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jezek/xgb/xproto"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	guardianTestEnvironmentOnly = "ROBOTGO_TEST_X11_GUARDIAN_ENVIRONMENT_ONLY"
+	guardianTestPIDFile         = "ROBOTGO_TEST_X11_GUARDIAN_PID_FILE"
+	guardianTestFDFile          = "ROBOTGO_TEST_X11_GUARDIAN_FD_FILE"
+	guardianTestBlockingProcess = "ROBOTGO_TEST_X11_GUARDIAN_BLOCKING_PROCESS"
+)
+
+type guardianTestEvent struct {
+	open bool
+	err  error
+}
+
+type guardianTestInput struct {
+	eventType byte
+	detail    byte
+}
+
+type guardianTestConnection struct {
+	mu sync.Mutex
+
+	setup                       Setup
+	version                     XTestVersion
+	mappings                    map[xproto.Keycode]KeyboardMapping
+	modifiers                   []xproto.Keycode
+	pressed                     []byte
+	pointer                     PointerState
+	inputs                      []guardianTestInput
+	grabbed                     bool
+	closed                      bool
+	grabCount                   int
+	ungrabCount                 int
+	clearPressedOnUngrab        bool
+	canonicalizeMapping         func(KeyboardMapping) KeyboardMapping
+	blockOperation              string
+	blockEntered                chan struct{}
+	blockRelease                chan struct{}
+	blockClose                  chan struct{}
+	operationFailures           map[string][]error
+	fakeInputFailures           map[guardianTestInput]int
+	changeFailuresAfterMutation []error
+
+	events           chan guardianTestEvent
+	closeOnce        sync.Once
+	blockEnteredOnce sync.Once
+	blockReleaseOnce sync.Once
+}
+
+type guardianTestDialer struct {
+	connection Connection
+	display    string
+	block      <-chan struct{}
+}
+
+func (dialer *guardianTestDialer) Dial(display string) (Connection, error) {
+	dialer.display = display
+	if dialer.block != nil {
+		<-dialer.block
+	}
+	return dialer.connection, nil
+}
+
+func newGuardianTestConnection() *guardianTestConnection {
+	return &guardianTestConnection{
+		setup:   Setup{Root: 1, MinKeycode: 8, MaxKeycode: 255},
+		version: XTestVersion{Major: 2, Minor: 2, Valid: true},
+		mappings: map[xproto.Keycode]KeyboardMapping{
+			10: {KeysymsPerKeycode: 2, Keysyms: []xproto.Keysym{0, 0}},
+			11: {KeysymsPerKeycode: 2, Keysyms: []xproto.Keysym{'a', 'A'}},
+		},
+		pressed:           make([]byte, 32),
+		pointer:           PointerState{RootX: 40, RootY: 50},
+		events:            make(chan guardianTestEvent, 8),
+		operationFailures: make(map[string][]error),
+		fakeInputFailures: make(map[guardianTestInput]int),
+	}
+}
+
+func (connection *guardianTestConnection) popOperationFailureLocked(operation string) error {
+	failures := connection.operationFailures[operation]
+	if len(failures) == 0 {
+		return nil
+	}
+	failure := failures[0]
+	if len(failures) == 1 {
+		delete(connection.operationFailures, operation)
+	} else {
+		connection.operationFailures[operation] = failures[1:]
+	}
+	return failure
+}
+
+func (connection *guardianTestConnection) Close() error {
+	if connection.blockRelease != nil {
+		connection.blockReleaseOnce.Do(func() { close(connection.blockRelease) })
+	}
+	if connection.blockClose != nil {
+		<-connection.blockClose
+	}
+	connection.closeOnce.Do(func() {
+		connection.mu.Lock()
+		connection.closed = true
+		connection.mu.Unlock()
+		close(connection.events)
+	})
+	return nil
+}
+
+func (connection *guardianTestConnection) waitIfBlocked(operation string) {
+	if connection.blockOperation != operation || connection.blockRelease == nil {
+		return
+	}
+	if connection.blockEntered != nil {
+		connection.blockEnteredOnce.Do(func() { close(connection.blockEntered) })
+	}
+	<-connection.blockRelease
+}
+
+func (connection *guardianTestConnection) WaitForEvent() (bool, error) {
+	event, open := <-connection.events
+	if !open {
+		return false, nil
+	}
+	return event.open, event.err
+}
+
+func (connection *guardianTestConnection) Setup() (Setup, error) {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	return connection.setup, nil
+}
+
+func (*guardianTestConnection) InitXTest() error { return nil }
+
+func (connection *guardianTestConnection) XTestVersion(byte, uint16) (XTestVersion, error) {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	return connection.version, nil
+}
+
+func (connection *guardianTestConnection) GrabServer() error {
+	connection.waitIfBlocked(guardianOperationGrabServer)
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	if connection.grabbed {
+		return errors.New("already grabbed")
+	}
+	connection.grabbed = true
+	connection.grabCount++
+	return nil
+}
+
+func (connection *guardianTestConnection) UngrabServer() error {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	if !connection.grabbed {
+		return errors.New("not grabbed")
+	}
+	connection.grabbed = false
+	connection.ungrabCount++
+	if connection.clearPressedOnUngrab {
+		clear(connection.pressed)
+	}
+	return nil
+}
+
+func (connection *guardianTestConnection) KeyboardMapping(first xproto.Keycode, count byte) (KeyboardMapping, error) {
+	connection.waitIfBlocked(guardianOperationKeyboardMapping)
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	if err := connection.popOperationFailureLocked(guardianOperationKeyboardMapping); err != nil {
+		return KeyboardMapping{}, err
+	}
+	if count != 1 {
+		return KeyboardMapping{}, errors.New("test transport supports one keycode")
+	}
+	mapping, ok := connection.mappings[first]
+	if !ok {
+		return KeyboardMapping{}, errors.New("mapping is absent")
+	}
+	return cloneGuardianMapping(mapping), nil
+}
+
+func (connection *guardianTestConnection) ModifierMapping() ([]xproto.Keycode, error) {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	if err := connection.popOperationFailureLocked(guardianOperationModifierMapping); err != nil {
+		return nil, err
+	}
+	return append([]xproto.Keycode(nil), connection.modifiers...), nil
+}
+
+func (connection *guardianTestConnection) ChangeKeyboardMapping(first xproto.Keycode, perKeycode byte, keysyms []xproto.Keysym) error {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	if err := connection.popOperationFailureLocked(guardianOperationChangeKeyboardMapping); err != nil {
+		return err
+	}
+	mapping := KeyboardMapping{
+		KeysymsPerKeycode: perKeycode,
+		Keysyms:           append([]xproto.Keysym(nil), keysyms...),
+	}
+	if connection.canonicalizeMapping != nil {
+		mapping = connection.canonicalizeMapping(mapping)
+	}
+	connection.mappings[first] = cloneGuardianMapping(mapping)
+	if len(connection.changeFailuresAfterMutation) > 0 {
+		err := connection.changeFailuresAfterMutation[0]
+		connection.changeFailuresAfterMutation = connection.changeFailuresAfterMutation[1:]
+		return err
+	}
+	return nil
+}
+
+func (connection *guardianTestConnection) PressedKeys() ([]byte, error) {
+	connection.waitIfBlocked(guardianOperationPressedKeys)
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	if err := connection.popOperationFailureLocked(guardianOperationPressedKeys); err != nil {
+		return nil, err
+	}
+	return append([]byte(nil), connection.pressed...), nil
+}
+
+func (connection *guardianTestConnection) QueryPointer(xproto.Window) (PointerState, error) {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	return connection.pointer, nil
+}
+
+func (connection *guardianTestConnection) FakeInput(eventType, detail byte, _ xproto.Window, _, _ int16) error {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	input := guardianTestInput{eventType: eventType, detail: detail}
+	connection.inputs = append(connection.inputs, input)
+	switch eventType {
+	case byte(xproto.KeyPress):
+		connection.pressed[int(detail)/8] |= 1 << uint(detail%8)
+	case byte(xproto.KeyRelease):
+		connection.pressed[int(detail)/8] &^= 1 << uint(detail%8)
+	case byte(xproto.ButtonPress):
+		connection.pointer.Mask |= 1 << (7 + detail)
+	case byte(xproto.ButtonRelease):
+		connection.pointer.Mask &^= 1 << (7 + detail)
+	}
+	if remaining := connection.fakeInputFailures[input]; remaining > 0 {
+		if remaining == 1 {
+			delete(connection.fakeInputFailures, input)
+		} else {
+			connection.fakeInputFailures[input] = remaining - 1
+		}
+		return errors.New("injected mutate-then-error FakeInput failure")
+	}
+	return nil
+}
+
+func newInProcessGuardian(t *testing.T, transport *guardianTestConnection) (*guardianConnection, <-chan error) {
+	return newInProcessGuardianWithOptions(t, transport, GuardianOptions{
+		RequestTimeout: time.Second,
+		CleanupTimeout: 100 * time.Millisecond,
+	})
+}
+
+func newInProcessGuardianWithOptions(
+	t *testing.T,
+	transport *guardianTestConnection,
+	options GuardianOptions,
+) (*guardianConnection, <-chan error) {
+	t.Helper()
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("create guardian test socket: %v", err)
+	}
+	parent := os.NewFile(uintptr(fds[0]), "guardian-test-parent")
+	child := os.NewFile(uintptr(fds[1]), "guardian-test-child")
+	connection := newGuardianConnection(parent, nil, options)
+	done := make(chan error, 1)
+	token := strings.Repeat("ab", 32)
+	dialer := &guardianTestDialer{connection: transport}
+	go func() {
+		done <- serveGuardian(child, token, dialer)
+		_ = child.Close()
+		close(done)
+	}()
+	hello := guardianHelloRequest{
+		Token:              token,
+		Display:            ":guardian-test",
+		RequestTimeoutNano: int64(options.RequestTimeout),
+		CleanupTimeoutNano: int64(options.CleanupTimeout),
+		CrashSettleNano:    0,
+	}
+	if err := connection.request(guardianOperationHello, hello, nil); err != nil {
+		t.Fatalf("guardian hello: %v", err)
+	}
+	return connection, done
+}
+
+func TestGuardianConnectionProxiesAndMultiplexesEvents(t *testing.T) {
+	transport := newGuardianTestConnection()
+	connection, done := newInProcessGuardian(t, transport)
+
+	setup, err := connection.Setup()
+	if err != nil || setup != transport.setup {
+		t.Fatalf("Setup = %+v, %v; want %+v", setup, err, transport.setup)
+	}
+	if err := connection.InitXTest(); err != nil {
+		t.Fatalf("InitXTest: %v", err)
+	}
+	version, err := connection.XTestVersion(2, 2)
+	if err != nil || version != transport.version {
+		t.Fatalf("XTestVersion = %+v, %v; want %+v", version, err, transport.version)
+	}
+	mapping, err := connection.KeyboardMapping(11, 1)
+	if err != nil || !guardianMappingsEqual(mapping, transport.mappings[11]) {
+		t.Fatalf("KeyboardMapping = %+v, %v", mapping, err)
+	}
+	state, err := connection.QueryPointer(1)
+	if err != nil || state != transport.pointer {
+		t.Fatalf("QueryPointer = %+v, %v; want %+v", state, err, transport.pointer)
+	}
+
+	transport.events <- guardianTestEvent{open: true}
+	open, err := connection.WaitForEvent()
+	if err != nil || !open {
+		t.Fatalf("WaitForEvent = %t, %v; want true, nil", open, err)
+	}
+	if err := connection.GrabServer(); err != nil {
+		t.Fatalf("GrabServer: %v", err)
+	}
+	if err := connection.ChangeKeyboardMapping(10, 2, []xproto.Keysym{0x0101f600, 0x0101f600}); err != nil {
+		t.Fatalf("ChangeKeyboardMapping: %v", err)
+	}
+	if err := connection.FakeInput(byte(xproto.KeyPress), 10, 1, 0, 0); err != nil {
+		t.Fatalf("FakeInput press: %v", err)
+	}
+	if err := connection.FakeInput(byte(xproto.KeyRelease), 10, 1, 0, 0); err != nil {
+		t.Fatalf("FakeInput release: %v", err)
+	}
+	if err := connection.UngrabServer(); err != nil {
+		t.Fatalf("UngrabServer: %v", err)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server: %v", err)
+	}
+
+	transport.mu.Lock()
+	restored := cloneGuardianMapping(transport.mappings[10])
+	closed := transport.closed
+	grabbed := transport.grabbed
+	transport.mu.Unlock()
+	if !guardianMappingsEqual(restored, KeyboardMapping{KeysymsPerKeycode: 2, Keysyms: []xproto.Keysym{0, 0}}) {
+		t.Fatalf("mapping after verified close = %+v", restored)
+	}
+	if !closed || grabbed {
+		t.Fatalf("transport close state: closed=%t grabbed=%t", closed, grabbed)
+	}
+}
+
+func TestGuardianEOFReleasesOwnedInputAndRestoresMapping(t *testing.T) {
+	transport := newGuardianTestConnection()
+	connection, done := newInProcessGuardian(t, transport)
+	if err := connection.GrabServer(); err != nil {
+		t.Fatalf("GrabServer: %v", err)
+	}
+	if err := connection.ChangeKeyboardMapping(10, 2, []xproto.Keysym{0x0101f600, 0x0101f600}); err != nil {
+		t.Fatalf("ChangeKeyboardMapping: %v", err)
+	}
+	if err := connection.FakeInput(byte(xproto.KeyPress), 10, 1, 0, 0); err != nil {
+		t.Fatalf("FakeInput key press: %v", err)
+	}
+	if err := connection.FakeInput(byte(xproto.ButtonPress), 1, 1, 0, 0); err != nil {
+		t.Fatalf("FakeInput button press: %v", err)
+	}
+	connection.finish(errors.New("simulated parent crash"))
+	if err := <-done; err != nil {
+		t.Fatalf("guardian EOF cleanup: %v", err)
+	}
+
+	transport.mu.Lock()
+	mapping := cloneGuardianMapping(transport.mappings[10])
+	pressed := append([]byte(nil), transport.pressed...)
+	mask := transport.pointer.Mask
+	grabbed := transport.grabbed
+	inputs := append([]guardianTestInput(nil), transport.inputs...)
+	transport.mu.Unlock()
+	if !guardianMappingsEqual(mapping, KeyboardMapping{KeysymsPerKeycode: 2, Keysyms: []xproto.Keysym{0, 0}}) {
+		t.Fatalf("mapping after parent EOF = %+v", mapping)
+	}
+	if guardianKeycodePressed(pressed, 10) || mask != 0 || grabbed {
+		t.Fatalf("state after parent EOF: pressed=%t mask=%#x grabbed=%t", guardianKeycodePressed(pressed, 10), mask, grabbed)
+	}
+	wantSuffix := []guardianTestInput{
+		{eventType: byte(xproto.ButtonRelease), detail: 1},
+		{eventType: byte(xproto.KeyRelease), detail: 10},
+	}
+	if len(inputs) < len(wantSuffix) {
+		t.Fatalf("input log too short: %+v", inputs)
+	}
+	gotSuffix := inputs[len(inputs)-len(wantSuffix):]
+	for index := range wantSuffix {
+		if gotSuffix[index] != wantSuffix[index] {
+			t.Fatalf("cleanup input suffix = %+v, want %+v", gotSuffix, wantSuffix)
+		}
+	}
+}
+
+func TestGuardianCleanupPreservesForeignMapping(t *testing.T) {
+	transport := newGuardianTestConnection()
+	connection, done := newInProcessGuardian(t, transport)
+	if err := connection.ChangeKeyboardMapping(10, 2, []xproto.Keysym{0x0101f600, 0x0101f600}); err != nil {
+		t.Fatalf("ChangeKeyboardMapping: %v", err)
+	}
+	foreign := KeyboardMapping{KeysymsPerKeycode: 2, Keysyms: []xproto.Keysym{'z', 'z'}}
+	transport.mu.Lock()
+	transport.mappings[10] = cloneGuardianMapping(foreign)
+	transport.mu.Unlock()
+	if err := connection.Close(); err != nil {
+		t.Fatalf("Close preserving foreign mapping: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	transport.mu.Unlock()
+	if !guardianMappingsEqual(got, foreign) {
+		t.Fatalf("foreign mapping after cleanup = %+v, want %+v", got, foreign)
+	}
+}
+
+func TestGuardianAcceptsServerCanonicalizedScratchMapping(t *testing.T) {
+	transport := newGuardianTestConnection()
+	transport.canonicalizeMapping = func(mapping KeyboardMapping) KeyboardMapping {
+		canonical := cloneGuardianMapping(mapping)
+		if len(canonical.Keysyms) > 2 && canonical.Keysyms[0] != 0 {
+			canonical.Keysyms[len(canonical.Keysyms)-1] = 0
+		}
+		return canonical
+	}
+	transport.mappings[10] = KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{0, 0, 0}}
+	connection, done := newInProcessGuardian(t, transport)
+	keysym := xproto.Keysym(0x010020ac)
+	if err := connection.ChangeKeyboardMapping(10, 3, []xproto.Keysym{keysym, keysym, keysym}); err != nil {
+		t.Fatalf("ChangeKeyboardMapping with canonicalized readback: %v", err)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("Close after canonicalized mapping: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	transport.mu.Unlock()
+	want := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{0, 0, 0}}
+	if !guardianMappingsEqual(got, want) {
+		t.Fatalf("mapping after canonicalized cleanup = %+v, want %+v", got, want)
+	}
+}
+
+func TestGuardianRestoresCanonicalizedMappingAfterLostChangeReply(t *testing.T) {
+	transport := newGuardianTestConnection()
+	transport.canonicalizeMapping = func(mapping KeyboardMapping) KeyboardMapping {
+		canonical := cloneGuardianMapping(mapping)
+		if len(canonical.Keysyms) > 2 && canonical.Keysyms[0] != 0 {
+			canonical.Keysyms[len(canonical.Keysyms)-1] = 0
+		}
+		return canonical
+	}
+	before := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{0, 0, 0}}
+	transport.mappings[10] = cloneGuardianMapping(before)
+	lostReply := errors.New("lost mapping-change reply")
+	transport.changeFailuresAfterMutation = []error{lostReply}
+	connection, done := newInProcessGuardian(t, transport)
+	if err := connection.GrabServer(); err != nil {
+		t.Fatalf("GrabServer before ambiguous mapping change: %v", err)
+	}
+	keysym := xproto.Keysym(0x010020ac)
+	err := connection.ChangeKeyboardMapping(10, 3, []xproto.Keysym{keysym, keysym, keysym})
+	if err == nil || !strings.Contains(err.Error(), lostReply.Error()) {
+		t.Fatalf("canonicalized mapping change error = %v; want lost reply", err)
+	}
+	if err := connection.UngrabServer(); err != nil {
+		t.Fatalf("UngrabServer after ambiguous mapping change: %v", err)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("Close after ambiguous canonicalized mapping change: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server after ambiguous canonicalized mapping change: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	transport.mu.Unlock()
+	if !guardianMappingsEqual(got, before) {
+		t.Fatalf("mapping after ambiguous canonicalized cleanup = %+v, want %+v", got, before)
+	}
+}
+
+func TestGuardianPreservesCanonicalizedMappingWhenChangeAndReadbackAreLost(t *testing.T) {
+	transport := newGuardianTestConnection()
+	transport.canonicalizeMapping = func(mapping KeyboardMapping) KeyboardMapping {
+		canonical := cloneGuardianMapping(mapping)
+		if len(canonical.Keysyms) > 2 && canonical.Keysyms[0] != 0 {
+			canonical.Keysyms[len(canonical.Keysyms)-1] = 0
+		}
+		return canonical
+	}
+	before := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{0, 0, 0}}
+	transport.mappings[10] = cloneGuardianMapping(before)
+	transport.operationFailures[guardianOperationKeyboardMapping] = []error{
+		nil,
+		errors.New("lost mapping readback"),
+	}
+	transport.changeFailuresAfterMutation = []error{errors.New("lost mapping-change reply")}
+	connection, done := newInProcessGuardian(t, transport)
+	if err := connection.GrabServer(); err != nil {
+		t.Fatalf("GrabServer before doubly ambiguous mapping change: %v", err)
+	}
+	keysym := xproto.Keysym(0x010020ac)
+	err := connection.ChangeKeyboardMapping(10, 3, []xproto.Keysym{keysym, keysym, keysym})
+	if err == nil || !strings.Contains(err.Error(), "lost mapping-change reply") ||
+		!strings.Contains(err.Error(), "lost mapping readback") {
+		t.Fatalf("doubly ambiguous mapping change error = %v; want both causes", err)
+	}
+	if err := connection.UngrabServer(); err != nil {
+		t.Fatalf("UngrabServer after doubly ambiguous mapping change: %v", err)
+	}
+	if err := connection.Close(); err == nil ||
+		(!strings.Contains(err.Error(), "ownership remains unresolved") && !strings.Contains(err.Error(), "cleanup timed out")) {
+		t.Fatalf("Close after doubly ambiguous mapping change = %v; want explicit cleanup failure", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server after doubly ambiguous mapping change: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	transport.mu.Unlock()
+	want := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{keysym, keysym, 0}}
+	if !guardianMappingsEqual(got, want) {
+		t.Fatalf("mapping after doubly ambiguous cleanup = %+v, want preserved %+v", got, want)
+	}
+}
+
+func TestGuardianPreservesCanonicalizedMappingWhenVerificationReadbackIsLost(t *testing.T) {
+	transport := newGuardianTestConnection()
+	transport.canonicalizeMapping = func(mapping KeyboardMapping) KeyboardMapping {
+		canonical := cloneGuardianMapping(mapping)
+		if len(canonical.Keysyms) > 2 && canonical.Keysyms[0] != 0 {
+			canonical.Keysyms[len(canonical.Keysyms)-1] = 0
+		}
+		return canonical
+	}
+	before := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{0, 0, 0}}
+	transport.mappings[10] = cloneGuardianMapping(before)
+	transport.operationFailures[guardianOperationKeyboardMapping] = []error{
+		nil,
+		errors.New("lost verification readback"),
+	}
+	connection, done := newInProcessGuardian(t, transport)
+	if err := connection.GrabServer(); err != nil {
+		t.Fatalf("GrabServer before lost verification readback: %v", err)
+	}
+	keysym := xproto.Keysym(0x010020ac)
+	err := connection.ChangeKeyboardMapping(10, 3, []xproto.Keysym{keysym, keysym, keysym})
+	if err == nil || !strings.Contains(err.Error(), "lost verification readback") {
+		t.Fatalf("mapping verification error = %v; want lost readback", err)
+	}
+	if err := connection.UngrabServer(); err != nil {
+		t.Fatalf("UngrabServer after lost verification readback: %v", err)
+	}
+	if err := connection.Close(); err == nil ||
+		(!strings.Contains(err.Error(), "ownership remains unresolved") && !strings.Contains(err.Error(), "cleanup timed out")) {
+		t.Fatalf("Close after lost verification readback = %v; want explicit cleanup failure", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server after lost verification readback: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	transport.mu.Unlock()
+	want := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{keysym, keysym, 0}}
+	if !guardianMappingsEqual(got, want) {
+		t.Fatalf("mapping after lost verification readback = %+v, want preserved %+v", got, want)
+	}
+}
+
+func TestGuardianReportsUnresolvedFailedMappingWithoutOverwrite(t *testing.T) {
+	transport := newGuardianTestConnection()
+	before := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{0, 0, 0}}
+	foreign := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{'z', 0, 0}}
+	transport.mappings[10] = cloneGuardianMapping(before)
+	transport.canonicalizeMapping = func(mapping KeyboardMapping) KeyboardMapping {
+		if len(mapping.Keysyms) > 0 && mapping.Keysyms[0] != 0 {
+			return cloneGuardianMapping(foreign)
+		}
+		return cloneGuardianMapping(mapping)
+	}
+	transport.changeFailuresAfterMutation = []error{errors.New("ambiguous mapping failure")}
+	connection, done := newInProcessGuardianWithOptions(t, transport, GuardianOptions{
+		RequestTimeout: 100 * time.Millisecond,
+		CleanupTimeout: 25 * time.Millisecond,
+	})
+	keysym := xproto.Keysym(0x010020ac)
+	err := connection.ChangeKeyboardMapping(10, 3, []xproto.Keysym{keysym, keysym, keysym})
+	if err == nil || !strings.Contains(err.Error(), "ownership is unresolved") {
+		t.Fatalf("unresolved mapping change error = %v; want explicit ownership error", err)
+	}
+	err = connection.ChangeKeyboardMapping(10, before.KeysymsPerKeycode, before.Keysyms)
+	if err == nil || !strings.Contains(err.Error(), "refuses to restore unresolved mapping") {
+		t.Fatalf("unresolved mapping restore error = %v; want explicit refusal", err)
+	}
+	if err := connection.Close(); err == nil ||
+		(!strings.Contains(err.Error(), "ownership remains unresolved") && !strings.Contains(err.Error(), "cleanup timed out")) {
+		t.Fatalf("Close with unresolved mapping = %v; want explicit ownership or cleanup-timeout error", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server after unresolved mapping close: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	transport.mu.Unlock()
+	if !guardianMappingsEqual(got, foreign) {
+		t.Fatalf("unresolved mapping after cleanup = %+v, want preserved %+v", got, foreign)
+	}
+}
+
+func TestGuardianPreservesSemanticallyEqualForeignMapping(t *testing.T) {
+	transport := newGuardianTestConnection()
+	transport.canonicalizeMapping = func(mapping KeyboardMapping) KeyboardMapping {
+		canonical := cloneGuardianMapping(mapping)
+		if len(canonical.Keysyms) > 2 && canonical.Keysyms[0] != 0 {
+			canonical.Keysyms[len(canonical.Keysyms)-1] = 0
+		}
+		return canonical
+	}
+	transport.mappings[10] = KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{0, 0, 0}}
+	connection, done := newInProcessGuardian(t, transport)
+	keysym := xproto.Keysym(0x010020ac)
+	if err := connection.ChangeKeyboardMapping(10, 3, []xproto.Keysym{keysym, keysym, keysym}); err != nil {
+		t.Fatalf("ChangeKeyboardMapping with canonicalized readback: %v", err)
+	}
+	foreign := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{keysym, 0, 0}}
+	transport.mu.Lock()
+	transport.mappings[10] = cloneGuardianMapping(foreign)
+	transport.mu.Unlock()
+	if err := connection.Close(); err != nil {
+		t.Fatalf("Close preserving semantically equal foreign mapping: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	transport.mu.Unlock()
+	if !guardianMappingsEqual(got, foreign) {
+		t.Fatalf("semantically equal foreign mapping after cleanup = %+v, want %+v", got, foreign)
+	}
+}
+
+func TestGuardianCleanupReleasesAmbiguousFailedPresses(t *testing.T) {
+	tests := []struct {
+		name        string
+		pressType   byte
+		releaseType byte
+		detail      byte
+		held        func(*guardianTestConnection) bool
+		owned       func(*guardianServer) bool
+	}{
+		{
+			name:        "key",
+			pressType:   byte(xproto.KeyPress),
+			releaseType: byte(xproto.KeyRelease),
+			detail:      10,
+			held: func(transport *guardianTestConnection) bool {
+				return guardianKeycodePressed(transport.pressed, 10)
+			},
+			owned: func(server *guardianServer) bool {
+				_, ok := server.ownedKeys[10]
+				return ok
+			},
+		},
+		{
+			name:        "button",
+			pressType:   byte(xproto.ButtonPress),
+			releaseType: byte(xproto.ButtonRelease),
+			detail:      1,
+			held: func(transport *guardianTestConnection) bool {
+				return transport.pointer.Mask&(1<<(7+1)) != 0
+			},
+			owned: func(server *guardianServer) bool {
+				_, ok := server.ownedButtons[1]
+				return ok
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := newGuardianTestConnection()
+			server := &guardianServer{
+				connection:     transport,
+				cleanupTimeout: 100 * time.Millisecond,
+				mappings:       make(map[xproto.Keycode]*guardianMappingClaim),
+				ownedKeys:      make(map[byte]guardianOwnedInput),
+				ownedButtons:   make(map[byte]guardianOwnedInput),
+			}
+			press := guardianTestInput{eventType: test.pressType, detail: test.detail}
+			transport.fakeInputFailures[press] = 1
+			request := guardianFakeInputRequest{EventType: test.pressType, Detail: test.detail, Root: 1}
+			if err := server.fakeInput(request); err == nil {
+				t.Fatal("ambiguous press unexpectedly succeeded")
+			}
+			transport.mu.Lock()
+			heldAfterError := test.held(transport)
+			transport.mu.Unlock()
+			if !heldAfterError || !test.owned(server) || len(server.inputOrder) != 1 {
+				t.Fatalf("state after ambiguous press: held=%t owned=%t order=%d", heldAfterError, test.owned(server), len(server.inputOrder))
+			}
+			if err := server.cleanup(false); err != nil {
+				t.Fatalf("cleanup ambiguous press: %v", err)
+			}
+			transport.mu.Lock()
+			heldAfterCleanup := test.held(transport)
+			inputs := append([]guardianTestInput(nil), transport.inputs...)
+			transport.mu.Unlock()
+			if heldAfterCleanup || test.owned(server) || len(server.inputOrder) != 0 {
+				t.Fatalf("state after cleanup: held=%t owned=%t order=%d", heldAfterCleanup, test.owned(server), len(server.inputOrder))
+			}
+			want := []guardianTestInput{
+				{eventType: test.pressType, detail: test.detail},
+				{eventType: test.releaseType, detail: test.detail},
+			}
+			if len(inputs) != len(want) || inputs[0] != want[0] || inputs[1] != want[1] {
+				t.Fatalf("input log = %+v, want %+v", inputs, want)
+			}
+		})
+	}
+}
+
+func TestGuardianCleanupRetainsAmbiguousFailedReleases(t *testing.T) {
+	tests := []struct {
+		name        string
+		pressType   byte
+		releaseType byte
+		detail      byte
+		owned       func(*guardianServer) bool
+	}{
+		{
+			name:        "key",
+			pressType:   byte(xproto.KeyPress),
+			releaseType: byte(xproto.KeyRelease),
+			detail:      10,
+			owned: func(server *guardianServer) bool {
+				_, ok := server.ownedKeys[10]
+				return ok
+			},
+		},
+		{
+			name:        "button",
+			pressType:   byte(xproto.ButtonPress),
+			releaseType: byte(xproto.ButtonRelease),
+			detail:      1,
+			owned: func(server *guardianServer) bool {
+				_, ok := server.ownedButtons[1]
+				return ok
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := newGuardianTestConnection()
+			server := &guardianServer{
+				connection:     transport,
+				cleanupTimeout: 100 * time.Millisecond,
+				mappings:       make(map[xproto.Keycode]*guardianMappingClaim),
+				ownedKeys:      make(map[byte]guardianOwnedInput),
+				ownedButtons:   make(map[byte]guardianOwnedInput),
+			}
+			if err := server.fakeInput(guardianFakeInputRequest{EventType: test.pressType, Detail: test.detail, Root: 1}); err != nil {
+				t.Fatalf("press: %v", err)
+			}
+			release := guardianTestInput{eventType: test.releaseType, detail: test.detail}
+			transport.fakeInputFailures[release] = 1
+			if err := server.fakeInput(guardianFakeInputRequest{EventType: test.releaseType, Detail: test.detail, Root: 1}); err == nil {
+				t.Fatal("ambiguous release unexpectedly succeeded")
+			}
+			if !test.owned(server) || len(server.inputOrder) != 1 {
+				t.Fatalf("ownership after ambiguous release: owned=%t order=%d", test.owned(server), len(server.inputOrder))
+			}
+			if err := server.cleanup(false); err != nil {
+				t.Fatalf("cleanup ambiguous release: %v", err)
+			}
+			if test.owned(server) || len(server.inputOrder) != 0 {
+				t.Fatalf("ownership after cleanup: owned=%t order=%d", test.owned(server), len(server.inputOrder))
+			}
+			transport.mu.Lock()
+			inputs := append([]guardianTestInput(nil), transport.inputs...)
+			transport.mu.Unlock()
+			want := []guardianTestInput{
+				{eventType: test.pressType, detail: test.detail},
+				{eventType: test.releaseType, detail: test.detail},
+				{eventType: test.releaseType, detail: test.detail},
+			}
+			if len(inputs) != len(want) || inputs[0] != want[0] || inputs[1] != want[1] || inputs[2] != want[2] {
+				t.Fatalf("input log = %+v, want %+v", inputs, want)
+			}
+		})
+	}
+}
+
+func TestGuardianCleanupRetriesTransientMappingFailures(t *testing.T) {
+	injected := errors.New("injected transient cleanup failure")
+	tests := []struct {
+		name     string
+		failures map[string][]error
+	}{
+		{name: "pressed keys", failures: map[string][]error{guardianOperationPressedKeys: {injected}}},
+		{name: "modifier mapping", failures: map[string][]error{guardianOperationModifierMapping: {injected}}},
+		{name: "keyboard mapping", failures: map[string][]error{guardianOperationKeyboardMapping: {injected}}},
+		{name: "change mapping", failures: map[string][]error{guardianOperationChangeKeyboardMapping: {injected}}},
+		{name: "verify mapping", failures: map[string][]error{guardianOperationKeyboardMapping: {nil, injected}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := newGuardianTestConnection()
+			before := cloneGuardianMapping(transport.mappings[10])
+			after := KeyboardMapping{KeysymsPerKeycode: 2, Keysyms: []xproto.Keysym{'x', 'x'}}
+			transport.mappings[10] = cloneGuardianMapping(after)
+			for operation, failures := range test.failures {
+				transport.operationFailures[operation] = append([]error(nil), failures...)
+			}
+			server := &guardianServer{
+				connection:     transport,
+				cleanupTimeout: 200 * time.Millisecond,
+				mappings: map[xproto.Keycode]*guardianMappingClaim{
+					10: {before: before, after: after},
+				},
+				mappingOrder: []xproto.Keycode{10},
+				ownedKeys:    make(map[byte]guardianOwnedInput),
+				ownedButtons: make(map[byte]guardianOwnedInput),
+			}
+			if err := server.cleanup(false); err != nil {
+				t.Fatalf("cleanup transient %s failure: %v", test.name, err)
+			}
+			transport.mu.Lock()
+			got := cloneGuardianMapping(transport.mappings[10])
+			grabCount := transport.grabCount
+			ungrabCount := transport.ungrabCount
+			remainingFailures := len(transport.operationFailures)
+			transport.mu.Unlock()
+			if !guardianMappingsEqual(got, before) || len(server.mappings) != 0 {
+				t.Fatalf("mapping after retry = %+v, claims=%d; want before and no claims", got, len(server.mappings))
+			}
+			if grabCount < 2 || ungrabCount < 2 {
+				t.Fatalf("cleanup retry grab transitions = %d/%d; want at least two", grabCount, ungrabCount)
+			}
+			if remainingFailures != 0 {
+				t.Fatalf("cleanup left %d injected failure queues", remainingFailures)
+			}
+		})
+	}
+}
+
+func TestGuardianCleanupPreservesSemanticForeignImageAfterRestoreMismatch(t *testing.T) {
+	transport := newGuardianTestConnection()
+	keysym := xproto.Keysym(0x010020ac)
+	before := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{0, 0, 0}}
+	after := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{keysym, keysym, 0}}
+	foreign := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{keysym, 0, 0}}
+	transport.mappings[10] = cloneGuardianMapping(before)
+	transport.canonicalizeMapping = func(mapping KeyboardMapping) KeyboardMapping {
+		if guardianMappingsEqual(mapping, before) {
+			return cloneGuardianMapping(foreign)
+		}
+		return cloneGuardianMapping(mapping)
+	}
+	if guardianMappingsEqual(foreign, after) || !guardianMappingMatchesWrittenImage(foreign, after) {
+		t.Fatal("test foreign image must be semantically owned but not exact-after")
+	}
+	connection, done := newInProcessGuardian(t, transport)
+	if err := connection.ChangeKeyboardMapping(10, after.KeysymsPerKeycode, after.Keysyms); err != nil {
+		t.Fatalf("assign mapping before restore mismatch: %v", err)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("Close preserving semantic foreign restore mismatch: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server preserving semantic foreign restore mismatch: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	grabCount := transport.grabCount
+	ungrabCount := transport.ungrabCount
+	transport.mu.Unlock()
+	if !guardianMappingsEqual(got, foreign) {
+		t.Fatalf("mapping after restore mismatch = %+v, want preserved foreign %+v", got, foreign)
+	}
+	if grabCount < 2 || ungrabCount < 2 {
+		t.Fatalf("restore mismatch grab transitions = %d/%d; want retry before relinquish", grabCount, ungrabCount)
+	}
+}
+
+func TestGuardianRestoreRequestRelinquishesSemanticForeignImageWithoutError(t *testing.T) {
+	transport := newGuardianTestConnection()
+	keysym := xproto.Keysym(0x010020ac)
+	before := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{0, 0, 0}}
+	after := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{keysym, keysym, 0}}
+	foreign := KeyboardMapping{KeysymsPerKeycode: 3, Keysyms: []xproto.Keysym{keysym, 0, 0}}
+	transport.mappings[10] = cloneGuardianMapping(before)
+	connection, done := newInProcessGuardian(t, transport)
+	if err := connection.ChangeKeyboardMapping(10, after.KeysymsPerKeycode, after.Keysyms); err != nil {
+		t.Fatalf("assign guardian mapping: %v", err)
+	}
+	transport.mu.Lock()
+	transport.mappings[10] = cloneGuardianMapping(foreign)
+	transport.mu.Unlock()
+	if err := connection.ChangeKeyboardMapping(10, before.KeysymsPerKeycode, before.Keysyms); err != nil {
+		t.Fatalf("restore request preserving semantic foreign image: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	transport.mu.Unlock()
+	if !guardianMappingsEqual(got, foreign) {
+		t.Fatalf("mapping after relinquished restore request = %+v, want foreign %+v", got, foreign)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("Close after relinquishing semantic foreign image: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server after relinquished restore request: %v", err)
+	}
+}
+
+func TestGuardianCleanupYieldsServerGrabBetweenPressedRetries(t *testing.T) {
+	transport := newGuardianTestConnection()
+	transport.clearPressedOnUngrab = true
+	transport.pressed[10/8] |= 1 << uint(10%8)
+	before := cloneGuardianMapping(transport.mappings[10])
+	after := KeyboardMapping{KeysymsPerKeycode: 2, Keysyms: []xproto.Keysym{'x', 'x'}}
+	transport.mappings[10] = cloneGuardianMapping(after)
+	server := &guardianServer{
+		connection:     transport,
+		cleanupTimeout: 100 * time.Millisecond,
+		mappings: map[xproto.Keycode]*guardianMappingClaim{
+			10: {before: before, after: after},
+		},
+		mappingOrder: []xproto.Keycode{10},
+		ownedKeys:    make(map[byte]guardianOwnedInput),
+		ownedButtons: make(map[byte]guardianOwnedInput),
+	}
+	if err := server.cleanup(false); err != nil {
+		t.Fatalf("cleanup after pressed retry: %v", err)
+	}
+	transport.mu.Lock()
+	got := cloneGuardianMapping(transport.mappings[10])
+	grabCount := transport.grabCount
+	ungrabCount := transport.ungrabCount
+	transport.mu.Unlock()
+	if !guardianMappingsEqual(got, before) {
+		t.Fatalf("mapping after retry cleanup = %+v, want %+v", got, before)
+	}
+	if grabCount < 2 || ungrabCount < 2 {
+		t.Fatalf("cleanup grab transitions = %d grabs/%d ungrabs, want retry yield", grabCount, ungrabCount)
+	}
+}
+
+func TestGuardianRequestTimeoutTerminatesAmbiguousConnection(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("create socketpair: %v", err)
+	}
+	parent := os.NewFile(uintptr(fds[0]), "guardian-timeout-parent")
+	peer := os.NewFile(uintptr(fds[1]), "guardian-timeout-peer")
+	connection := newGuardianConnection(parent, nil, GuardianOptions{RequestTimeout: 5 * time.Millisecond})
+	peerDone := make(chan error, 1)
+	go func() {
+		if _, err := readGuardianEnvelope(peer); err != nil {
+			peerDone <- err
+			return
+		}
+		var one [1]byte
+		_, err := peer.Read(one[:])
+		peerDone <- err
+	}()
+	if _, err := connection.Setup(); err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("Setup timeout error = %v", err)
+	}
+	if err := <-peerDone; !errors.Is(err, io.EOF) {
+		t.Fatalf("guardian peer after request timeout = %v, want EOF", err)
+	}
+	if err := peer.Close(); err != nil {
+		t.Fatalf("close timeout peer: %v", err)
+	}
+}
+
+func TestGuardianDisplayDialIsDeadlineBounded(t *testing.T) {
+	release := make(chan struct{})
+	dialer := &guardianTestDialer{block: release}
+	started := time.Now()
+	connection, err := dialGuardianConnection(dialer, ":blocked", 10*time.Millisecond)
+	close(release)
+	if connection != nil || err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("blocked guardian dial = %T, %v; want nil timeout", connection, err)
+	}
+	if elapsed := time.Since(started); elapsed > 200*time.Millisecond {
+		t.Fatalf("blocked guardian dial took %s; want bounded completion", elapsed)
+	}
+}
+
+func TestGuardianDispatchTimeoutClosesTransportAndTerminatesServer(t *testing.T) {
+	transport := newGuardianTestConnection()
+	transport.blockOperation = guardianOperationGrabServer
+	transport.blockEntered = make(chan struct{})
+	transport.blockRelease = make(chan struct{})
+	connection, done := newInProcessGuardianWithOptions(t, transport, GuardianOptions{
+		RequestTimeout: 20 * time.Millisecond,
+		CleanupTimeout: 20 * time.Millisecond,
+	})
+
+	started := time.Now()
+	err := connection.GrabServer()
+	if err == nil || !strings.Contains(err.Error(), "dispatch timed out") {
+		t.Fatalf("blocked guardian dispatch error = %v; want dispatch timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+		t.Fatalf("blocked guardian dispatch took %s; want bounded completion", elapsed)
+	}
+	select {
+	case serveErr := <-done:
+		if serveErr == nil || !strings.Contains(serveErr.Error(), "dispatch timed out") {
+			t.Fatalf("guardian server terminal error = %v; want dispatch timeout", serveErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("guardian server did not terminate after dispatch timeout")
+	}
+	transport.mu.Lock()
+	closed := transport.closed
+	transport.mu.Unlock()
+	if !closed {
+		t.Fatal("dispatch watchdog did not close the blocked X11 transport")
+	}
+}
+
+func TestGuardianCloseKillsAndReapsHelperAfterExitTimeout(t *testing.T) {
+	if os.Getenv(guardianTestBlockingProcess) == "1" {
+		time.Sleep(time.Minute)
+		return
+	}
+	command := exec.Command(os.Args[0], "-test.run=^TestGuardianCloseKillsAndReapsHelperAfterExitTimeout$")
+	command.Env = append(os.Environ(), guardianTestBlockingProcess+"=1")
+	if err := command.Start(); err != nil {
+		t.Fatalf("start blocking helper process: %v", err)
+	}
+	pid := command.Process.Pid
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		_ = command.Process.Kill()
+		_ = command.Wait()
+		t.Fatalf("create guardian close-timeout socketpair: %v", err)
+	}
+	parent := os.NewFile(uintptr(fds[0]), "guardian-close-timeout-parent")
+	peer := os.NewFile(uintptr(fds[1]), "guardian-close-timeout-peer")
+	defer func() { _ = peer.Close() }()
+	connection := newGuardianConnection(parent, command, GuardianOptions{
+		RequestTimeout: 5 * time.Millisecond,
+		CleanupTimeout: 5 * time.Millisecond,
+	})
+	if err := connection.Close(); err == nil || !strings.Contains(err.Error(), "did not exit") {
+		t.Fatalf("Close with stuck helper error = %v; want process exit timeout", err)
+	}
+	if signalErr := unix.Kill(pid, 0); !errors.Is(signalErr, unix.ESRCH) {
+		t.Fatalf("stuck helper PID %d remains after Close fallback: %v", pid, signalErr)
+	}
+}
+
+func TestTerminateGuardianCommandPreservesNaturalFailure(t *testing.T) {
+	command := exec.Command("/bin/sh", "-c", "exit 7")
+	if err := command.Start(); err != nil {
+		t.Fatalf("start failing helper process: %v", err)
+	}
+	pid := command.Process.Pid
+	deadline := time.Now().Add(time.Second)
+	for {
+		state, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+		if err == nil && strings.Contains(string(state), ") Z ") {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = command.Process.Kill()
+			_ = command.Wait()
+			t.Fatalf("helper PID %d did not reach zombie state: %v", pid, err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	err := terminateGuardianCommand(command, time.Second, "test natural failure")
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("natural helper failure = %v; want exit status 7", err)
+	}
+}
+
+func TestGuardianWaitForEventReportsTerminalErrorOnce(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("create socketpair: %v", err)
+	}
+	parent := os.NewFile(uintptr(fds[0]), "guardian-terminal-parent")
+	peer := os.NewFile(uintptr(fds[1]), "guardian-terminal-peer")
+	connection := newGuardianConnection(parent, nil, GuardianOptions{RequestTimeout: time.Second})
+	if err := peer.Close(); err != nil {
+		t.Fatalf("close peer: %v", err)
+	}
+	if open, err := connection.WaitForEvent(); open || err == nil {
+		t.Fatalf("first terminal WaitForEvent = %t, %v; want false, error", open, err)
+	}
+	if open, err := connection.WaitForEvent(); open || err != nil {
+		t.Fatalf("second terminal WaitForEvent = %t, %v; want false, nil", open, err)
+	}
+}
+
+func TestGuardianWaitForEventPreservesTerminalWhenOrdinaryBufferIsFull(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("create socketpair: %v", err)
+	}
+	parent := os.NewFile(uintptr(fds[0]), "guardian-full-events-parent")
+	peer := os.NewFile(uintptr(fds[1]), "guardian-full-events-peer")
+	connection := newGuardianConnection(parent, nil, GuardianOptions{RequestTimeout: time.Second})
+	for index := 0; index < cap(connection.events); index++ {
+		connection.events <- guardianEvent{Open: true}
+	}
+	payload, err := guardianPayload(guardianEvent{Open: false, Error: "terminal transport failure"})
+	if err != nil {
+		t.Fatalf("encode terminal event: %v", err)
+	}
+	writer := guardianFramedWriter{writer: peer}
+	if err := writer.write(guardianEnvelope{
+		Version: guardianProtocolVersion,
+		Kind:    guardianFrameEvent,
+		Payload: payload,
+	}); err != nil {
+		t.Fatalf("write terminal event: %v", err)
+	}
+	select {
+	case <-connection.done:
+	case <-time.After(time.Second):
+		t.Fatal("terminal event did not finish guardian connection")
+	}
+	if open, err := connection.WaitForEvent(); open || err == nil || !strings.Contains(err.Error(), "terminal transport failure") {
+		t.Fatalf("first terminal WaitForEvent = %t, %v; want terminal transport failure", open, err)
+	}
+	if open, err := connection.WaitForEvent(); open || err != nil {
+		t.Fatalf("second terminal WaitForEvent = %t, %v; want false, nil", open, err)
+	}
+	if err := peer.Close(); err != nil {
+		t.Fatalf("close terminal peer: %v", err)
+	}
+}
+
+func TestGuardianCleanupTimeoutInterruptsBlockingRoundTrips(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		configure func(*guardianTestConnection, *guardianServer)
+	}{
+		{
+			name:      "grab",
+			operation: guardianOperationGrabServer,
+			configure: func(*guardianTestConnection, *guardianServer) {},
+		},
+		{
+			name:      "pressed keys",
+			operation: guardianOperationPressedKeys,
+			configure: func(transport *guardianTestConnection, server *guardianServer) {
+				server.mappings[10] = &guardianMappingClaim{
+					before: cloneGuardianMapping(transport.mappings[10]),
+					after:  KeyboardMapping{KeysymsPerKeycode: 2, Keysyms: []xproto.Keysym{'x', 'x'}},
+				}
+				server.mappingOrder = []xproto.Keycode{10}
+				transport.mappings[10] = cloneGuardianMapping(server.mappings[10].after)
+			},
+		},
+		{
+			name:      "mapping",
+			operation: guardianOperationKeyboardMapping,
+			configure: func(transport *guardianTestConnection, server *guardianServer) {
+				server.mappings[10] = &guardianMappingClaim{
+					before: cloneGuardianMapping(transport.mappings[10]),
+					after:  KeyboardMapping{KeysymsPerKeycode: 2, Keysyms: []xproto.Keysym{'x', 'x'}},
+				}
+				server.mappingOrder = []xproto.Keycode{10}
+				transport.mappings[10] = cloneGuardianMapping(server.mappings[10].after)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport := newGuardianTestConnection()
+			transport.blockOperation = test.operation
+			transport.blockEntered = make(chan struct{})
+			transport.blockRelease = make(chan struct{})
+			transport.blockClose = make(chan struct{})
+			server := &guardianServer{
+				connection:     transport,
+				cleanupTimeout: 20 * time.Millisecond,
+				mappings:       make(map[xproto.Keycode]*guardianMappingClaim),
+				ownedKeys:      make(map[byte]guardianOwnedInput),
+				ownedButtons:   make(map[byte]guardianOwnedInput),
+			}
+			test.configure(transport, server)
+
+			started := time.Now()
+			err := server.cleanup(false)
+			if err == nil || !strings.Contains(err.Error(), "cleanup timed out") {
+				t.Fatalf("cleanup error = %v; want timeout", err)
+			}
+			if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+				t.Fatalf("cleanup took %s; want bounded completion", elapsed)
+			}
+			select {
+			case <-transport.blockEntered:
+			default:
+				t.Fatalf("cleanup never entered blocking %s round trip", test.operation)
+			}
+			select {
+			case <-transport.blockRelease:
+			case <-time.After(time.Second):
+				t.Fatal("cleanup watchdog did not initiate transport Close")
+			}
+
+			// Keep Close blocked until cleanup has already returned. This proves
+			// the watchdog itself never waits synchronously for Connection.Close.
+			close(transport.blockClose)
+			select {
+			case <-server.cleanupWorkDone:
+			case <-time.After(time.Second):
+				t.Fatal("cleanup worker did not stop after transport Close unblocked its round trip")
+			}
+			select {
+			case <-server.connectionCloseDone:
+			case <-time.After(time.Second):
+				t.Fatal("transport Close did not finish after test released it")
+			}
+		})
+	}
+}
+
+func TestGuardianCloseReturnsWhenCleanupAndTransportCloseBlock(t *testing.T) {
+	transport := newGuardianTestConnection()
+	connection, done := newInProcessGuardian(t, transport)
+	transport.blockOperation = guardianOperationGrabServer
+	transport.blockEntered = make(chan struct{})
+	transport.blockRelease = make(chan struct{})
+	transport.blockClose = make(chan struct{})
+
+	started := time.Now()
+	err := connection.Close()
+	if err == nil || !strings.Contains(err.Error(), "cleanup timed out") {
+		t.Fatalf("Close error = %v; want cleanup timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("Close took %s; want bounded completion", elapsed)
+	}
+	select {
+	case serveErr := <-done:
+		if serveErr != nil {
+			t.Fatalf("guardian server after bounded Close: %v", serveErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("guardian request loop did not terminate after bounded Close")
+	}
+
+	close(transport.blockClose)
+	deadline := time.Now().Add(time.Second)
+	for {
+		transport.mu.Lock()
+		closed := transport.closed
+		transport.mu.Unlock()
+		if closed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("test transport Close did not finish after release")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestGuardianProtocolRejectsOversizedFrame(t *testing.T) {
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], guardianMaximumFrame+1)
+	if _, err := readGuardianEnvelope(strings.NewReader(string(header[:]))); err == nil {
+		t.Fatal("oversized guardian frame unexpectedly succeeded")
+	}
+}
+
+func TestGuardianAbstractSocketRequiresExpectedKernelPeer(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		expectedPID int
+		wantSuccess bool
+	}{
+		{name: "exact helper", expectedPID: os.Getpid(), wantSuccess: true},
+		{name: "different process", expectedPID: os.Getpid() + 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			token, err := newGuardianToken()
+			if err != nil {
+				t.Fatalf("create guardian test token: %v", err)
+			}
+			listener, err := net.ListenUnix("unix", guardianAbstractSocketAddress(token))
+			if err != nil {
+				t.Fatalf("listen on guardian test socket: %v", err)
+			}
+			defer func() { _ = listener.Close() }()
+			dialDone := make(chan error, 1)
+			go func() {
+				connection, dialErr := net.DialUnix("unix", nil, guardianAbstractSocketAddress(token))
+				if connection != nil {
+					_ = connection.Close()
+				}
+				dialDone <- dialErr
+			}()
+			command := &exec.Cmd{Process: &os.Process{Pid: test.expectedPID}}
+			connection, acceptErr := acceptGuardianControl(listener, command, 30*time.Millisecond)
+			if connection != nil {
+				_ = connection.Close()
+			}
+			if dialErr := <-dialDone; dialErr != nil {
+				t.Fatalf("dial guardian test socket: %v", dialErr)
+			}
+			if test.wantSuccess && acceptErr != nil {
+				t.Fatalf("accept exact guardian peer: %v", acceptErr)
+			}
+			if !test.wantSuccess && acceptErr == nil {
+				t.Fatal("accepted guardian peer with a different expected PID")
+			}
+		})
+	}
+}
+
+func TestGuardianReexecSelectionRequiresExactMarker(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments []string
+		want      bool
+	}{
+		{name: "marker", arguments: []string{"robotgo-test", guardianReexecArgument}, want: true},
+		{name: "no marker", arguments: []string{"robotgo-test"}},
+		{name: "different marker", arguments: []string{"robotgo-test", "--other"}},
+		{name: "extra argument", arguments: []string{"robotgo-test", guardianReexecArgument, "extra"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := guardianReexecSelected(test.arguments); got != test.want {
+				t.Fatalf("guardianReexecSelected(%q) = %t, want %t", test.arguments, got, test.want)
+			}
+		})
+	}
+}
+
+func TestGuardianEnvironmentAloneDoesNotSelectReexec(t *testing.T) {
+	if os.Getenv(guardianTestEnvironmentOnly) == "1" {
+		return
+	}
+	token := strings.Repeat("ab", 32)
+	command := exec.Command(os.Args[0], "-test.run=^TestGuardianEnvironmentAloneDoesNotSelectReexec$")
+	command.Env = append(
+		guardianChildEnvironment(os.Environ(), token),
+		guardianTestEnvironmentOnly+"=1",
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("test binary with guardian environment but no marker exited: %v\n%s", err, output)
+	}
+}
+
+func TestGuardianMarkerFailsClosedWithoutValidToken(t *testing.T) {
+	command := exec.Command(os.Args[0], guardianReexecArgument)
+	environment := make([]string, 0, len(os.Environ())+1)
+	for _, entry := range os.Environ() {
+		if hasEnvironmentKey(entry, guardianEnvironmentToken) {
+			continue
+		}
+		environment = append(environment, entry)
+	}
+	command.Env = append(environment, guardianEnvironmentToken+"=invalid")
+	err := command.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 125 {
+		t.Fatalf("guardian marker with invalid environment error = %v; want exit status 125", err)
+	}
+}
+
+func TestGuardianStartupTimeoutKillsAndReapsHelper(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "guardian.pid")
+	fdFile := filepath.Join(t.TempDir(), "guardian-fd.txt")
+	executable := filepath.Join(t.TempDir(), "blocking-guardian")
+	script := "#!/bin/sh\n" +
+		"printf '%s' \"$$\" > \"${" + guardianTestPIDFile + ":?}\"\n" +
+		"if [ -e /proc/self/fd/3 ]; then printf inherited; else printf none; fi > \"${" + guardianTestFDFile + ":?}\"\n" +
+		"exec sleep 60\n"
+	if err := os.WriteFile(executable, []byte(script), 0o700); err != nil {
+		t.Fatalf("write blocking guardian helper: %v", err)
+	}
+	t.Setenv(guardianTestPIDFile, pidFile)
+	t.Setenv(guardianTestFDFile, fdFile)
+	dialer := NewGuardianDialer(GuardianOptions{
+		Executable:     executable,
+		StartupTimeout: 50 * time.Millisecond,
+		RequestTimeout: time.Second,
+		CleanupTimeout: 50 * time.Millisecond,
+		CrashSettle:    time.Millisecond,
+	})
+	connection, err := dialer.Dial(":guardian-startup-timeout")
+	if connection != nil || err == nil || (!os.IsTimeout(err) && !strings.Contains(err.Error(), "timeout")) {
+		t.Fatalf("blocking guardian Dial = %T, %v; want nil timeout", connection, err)
+	}
+	pidData, readErr := os.ReadFile(pidFile)
+	if readErr != nil {
+		t.Fatalf("read blocking guardian PID: %v", readErr)
+	}
+	pid, parseErr := strconv.Atoi(string(pidData))
+	if parseErr != nil {
+		t.Fatalf("parse blocking guardian PID %q: %v", pidData, parseErr)
+	}
+	if signalErr := unix.Kill(pid, 0); !errors.Is(signalErr, unix.ESRCH) {
+		t.Fatalf("guardian helper PID %d remains after startup failure: %v", pid, signalErr)
+	}
+	fdState, readErr := os.ReadFile(fdFile)
+	if readErr != nil {
+		t.Fatalf("read blocking guardian FD state: %v", readErr)
+	}
+	if string(fdState) != "none" {
+		t.Fatalf("re-executed helper inherited control descriptor 3: %q", fdState)
+	}
+}
+
+func TestGuardianReexecFailsClosedForInvalidDisplay(t *testing.T) {
+	dialer := NewGuardianDialer(GuardianOptions{
+		StartupTimeout: time.Second,
+		RequestTimeout: time.Second,
+		CleanupTimeout: 100 * time.Millisecond,
+		CrashSettle:    time.Millisecond,
+	})
+	connection, err := dialer.Dial("not-a-valid-x11-display")
+	if connection != nil || err == nil {
+		if connection != nil {
+			_ = connection.Close()
+		}
+		t.Fatalf("invalid display Dial = %T, %v; want nil, error", connection, err)
+	}
+	if errors.Is(err, io.EOF) {
+		t.Fatalf("invalid display failed before authenticated response: %v", err)
+	}
+}

--- a/internal/x11input/guardian_protocol_linux.go
+++ b/internal/x11input/guardian_protocol_linux.go
@@ -1,0 +1,205 @@
+//go:build linux
+
+package x11input
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/jezek/xgb/xproto"
+)
+
+const (
+	guardianProtocolVersion uint16 = 2
+	guardianMaximumFrame           = 1 << 20
+)
+
+const (
+	guardianFrameRequest  = "request"
+	guardianFrameResponse = "response"
+	guardianFrameEvent    = "event"
+)
+
+const (
+	guardianOperationHello                 = "hello"
+	guardianOperationSetup                 = "setup"
+	guardianOperationInitXTest             = "init-xtest"
+	guardianOperationXTestVersion          = "xtest-version"
+	guardianOperationGrabServer            = "grab-server"
+	guardianOperationUngrabServer          = "ungrab-server"
+	guardianOperationKeyboardMapping       = "keyboard-mapping"
+	guardianOperationModifierMapping       = "modifier-mapping"
+	guardianOperationChangeKeyboardMapping = "change-keyboard-mapping"
+	guardianOperationPressedKeys           = "pressed-keys"
+	guardianOperationQueryPointer          = "query-pointer"
+	guardianOperationFakeInput             = "fake-input"
+	guardianOperationClose                 = "close"
+)
+
+type guardianEnvelope struct {
+	Version   uint16          `json:"version"`
+	Kind      string          `json:"kind"`
+	ID        uint64          `json:"id,omitempty"`
+	Operation string          `json:"operation,omitempty"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+	Error     string          `json:"error,omitempty"`
+}
+
+type guardianHelloRequest struct {
+	Token              string `json:"token"`
+	Display            string `json:"display"`
+	RequestTimeoutNano int64  `json:"request_timeout_nano"`
+	CleanupTimeoutNano int64  `json:"cleanup_timeout_nano"`
+	CrashSettleNano    int64  `json:"crash_settle_nano"`
+}
+
+type guardianSetupResponse struct {
+	Setup Setup `json:"setup"`
+}
+
+type guardianXTestVersionRequest struct {
+	Major byte   `json:"major"`
+	Minor uint16 `json:"minor"`
+}
+
+type guardianXTestVersionResponse struct {
+	Version XTestVersion `json:"version"`
+}
+
+type guardianKeyboardMappingRequest struct {
+	First xproto.Keycode `json:"first"`
+	Count byte           `json:"count"`
+}
+
+type guardianKeyboardMappingResponse struct {
+	Mapping KeyboardMapping `json:"mapping"`
+}
+
+type guardianModifierMappingResponse struct {
+	Keycodes []xproto.Keycode `json:"keycodes"`
+}
+
+type guardianChangeKeyboardMappingRequest struct {
+	First      xproto.Keycode  `json:"first"`
+	PerKeycode byte            `json:"per_keycode"`
+	Keysyms    []xproto.Keysym `json:"keysyms"`
+}
+
+type guardianPressedKeysResponse struct {
+	Keys []byte `json:"keys"`
+}
+
+type guardianQueryPointerRequest struct {
+	Root xproto.Window `json:"root"`
+}
+
+type guardianQueryPointerResponse struct {
+	State PointerState `json:"state"`
+}
+
+type guardianFakeInputRequest struct {
+	EventType byte          `json:"event_type"`
+	Detail    byte          `json:"detail"`
+	Root      xproto.Window `json:"root"`
+	X         int16         `json:"x"`
+	Y         int16         `json:"y"`
+}
+
+type guardianEvent struct {
+	Open  bool   `json:"open"`
+	Error string `json:"error,omitempty"`
+}
+
+type guardianFramedWriter struct {
+	mu     sync.Mutex
+	writer io.Writer
+}
+
+func (writer *guardianFramedWriter) write(envelope guardianEnvelope) error {
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("encode guardian frame: %w", err)
+	}
+	if len(encoded) == 0 || len(encoded) > guardianMaximumFrame {
+		return fmt.Errorf("guardian frame size %d exceeds limit %d", len(encoded), guardianMaximumFrame)
+	}
+	header := make([]byte, 4)
+	binary.BigEndian.PutUint32(header, uint32(len(encoded)))
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	if err := writeAll(writer.writer, header); err != nil {
+		return fmt.Errorf("write guardian frame header: %w", err)
+	}
+	if err := writeAll(writer.writer, encoded); err != nil {
+		return fmt.Errorf("write guardian frame body: %w", err)
+	}
+	return nil
+}
+
+func readGuardianEnvelope(reader io.Reader) (guardianEnvelope, error) {
+	var header [4]byte
+	if _, err := io.ReadFull(reader, header[:]); err != nil {
+		return guardianEnvelope{}, err
+	}
+	size := binary.BigEndian.Uint32(header[:])
+	if size == 0 || size > guardianMaximumFrame {
+		return guardianEnvelope{}, fmt.Errorf("invalid guardian frame size %d", size)
+	}
+	encoded := make([]byte, int(size))
+	if _, err := io.ReadFull(reader, encoded); err != nil {
+		return guardianEnvelope{}, fmt.Errorf("read guardian frame body: %w", err)
+	}
+	var envelope guardianEnvelope
+	if err := json.Unmarshal(encoded, &envelope); err != nil {
+		return guardianEnvelope{}, fmt.Errorf("decode guardian frame: %w", err)
+	}
+	if envelope.Version != guardianProtocolVersion {
+		return guardianEnvelope{}, fmt.Errorf("guardian protocol version %d is not supported (want %d)", envelope.Version, guardianProtocolVersion)
+	}
+	return envelope, nil
+}
+
+func writeAll(writer io.Writer, data []byte) error {
+	for len(data) > 0 {
+		written, err := writer.Write(data)
+		if err != nil {
+			return err
+		}
+		if written <= 0 {
+			return io.ErrShortWrite
+		}
+		data = data[written:]
+	}
+	return nil
+}
+
+func guardianPayload(value any) (json.RawMessage, error) {
+	if value == nil {
+		return nil, nil
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode guardian payload: %w", err)
+	}
+	return payload, nil
+}
+
+func decodeGuardianPayload(payload json.RawMessage, target any) error {
+	if target == nil {
+		if len(payload) != 0 && string(payload) != "null" && string(payload) != "{}" {
+			return errors.New("guardian response unexpectedly contains a payload")
+		}
+		return nil
+	}
+	if len(payload) == 0 {
+		return errors.New("guardian response payload is missing")
+	}
+	if err := json.Unmarshal(payload, target); err != nil {
+		return fmt.Errorf("decode guardian payload: %w", err)
+	}
+	return nil
+}

--- a/internal/x11input/guardian_reexec_linux.go
+++ b/internal/x11input/guardian_reexec_linux.go
@@ -1,0 +1,899 @@
+//go:build linux
+
+package x11input
+
+import (
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/jezek/xgb/xproto"
+)
+
+const guardianCleanupRetryDelay = 10 * time.Millisecond
+
+type guardianMappingClaim struct {
+	before     KeyboardMapping
+	after      KeyboardMapping
+	unresolved bool
+}
+
+type guardianOwnedInput struct {
+	eventType byte
+	detail    byte
+	root      xproto.Window
+}
+
+type guardianServer struct {
+	connection Connection
+	writer     *guardianFramedWriter
+	eventsMu   sync.RWMutex
+	closing    bool
+
+	connectionCloseOnce sync.Once
+	connectionCloseDone chan struct{}
+	connectionCloseErr  error
+	cleanupWorkDone     <-chan struct{}
+	cleanupDeadline     time.Time
+
+	cleanupTimeout time.Duration
+	requestTimeout time.Duration
+	crashSettle    time.Duration
+	grabbed        bool
+	closed         bool
+
+	mappings     map[xproto.Keycode]*guardianMappingClaim
+	mappingOrder []xproto.Keycode
+	ownedKeys    map[byte]guardianOwnedInput
+	ownedButtons map[byte]guardianOwnedInput
+	inputOrder   []guardianOwnedInput
+	lastKeyEvent time.Time
+}
+
+func init() {
+	if !guardianReexecSelected(os.Args) {
+		return
+	}
+	status := runGuardianReexecChild()
+	os.Exit(status)
+}
+
+func guardianReexecSelected(arguments []string) bool {
+	return len(arguments) == 2 && arguments[1] == guardianReexecArgument
+}
+
+func runGuardianReexecChild() int {
+	expectedToken, ok := guardianTokenFromEnvironment()
+	if !ok {
+		return 125
+	}
+	control, err := net.DialUnix("unix", nil, guardianAbstractSocketAddress(expectedToken))
+	if err != nil {
+		return 125
+	}
+	_ = os.Unsetenv(guardianEnvironmentToken)
+	err = serveGuardian(control, expectedToken, xgbDialer{})
+	_ = control.Close()
+	if err != nil {
+		return 1
+	}
+	return 0
+}
+
+func serveGuardian(control io.ReadWriteCloser, expectedToken string, dialer Dialer) error {
+	writer := &guardianFramedWriter{writer: control}
+	helloEnvelope, err := readGuardianEnvelope(control)
+	if err != nil {
+		return err
+	}
+	if helloEnvelope.Kind != guardianFrameRequest || helloEnvelope.ID == 0 || helloEnvelope.Operation != guardianOperationHello {
+		return errors.New("X11 guardian expected hello as its first request")
+	}
+	var hello guardianHelloRequest
+	if err := decodeGuardianPayload(helloEnvelope.Payload, &hello); err != nil {
+		_ = writeGuardianResponse(writer, helloEnvelope, nil, err)
+		return nil
+	}
+	if err := validateGuardianHello(expectedToken, hello); err != nil {
+		_ = writeGuardianResponse(writer, helloEnvelope, nil, err)
+		return nil
+	}
+	connection, err := dialGuardianConnection(dialer, hello.Display, time.Duration(hello.RequestTimeoutNano))
+	if err != nil {
+		_ = writeGuardianResponse(writer, helloEnvelope, nil, fmt.Errorf("dial X11 display %q: %w", hello.Display, err))
+		return nil
+	}
+	server := &guardianServer{
+		connection:     connection,
+		writer:         writer,
+		requestTimeout: time.Duration(hello.RequestTimeoutNano),
+		cleanupTimeout: time.Duration(hello.CleanupTimeoutNano),
+		crashSettle:    time.Duration(hello.CrashSettleNano),
+		mappings:       make(map[xproto.Keycode]*guardianMappingClaim),
+		ownedKeys:      make(map[byte]guardianOwnedInput),
+		ownedButtons:   make(map[byte]guardianOwnedInput),
+	}
+	defer func() {
+		if !server.closed {
+			_ = server.closeConnection()
+		}
+	}()
+	if err := writeGuardianResponse(writer, helloEnvelope, nil, nil); err != nil {
+		return errors.Join(err, server.cleanup(true), server.closeConnection())
+	}
+	go server.forwardEvents()
+
+	for {
+		envelope, readErr := readGuardianEnvelope(control)
+		if readErr != nil {
+			server.stopForwardingEvents()
+			if errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
+				return errors.Join(server.cleanup(true), server.closeConnection())
+			}
+			return errors.Join(readErr, server.cleanup(true), server.closeConnection())
+		}
+		if envelope.Kind != guardianFrameRequest || envelope.ID == 0 || envelope.Operation == guardianOperationHello {
+			protocolErr := errors.New("invalid X11 guardian request envelope")
+			_ = writeGuardianResponse(writer, envelope, nil, protocolErr)
+			server.stopForwardingEvents()
+			return errors.Join(protocolErr, server.cleanup(true), server.closeConnection())
+		}
+		payload, operationErr, terminalErr := server.dispatchBounded(envelope)
+		if writeErr := writeGuardianResponse(writer, envelope, payload, operationErr); writeErr != nil {
+			server.stopForwardingEvents()
+			if terminalErr != nil {
+				return errors.Join(writeErr, terminalErr)
+			}
+			return errors.Join(writeErr, server.cleanup(true), server.closeConnection())
+		}
+		if terminalErr != nil {
+			server.stopForwardingEvents()
+			return terminalErr
+		}
+		if envelope.Operation == guardianOperationClose {
+			return nil
+		}
+	}
+}
+
+type guardianDialResult struct {
+	connection Connection
+	err        error
+}
+
+func dialGuardianConnection(dialer Dialer, display string, timeout time.Duration) (Connection, error) {
+	if timeout <= 0 {
+		timeout = guardianDefaultRequestTimeout
+	}
+	result := make(chan guardianDialResult, 1)
+	go func() {
+		connection, err := dialer.Dial(display)
+		result <- guardianDialResult{connection: connection, err: err}
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case completed := <-result:
+		return completed.connection, completed.err
+	case <-timer.C:
+		go func() {
+			completed := <-result
+			if completed.connection != nil {
+				_ = completed.connection.Close()
+			}
+		}()
+		return nil, fmt.Errorf("X11 guardian display dial timed out after %s", timeout)
+	}
+}
+
+func validateGuardianHello(expectedToken string, hello guardianHelloRequest) error {
+	if len(expectedToken) != 64 || len(hello.Token) != len(expectedToken) {
+		return errors.New("invalid X11 guardian authentication token")
+	}
+	if _, err := hex.DecodeString(expectedToken); err != nil {
+		return errors.New("invalid X11 guardian authentication token")
+	}
+	if subtle.ConstantTimeCompare([]byte(expectedToken), []byte(hello.Token)) != 1 {
+		return errors.New("X11 guardian authentication failed")
+	}
+	if hello.Display == "" {
+		return errors.New("X11 guardian display is empty")
+	}
+	for name, duration := range map[string]int64{
+		"request timeout": hello.RequestTimeoutNano,
+		"cleanup timeout": hello.CleanupTimeoutNano,
+		"crash settle":    hello.CrashSettleNano,
+	} {
+		if duration < 0 || time.Duration(duration) > guardianMaximumDuration {
+			return fmt.Errorf("X11 guardian %s is outside the supported range", name)
+		}
+	}
+	return nil
+}
+
+type guardianDispatchResult struct {
+	payload any
+	err     error
+}
+
+func (server *guardianServer) dispatchBounded(envelope guardianEnvelope) (any, error, error) {
+	// Close already contains independently bounded cleanup and transport-close
+	// phases. Running it through a second watchdog would race those state owners.
+	if envelope.Operation == guardianOperationClose {
+		payload, err := server.dispatch(envelope)
+		return payload, err, nil
+	}
+	timeout := server.requestTimeout
+	if timeout <= 0 {
+		timeout = guardianDefaultRequestTimeout
+	}
+	result := make(chan guardianDispatchResult, 1)
+	go func() {
+		payload, err := server.dispatch(envelope)
+		result <- guardianDispatchResult{payload: payload, err: err}
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case completed := <-result:
+		return completed.payload, completed.err, nil
+	case <-timer.C:
+		timeoutErr := fmt.Errorf("X11 guardian %s dispatch timed out after %s", envelope.Operation, timeout)
+		server.stopForwardingEvents()
+		closeErr := server.closeConnection()
+		terminalErr := errors.Join(timeoutErr, closeErr)
+		return nil, timeoutErr, terminalErr
+	}
+}
+
+func (server *guardianServer) forwardEvents() {
+	for {
+		open, err := server.connection.WaitForEvent()
+		event := guardianEvent{Open: open}
+		if err != nil {
+			event.Error = err.Error()
+		}
+		payload, payloadErr := guardianPayload(event)
+		if payloadErr != nil {
+			return
+		}
+		server.eventsMu.RLock()
+		if server.closing {
+			server.eventsMu.RUnlock()
+			return
+		}
+		writeErr := server.writer.write(guardianEnvelope{
+			Version: guardianProtocolVersion,
+			Kind:    guardianFrameEvent,
+			Payload: payload,
+		})
+		server.eventsMu.RUnlock()
+		if writeErr != nil || !open || err != nil {
+			return
+		}
+	}
+}
+
+func (server *guardianServer) stopForwardingEvents() {
+	server.eventsMu.Lock()
+	server.closing = true
+	server.eventsMu.Unlock()
+}
+
+func (server *guardianServer) dispatch(envelope guardianEnvelope) (any, error) {
+	switch envelope.Operation {
+	case guardianOperationSetup:
+		setup, err := server.connection.Setup()
+		return guardianSetupResponse{Setup: setup}, err
+	case guardianOperationInitXTest:
+		return nil, server.connection.InitXTest()
+	case guardianOperationXTestVersion:
+		var request guardianXTestVersionRequest
+		if err := decodeGuardianPayload(envelope.Payload, &request); err != nil {
+			return nil, err
+		}
+		version, err := server.connection.XTestVersion(request.Major, request.Minor)
+		return guardianXTestVersionResponse{Version: version}, err
+	case guardianOperationGrabServer:
+		if server.grabbed {
+			return nil, errors.New("X11 guardian server is already grabbed")
+		}
+		if err := server.connection.GrabServer(); err != nil {
+			return nil, err
+		}
+		server.grabbed = true
+		return nil, nil
+	case guardianOperationUngrabServer:
+		if !server.grabbed {
+			return nil, errors.New("X11 guardian server is not grabbed")
+		}
+		if err := server.connection.UngrabServer(); err != nil {
+			return nil, err
+		}
+		server.grabbed = false
+		return nil, nil
+	case guardianOperationKeyboardMapping:
+		var request guardianKeyboardMappingRequest
+		if err := decodeGuardianPayload(envelope.Payload, &request); err != nil {
+			return nil, err
+		}
+		mapping, err := server.connection.KeyboardMapping(request.First, request.Count)
+		return guardianKeyboardMappingResponse{Mapping: mapping}, err
+	case guardianOperationModifierMapping:
+		mapping, err := server.connection.ModifierMapping()
+		return guardianModifierMappingResponse{Keycodes: mapping}, err
+	case guardianOperationChangeKeyboardMapping:
+		var request guardianChangeKeyboardMappingRequest
+		if err := decodeGuardianPayload(envelope.Payload, &request); err != nil {
+			return nil, err
+		}
+		return nil, server.changeKeyboardMapping(request)
+	case guardianOperationPressedKeys:
+		keys, err := server.connection.PressedKeys()
+		return guardianPressedKeysResponse{Keys: keys}, err
+	case guardianOperationQueryPointer:
+		var request guardianQueryPointerRequest
+		if err := decodeGuardianPayload(envelope.Payload, &request); err != nil {
+			return nil, err
+		}
+		state, err := server.connection.QueryPointer(request.Root)
+		return guardianQueryPointerResponse{State: state}, err
+	case guardianOperationFakeInput:
+		var request guardianFakeInputRequest
+		if err := decodeGuardianPayload(envelope.Payload, &request); err != nil {
+			return nil, err
+		}
+		return nil, server.fakeInput(request)
+	case guardianOperationClose:
+		server.stopForwardingEvents()
+		cleanupErr := server.cleanup(false)
+		return nil, errors.Join(cleanupErr, server.closeConnection())
+	default:
+		return nil, fmt.Errorf("unsupported X11 guardian operation %q", envelope.Operation)
+	}
+}
+
+func writeGuardianResponse(writer *guardianFramedWriter, request guardianEnvelope, response any, responseErr error) error {
+	payload, err := guardianPayload(response)
+	if err != nil {
+		return err
+	}
+	envelope := guardianEnvelope{
+		Version:   guardianProtocolVersion,
+		Kind:      guardianFrameResponse,
+		ID:        request.ID,
+		Operation: request.Operation,
+		Payload:   payload,
+	}
+	if responseErr != nil {
+		envelope.Error = responseErr.Error()
+	}
+	return writer.write(envelope)
+}
+
+func (server *guardianServer) changeKeyboardMapping(request guardianChangeKeyboardMappingRequest) error {
+	if request.PerKeycode == 0 || len(request.Keysyms) != int(request.PerKeycode) {
+		return fmt.Errorf("invalid keyboard mapping width %d with %d keysyms", request.PerKeycode, len(request.Keysyms))
+	}
+	current, err := server.connection.KeyboardMapping(request.First, 1)
+	if err != nil {
+		return fmt.Errorf("snapshot keyboard mapping %d: %w", request.First, err)
+	}
+	if err := validGuardianMapping(current); err != nil {
+		return fmt.Errorf("snapshot keyboard mapping %d: %w", request.First, err)
+	}
+	after := KeyboardMapping{
+		KeysymsPerKeycode: request.PerKeycode,
+		Keysyms:           append([]xproto.Keysym(nil), request.Keysyms...),
+	}
+	claim := server.mappings[request.First]
+	if claim != nil {
+		if guardianMappingsEqual(after, claim.before) {
+			if guardianMappingsEqual(current, claim.before) {
+				server.removeMappingClaim(request.First)
+				return nil
+			}
+			if !guardianMappingsEqual(current, claim.after) {
+				if claim.unresolved {
+					return fmt.Errorf(
+						"X11 guardian refuses to restore unresolved mapping of keycode %d", request.First,
+					)
+				}
+			}
+			if !guardianMappingsEqual(current, claim.after) {
+				// The parent may recognize a semantically owned X11 image that is
+				// not the exact server image recorded by the guardian. Exact
+				// mismatch is foreign ownership: preserve it, relinquish our claim,
+				// and report successful cleanup instead of forcing a connection error.
+				server.removeMappingClaim(request.First)
+				return nil
+			}
+			if err := server.connection.ChangeKeyboardMapping(request.First, request.PerKeycode, request.Keysyms); err != nil {
+				return err
+			}
+			if err := server.verifyMapping(request.First, claim.before); err != nil {
+				return err
+			}
+			server.removeMappingClaim(request.First)
+			return nil
+		}
+		if !guardianMappingsEqual(current, claim.after) {
+			return fmt.Errorf("X11 guardian refuses to replace foreign mapping of keycode %d", request.First)
+		}
+		if guardianMappingsEqual(after, claim.after) {
+			return nil
+		}
+		return fmt.Errorf("X11 guardian refuses to remap owned keycode %d before restoring it", request.First)
+	} else if guardianMappingsEqual(current, after) {
+		return nil
+	} else {
+		// Store both images before the checked request. If its round trip is
+		// interrupted, cleanup treats the mutation as possibly applied.
+		claim = &guardianMappingClaim{
+			before: cloneGuardianMapping(current),
+			after:  cloneGuardianMapping(after),
+		}
+		server.mappings[request.First] = claim
+		server.mappingOrder = append(server.mappingOrder, request.First)
+	}
+	if err := server.connection.ChangeKeyboardMapping(request.First, request.PerKeycode, request.Keysyms); err != nil {
+		return server.reconcileFailedMappingChange(request.First, claim, err)
+	}
+	actual, err := server.readBackAppliedMapping(request.First, claim.after)
+	if err != nil {
+		claim.unresolved = true
+		return err
+	}
+	// X11 servers may canonicalize repeated scratch columns to NoSymbol.
+	// Track the actual server image so cleanup can distinguish our state from
+	// a later foreign replacement while preserving the exact before-image.
+	claim.after = actual
+	return nil
+}
+
+func (server *guardianServer) reconcileFailedMappingChange(
+	code xproto.Keycode,
+	claim *guardianMappingClaim,
+	changeErr error,
+) error {
+	actual, readbackErr := server.connection.KeyboardMapping(code, 1)
+	if readbackErr != nil {
+		claim.unresolved = true
+		return errors.Join(changeErr, fmt.Errorf(
+			"read back possibly applied keyboard mapping %d: %w", code, readbackErr,
+		))
+	}
+	if validErr := validGuardianMapping(actual); validErr != nil {
+		claim.unresolved = true
+		return errors.Join(changeErr, fmt.Errorf(
+			"read back possibly applied keyboard mapping %d: %w", code, validErr,
+		))
+	}
+	if guardianMappingsEqual(actual, claim.before) {
+		server.removeMappingClaim(code)
+		return changeErr
+	}
+	if server.grabbed {
+		// A checked X11 request may mutate global state before its reply is lost.
+		// While this client owns the server grab, any changed readback is the
+		// request's actual (possibly canonicalized) image. Without that exclusion,
+		// ownership remains ambiguous even when the image looks semantically equal.
+		claim.after = cloneGuardianMapping(actual)
+		claim.unresolved = false
+		return changeErr
+	}
+	claim.unresolved = true
+	return errors.Join(changeErr, fmt.Errorf(
+		"keyboard mapping %d ownership is unresolved after a failed change", code,
+	))
+}
+
+func validGuardianMapping(mapping KeyboardMapping) error {
+	if mapping.KeysymsPerKeycode == 0 {
+		return errors.New("keyboard mapping has zero width")
+	}
+	if len(mapping.Keysyms) != int(mapping.KeysymsPerKeycode) {
+		return fmt.Errorf("keyboard mapping has %d keysyms for width %d", len(mapping.Keysyms), mapping.KeysymsPerKeycode)
+	}
+	return nil
+}
+
+func cloneGuardianMapping(mapping KeyboardMapping) KeyboardMapping {
+	return KeyboardMapping{
+		KeysymsPerKeycode: mapping.KeysymsPerKeycode,
+		Keysyms:           append([]xproto.Keysym(nil), mapping.Keysyms...),
+	}
+}
+
+func guardianMappingsEqual(left, right KeyboardMapping) bool {
+	if left.KeysymsPerKeycode != right.KeysymsPerKeycode || len(left.Keysyms) != len(right.Keysyms) {
+		return false
+	}
+	for index := range left.Keysyms {
+		if left.Keysyms[index] != right.Keysyms[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func guardianMappingMatchesWrittenImage(current, written KeyboardMapping) bool {
+	if guardianMappingsEqual(current, written) {
+		return true
+	}
+	if current.KeysymsPerKeycode != written.KeysymsPerKeycode ||
+		len(current.Keysyms) != int(current.KeysymsPerKeycode) ||
+		len(written.Keysyms) != int(written.KeysymsPerKeycode) || len(written.Keysyms) == 0 {
+		return false
+	}
+	keysym := uint32(written.Keysyms[0])
+	if keysym == 0 || !x11MappingOwnedBy(written.Keysyms, keysym) {
+		return false
+	}
+	return x11MappingOwnedBy(current.Keysyms, keysym)
+}
+
+func (server *guardianServer) readBackAppliedMapping(code xproto.Keycode, expected KeyboardMapping) (KeyboardMapping, error) {
+	current, err := server.connection.KeyboardMapping(code, 1)
+	if err != nil {
+		return KeyboardMapping{}, fmt.Errorf("verify keyboard mapping %d: %w", code, err)
+	}
+	if err := validGuardianMapping(current); err != nil {
+		return KeyboardMapping{}, fmt.Errorf("verify keyboard mapping %d: %w", code, err)
+	}
+	if !guardianMappingMatchesWrittenImage(current, expected) {
+		return KeyboardMapping{}, fmt.Errorf("keyboard mapping %d failed ownership readback verification", code)
+	}
+	return cloneGuardianMapping(current), nil
+}
+
+func (server *guardianServer) verifyMapping(code xproto.Keycode, expected KeyboardMapping) error {
+	current, err := server.connection.KeyboardMapping(code, 1)
+	if err != nil {
+		return fmt.Errorf("verify keyboard mapping %d: %w", code, err)
+	}
+	if !guardianMappingsEqual(current, expected) {
+		return fmt.Errorf("keyboard mapping %d failed readback verification", code)
+	}
+	return nil
+}
+
+func (server *guardianServer) removeMappingClaim(code xproto.Keycode) {
+	delete(server.mappings, code)
+	for index := len(server.mappingOrder) - 1; index >= 0; index-- {
+		if server.mappingOrder[index] != code {
+			continue
+		}
+		copy(server.mappingOrder[index:], server.mappingOrder[index+1:])
+		server.mappingOrder[len(server.mappingOrder)-1] = 0
+		server.mappingOrder = server.mappingOrder[:len(server.mappingOrder)-1]
+		return
+	}
+}
+
+func (server *guardianServer) fakeInput(request guardianFakeInputRequest) error {
+	switch request.EventType {
+	case byte(xproto.KeyPress):
+		server.armOwnedInput(request, true)
+		server.lastKeyEvent = time.Now()
+	case byte(xproto.KeyRelease):
+		server.lastKeyEvent = time.Now()
+	case byte(xproto.ButtonPress):
+		server.armOwnedInput(request, false)
+	}
+	// Press ownership is armed before the checked XTEST request because a
+	// transport error cannot prove that the server rejected the mutation.
+	// Conversely, release ownership is removed only after a verified success.
+	if err := server.connection.FakeInput(request.EventType, request.Detail, request.Root, request.X, request.Y); err != nil {
+		return err
+	}
+	switch request.EventType {
+	case byte(xproto.KeyRelease):
+		server.removeOwnedInput(request.Detail, true)
+	case byte(xproto.ButtonRelease):
+		server.removeOwnedInput(request.Detail, false)
+	}
+	return nil
+}
+
+func (server *guardianServer) armOwnedInput(request guardianFakeInputRequest, key bool) {
+	owned := guardianOwnedInput{eventType: request.EventType, detail: request.Detail, root: request.Root}
+	if key {
+		if _, exists := server.ownedKeys[request.Detail]; exists {
+			return
+		}
+		server.ownedKeys[request.Detail] = owned
+	} else {
+		if _, exists := server.ownedButtons[request.Detail]; exists {
+			return
+		}
+		server.ownedButtons[request.Detail] = owned
+	}
+	server.inputOrder = append(server.inputOrder, owned)
+}
+
+func (server *guardianServer) removeOwnedInput(detail byte, key bool) {
+	if key {
+		delete(server.ownedKeys, detail)
+	} else {
+		delete(server.ownedButtons, detail)
+	}
+	for index := len(server.inputOrder) - 1; index >= 0; index-- {
+		input := server.inputOrder[index]
+		if input.detail != detail || (input.eventType == byte(xproto.KeyPress)) != key {
+			continue
+		}
+		copy(server.inputOrder[index:], server.inputOrder[index+1:])
+		server.inputOrder[len(server.inputOrder)-1] = guardianOwnedInput{}
+		server.inputOrder = server.inputOrder[:len(server.inputOrder)-1]
+		return
+	}
+}
+
+func (server *guardianServer) cleanup(crashed bool) error {
+	if server.closed {
+		return nil
+	}
+	timeout := server.cleanupTimeout
+	if timeout <= 0 {
+		timeout = guardianDefaultCleanupTimeout
+	}
+	server.cleanupDeadline = time.Now().Add(timeout)
+	result := make(chan error, 1)
+	done := make(chan struct{})
+	server.cleanupWorkDone = done
+	go func() {
+		result <- server.cleanupTransaction(crashed, server.cleanupDeadline)
+		close(done)
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-result:
+		return err
+	case <-timer.C:
+		// Connection.Close is deliberately started in its own goroutine. XGB
+		// Close normally interrupts blocked round trips, but if a transport's
+		// Close itself blocks, neither this watchdog nor the helper's request
+		// loop waits for it. The re-executed helper process then exits and the OS
+		// reclaims that abandoned goroutine; in-process test transports must
+		// release their Close seam explicitly.
+		server.beginConnectionClose()
+		return fmt.Errorf("X11 guardian cleanup timed out after %s; transport close initiated", timeout)
+	}
+}
+
+func (server *guardianServer) cleanupTransaction(crashed bool, deadline time.Time) error {
+	var cleanupErr error
+	if !server.grabbed {
+		if err := server.connection.GrabServer(); err != nil {
+			return fmt.Errorf("X11 guardian grab server for cleanup: %w", err)
+		}
+		server.grabbed = true
+	}
+	lastReleaseErr := server.releaseOwnedInput()
+	if crashed && len(server.inputOrder) == 0 && !server.lastKeyEvent.IsZero() && len(server.mappings) > 0 {
+		settleUntil := server.lastKeyEvent.Add(server.crashSettle)
+		if settleUntil.After(time.Now()) {
+			if err := server.connection.UngrabServer(); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("X11 guardian ungrab before crash settle: %w", err))
+			} else {
+				server.grabbed = false
+				remaining := time.Until(settleUntil)
+				if deadlineRemaining := time.Until(deadline); remaining > deadlineRemaining {
+					remaining = deadlineRemaining
+				}
+				if remaining > 0 {
+					time.Sleep(remaining)
+				}
+				if err := server.connection.GrabServer(); err != nil {
+					return errors.Join(cleanupErr, fmt.Errorf("X11 guardian re-grab after crash settle: %w", err))
+				}
+				server.grabbed = true
+			}
+		}
+	}
+
+	var lastRestoreErr error
+	for {
+		if len(server.inputOrder) > 0 {
+			lastReleaseErr = server.releaseOwnedInput()
+		}
+		retry, restoreErr := server.restoreMappingsOnce()
+		lastRestoreErr = restoreErr
+		retry = retry || len(server.inputOrder) > 0
+		if !retry || !time.Now().Before(deadline) {
+			break
+		}
+		if err := server.yieldCleanupGrab(deadline); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+			break
+		}
+	}
+	cleanupErr = errors.Join(cleanupErr, lastReleaseErr, lastRestoreErr)
+	if server.grabbed {
+		if err := server.connection.UngrabServer(); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("X11 guardian ungrab after cleanup: %w", err))
+		} else {
+			server.grabbed = false
+		}
+	}
+	return cleanupErr
+}
+
+func (server *guardianServer) yieldCleanupGrab(deadline time.Time) error {
+	if !server.grabbed {
+		return errors.New("X11 guardian cannot yield an unowned cleanup grab")
+	}
+	if err := server.connection.UngrabServer(); err != nil {
+		return fmt.Errorf("X11 guardian ungrab between cleanup retries: %w", err)
+	}
+	server.grabbed = false
+	delay := guardianCleanupRetryDelay
+	if remaining := time.Until(deadline); delay > remaining {
+		delay = remaining
+	}
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	if err := server.connection.GrabServer(); err != nil {
+		return fmt.Errorf("X11 guardian re-grab between cleanup retries: %w", err)
+	}
+	server.grabbed = true
+	return nil
+}
+
+func (server *guardianServer) releaseOwnedInput() error {
+	var releaseErr error
+	for index := len(server.inputOrder) - 1; index >= 0; index-- {
+		owned := server.inputOrder[index]
+		releaseType := owned.eventType + 1
+		if err := server.connection.FakeInput(releaseType, owned.detail, owned.root, 0, 0); err != nil {
+			releaseErr = errors.Join(releaseErr, fmt.Errorf("release X11 guardian input %d/%d: %w", owned.eventType, owned.detail, err))
+			continue
+		}
+		if owned.eventType == byte(xproto.KeyPress) {
+			delete(server.ownedKeys, owned.detail)
+		} else {
+			delete(server.ownedButtons, owned.detail)
+		}
+		server.inputOrder[index] = guardianOwnedInput{}
+	}
+	kept := server.inputOrder[:0]
+	for _, owned := range server.inputOrder {
+		if owned.eventType != 0 {
+			kept = append(kept, owned)
+		}
+	}
+	server.inputOrder = kept
+	return releaseErr
+}
+
+func (server *guardianServer) restoreMappingsOnce() (bool, error) {
+	if len(server.mappings) == 0 {
+		return false, nil
+	}
+	pressed, err := server.connection.PressedKeys()
+	if err != nil {
+		return true, fmt.Errorf("query pressed keys during X11 guardian cleanup: %w", err)
+	}
+	modifierList, err := server.connection.ModifierMapping()
+	if err != nil {
+		return true, fmt.Errorf("query modifiers during X11 guardian cleanup: %w", err)
+	}
+	modifiers := make(map[xproto.Keycode]struct{}, len(modifierList))
+	for _, code := range modifierList {
+		if code != 0 {
+			modifiers[code] = struct{}{}
+		}
+	}
+	var restoreErr error
+	retry := false
+	for index := len(server.mappingOrder) - 1; index >= 0; index-- {
+		code := server.mappingOrder[index]
+		claim := server.mappings[code]
+		if claim == nil {
+			continue
+		}
+		current, mappingErr := server.connection.KeyboardMapping(code, 1)
+		if mappingErr != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("query X11 guardian mapping %d: %w", code, mappingErr))
+			retry = true
+			continue
+		}
+		if guardianMappingsEqual(current, claim.before) {
+			server.removeMappingClaim(code)
+			continue
+		}
+		if !guardianMappingsEqual(current, claim.after) && claim.unresolved {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf(
+				"X11 guardian mapping %d ownership remains unresolved after a failed change", code,
+			))
+			retry = true
+			continue
+		}
+		if !guardianMappingsEqual(current, claim.after) {
+			// Ownership is deliberately conservative: an exact-after mismatch is
+			// another client's state. Relinquish the claim without overwriting or
+			// turning a successful preserve-foreign close into an error.
+			server.removeMappingClaim(code)
+			continue
+		}
+		if guardianKeycodePressed(pressed, code) {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("X11 guardian keycode %d remains pressed", code))
+			retry = true
+			continue
+		}
+		if _, modifier := modifiers[code]; modifier {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("X11 guardian keycode %d became a modifier", code))
+			retry = true
+			continue
+		}
+		if err := server.connection.ChangeKeyboardMapping(code, claim.before.KeysymsPerKeycode, claim.before.Keysyms); err != nil {
+			claim.unresolved = true
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("restore X11 guardian mapping %d: %w", code, err))
+			retry = true
+			continue
+		}
+		if err := server.verifyMapping(code, claim.before); err != nil {
+			restoreErr = errors.Join(restoreErr, err)
+			retry = true
+			continue
+		}
+		server.removeMappingClaim(code)
+	}
+	return retry, restoreErr
+}
+
+func guardianKeycodePressed(keys []byte, code xproto.Keycode) bool {
+	index := int(code) / 8
+	return index < len(keys) && keys[index]&(1<<uint(code%8)) != 0
+}
+
+func (server *guardianServer) closeConnection() error {
+	if server.closed {
+		return nil
+	}
+	server.closed = true
+	done := server.beginConnectionClose()
+	timeout := server.cleanupTimeout
+	if timeout <= 0 {
+		timeout = guardianDefaultCleanupTimeout
+	}
+	if !server.cleanupDeadline.IsZero() {
+		timeout = time.Until(server.cleanupDeadline)
+	}
+	if timeout <= 0 {
+		select {
+		case <-done:
+			return server.connectionCloseErr
+		default:
+			return errors.New("X11 guardian transport close exceeded the cleanup deadline")
+		}
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return server.connectionCloseErr
+	case <-timer.C:
+		return fmt.Errorf("X11 guardian transport close did not finish within %s", timeout)
+	}
+}
+
+func (server *guardianServer) beginConnectionClose() <-chan struct{} {
+	server.connectionCloseOnce.Do(func() {
+		server.connectionCloseDone = make(chan struct{})
+		go func() {
+			server.connectionCloseErr = server.connection.Close()
+			close(server.connectionCloseDone)
+		}()
+	})
+	return server.connectionCloseDone
+}

--- a/internal/x11input/keyboard_linux.go
+++ b/internal/x11input/keyboard_linux.go
@@ -1,41 +1,31 @@
-//go:build linux && !cgo
+//go:build linux
 
-package robotgo
+package x11input
 
 import (
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
-	"strings"
 	"time"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/jezek/xgb/xproto"
-	"github.com/jezek/xgb/xtest"
 )
 
-const (
-	x11KeysymF1 = 0xffbe
-)
-
-var x11KeyHoldDelay = 5 * time.Millisecond
-var x11BeforeTextTapHook func()
-
-var x11ModifierNames = map[string]struct{}{
-	"none": {},
-	"alt":  {}, "lalt": {}, "ralt": {},
-	"cmd": {}, "command": {}, "lcmd": {}, "rcmd": {},
-	"ctrl": {}, "control": {}, "lctrl": {}, "rctrl": {},
-	"shift": {}, "lshift": {}, "rshift": {}, "right_shift": {},
+// KeyEvent is a normalized X11 keysym transaction. Public key names and
+// aliases are resolved by the caller before entering the stateful core.
+type KeyEvent struct {
+	Keysym       uint32
+	Modifiers    []uint32
+	Down         bool
+	Tap          bool
+	AllowScratch bool
+	ForceScratch bool
 }
 
-var x11ShiftedSpecialKeys = map[rune]rune{
-	'`': '~', '1': '!', '2': '@', '3': '#', '4': '$', '5': '%',
-	'6': '^', '7': '&', '8': '*', '9': '(', '0': ')', '-': '_',
-	'=': '+', '[': '{', ']': '}', '\\': '|', ';': ':', '\'': '"',
-	',': '<', '.': '>', '/': '?',
+// TextEvent is one prevalidated text transaction expressed as X11 keysyms.
+type TextEvent struct {
+	Keysyms []uint32
+	Delay   time.Duration
 }
 
 type x11ResolvedKey struct {
@@ -59,7 +49,7 @@ type x11HeldKey struct {
 	modifiers []xproto.Keycode
 }
 
-func (backend *x11InputBackend) KeyboardReady() error {
+func (backend *Backend) KeyboardReady() error {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 	if err := backend.openLocked(); err != nil {
@@ -71,20 +61,20 @@ func (backend *x11InputBackend) KeyboardReady() error {
 	return nil
 }
 
-func (backend *x11InputBackend) loadKeyboardMapLocked() error {
-	setup := xproto.Setup(backend.conn)
-	if setup == nil {
-		return errors.New("missing setup information")
+func (backend *Backend) loadKeyboardMapLocked() error {
+	setup, err := backend.conn.Setup()
+	if err != nil {
+		return errors.Join(errX11Connection, err)
 	}
 	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
 	if count <= 0 || count > math.MaxUint8 {
 		return fmt.Errorf("invalid keycode range %d..%d", setup.MinKeycode, setup.MaxKeycode)
 	}
-	reply, err := xproto.GetKeyboardMapping(backend.conn, setup.MinKeycode, byte(count)).Reply()
+	reply, err := backend.conn.KeyboardMapping(setup.MinKeycode, byte(count))
 	if err != nil {
 		return err
 	}
-	if reply == nil || reply.KeysymsPerKeycode == 0 {
+	if reply.KeysymsPerKeycode == 0 {
 		return errors.New("server returned an empty keyboard map")
 	}
 	expected := count * int(reply.KeysymsPerKeycode)
@@ -108,16 +98,13 @@ func (backend *x11InputBackend) loadKeyboardMapLocked() error {
 	return nil
 }
 
-func (backend *x11InputBackend) modifierKeycodesLocked() (map[xproto.Keycode]struct{}, error) {
-	reply, err := xproto.GetModifierMapping(backend.conn).Reply()
+func (backend *Backend) modifierKeycodesLocked() (map[xproto.Keycode]struct{}, error) {
+	keycodes, err := backend.conn.ModifierMapping()
 	if err != nil {
 		return nil, errors.Join(errX11Connection, err)
 	}
-	if reply == nil {
-		return nil, errors.Join(errX11Connection, errors.New("server returned an empty modifier map"))
-	}
 	modifiers := make(map[xproto.Keycode]struct{})
-	for _, code := range reply.Keycodes {
+	for _, code := range keycodes {
 		if code != 0 {
 			modifiers[code] = struct{}{}
 		}
@@ -203,30 +190,20 @@ func x11MappingOwnedBy(mapping []xproto.Keysym, keysym uint32) bool {
 	return true
 }
 
-func (backend *x11InputBackend) updateScratchStateLocked(keyboard *x11KeyboardMap) error {
+func (backend *Backend) updateScratchStateLocked(keyboard *x11KeyboardMap) error {
 	if !backend.scratchInitialized {
-		per := int(keyboard.perKeycode)
-		for offset := 0; offset+per <= len(keyboard.keysyms); offset += per {
-			code := keyboard.minimum + xproto.Keycode(offset/per)
-			if _, modifier := keyboard.modifiers[code]; modifier {
-				continue
-			}
-			if x11MappingIs(keyboard.keysyms[offset:offset+per], 0) {
-				backend.scratchSlots = append(backend.scratchSlots, x11ScratchSlot{
-					code: code,
-				})
-			}
-		}
-		backend.scratchInitialized = true
-		backend.scratchPerKeycode = keyboard.perKeycode
-		backend.scratchByKeysym = make(map[uint32]xproto.Keycode)
+		backend.initializeScratchStateLocked(keyboard)
 		return nil
 	}
 	if keyboard.perKeycode != backend.scratchPerKeycode {
+		if len(backend.scratchByKeysym) == 0 {
+			backend.initializeScratchStateLocked(keyboard)
+			return nil
+		}
 		return fmt.Errorf("X11 keysyms-per-keycode changed from %d to %d while RobotGo owns scratch mappings",
 			backend.scratchPerKeycode, keyboard.perKeycode)
 	}
-	kept := backend.scratchSlots[:0]
+	kept := make([]x11ScratchSlot, 0, len(backend.scratchSlots))
 	for _, slot := range backend.scratchSlots {
 		if _, modifier := keyboard.modifiers[slot.code]; modifier {
 			if slot.keysym != 0 {
@@ -253,8 +230,26 @@ func (backend *x11InputBackend) updateScratchStateLocked(keyboard *x11KeyboardMa
 	return nil
 }
 
-func x11ScratchMappingCanRestore(current *xproto.GetKeyboardMappingReply, keysym uint32) (byte, bool, error) {
-	if current == nil || current.KeysymsPerKeycode == 0 {
+func (backend *Backend) initializeScratchStateLocked(keyboard *x11KeyboardMap) {
+	per := int(keyboard.perKeycode)
+	slots := make([]x11ScratchSlot, 0)
+	for offset := 0; offset+per <= len(keyboard.keysyms); offset += per {
+		code := keyboard.minimum + xproto.Keycode(offset/per)
+		if _, modifier := keyboard.modifiers[code]; modifier {
+			continue
+		}
+		if x11MappingIs(keyboard.keysyms[offset:offset+per], 0) {
+			slots = append(slots, x11ScratchSlot{code: code})
+		}
+	}
+	backend.scratchInitialized = true
+	backend.scratchPerKeycode = keyboard.perKeycode
+	backend.scratchSlots = slots
+	backend.scratchByKeysym = make(map[uint32]xproto.Keycode)
+}
+
+func x11ScratchMappingCanRestore(current KeyboardMapping, keysym uint32) (byte, bool, error) {
+	if current.KeysymsPerKeycode == 0 {
 		return 0, false, errors.New("server returned an empty scratch-key mapping")
 	}
 	width := int(current.KeysymsPerKeycode)
@@ -264,7 +259,7 @@ func x11ScratchMappingCanRestore(current *xproto.GetKeyboardMappingReply, keysym
 	return current.KeysymsPerKeycode, x11MappingOwnedBy(current.Keysyms[:width], keysym), nil
 }
 
-func (backend *x11InputBackend) restoreScratchMappingsLocked() error {
+func (backend *Backend) restoreScratchMappingsLocked() error {
 	if backend.conn == nil || backend.scratchPerKeycode == 0 {
 		return nil
 	}
@@ -278,7 +273,7 @@ func (backend *x11InputBackend) restoreScratchMappingsLocked() error {
 			if slot.keysym == 0 {
 				continue
 			}
-			current, err := xproto.GetKeyboardMapping(backend.conn, slot.code, 1).Reply()
+			current, err := backend.conn.KeyboardMapping(slot.code, 1)
 			if err != nil {
 				restoreErr = errors.Join(restoreErr, errX11Connection,
 					fmt.Errorf("query X11 scratch keycode %d during cleanup: %w", slot.code, err))
@@ -320,9 +315,7 @@ func (backend *x11InputBackend) restoreScratchMappingsLocked() error {
 				continue
 			}
 			empty := make([]xproto.Keysym, int(width))
-			if err := xproto.ChangeKeyboardMappingChecked(
-				backend.conn, 1, slot.code, width, empty,
-			).Check(); err != nil {
+			if err := backend.conn.ChangeKeyboardMapping(slot.code, width, empty); err != nil {
 				restoreErr = errors.Join(restoreErr, errX11Connection,
 					fmt.Errorf("restore X11 scratch keycode %d: %w", slot.code, err))
 				continue
@@ -334,34 +327,12 @@ func (backend *x11InputBackend) restoreScratchMappingsLocked() error {
 	})
 }
 
-func x11KeysymForKey(key string) (uint32, error) {
-	if key == "" || !utf8.ValidString(key) {
-		return 0, fmt.Errorf("%w: invalid X11 keyboard key %q", ErrNotSupported, key)
-	}
-	if named, ok := portalNamedKeysyms[strings.ToLower(key)]; ok {
-		return uint32(named), nil
-	}
-	lower := strings.ToLower(key)
-	if strings.HasPrefix(lower, "f") {
-		number, err := strconv.Atoi(strings.TrimPrefix(lower, "f"))
-		if err == nil && number >= 1 && number <= 24 {
-			return x11KeysymF1 + uint32(number-1), nil
-		}
-	}
-	if utf8.RuneCountInString(key) == 1 {
-		value, _ := utf8.DecodeRuneInString(key)
-		keysym, err := portalKeysymForRune(value)
-		return uint32(keysym), err
-	}
-	return 0, fmt.Errorf("%w: X11 keyboard key %q", ErrNotSupported, key)
-}
-
-func (backend *x11InputBackend) sendKeyLocked(code xproto.Keycode, down bool) error {
+func (backend *Backend) sendKeyLocked(code xproto.Keycode, down bool) error {
 	eventType := byte(xproto.KeyRelease)
 	if down {
 		eventType = byte(xproto.KeyPress)
 	}
-	if err := xtest.FakeInputChecked(backend.conn, eventType, byte(code), 0, backend.root, 0, 0, 0).Check(); err != nil {
+	if err := backend.conn.FakeInput(eventType, byte(code), backend.root, 0, 0); err != nil {
 		return errors.Join(errX11Connection, err)
 	}
 	return nil
@@ -379,26 +350,19 @@ func appendUniqueKeycode(codes []xproto.Keycode, code xproto.Keycode) []xproto.K
 	return append(codes, code)
 }
 
-func (backend *x11InputBackend) modifierCodesLocked(names []string) ([]xproto.Keycode, error) {
-	codes := make([]xproto.Keycode, 0, len(names)+2)
-	for _, name := range names {
-		if strings.EqualFold(name, "none") {
-			continue
-		}
-		keysym, err := x11KeysymForKey(name)
-		if err != nil {
-			return nil, err
-		}
+func (backend *Backend) modifierCodesLocked(keysyms []uint32) ([]xproto.Keycode, error) {
+	codes := make([]xproto.Keycode, 0, len(keysyms)+2)
+	for _, keysym := range keysyms {
 		modifier, ok := backend.keyboard.resolveModifier(keysym)
 		if !ok {
-			return nil, fmt.Errorf("%w: modifier %q is absent from the active X11 keymap", ErrNotSupported, name)
+			return nil, fmt.Errorf("%w: modifier keysym %#x is absent from the active X11 modifier map", ErrUnsupported, keysym)
 		}
 		codes = appendUniqueKeycode(codes, modifier.code)
 	}
 	return codes, nil
 }
 
-func (backend *x11InputBackend) reserveScratchMappingsLocked(keysyms []uint32) error {
+func (backend *Backend) reserveScratchMappingsLocked(keysyms []uint32) error {
 	return backend.withServerGrabLocked(func() error {
 		// Refresh after grabbing the server. Another client may have claimed an
 		// originally empty keycode before this transaction; never overwrite it.
@@ -409,7 +373,7 @@ func (backend *x11InputBackend) reserveScratchMappingsLocked(keysyms []uint32) e
 	})
 }
 
-func (backend *x11InputBackend) reserveScratchMappingsUnderGrabLocked(keysyms []uint32) error {
+func (backend *Backend) reserveScratchMappingsUnderGrabLocked(keysyms []uint32) error {
 	pressed, err := backend.pressedKeysLocked()
 	if err != nil {
 		return err
@@ -428,7 +392,7 @@ func (backend *x11InputBackend) reserveScratchMappingsUnderGrabLocked(keysyms []
 	return nil
 }
 
-func (backend *x11InputBackend) validateScratchCapacityLocked(keysyms []uint32, pressed []byte) error {
+func (backend *Backend) validateScratchCapacityLocked(keysyms []uint32, pressed []byte) error {
 	missing := make(map[uint32]struct{}, len(keysyms))
 	for _, keysym := range keysyms {
 		if _, assigned := backend.scratchByKeysym[keysym]; !assigned {
@@ -443,12 +407,12 @@ func (backend *x11InputBackend) validateScratchCapacityLocked(keysyms []uint32, 
 	}
 	if len(missing) > available {
 		return fmt.Errorf("%w: X11 keyboard input requires %d new stable scratch keycodes, but only %d are available; call CloseMainDisplayE after the target has processed prior keyboard input to reset the pool",
-			ErrNotSupported, len(missing), available)
+			ErrUnsupported, len(missing), available)
 	}
 	return nil
 }
 
-func (backend *x11InputBackend) assignScratchMappingLocked(keysym uint32, pressed []byte) (xproto.Keycode, error) {
+func (backend *Backend) assignScratchMappingLocked(keysym uint32, pressed []byte) (xproto.Keycode, error) {
 	if code, assigned := backend.scratchByKeysym[keysym]; assigned {
 		return code, nil
 	}
@@ -461,9 +425,9 @@ func (backend *x11InputBackend) assignScratchMappingLocked(keysym uint32, presse
 		for column := range replacement {
 			replacement[column] = xproto.Keysym(keysym)
 		}
-		if err := xproto.ChangeKeyboardMappingChecked(
-			backend.conn, 1, slot.code, backend.keyboard.perKeycode, replacement,
-		).Check(); err != nil {
+		if err := backend.conn.ChangeKeyboardMapping(
+			slot.code, backend.keyboard.perKeycode, replacement,
+		); err != nil {
 			return 0, errors.Join(errX11Connection, err)
 		}
 		slot.keysym = keysym
@@ -475,19 +439,19 @@ func (backend *x11InputBackend) assignScratchMappingLocked(keysym uint32, presse
 		copy(mapping, replacement)
 		return slot.code, nil
 	}
-	return 0, fmt.Errorf("%w: no stable X11 scratch keycode is available", ErrNotSupported)
+	return 0, fmt.Errorf("%w: no stable X11 scratch keycode is available", ErrUnsupported)
 }
 
 // prepareKeysymUnderGrabLocked must run while this X client owns the server
 // grab and after loadKeyboardMapLocked refreshed the global keymap.
-func (backend *x11InputBackend) prepareKeysymUnderGrabLocked(keysym uint32, allowScratch, forceScratch bool) (x11ResolvedKey, error) {
+func (backend *Backend) prepareKeysymUnderGrabLocked(keysym uint32, allowScratch, forceScratch bool) (x11ResolvedKey, error) {
 	if !forceScratch {
 		if resolved, ok := backend.keyboard.resolve(keysym); ok {
 			return resolved, nil
 		}
 	}
 	if !allowScratch {
-		return x11ResolvedKey{}, fmt.Errorf("%w: keysym %#x has no unambiguous mapping in the active X11 keymap", ErrNotSupported, keysym)
+		return x11ResolvedKey{}, fmt.Errorf("%w: keysym %#x has no unambiguous mapping in the active X11 keymap", ErrUnsupported, keysym)
 	}
 	if err := backend.reserveScratchMappingsUnderGrabLocked([]uint32{keysym}); err != nil {
 		return x11ResolvedKey{}, err
@@ -495,65 +459,15 @@ func (backend *x11InputBackend) prepareKeysymUnderGrabLocked(keysym uint32, allo
 	return x11ResolvedKey{code: backend.scratchByKeysym[keysym]}, nil
 }
 
-func x11LiteralKey(key string) bool {
-	if !utf8.ValidString(key) {
-		return false
-	}
-	if _, named := portalNamedKeysyms[strings.ToLower(key)]; named {
-		return false
-	}
-	if utf8.RuneCountInString(key) != 1 {
-		return false
-	}
-	_, size := utf8.DecodeRuneInString(key)
-	return size > 0
-}
-
-func validateX11KeyEvent(event pureGoKeyEvent) error {
-	if !event.Tap && event.Down && x11LiteralKey(event.Key) {
-		return fmt.Errorf("%w: Pure-Go X11 cannot safely hold literal keys across XKB layout groups; use KeyTap, KeyPress, or a named key", ErrNotSupported)
-	}
-	for _, modifier := range event.Modifiers {
-		if _, supported := x11ModifierNames[strings.ToLower(modifier)]; !supported {
-			return fmt.Errorf("%w: Pure-Go X11 modifier %q is not a supported modifier key", ErrNotSupported, modifier)
-		}
-	}
-	return nil
-}
-
-func x11EventKeysym(event pureGoKeyEvent) (uint32, error) {
-	key := event.Key
-	if x11LiteralKey(key) && x11EventHasShift(event.Modifiers) {
-		value, _ := utf8.DecodeRuneInString(key)
-		if shifted, ok := x11ShiftedSpecialKeys[value]; ok {
-			value = shifted
-		} else {
-			value = unicode.ToUpper(value)
-		}
-		key = string(value)
-	}
-	return x11KeysymForKey(key)
-}
-
-func x11EventHasShift(modifiers []string) bool {
-	for _, modifier := range modifiers {
-		switch strings.ToLower(modifier) {
-		case "shift", "lshift", "rshift", "right_shift":
-			return true
-		}
-	}
-	return false
-}
-
-func (backend *x11InputBackend) pressedKeysLocked() ([]byte, error) {
-	reply, err := xproto.QueryKeymap(backend.conn).Reply()
+func (backend *Backend) pressedKeysLocked() ([]byte, error) {
+	keys, err := backend.conn.PressedKeys()
 	if err != nil {
 		return nil, errors.Join(errX11Connection, err)
 	}
-	if reply == nil || len(reply.Keys) != 32 {
+	if len(keys) != 32 {
 		return nil, errors.Join(errX11Connection, errors.New("X11 returned an invalid pressed-key map"))
 	}
-	return reply.Keys, nil
+	return keys, nil
 }
 
 func x11KeycodePressed(keys []byte, code xproto.Keycode) bool {
@@ -561,7 +475,7 @@ func x11KeycodePressed(keys []byte, code xproto.Keycode) bool {
 	return index < len(keys) && keys[index]&(1<<uint(code%8)) != 0
 }
 
-func (backend *x11InputBackend) acquireModifierLocked(code xproto.Keycode, pressed []byte) (bool, error) {
+func (backend *Backend) acquireModifierLocked(code xproto.Keycode, pressed []byte) (bool, error) {
 	if backend.keyRefs == nil {
 		backend.keyRefs = make(map[xproto.Keycode]int)
 	}
@@ -580,7 +494,7 @@ func (backend *x11InputBackend) acquireModifierLocked(code xproto.Keycode, press
 	return true, nil
 }
 
-func (backend *x11InputBackend) acquireMainKeyLocked(code xproto.Keycode, pressed []byte) error {
+func (backend *Backend) acquireMainKeyLocked(code xproto.Keycode, pressed []byte) error {
 	if backend.keyRefs[code] > 0 || x11KeycodePressed(pressed, code) {
 		return fmt.Errorf("robotgo: X11 keycode %d is already held; refusing to alter foreign input state", code)
 	}
@@ -595,7 +509,7 @@ func (backend *x11InputBackend) acquireMainKeyLocked(code xproto.Keycode, presse
 	return nil
 }
 
-func (backend *x11InputBackend) releaseOwnedKeyLocked(code xproto.Keycode) error {
+func (backend *Backend) releaseOwnedKeyLocked(code xproto.Keycode) error {
 	refs := backend.keyRefs[code]
 	if refs <= 0 {
 		return nil
@@ -624,7 +538,7 @@ func removeX11Keycode(codes []xproto.Keycode, code xproto.Keycode) []xproto.Keyc
 	return codes
 }
 
-func (backend *x11InputBackend) releaseOwnedModifiersLocked(codes []xproto.Keycode) error {
+func (backend *Backend) releaseOwnedModifiersLocked(codes []xproto.Keycode) error {
 	var releaseErr error
 	for index := len(codes) - 1; index >= 0; index-- {
 		releaseErr = errors.Join(releaseErr, backend.releaseOwnedKeyLocked(codes[index]))
@@ -632,7 +546,7 @@ func (backend *x11InputBackend) releaseOwnedModifiersLocked(codes []xproto.Keyco
 	return releaseErr
 }
 
-func (backend *x11InputBackend) acquireModifiersLocked(codes []xproto.Keycode, pressed []byte) ([]xproto.Keycode, error) {
+func (backend *Backend) acquireModifiersLocked(codes []xproto.Keycode, pressed []byte) ([]xproto.Keycode, error) {
 	owned := make([]xproto.Keycode, 0, len(codes))
 	for _, code := range codes {
 		acquired, err := backend.acquireModifierLocked(code, pressed)
@@ -646,7 +560,7 @@ func (backend *x11InputBackend) acquireModifiersLocked(codes []xproto.Keycode, p
 	return owned, nil
 }
 
-func (backend *x11InputBackend) tapResolvedLocked(resolved x11ResolvedKey, modifierCodes []xproto.Keycode) error {
+func (backend *Backend) tapResolvedLocked(resolved x11ResolvedKey, modifierCodes []xproto.Keycode) error {
 	pressed, err := backend.pressedKeysLocked()
 	if err != nil {
 		return err
@@ -658,13 +572,13 @@ func (backend *x11InputBackend) tapResolvedLocked(resolved x11ResolvedKey, modif
 	mainDown := backend.acquireMainKeyLocked(resolved.code, pressed)
 	var mainUp error
 	if mainDown == nil {
-		time.Sleep(x11KeyHoldDelay)
+		backend.config.Sleep(backend.config.KeyHoldDelay)
 		mainUp = backend.releaseOwnedKeyLocked(resolved.code)
 	}
 	return errors.Join(mainDown, mainUp, backend.releaseOwnedModifiersLocked(ownedModifiers))
 }
 
-func (backend *x11InputBackend) tapKeysymLocked(keysym uint32, modifiers []string, allowScratch, forceScratch bool) error {
+func (backend *Backend) tapKeysymLocked(keysym uint32, modifiers []uint32, allowScratch, forceScratch bool) error {
 	return backend.withServerGrabLocked(func() error {
 		if err := backend.loadKeyboardMapLocked(); err != nil {
 			return errors.Join(errX11KeyboardMap, err)
@@ -681,7 +595,7 @@ func (backend *x11InputBackend) tapKeysymLocked(keysym uint32, modifiers []strin
 	})
 }
 
-func (backend *x11InputBackend) toggleDownResolvedLocked(keysym uint32, resolved x11ResolvedKey, modifierCodes []xproto.Keycode) error {
+func (backend *Backend) toggleDownResolvedLocked(keysym uint32, resolved x11ResolvedKey, modifierCodes []xproto.Keycode) error {
 	if backend.heldKeys != nil {
 		if _, held := backend.heldKeys[keysym]; held {
 			return nil
@@ -705,7 +619,7 @@ func (backend *x11InputBackend) toggleDownResolvedLocked(keysym uint32, resolved
 	return nil
 }
 
-func (backend *x11InputBackend) toggleDownKeysymLocked(keysym uint32, modifiers []string) error {
+func (backend *Backend) toggleDownKeysymLocked(keysym uint32, modifiers []uint32) error {
 	return backend.withServerGrabLocked(func() error {
 		if err := backend.loadKeyboardMapLocked(); err != nil {
 			return errors.Join(errX11KeyboardMap, err)
@@ -722,7 +636,7 @@ func (backend *x11InputBackend) toggleDownKeysymLocked(keysym uint32, modifiers 
 	})
 }
 
-func (backend *x11InputBackend) toggleUpLocked(keysym uint32) error {
+func (backend *Backend) toggleUpLocked(keysym uint32) error {
 	held, ok := backend.heldKeys[keysym]
 	if !ok {
 		return fmt.Errorf("robotgo: X11 key %#x is not held by this RobotGo backend", keysym)
@@ -737,17 +651,8 @@ func (backend *x11InputBackend) toggleUpLocked(keysym uint32) error {
 	return err
 }
 
-func (backend *x11InputBackend) Key(event pureGoKeyEvent) (err error) {
-	if event.PID != 0 {
-		return fmt.Errorf("%w: Pure-Go X11 input cannot target a process", ErrNotSupported)
-	}
-	if err := validateX11KeyEvent(event); err != nil {
-		return err
-	}
-	keysym, err := x11EventKeysym(event)
-	if err != nil {
-		return err
-	}
+func (backend *Backend) Key(event KeyEvent) (err error) {
+	keysym := event.Keysym
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 	if err := backend.openLocked(); err != nil {
@@ -761,7 +666,7 @@ func (backend *x11InputBackend) Key(event pureGoKeyEvent) (err error) {
 		return err
 	}
 	if event.Tap {
-		err = backend.tapKeysymLocked(keysym, event.Modifiers, true, x11LiteralKey(event.Key))
+		err = backend.tapKeysymLocked(keysym, event.Modifiers, event.AllowScratch, event.ForceScratch)
 	} else {
 		err = backend.toggleDownKeysymLocked(keysym, event.Modifiers)
 	}
@@ -771,37 +676,24 @@ func (backend *x11InputBackend) Key(event pureGoKeyEvent) (err error) {
 	return err
 }
 
-func (backend *x11InputBackend) Text(event pureGoTextEvent) (err error) {
-	if event.PID != 0 {
-		return fmt.Errorf("%w: Pure-Go X11 input cannot target a process", ErrNotSupported)
-	}
+func (backend *Backend) Text(event TextEvent) (err error) {
 	if event.Delay < 0 {
 		return errors.New("robotgo: text delay must be non-negative")
-	}
-	if !utf8.ValidString(event.Text) {
-		return errors.New("robotgo: text is not valid UTF-8")
 	}
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 	if err := backend.openLocked(); err != nil {
 		return err
 	}
-	keysyms := make([]uint32, 0, utf8.RuneCountInString(event.Text))
-	for _, value := range event.Text {
-		keysym, keysymErr := portalKeysymForRune(value)
-		if keysymErr != nil {
-			return keysymErr
-		}
-		keysyms = append(keysyms, uint32(keysym))
-	}
+	keysyms := append([]uint32(nil), event.Keysyms...)
 	if reserveErr := backend.reserveScratchMappingsLocked(keysyms); reserveErr != nil {
 		if errors.Is(reserveErr, errX11Connection) || errors.Is(reserveErr, errX11KeyboardMap) {
 			return backend.failLocked("prepare Unicode keyboard mappings", reserveErr)
 		}
 		return reserveErr
 	}
-	if x11BeforeTextTapHook != nil {
-		x11BeforeTextTapHook()
+	if backend.beforeTextTap != nil {
+		backend.beforeTextTap()
 	}
 	for _, keysym := range keysyms {
 		tapErr := backend.tapKeysymLocked(keysym, nil, true, true)
@@ -812,7 +704,7 @@ func (backend *x11InputBackend) Text(event pureGoTextEvent) (err error) {
 			}
 			return err
 		}
-		MilliSleep(event.Delay)
+		backend.config.Sleep(event.Delay)
 	}
 	return nil
 }

--- a/internal/x11input/pointer_linux.go
+++ b/internal/x11input/pointer_linux.go
@@ -1,6 +1,6 @@
-//go:build linux && !cgo
+//go:build linux
 
-package robotgo
+package x11input
 
 import (
 	"errors"
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/jezek/xgb/xproto"
-	"github.com/jezek/xgb/xtest"
 )
 
 const (
@@ -20,16 +19,27 @@ const (
 )
 
 const (
-	x11ButtonLeft       byte = 1
-	x11ButtonMiddle     byte = 2
-	x11ButtonRight      byte = 3
-	x11ButtonWheelUp    byte = 4
-	x11ButtonWheelDown  byte = 5
-	x11ButtonWheelLeft  byte = 6
-	x11ButtonWheelRight byte = 7
+	ButtonLeft       Button = 1
+	ButtonMiddle     Button = 2
+	ButtonRight      Button = 3
+	ButtonWheelUp    Button = 4
+	ButtonWheelDown  Button = 5
+	ButtonWheelLeft  Button = 6
+	ButtonWheelRight Button = 7
+
+	x11ButtonLeft       = ButtonLeft
+	x11ButtonMiddle     = ButtonMiddle
+	x11ButtonRight      = ButtonRight
+	x11ButtonWheelUp    = ButtonWheelUp
+	x11ButtonWheelDown  = ButtonWheelDown
+	x11ButtonWheelLeft  = ButtonWheelLeft
+	x11ButtonWheelRight = ButtonWheelRight
 )
 
-func (backend *x11InputBackend) MouseReady() error {
+// Button is an X11 core pointer-button number.
+type Button = byte
+
+func (backend *Backend) MouseReady() error {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 	if err := backend.openLocked(); err != nil {
@@ -39,27 +49,6 @@ func (backend *x11InputBackend) MouseReady() error {
 		return backend.failLocked("query pointer", err)
 	}
 	return nil
-}
-
-func x11MouseButton(name string) (byte, error) {
-	switch name {
-	case "", "left":
-		return x11ButtonLeft, nil
-	case "center", "middle":
-		return x11ButtonMiddle, nil
-	case "right":
-		return x11ButtonRight, nil
-	case "wheelUp":
-		return x11ButtonWheelUp, nil
-	case "wheelDown":
-		return x11ButtonWheelDown, nil
-	case "wheelLeft":
-		return x11ButtonWheelLeft, nil
-	case "wheelRight":
-		return x11ButtonWheelRight, nil
-	default:
-		return 0, fmt.Errorf("robotgo: invalid X11 pointer button %q", name)
-	}
 }
 
 func x11Coordinate(value int) (int16, error) {
@@ -81,12 +70,12 @@ func x11Coordinates(x, y int) (int16, int16, error) {
 	return xCoordinate, yCoordinate, nil
 }
 
-func (backend *x11InputBackend) sendButtonLocked(button byte, down bool) error {
+func (backend *Backend) sendButtonLocked(button byte, down bool) error {
 	eventType := byte(xproto.ButtonRelease)
 	if down {
 		eventType = byte(xproto.ButtonPress)
 	}
-	if err := xtest.FakeInputChecked(backend.conn, eventType, button, 0, backend.root, 0, 0, 0).Check(); err != nil {
+	if err := backend.conn.FakeInput(eventType, button, backend.root, 0, 0); err != nil {
 		return errors.Join(errX11Connection, err)
 	}
 	return nil
@@ -113,7 +102,7 @@ func x11ButtonStateObservable(button byte) bool {
 	return x11ButtonMask(button) != 0
 }
 
-func (backend *x11InputBackend) acquireButtonLocked(button byte, pointerMask uint16) error {
+func (backend *Backend) acquireButtonLocked(button byte, pointerMask uint16) error {
 	if _, held := backend.buttons[button]; held {
 		return fmt.Errorf("robotgo: X11 button %d is already held by this RobotGo backend", button)
 	}
@@ -131,7 +120,7 @@ func (backend *x11InputBackend) acquireButtonLocked(button byte, pointerMask uin
 	return nil
 }
 
-func (backend *x11InputBackend) releaseOwnedButtonLocked(button byte) error {
+func (backend *Backend) releaseOwnedButtonLocked(button byte) error {
 	if _, held := backend.buttons[button]; !held {
 		return fmt.Errorf("robotgo: X11 button %d is not held by this RobotGo backend", button)
 	}
@@ -155,35 +144,33 @@ func removeX11Button(buttons []byte, button byte) []byte {
 	return buttons
 }
 
-func (backend *x11InputBackend) moveLocked(x, y int) error {
+func (backend *Backend) moveLocked(x, y int) error {
 	xCoordinate, yCoordinate, err := x11Coordinates(x, y)
 	if err != nil {
 		return err
 	}
-	if err := xtest.FakeInputChecked(
-		backend.conn, byte(xproto.MotionNotify), 0, 0, backend.root,
-		xCoordinate, yCoordinate, 0,
-	).Check(); err != nil {
+	if err := backend.conn.FakeInput(
+		byte(xproto.MotionNotify), 0, backend.root, xCoordinate, yCoordinate,
+	); err != nil {
 		return errors.Join(errX11Connection, err)
 	}
 	return nil
 }
 
-func (backend *x11InputBackend) moveRelativeLocked(x, y int) error {
+func (backend *Backend) moveRelativeLocked(x, y int) error {
 	xDelta, yDelta, err := x11Coordinates(x, y)
 	if err != nil {
 		return err
 	}
-	if err := xtest.FakeInputChecked(
-		backend.conn, byte(xproto.MotionNotify), x11RelativeMotion, 0,
-		xproto.Window(0), xDelta, yDelta, 0,
-	).Check(); err != nil {
+	if err := backend.conn.FakeInput(
+		byte(xproto.MotionNotify), x11RelativeMotion, xproto.Window(0), xDelta, yDelta,
+	); err != nil {
 		return errors.Join(errX11Connection, err)
 	}
 	return nil
 }
 
-func (backend *x11InputBackend) MoveAbsolute(x, y int, _ []int) error {
+func (backend *Backend) MoveAbsolute(x, y int, _ []int) error {
 	if _, _, err := x11Coordinates(x, y); err != nil {
 		return err
 	}
@@ -198,18 +185,15 @@ func (backend *x11InputBackend) MoveAbsolute(x, y int, _ []int) error {
 	return nil
 }
 
-func (backend *x11InputBackend) pointerStateLocked() (*xproto.QueryPointerReply, error) {
-	reply, err := xproto.QueryPointer(backend.conn, backend.root).Reply()
+func (backend *Backend) pointerStateLocked() (PointerState, error) {
+	reply, err := backend.conn.QueryPointer(backend.root)
 	if err != nil {
-		return nil, errors.Join(errX11Connection, err)
-	}
-	if reply == nil {
-		return nil, errors.Join(errX11Connection, errors.New("server returned no pointer reply"))
+		return PointerState{}, errors.Join(errX11Connection, err)
 	}
 	return reply, nil
 }
 
-func (backend *x11InputBackend) pointerLocationLocked() (int, int, error) {
+func (backend *Backend) pointerLocationLocked() (int, int, error) {
 	reply, err := backend.pointerStateLocked()
 	if err != nil {
 		return 0, 0, err
@@ -217,7 +201,7 @@ func (backend *x11InputBackend) pointerLocationLocked() (int, int, error) {
 	return int(reply.RootX), int(reply.RootY), nil
 }
 
-func (backend *x11InputBackend) MoveRelative(x, y int) error {
+func (backend *Backend) MoveRelative(x, y int) error {
 	if _, _, err := x11Coordinates(x, y); err != nil {
 		return err
 	}
@@ -250,7 +234,13 @@ func validateX11SmoothMove(x, y int, lowDelay, highDelay float64) error {
 	return nil
 }
 
-func (backend *x11InputBackend) planSmoothMoveLocked(x, y int, relative bool, lowDelay, highDelay float64) (x11SmoothMovePlan, error) {
+func validSmoothDelayRange(lowDelay, highDelay float64) bool {
+	return !math.IsNaN(lowDelay) && !math.IsNaN(highDelay) &&
+		!math.IsInf(lowDelay, 0) && !math.IsInf(highDelay, 0) &&
+		lowDelay >= 0 && highDelay >= lowDelay
+}
+
+func (backend *Backend) planSmoothMoveLocked(x, y int, relative bool, lowDelay, highDelay float64) (x11SmoothMovePlan, error) {
 	plan := x11SmoothMovePlan{relative: relative, targetX: x, targetY: y}
 	if !relative {
 		startX, startY, err := backend.pointerLocationLocked()
@@ -272,7 +262,7 @@ func (backend *x11InputBackend) planSmoothMoveLocked(x, y int, relative bool, lo
 	return plan, nil
 }
 
-func (backend *x11InputBackend) executeSmoothMoveLocked(plan x11SmoothMovePlan) error {
+func (backend *Backend) executeSmoothMoveLocked(plan x11SmoothMovePlan) error {
 	lastX, lastY := plan.startX, plan.startY
 	for step := 1; step <= plan.steps; step++ {
 		progress := float64(step) / float64(plan.steps)
@@ -298,13 +288,13 @@ func (backend *x11InputBackend) executeSmoothMoveLocked(plan x11SmoothMovePlan) 
 		}
 		lastX, lastY = currentX, currentY
 		if plan.delay > 0 && step != plan.steps {
-			time.Sleep(plan.delay)
+			backend.config.Sleep(plan.delay)
 		}
 	}
 	return nil
 }
 
-func (backend *x11InputBackend) MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error {
+func (backend *Backend) MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error {
 	if err := validateX11SmoothMove(x, y, lowDelay, highDelay); err != nil {
 		return err
 	}
@@ -323,7 +313,7 @@ func (backend *x11InputBackend) MoveSmooth(x, y int, relative bool, lowDelay, hi
 	return nil
 }
 
-func (backend *x11InputBackend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
+func (backend *Backend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
 	if err := validateX11SmoothMove(x, y, lowDelay, highDelay); err != nil {
 		return err
 	}
@@ -341,7 +331,7 @@ func (backend *x11InputBackend) DragSmooth(x, y int, lowDelay, highDelay float64
 		return downErr
 	}
 	if downErr == nil {
-		time.Sleep(50 * time.Millisecond)
+		backend.config.Sleep(50 * time.Millisecond)
 	}
 	moveErr := downErr
 	if downErr == nil {
@@ -358,7 +348,7 @@ func (backend *x11InputBackend) DragSmooth(x, y int, lowDelay, highDelay float64
 	return nil
 }
 
-func (backend *x11InputBackend) Location() (int, int, error) {
+func (backend *Backend) Location() (int, int, error) {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 	if err := backend.openLocked(); err != nil {
@@ -371,10 +361,9 @@ func (backend *x11InputBackend) Location() (int, int, error) {
 	return x, y, nil
 }
 
-func (backend *x11InputBackend) Click(name string, double bool) error {
-	button, err := x11MouseButton(name)
-	if err != nil {
-		return err
+func (backend *Backend) Click(button Button, double bool) error {
+	if !x11ButtonStateObservable(button) {
+		return fmt.Errorf("%w: Pure-Go X11 cannot safely click button %d because core X11 exposes state only for buttons 1-5", ErrUnsupported, button)
 	}
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
@@ -393,7 +382,7 @@ func (backend *x11InputBackend) Click(name string, double bool) error {
 			break
 		}
 		if click+1 < clicks {
-			time.Sleep(x11DoubleClickGap)
+			backend.config.Sleep(x11DoubleClickGap)
 		}
 	}
 	if eventErr != nil {
@@ -405,13 +394,9 @@ func (backend *x11InputBackend) Click(name string, double bool) error {
 	return nil
 }
 
-func (backend *x11InputBackend) Toggle(name string, down bool) error {
-	button, err := x11MouseButton(name)
-	if err != nil {
-		return err
-	}
+func (backend *Backend) Toggle(button Button, down bool) error {
 	if !x11ButtonStateObservable(button) {
-		return fmt.Errorf("%w: Pure-Go X11 cannot safely own button %d because core X11 exposes state only for buttons 1-5", ErrNotSupported, button)
+		return fmt.Errorf("%w: Pure-Go X11 cannot safely own button %d because core X11 exposes state only for buttons 1-5", ErrUnsupported, button)
 	}
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
@@ -446,7 +431,7 @@ func x11ScrollSteps(value int) (uint64, error) {
 	return steps, nil
 }
 
-func (backend *x11InputBackend) scrollWheelLocked(button byte, count uint64) error {
+func (backend *Backend) scrollWheelLocked(button byte, count uint64) error {
 	for step := uint64(0); step < count; step++ {
 		if err := backend.pulseButtonTransactionLocked(button); err != nil {
 			return err
@@ -455,7 +440,7 @@ func (backend *x11InputBackend) scrollWheelLocked(button byte, count uint64) err
 	return nil
 }
 
-func (backend *x11InputBackend) pulseButtonTransactionLocked(button byte) error {
+func (backend *Backend) pulseButtonTransactionLocked(button byte) error {
 	return backend.withServerGrabLocked(func() error {
 		pointer, err := backend.pointerStateLocked()
 		if err != nil {
@@ -468,10 +453,9 @@ func (backend *x11InputBackend) pulseButtonTransactionLocked(button byte) error 
 	})
 }
 
-func (backend *x11InputBackend) Scroll(x, y int) error {
-	xSteps, err := x11ScrollSteps(x)
-	if err != nil {
-		return err
+func (backend *Backend) Scroll(x, y int) error {
+	if x != 0 {
+		return fmt.Errorf("%w: Pure-Go X11 cannot safely scroll horizontally because core X11 does not expose buttons 6-7 state", ErrUnsupported)
 	}
 	ySteps, err := x11ScrollSteps(y)
 	if err != nil {
@@ -481,18 +465,6 @@ func (backend *x11InputBackend) Scroll(x, y int) error {
 	defer backend.mu.Unlock()
 	if err := backend.openLocked(); err != nil {
 		return err
-	}
-	if x != 0 {
-		button := x11ButtonWheelLeft
-		if x < 0 {
-			button = x11ButtonWheelRight
-		}
-		if err := backend.scrollWheelLocked(button, xSteps); err != nil {
-			if errors.Is(err, errX11Connection) {
-				return backend.failLocked("scroll pointer horizontally", err)
-			}
-			return err
-		}
 	}
 	if y != 0 {
 		button := x11ButtonWheelUp
@@ -509,7 +481,7 @@ func (backend *x11InputBackend) Scroll(x, y int) error {
 	return nil
 }
 
-func (backend *x11InputBackend) acquireButtonTransactionLocked(button byte) error {
+func (backend *Backend) acquireButtonTransactionLocked(button byte) error {
 	return backend.withServerGrabLocked(func() error {
 		pointer, err := backend.pointerStateLocked()
 		if err != nil {
@@ -519,13 +491,13 @@ func (backend *x11InputBackend) acquireButtonTransactionLocked(button byte) erro
 	})
 }
 
-func (backend *x11InputBackend) releaseButtonTransactionLocked(button byte) error {
+func (backend *Backend) releaseButtonTransactionLocked(button byte) error {
 	return backend.withServerGrabLocked(func() error {
 		return backend.releaseOwnedButtonLocked(button)
 	})
 }
 
-func (backend *x11InputBackend) clickButtonTransactionLocked(button byte) error {
+func (backend *Backend) clickButtonTransactionLocked(button byte) error {
 	return backend.withServerGrabLocked(func() error {
 		pointer, err := backend.pointerStateLocked()
 		if err != nil {
@@ -533,7 +505,7 @@ func (backend *x11InputBackend) clickButtonTransactionLocked(button byte) error 
 		}
 		downErr := backend.acquireButtonLocked(button, pointer.Mask)
 		if downErr == nil {
-			time.Sleep(x11KeyHoldDelay)
+			backend.config.Sleep(backend.config.KeyHoldDelay)
 		}
 		var upErr error
 		if downErr == nil {

--- a/internal/x11input/testing_linux_x11integration.go
+++ b/internal/x11input/testing_linux_x11integration.go
@@ -1,0 +1,46 @@
+//go:build linux && x11integration
+
+package x11input
+
+import "time"
+
+// SetKeyHoldDelayForIntegrationTest changes the per-backend key hold while an
+// external XKB client observes delivery. It is available only to tagged tests.
+func (backend *Backend) SetKeyHoldDelayForIntegrationTest(delay time.Duration) func() {
+	backend.mu.Lock()
+	previous := backend.config.KeyHoldDelay
+	backend.config.KeyHoldDelay = delay
+	backend.mu.Unlock()
+	return func() {
+		backend.mu.Lock()
+		backend.config.KeyHoldDelay = previous
+		backend.mu.Unlock()
+	}
+}
+
+// SetBeforeTextTapHookForIntegrationTest installs an adversarial hook between
+// scratch reservation and the first text tap. The hook must not call Backend.
+func (backend *Backend) SetBeforeTextTapHookForIntegrationTest(hook func()) func() {
+	backend.mu.Lock()
+	previous := backend.beforeTextTap
+	backend.beforeTextTap = hook
+	backend.mu.Unlock()
+	return func() {
+		backend.mu.Lock()
+		backend.beforeTextTap = previous
+		backend.mu.Unlock()
+	}
+}
+
+// GuardianPIDForIntegrationTest returns the PID of the live re-executed
+// guardian backing this Backend. It is available only to tagged integration
+// tests and deliberately exposes no production lifecycle control.
+func (backend *Backend) GuardianPIDForIntegrationTest() (int, bool) {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	connection, ok := backend.conn.(*guardianConnection)
+	if !ok || connection.process == nil || connection.process.Process == nil {
+		return 0, false
+	}
+	return connection.process.Process.Pid, true
+}

--- a/internal/x11input/transport_linux.go
+++ b/internal/x11input/transport_linux.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package x11input
+
+import (
+	"time"
+
+	"github.com/jezek/xgb/xproto"
+)
+
+// Setup is the immutable X11 connection information needed by the input core.
+type Setup struct {
+	Root       xproto.Window
+	MinKeycode xproto.Keycode
+	MaxKeycode xproto.Keycode
+}
+
+// XTestVersion is the server's negotiated XTEST protocol version.
+type XTestVersion struct {
+	Major byte
+	Minor uint16
+	Valid bool
+}
+
+// KeyboardMapping is a detached snapshot of one contiguous keyboard-map range.
+type KeyboardMapping struct {
+	KeysymsPerKeycode byte
+	Keysyms           []xproto.Keysym
+}
+
+// PointerState is the root-relative position and core button mask.
+type PointerState struct {
+	RootX int16
+	RootY int16
+	Mask  uint16
+}
+
+// Connection owns every X11 primitive used by Backend. The boundary is
+// intentionally complete so another process can own the same transaction and
+// lifecycle machinery without exposing *xgb.Conn to the stateful core. Close
+// must synchronously finish verified transport cleanup and unblock
+// WaitForEvent, even when it returns an error.
+type Connection interface {
+	Close() error
+	WaitForEvent() (open bool, err error)
+	Setup() (Setup, error)
+	InitXTest() error
+	XTestVersion(major byte, minor uint16) (XTestVersion, error)
+	GrabServer() error
+	UngrabServer() error
+	KeyboardMapping(first xproto.Keycode, count byte) (KeyboardMapping, error)
+	ModifierMapping() ([]xproto.Keycode, error)
+	ChangeKeyboardMapping(first xproto.Keycode, perKeycode byte, keysyms []xproto.Keysym) error
+	PressedKeys() ([]byte, error)
+	QueryPointer(root xproto.Window) (PointerState, error)
+	FakeInput(eventType, detail byte, root xproto.Window, x, y int16) error
+}
+
+// Dialer creates one complete X11 connection owned by Backend.
+type Dialer interface {
+	Dial(display string) (Connection, error)
+}
+
+// Config defines immutable dependencies and timings for one Backend.
+type Config struct {
+	ResolveDisplay func() (string, error)
+	Dialer         Dialer
+	KeyHoldDelay   time.Duration
+	Sleep          func(time.Duration)
+}

--- a/internal/x11input/transport_xgb_linux.go
+++ b/internal/x11input/transport_xgb_linux.go
@@ -1,0 +1,150 @@
+//go:build linux
+
+package x11input
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgb/xtest"
+)
+
+type xgbDialer struct{}
+
+var _ Dialer = xgbDialer{}
+
+func (xgbDialer) Dial(display string) (Connection, error) {
+	connection, err := xgb.NewConnDisplay(display)
+	if err != nil {
+		return nil, err
+	}
+	return &xgbConnection{connection: connection, events: connection}, nil
+}
+
+type xgbEventSource interface {
+	Close()
+	WaitForEvent() (xgb.Event, xgb.Error)
+}
+
+type xgbConnection struct {
+	connection *xgb.Conn
+	events     xgbEventSource
+	closeOnce  sync.Once
+}
+
+var _ Connection = (*xgbConnection)(nil)
+
+func (connection *xgbConnection) Close() error {
+	connection.closeOnce.Do(func() {
+		// xgb.Conn.Close only queues the close request. Drain until xgb's
+		// event channel is actually closed so callers know that no event-pump
+		// goroutine can still be using this transport when Close returns.
+		connection.events.Close()
+		for {
+			event, err := connection.events.WaitForEvent()
+			if event == nil && err == nil {
+				return
+			}
+		}
+	})
+	return nil
+}
+
+func (connection *xgbConnection) WaitForEvent() (bool, error) {
+	event, err := connection.events.WaitForEvent()
+	return event != nil || err != nil, err
+}
+
+func (connection *xgbConnection) Setup() (Setup, error) {
+	setup := xproto.Setup(connection.connection)
+	if setup == nil {
+		return Setup{}, errors.New("X11 returned no setup information")
+	}
+	screen := setup.DefaultScreen(connection.connection)
+	if screen == nil || screen.Root == 0 {
+		return Setup{}, errors.New("X11 returned no default root window")
+	}
+	return Setup{Root: screen.Root, MinKeycode: setup.MinKeycode, MaxKeycode: setup.MaxKeycode}, nil
+}
+
+func (connection *xgbConnection) InitXTest() error { return xtest.Init(connection.connection) }
+
+func (connection *xgbConnection) XTestVersion(major byte, minor uint16) (XTestVersion, error) {
+	reply, err := xtest.GetVersion(connection.connection, major, minor).Reply()
+	if err != nil {
+		return XTestVersion{}, err
+	}
+	if reply == nil {
+		return XTestVersion{}, nil
+	}
+	return XTestVersion{Major: reply.MajorVersion, Minor: reply.MinorVersion, Valid: true}, nil
+}
+
+func (connection *xgbConnection) GrabServer() error {
+	return xproto.GrabServerChecked(connection.connection).Check()
+}
+
+func (connection *xgbConnection) UngrabServer() error {
+	return xproto.UngrabServerChecked(connection.connection).Check()
+}
+
+func (connection *xgbConnection) KeyboardMapping(first xproto.Keycode, count byte) (KeyboardMapping, error) {
+	reply, err := xproto.GetKeyboardMapping(connection.connection, first, count).Reply()
+	if err != nil {
+		return KeyboardMapping{}, err
+	}
+	if reply == nil {
+		return KeyboardMapping{}, errors.New("server returned no keyboard map")
+	}
+	return KeyboardMapping{
+		KeysymsPerKeycode: reply.KeysymsPerKeycode,
+		Keysyms:           append([]xproto.Keysym(nil), reply.Keysyms...),
+	}, nil
+}
+
+func (connection *xgbConnection) ModifierMapping() ([]xproto.Keycode, error) {
+	reply, err := xproto.GetModifierMapping(connection.connection).Reply()
+	if err != nil {
+		return nil, err
+	}
+	if reply == nil {
+		return nil, errors.New("server returned an empty modifier map")
+	}
+	return append([]xproto.Keycode(nil), reply.Keycodes...), nil
+}
+
+func (connection *xgbConnection) ChangeKeyboardMapping(first xproto.Keycode, perKeycode byte, keysyms []xproto.Keysym) error {
+	return xproto.ChangeKeyboardMappingChecked(
+		connection.connection, 1, first, perKeycode, keysyms,
+	).Check()
+}
+
+func (connection *xgbConnection) PressedKeys() ([]byte, error) {
+	reply, err := xproto.QueryKeymap(connection.connection).Reply()
+	if err != nil {
+		return nil, err
+	}
+	if reply == nil {
+		return nil, errors.New("X11 returned no pressed-key map")
+	}
+	return append([]byte(nil), reply.Keys...), nil
+}
+
+func (connection *xgbConnection) QueryPointer(root xproto.Window) (PointerState, error) {
+	reply, err := xproto.QueryPointer(connection.connection, root).Reply()
+	if err != nil {
+		return PointerState{}, err
+	}
+	if reply == nil {
+		return PointerState{}, errors.New("server returned no pointer reply")
+	}
+	return PointerState{RootX: reply.RootX, RootY: reply.RootY, Mask: reply.Mask}, nil
+}
+
+func (connection *xgbConnection) FakeInput(eventType, detail byte, root xproto.Window, x, y int16) error {
+	return xtest.FakeInputChecked(
+		connection.connection, eventType, detail, 0, root, x, y, 0,
+	).Check()
+}

--- a/internal/x11input/transport_xgb_linux_test.go
+++ b/internal/x11input/transport_xgb_linux_test.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package x11input
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jezek/xgb"
+)
+
+type fakeXGBEvent struct{}
+
+func (fakeXGBEvent) Bytes() []byte  { return nil }
+func (fakeXGBEvent) String() string { return "fake XGB event" }
+
+type fakeXGBEventSource struct {
+	closeOnce   sync.Once
+	closeCalled chan struct{}
+	events      chan xgb.Event
+}
+
+func (source *fakeXGBEventSource) Close() {
+	source.closeOnce.Do(func() { close(source.closeCalled) })
+}
+
+func (source *fakeXGBEventSource) WaitForEvent() (xgb.Event, xgb.Error) {
+	event, open := <-source.events
+	if !open {
+		return nil, nil
+	}
+	return event, nil
+}
+
+func TestXGBConnectionCloseWaitsForEventTransportTermination(t *testing.T) {
+	source := &fakeXGBEventSource{
+		closeCalled: make(chan struct{}),
+		events:      make(chan xgb.Event, 1),
+	}
+	source.events <- fakeXGBEvent{}
+	connection := &xgbConnection{events: source}
+	closed := make(chan struct{})
+	go func() {
+		_ = connection.Close()
+		close(closed)
+	}()
+	select {
+	case <-source.closeCalled:
+	case <-time.After(time.Second):
+		t.Fatal("transport Close was not called")
+	}
+	select {
+	case <-closed:
+		t.Fatal("xgbConnection.Close returned before the event transport terminated")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(source.events)
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("xgbConnection.Close did not return after event transport termination")
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}

--- a/scripts/benchmark-x11-backends.sh
+++ b/scripts/benchmark-x11-backends.sh
@@ -44,6 +44,7 @@ readonly -a PUREGO_ONLY_BEHAVIOR_TESTS=(
 	'TestPureGoX11PointerInput'
 	'TestPureGoX11KeyboardInput'
 	'TestPureGoX11TextReachesDelayedXKBClient'
+	'TestPureGoX11CrashRestoresScratchAndOwnedInput'
 	'TestPureGoX11ExplicitShiftReachesXKBClient'
 	'TestPureGoX11ScratchReservationSkipsPressedEmptyKeycode'
 	'TestPureGoX11ScratchCleanupCanRetryAfterForeignRelease'
@@ -66,7 +67,6 @@ readonly -a EXPECTED_BENCHMARK_NAMES=(
 	'BenchmarkX11InputRuntime/ButtonTogglePair'
 	'BenchmarkX11InputRuntime/ClickLeft'
 	'BenchmarkX11InputRuntime/ScrollVertical1'
-	'BenchmarkX11InputRuntime/ScrollHorizontal1'
 	'BenchmarkX11InputRuntime/KeyTogglePairEnter'
 	'BenchmarkX11InputRuntime/KeyPressEnter'
 	'BenchmarkX11InputRuntime/TypeASCII8'
@@ -606,6 +606,7 @@ require_command git
 require_command xvfb-run
 require_command Xvfb
 require_command setxkbmap
+require_command xkbcomp
 require_command tee
 require_command pkg-config
 

--- a/x11_input_benchmark_test.go
+++ b/x11_input_benchmark_test.go
@@ -92,11 +92,6 @@ func BenchmarkX11InputRuntime(b *testing.B) {
 			return robotgo.ScrollE(0, 1, 0)
 		})
 	})
-	b.Run("ScrollHorizontal1", func(b *testing.B) {
-		benchmarkX11Operation(b, harness, func(_ int) error {
-			return robotgo.ScrollE(1, 0, 0)
-		})
-	})
 	b.Run("KeyTogglePairEnter", func(b *testing.B) {
 		benchmarkX11Operation(b, harness, func(_ int) error {
 			if err := robotgo.KeyToggle("enter", "down"); err != nil {

--- a/x11_input_crash_integration_test.go
+++ b/x11_input_crash_integration_test.go
@@ -1,0 +1,360 @@
+//go:build linux && !cgo && x11integration && !wayland
+
+package robotgo_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/jezek/xgb/xproto"
+	"github.com/marang/robotgo"
+)
+
+func TestPureGoX11CrashRestoresScratchAndOwnedInput(t *testing.T) {
+	if os.Getenv(x11CrashObserverEnv) == "1" {
+		x11CrashWriteObserverSnapshot(t)
+		return
+	}
+	if os.Getenv(x11CrashHelperEnv) == "1" {
+		runPureGoX11CrashWorkload(t)
+		return
+	}
+
+	harness := newX11InputHarness(t)
+	initialInput := harness.inputState()
+	foreignKey := x11CrashForeignKey(t, harness, initialInput)
+	foreignButton, foreignButtonMask := x11CrashForeignButton(t, initialInput.pointerMask)
+	harness.fakeKey(foreignKey, true)
+	t.Cleanup(func() { harness.fakeKey(foreignKey, false) })
+	harness.fakeButton(foreignButton, true)
+	t.Cleanup(func() { harness.fakeButton(foreignButton, false) })
+	harness.conn.Sync()
+	beforeKeyboard := harness.keyboardState()
+	beforeKeyboardBytes := x11CrashKeyboardBytes(beforeKeyboard)
+	beforeInput := harness.inputState()
+	if !x11CrashKeyPressed(beforeInput.pressedKeys, foreignKey) || beforeInput.pointerMask&foreignButtonMask == 0 {
+		t.Fatalf("foreign baseline was not established: keycode=%d button=%d input=%+v", foreignKey, foreignButton, beforeInput)
+	}
+	beforeXKB, compareXKB := x11CrashXKBCompSnapshot(t)
+
+	restoreSubreaper, err := x11CrashEnableSubreaper()
+	if err != nil {
+		t.Fatalf("enable child subreaper for crash lifecycle: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := restoreSubreaper(); err != nil {
+			t.Errorf("restore child-subreaper state: %v", err)
+		}
+	})
+
+	readyRead, readyWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create crash-helper readiness pipe: %v", err)
+	}
+	defer func() {
+		if err := readyRead.Close(); err != nil {
+			t.Errorf("close crash-helper readiness reader: %v", err)
+		}
+	}()
+
+	logPath := t.TempDir() + "/workload.log"
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		_ = readyWrite.Close()
+		t.Fatalf("create crash-helper log: %v", err)
+	}
+	defer func() {
+		if err := logFile.Close(); err != nil {
+			t.Errorf("close crash-helper log: %v", err)
+		}
+	}()
+
+	executable, err := os.Executable()
+	if err != nil {
+		_ = readyWrite.Close()
+		t.Fatalf("resolve crash-helper executable: %v", err)
+	}
+	command := exec.Command(
+		executable,
+		"-test.run="+x11CrashTestPattern,
+		"-test.count=1",
+		"-test.timeout="+x11CrashHelperTimeout.String(),
+	)
+	command.Env = x11CrashHelperEnvironment(os.Environ())
+	command.ExtraFiles = []*os.File{readyWrite}
+	command.Stdout = logFile
+	command.Stderr = logFile
+	command.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL}
+	if err := command.Start(); err != nil {
+		_ = readyWrite.Close()
+		t.Fatalf("start Pure-Go X11 crash workload: %v", err)
+	}
+	waitResult := make(chan error, 1)
+	go func() { waitResult <- command.Wait() }()
+	var (
+		helperWaited   bool
+		helperWaitErr  error
+		guardianPID    int
+		guardianWaited bool
+		restored       bool
+		claim          x11CrashWorkloadClaim
+	)
+	waitForHelper := func(timeout time.Duration) (error, bool) {
+		if helperWaited {
+			return helperWaitErr, true
+		}
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case helperWaitErr = <-waitResult:
+			helperWaited = true
+			return helperWaitErr, true
+		case <-timer.C:
+			return nil, false
+		}
+	}
+	t.Cleanup(func() {
+		if guardianPID == 0 && !helperWaited {
+			if pid, err := x11CrashOnlyChildPID(command.Process.Pid); err == nil {
+				guardianPID = pid
+			}
+		}
+		if !helperWaited {
+			_ = command.Process.Signal(syscall.SIGKILL)
+			if _, ok := waitForHelper(x11CrashWaitTimeout); !ok {
+				t.Errorf("crash workload did not exit during test cleanup; log:\n%s", x11CrashHelperLog(logPath))
+			}
+		}
+		if guardianPID == 0 && helperWaited {
+			if pid, err := x11CrashOnlyChildPID(os.Getpid()); err == nil {
+				guardianPID = pid
+			}
+		}
+		if guardianPID != 0 && !guardianWaited {
+			status, ok, waitErr := x11CrashWaitAdoptedChild(guardianPID, x11CrashGuardianTimeout)
+			if waitErr != nil {
+				t.Errorf("wait for guardian pid %d during cleanup: %v", guardianPID, waitErr)
+			} else if ok {
+				guardianWaited = true
+				if err := x11CrashAssertGuardianExit(status); err != nil {
+					t.Errorf("guardian cleanup exit: %v", err)
+				}
+			}
+			if !guardianWaited {
+				if terminateErr := x11CrashKillAndReapGuardian(guardianPID); terminateErr != nil {
+					t.Errorf("terminate leaked guardian pid %d: %v", guardianPID, terminateErr)
+				} else {
+					guardianWaited = true
+				}
+			}
+		}
+		if !restored && claim.ready && (guardianPID == 0 || guardianWaited) {
+			restoreErr := x11CrashEmergencyRestore(harness, claim)
+			restoreErr = errors.Join(
+				restoreErr,
+				x11CrashVerifyBaseline(beforeKeyboardBytes, beforeInput, beforeXKB, compareXKB),
+			)
+			if restoreErr != nil {
+				t.Errorf("%s failed: %v", x11CrashEmergencyReason, restoreErr)
+			}
+		}
+	})
+	if err := readyWrite.Close(); err != nil {
+		t.Fatalf("close parent crash-helper readiness writer: %v", err)
+	}
+
+	ready, err := x11CrashReadReady(readyRead)
+	if err != nil {
+		if waitErr, ok := waitForHelper(100 * time.Millisecond); ok {
+			t.Fatalf("crash workload exited before READY: ready error=%v wait=%v log:\n%s", err, waitErr, x11CrashHelperLog(logPath))
+		}
+		t.Fatalf("wait for crash workload READY: %v; log:\n%s", err, x11CrashHelperLog(logPath))
+	}
+
+	// Arm claim-bounded emergency cleanup immediately after the first trusted
+	// server snapshot. All remaining checks are diagnostic and may fail without
+	// leaving the exact scratch claim or synthetic holds behind.
+	harness.conn.Sync()
+	duringKeyboard := harness.keyboardState()
+	claim, err = x11CrashClaim(beforeKeyboard, duringKeyboard, ready)
+	if err != nil {
+		t.Fatalf("record exact crash-workload ownership claim: %v", err)
+	}
+	guardianPID = ready.guardianPID
+
+	if ready.pid != command.Process.Pid {
+		t.Fatalf("crash workload READY pid = %d, want started pid %d", ready.pid, command.Process.Pid)
+	}
+	if guardianPID == ready.pid {
+		t.Fatalf("guardian pid = workload pid = %d, want a separate process", guardianPID)
+	}
+	childPID, err := x11CrashOnlyChildPID(ready.pid)
+	if err != nil {
+		t.Fatalf("identify workload guardian child: %v", err)
+	}
+	if childPID != guardianPID {
+		t.Fatalf("workload child pid = %d, helper reported guardian pid %d", childPID, guardianPID)
+	}
+
+	scratchCode, err := x11CrashScratchMutation(beforeKeyboard, duringKeyboard)
+	if err != nil {
+		t.Fatalf("crash workload did not establish the expected scratch mapping: %v", err)
+	}
+	if scratchCode != ready.scratchCode {
+		t.Fatalf("observed scratch keycode = %d, helper reported %d", scratchCode, ready.scratchCode)
+	}
+	if ready.keysym != x11KeysymForRune('😀') {
+		t.Fatalf("helper reported scratch keysym %#x, want %#x", ready.keysym, x11KeysymForRune('😀'))
+	}
+	duringInput := harness.inputState()
+	heldKey, err := x11CrashHeldInput(beforeInput, duringInput, harness)
+	if err != nil {
+		t.Fatalf("crash workload did not establish the expected held input: %v", err)
+	}
+	if heldKey != ready.heldKeycode {
+		t.Fatalf("observed held keycode = %d, helper reported %d", heldKey, ready.heldKeycode)
+	}
+	if compareXKB {
+		duringXKB, ok := x11CrashXKBCompSnapshot(t)
+		if !ok {
+			t.Fatal("xkbcomp became unavailable after the before-state snapshot")
+		}
+		if bytes.Equal(duringXKB, beforeXKB) {
+			t.Fatal("xkbcomp snapshot did not observe the confirmed server-side scratch mapping")
+		}
+	}
+
+	// Kill only the workload PID. A crash-cleanup guardian must remain alive long
+	// enough to observe the workload death, restore server-global state, and exit.
+	if err := command.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("send SIGKILL to crash workload pid %d: %v; log:\n%s", command.Process.Pid, err, x11CrashHelperLog(logPath))
+	}
+	waitErr, ok := waitForHelper(x11CrashWaitTimeout)
+	if !ok {
+		t.Fatalf("crash workload pid %d did not report exit within %s", command.Process.Pid, x11CrashWaitTimeout)
+	}
+	if err := x11CrashAssertSIGKILL(waitErr); err != nil {
+		t.Fatalf("crash workload termination: %v; log:\n%s", err, x11CrashHelperLog(logPath))
+	}
+	guardianStatus, guardianExited, guardianErr := x11CrashWaitAdoptedChild(guardianPID, x11CrashGuardianTimeout)
+	if guardianErr != nil {
+		terminateErr := x11CrashKillAndReapGuardian(guardianPID)
+		guardianWaited = terminateErr == nil
+		t.Fatalf("wait for adopted guardian pid %d: %v; forced cleanup: %v", guardianPID, guardianErr, terminateErr)
+	}
+	if !guardianExited {
+		terminateErr := x11CrashKillAndReapGuardian(guardianPID)
+		guardianWaited = terminateErr == nil
+		t.Fatalf("guardian pid %d did not exit within %s; forced cleanup: %v", guardianPID, x11CrashGuardianTimeout, terminateErr)
+	}
+	guardianWaited = true
+	if err := x11CrashAssertGuardianExit(guardianStatus); err != nil {
+		t.Fatalf("guardian pid %d termination: %v", guardianPID, err)
+	}
+
+	if err := x11CrashAwaitRestoration(
+		beforeKeyboard,
+		beforeKeyboardBytes,
+		beforeInput,
+		beforeXKB,
+		compareXKB,
+	); err != nil {
+		t.Fatalf("state was not restored after workload SIGKILL: %v; helper log:\n%s", err, x11CrashHelperLog(logPath))
+	}
+	restored = true
+}
+
+func runPureGoX11CrashWorkload(t *testing.T) {
+	readyFile := os.NewFile(x11CrashReadyFD, "robotgo-x11-crash-ready")
+	if readyFile == nil {
+		t.Fatalf("crash workload has no readiness fd %d", x11CrashReadyFD)
+	}
+	defer func() { _ = readyFile.Close() }()
+	defer func() {
+		if err := robotgo.CloseMainDisplayE(); err != nil {
+			t.Errorf("crash workload fallback cleanup: %v", err)
+		}
+	}()
+
+	info := robotgo.GetRuntimeBackendInfo()
+	if info.CGOEnabled || info.BuildImplementation != robotgo.RuntimeImplementationPureGo || info.DisplayServer != robotgo.DisplayServerX11 {
+		t.Fatalf("crash workload backend = %+v, want Pure-Go X11", info)
+	}
+	if err := robotgo.KeyToggle("enter", "down"); err != nil {
+		t.Fatalf("hold named key in crash workload: %v", err)
+	}
+	if err := robotgo.Toggle("right", "down"); err != nil {
+		t.Fatalf("hold pointer button in crash workload: %v", err)
+	}
+	if err := robotgo.TypeStrE("😀"); err != nil {
+		t.Fatalf("establish Unicode scratch mapping in crash workload: %v", err)
+	}
+	guardianPID, ok := robotgo.X11GuardianPIDForIntegrationTest()
+	if !ok || guardianPID <= 0 || guardianPID == os.Getpid() {
+		t.Fatalf("resolve live Pure-Go X11 guardian pid: pid=%d available=%v", guardianPID, ok)
+	}
+
+	connection, err := x11CrashOpenObserver()
+	if err != nil {
+		t.Fatalf("open crash workload observer: %v", err)
+	}
+	setup := xproto.Setup(connection)
+	if setup == nil {
+		connection.Close()
+		t.Fatal("crash workload observer has no X11 setup")
+	}
+	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
+	mapping, err := xproto.GetKeyboardMapping(connection, setup.MinKeycode, byte(count)).Reply()
+	if err != nil || mapping == nil || mapping.KeysymsPerKeycode == 0 {
+		connection.Close()
+		t.Fatalf("query crash workload scratch mapping: reply=%+v err=%v", mapping, err)
+	}
+	wantKeysym := x11KeysymForRune('😀')
+	scratchCode := xproto.Keycode(0)
+	per := int(mapping.KeysymsPerKeycode)
+	for offset := 0; offset+per <= len(mapping.Keysyms); offset += per {
+		if x11CrashMappingOwnedBy(mapping.Keysyms[offset:offset+per], xproto.Keysym(wantKeysym)) {
+			scratchCode = setup.MinKeycode + xproto.Keycode(offset/per)
+			break
+		}
+	}
+	keys, err := xproto.QueryKeymap(connection).Reply()
+	if err != nil || keys == nil {
+		connection.Close()
+		t.Fatalf("query crash workload held key: reply=%+v err=%v", keys, err)
+	}
+	heldKey := x11CrashFindPressedKeysym(connection, setup, keys.Keys, x11KeysymEnter)
+	connection.Close()
+	if scratchCode == 0 {
+		t.Fatalf("crash workload cannot find its Unicode scratch keysym %#x", wantKeysym)
+	}
+	if heldKey == 0 {
+		t.Fatal("crash workload cannot find its held Enter key")
+	}
+	if _, err := fmt.Fprintf(
+		readyFile,
+		"%s pid=%d guardian=%d held=%d scratch=%d keysym=%d\n",
+		x11CrashReadyVersion,
+		os.Getpid(),
+		guardianPID,
+		heldKey,
+		scratchCode,
+		wantKeysym,
+	); err != nil {
+		t.Fatalf("write crash workload READY: %v", err)
+	}
+	if err := readyFile.Close(); err != nil {
+		t.Fatalf("close crash workload readiness fd: %v", err)
+	}
+
+	// The parent must be the only actor that terminates this workload, using
+	// SIGKILL. No normal return or signal-handler cleanup is part of the proof.
+	blocked := make(chan struct{})
+	<-blocked
+}

--- a/x11_input_crash_process_integration_test.go
+++ b/x11_input_crash_process_integration_test.go
@@ -1,0 +1,268 @@
+//go:build linux && !cgo && x11integration && !wayland
+
+package robotgo_test
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/jezek/xgb/xproto"
+	"github.com/marang/robotgo"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	x11CrashHelperEnv              = "ROBOTGO_X11_CRASH_WORKLOAD_HELPER"
+	x11CrashObserverEnv            = "ROBOTGO_X11_CRASH_OBSERVER_HELPER"
+	x11CrashDisplayEnv             = "DISPLAY"
+	x11CrashWaylandDisplayEnv      = "WAYLAND_DISPLAY"
+	x11CrashSessionTypeEnv         = "XDG_SESSION_TYPE"
+	x11CrashProcRoot               = "/proc"
+	x11CrashReadyFD                = 3
+	x11CrashReadyVersion           = "robotgo-x11-crash-ready-v2"
+	x11CrashTestPattern            = "^TestPureGoX11CrashRestoresScratchAndOwnedInput$"
+	x11CrashHelperTimeout          = 20 * time.Second
+	x11CrashReadyTimeout           = 5 * time.Second
+	x11CrashWaitTimeout            = 5 * time.Second
+	x11CrashGuardianTimeout        = 8 * time.Second
+	x11CrashRestoreTimeout         = 8 * time.Second
+	x11CrashObserverTimeout        = 2 * time.Second
+	x11CrashObserverShutdownWindow = 250 * time.Millisecond
+	x11CrashPollInterval           = 100 * time.Millisecond
+	x11CrashXKBCompTimeout         = 3 * time.Second
+	x11CrashKeycodeMaximum         = 255
+	x11CrashPRSetChildSubreaper    = 36
+	x11CrashPRGetChildSubreaper    = 37
+	x11CrashMiddleButton           = 2
+	x11CrashEmergencyReason        = "emergency restoration after failed crash-lifecycle assertion"
+)
+
+type x11CrashReadyMessage struct {
+	pid         int
+	guardianPID int
+	heldKeycode xproto.Keycode
+	scratchCode xproto.Keycode
+	keysym      uint32
+}
+
+func x11CrashHelperEnvironment(environment []string) []string {
+	filtered := x11CrashFilteredEnvironment(environment)
+	return append(
+		filtered,
+		x11CrashHelperEnv+"=1",
+		x11RequiredEnv+"=1",
+		envExpectedX11Implementation+"="+string(robotgo.RuntimeImplementationPureGo),
+	)
+}
+
+func x11CrashObserverEnvironment(environment []string) []string {
+	return append(x11CrashFilteredEnvironment(environment), x11CrashObserverEnv+"=1")
+}
+
+func x11CrashFilteredEnvironment(environment []string) []string {
+	filtered := make([]string, 0, len(environment)+3)
+	for _, value := range environment {
+		name, _, _ := strings.Cut(value, "=")
+		switch name {
+		case x11CrashHelperEnv, x11CrashObserverEnv, x11RequiredEnv,
+			x11CrashWaylandDisplayEnv, x11CrashSessionTypeEnv,
+			envExpectedX11Implementation:
+			continue
+		default:
+			filtered = append(filtered, value)
+		}
+	}
+	return filtered
+}
+
+func x11CrashReadReady(file *os.File) (x11CrashReadyMessage, error) {
+	if err := file.SetReadDeadline(time.Now().Add(x11CrashReadyTimeout)); err != nil {
+		return x11CrashReadyMessage{}, fmt.Errorf("set READY deadline: %w", err)
+	}
+	line, err := bufio.NewReader(file).ReadString('\n')
+	if err != nil {
+		return x11CrashReadyMessage{}, err
+	}
+	fields := strings.Fields(line)
+	if len(fields) != 6 || fields[0] != x11CrashReadyVersion {
+		return x11CrashReadyMessage{}, fmt.Errorf("invalid READY payload %q", strings.TrimSpace(line))
+	}
+	values := make(map[string]uint64, 5)
+	for _, field := range fields[1:] {
+		name, raw, found := strings.Cut(field, "=")
+		if !found {
+			return x11CrashReadyMessage{}, fmt.Errorf("invalid READY field %q", field)
+		}
+		value, parseErr := strconv.ParseUint(raw, 10, 32)
+		if parseErr != nil {
+			return x11CrashReadyMessage{}, fmt.Errorf("parse READY field %q: %w", field, parseErr)
+		}
+		values[name] = value
+	}
+	if values["pid"] == 0 || values["guardian"] == 0 || values["held"] == 0 || values["scratch"] == 0 || values["keysym"] == 0 {
+		return x11CrashReadyMessage{}, fmt.Errorf("incomplete READY payload %q", strings.TrimSpace(line))
+	}
+	if values["held"] > x11CrashKeycodeMaximum || values["scratch"] > x11CrashKeycodeMaximum {
+		return x11CrashReadyMessage{}, fmt.Errorf("READY keycode is outside 1..%d in %q", x11CrashKeycodeMaximum, strings.TrimSpace(line))
+	}
+	return x11CrashReadyMessage{
+		pid:         int(values["pid"]),
+		guardianPID: int(values["guardian"]),
+		heldKeycode: xproto.Keycode(values["held"]),
+		scratchCode: xproto.Keycode(values["scratch"]),
+		keysym:      uint32(values["keysym"]),
+	}, nil
+}
+
+func x11CrashEnableSubreaper() (func() error, error) {
+	var previous int32
+	if err := unix.Prctl(
+		x11CrashPRGetChildSubreaper,
+		uintptr(unsafe.Pointer(&previous)),
+		0,
+		0,
+		0,
+	); err != nil {
+		return nil, fmt.Errorf("get child-subreaper state: %w", err)
+	}
+	runtime.KeepAlive(&previous)
+	if previous != 0 && previous != 1 {
+		return nil, fmt.Errorf("invalid child-subreaper state %d", previous)
+	}
+	if previous == 0 {
+		if err := unix.Prctl(x11CrashPRSetChildSubreaper, 1, 0, 0, 0); err != nil {
+			return nil, fmt.Errorf("set child subreaper: %w", err)
+		}
+	}
+	return func() error {
+		if previous == 1 {
+			return nil
+		}
+		if err := unix.Prctl(x11CrashPRSetChildSubreaper, 0, 0, 0, 0); err != nil {
+			return fmt.Errorf("clear child subreaper: %w", err)
+		}
+		return nil
+	}, nil
+}
+
+func x11CrashOnlyChildPID(parentPID int) (int, error) {
+	taskPath := fmt.Sprintf("%s/%d/task", x11CrashProcRoot, parentPID)
+	tasks, err := os.ReadDir(taskPath)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", taskPath, err)
+	}
+	children := make(map[int]struct{})
+	for _, task := range tasks {
+		if !task.IsDir() {
+			continue
+		}
+		path := fmt.Sprintf("%s/%s/children", taskPath, task.Name())
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			if errors.Is(readErr, os.ErrNotExist) {
+				continue
+			}
+			return 0, fmt.Errorf("read %s: %w", path, readErr)
+		}
+		for _, field := range strings.Fields(string(content)) {
+			pid, parseErr := strconv.Atoi(field)
+			if parseErr != nil || pid <= 0 {
+				return 0, fmt.Errorf("parse guardian child pid %q: %v", field, parseErr)
+			}
+			children[pid] = struct{}{}
+		}
+	}
+	if len(children) != 1 {
+		return 0, fmt.Errorf("workload child pids = %v, want exactly one guardian", children)
+	}
+	for pid := range children {
+		return pid, nil
+	}
+	return 0, errors.New("workload guardian child disappeared")
+}
+
+func x11CrashWaitAdoptedChild(pid int, timeout time.Duration) (syscall.WaitStatus, bool, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		var status syscall.WaitStatus
+		waitedPID, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+		switch {
+		case err == nil && waitedPID == pid:
+			return status, true, nil
+		case err == nil && waitedPID == 0:
+		case errors.Is(err, syscall.EINTR):
+		case err != nil:
+			return 0, false, err
+		default:
+			return 0, false, fmt.Errorf("wait4 returned pid %d for guardian %d", waitedPID, pid)
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return 0, false, nil
+		}
+		if remaining > x11CrashPollInterval {
+			remaining = x11CrashPollInterval
+		}
+		timer := time.NewTimer(remaining)
+		<-timer.C
+	}
+}
+
+func x11CrashKillAndReapGuardian(pid int) error {
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("kill: %w", err)
+	}
+	_, reaped, err := x11CrashWaitAdoptedChild(pid, x11CrashWaitTimeout)
+	if err != nil {
+		return fmt.Errorf("reap: %w", err)
+	}
+	if !reaped {
+		return fmt.Errorf("not reaped within %s", x11CrashWaitTimeout)
+	}
+	return nil
+}
+
+func x11CrashAssertGuardianExit(status syscall.WaitStatus) error {
+	if !status.Exited() || status.ExitStatus() != 0 {
+		return fmt.Errorf("wait status %v, want successful exit", status)
+	}
+	return nil
+}
+
+func x11CrashAssertSIGKILL(waitErr error) error {
+	if waitErr == nil {
+		return errors.New("workload exited successfully instead of being killed")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(waitErr, &exitErr) {
+		return fmt.Errorf("wait error %T %v, want *exec.ExitError", waitErr, waitErr)
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return fmt.Errorf("exit status %T, want syscall.WaitStatus", exitErr.Sys())
+	}
+	if !status.Signaled() || status.Signal() != syscall.SIGKILL {
+		return fmt.Errorf("wait status %v, want signal %s", status, syscall.SIGKILL)
+	}
+	return nil
+}
+
+func x11CrashHelperLog(path string) string {
+	output, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("<read helper log: %v>", err)
+	}
+	if len(output) == 0 {
+		return "<empty>"
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/x11_input_crash_state_integration_test.go
+++ b/x11_input_crash_state_integration_test.go
@@ -1,0 +1,699 @@
+//go:build linux && !cgo && x11integration && !wayland
+
+package robotgo_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgb/xtest"
+)
+
+type x11CrashWorkloadClaim struct {
+	ready         bool
+	heldKeycode   xproto.Keycode
+	button        byte
+	buttonMask    uint16
+	scratchCode   xproto.Keycode
+	scratchBefore []xproto.Keysym
+	scratchAfter  []xproto.Keysym
+}
+
+type x11CrashObservedState struct {
+	keyboard x11KeyboardState
+	input    x11InputState
+}
+
+type x11CrashObservedWire struct {
+	MinKeycode          xproto.Keycode   `json:"min_keycode"`
+	KeysymsPerKeycode   byte             `json:"keysyms_per_keycode"`
+	Keysyms             []xproto.Keysym  `json:"keysyms"`
+	KeycodesPerModifier byte             `json:"keycodes_per_modifier"`
+	ModifierKeycodes    []xproto.Keycode `json:"modifier_keycodes"`
+	PressedKeys         []byte           `json:"pressed_keys"`
+	PointerX            int              `json:"pointer_x"`
+	PointerY            int              `json:"pointer_y"`
+	PointerMask         uint16           `json:"pointer_mask"`
+}
+
+func x11CrashForeignKey(t *testing.T, harness *x11InputHarness, input x11InputState) xproto.Keycode {
+	t.Helper()
+	for _, keysym := range []uint32{'a', 'b', 'c'} {
+		keycode, _ := harness.findKeycode(keysym)
+		if keycode != 0 && !x11CrashKeyPressed(input.pressedKeys, keycode) {
+			return keycode
+		}
+	}
+	t.Fatal("cannot find an unpressed mapped key for the foreign-input baseline")
+	return 0
+}
+
+func x11CrashForeignButton(t *testing.T, pointerMask uint16) (byte, uint16) {
+	t.Helper()
+	for _, candidate := range []struct {
+		button byte
+		mask   uint16
+	}{
+		{button: x11ButtonLeft, mask: xproto.ButtonMask1},
+		{button: x11CrashMiddleButton, mask: xproto.ButtonMask2},
+	} {
+		if pointerMask&candidate.mask == 0 {
+			return candidate.button, candidate.mask
+		}
+	}
+	t.Fatal("cannot find an unpressed pointer button for the foreign-input baseline")
+	return 0, 0
+}
+
+func x11CrashKeyPressed(pressed []byte, keycode xproto.Keycode) bool {
+	index := int(keycode) / 8
+	return index < len(pressed) && pressed[index]&(1<<uint(keycode%8)) != 0
+}
+
+func x11CrashClaim(before, during x11KeyboardState, ready x11CrashReadyMessage) (x11CrashWorkloadClaim, error) {
+	beforeMapping, err := x11CrashMappingAt(before, ready.scratchCode)
+	if err != nil {
+		return x11CrashWorkloadClaim{}, fmt.Errorf("baseline scratch mapping: %w", err)
+	}
+	duringMapping, err := x11CrashMappingAt(during, ready.scratchCode)
+	if err != nil {
+		return x11CrashWorkloadClaim{}, fmt.Errorf("active scratch mapping: %w", err)
+	}
+	if !x11CrashMappingIs(beforeMapping, 0) {
+		return x11CrashWorkloadClaim{}, fmt.Errorf("scratch keycode %d was not empty in baseline: %#v", ready.scratchCode, beforeMapping)
+	}
+	if !x11CrashMappingOwnedBy(duringMapping, xproto.Keysym(ready.keysym)) {
+		return x11CrashWorkloadClaim{}, fmt.Errorf("scratch keycode %d is not the helper claim: %#v", ready.scratchCode, duringMapping)
+	}
+	return x11CrashWorkloadClaim{
+		ready:         true,
+		heldKeycode:   ready.heldKeycode,
+		button:        x11ButtonRight,
+		buttonMask:    xproto.ButtonMask3,
+		scratchCode:   ready.scratchCode,
+		scratchBefore: beforeMapping,
+		scratchAfter:  duringMapping,
+	}, nil
+}
+
+func x11CrashMappingAt(state x11KeyboardState, keycode xproto.Keycode) ([]xproto.Keysym, error) {
+	if state.keysymsPerKeycode == 0 || keycode < state.minKeycode {
+		return nil, fmt.Errorf("keycode %d is outside keyboard-map baseline", keycode)
+	}
+	per := int(state.keysymsPerKeycode)
+	offset := int(keycode-state.minKeycode) * per
+	if offset < 0 || offset+per > len(state.keysyms) {
+		return nil, fmt.Errorf("keycode %d is outside keyboard-map keysyms", keycode)
+	}
+	return append([]xproto.Keysym(nil), state.keysyms[offset:offset+per]...), nil
+}
+
+func x11CrashKeyboardBytes(state x11KeyboardState) []byte {
+	buffer := bytes.NewBuffer(make([]byte, 0, 16+len(state.keysyms)*4+len(state.modifierKeycodes)))
+	buffer.WriteString("robotgo-x11-keyboard-v1\x00")
+	buffer.WriteByte(byte(state.minKeycode))
+	buffer.WriteByte(state.keysymsPerKeycode)
+	_ = binary.Write(buffer, binary.LittleEndian, uint32(len(state.keysyms)))
+	for _, keysym := range state.keysyms {
+		_ = binary.Write(buffer, binary.LittleEndian, uint32(keysym))
+	}
+	buffer.WriteByte(state.keycodesPerModifier)
+	_ = binary.Write(buffer, binary.LittleEndian, uint32(len(state.modifierKeycodes)))
+	for _, keycode := range state.modifierKeycodes {
+		buffer.WriteByte(byte(keycode))
+	}
+	return buffer.Bytes()
+}
+
+func x11CrashScratchMutation(before, during x11KeyboardState) (xproto.Keycode, error) {
+	if before.minKeycode != during.minKeycode || before.keysymsPerKeycode != during.keysymsPerKeycode || len(before.keysyms) != len(during.keysyms) {
+		return 0, fmt.Errorf("keyboard-map shape changed: %s", x11KeyboardStateDifference(before, during))
+	}
+	if before.keycodesPerModifier != during.keycodesPerModifier || !bytes.Equal(x11CrashModifierBytes(before), x11CrashModifierBytes(during)) {
+		return 0, fmt.Errorf("modifier map changed while establishing scratch mapping: %s", x11KeyboardStateDifference(before, during))
+	}
+	per := int(before.keysymsPerKeycode)
+	want := xproto.Keysym(x11KeysymForRune('😀'))
+	changed := make([]xproto.Keycode, 0, 1)
+	for offset := 0; offset+per <= len(before.keysyms); offset += per {
+		beforeMapping := before.keysyms[offset : offset+per]
+		duringMapping := during.keysyms[offset : offset+per]
+		if x11CrashMappingsEqual(beforeMapping, duringMapping) {
+			continue
+		}
+		if !x11CrashMappingIs(beforeMapping, 0) || !x11CrashMappingOwnedBy(duringMapping, want) {
+			code := before.minKeycode + xproto.Keycode(offset/per)
+			return 0, fmt.Errorf("unexpected mapping change at keycode %d: before=%#v during=%#v", code, beforeMapping, duringMapping)
+		}
+		changed = append(changed, before.minKeycode+xproto.Keycode(offset/per))
+	}
+	if len(changed) != 1 {
+		return 0, fmt.Errorf("changed scratch keycodes = %v, want exactly one", changed)
+	}
+	return changed[0], nil
+}
+
+func x11CrashModifierBytes(state x11KeyboardState) []byte {
+	result := make([]byte, 1+len(state.modifierKeycodes))
+	result[0] = state.keycodesPerModifier
+	for index, keycode := range state.modifierKeycodes {
+		result[index+1] = byte(keycode)
+	}
+	return result
+}
+
+func x11CrashMappingsEqual(left, right []xproto.Keysym) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func x11CrashMappingIs(mapping []xproto.Keysym, want xproto.Keysym) bool {
+	if len(mapping) == 0 {
+		return false
+	}
+	for _, keysym := range mapping {
+		if keysym != want {
+			return false
+		}
+	}
+	return true
+}
+
+func x11CrashMappingOwnedBy(mapping []xproto.Keysym, want xproto.Keysym) bool {
+	if len(mapping) == 0 || mapping[0] != want {
+		return false
+	}
+	for _, keysym := range mapping[1:] {
+		if keysym != 0 && keysym != want {
+			return false
+		}
+	}
+	return true
+}
+
+func x11CrashHeldInput(before, during x11InputState, harness *x11InputHarness) (xproto.Keycode, error) {
+	added, removed := x11CrashPressedKeyDifference(before.pressedKeys, during.pressedKeys)
+	if len(removed) != 0 || len(added) != 1 {
+		return 0, fmt.Errorf("pressed-key delta added=%v removed=%v, want one added Enter", added, removed)
+	}
+	if got := harness.keysym(added[0]); got != x11KeysymEnter {
+		return 0, fmt.Errorf("newly held keycode %d has keysym %#x, want Enter %#x", added[0], got, x11KeysymEnter)
+	}
+	if before.pointerMask&xproto.ButtonMask3 != 0 {
+		return 0, errors.New("baseline unexpectedly has the right pointer button held")
+	}
+	if during.pointerMask != before.pointerMask|xproto.ButtonMask3 {
+		return 0, fmt.Errorf("pointer mask changed from %#x to %#x, want only Button3", before.pointerMask, during.pointerMask)
+	}
+	if during.pointerX != before.pointerX || during.pointerY != before.pointerY {
+		return 0, fmt.Errorf("pointer moved from (%d,%d) to (%d,%d)", before.pointerX, before.pointerY, during.pointerX, during.pointerY)
+	}
+	return added[0], nil
+}
+
+func x11CrashPressedKeyDifference(before, after []byte) (added, removed []xproto.Keycode) {
+	length := len(before)
+	if len(after) < length {
+		length = len(after)
+	}
+	for index := 0; index < length*8; index++ {
+		mask := byte(1 << uint(index%8))
+		wasPressed := before[index/8]&mask != 0
+		isPressed := after[index/8]&mask != 0
+		switch {
+		case !wasPressed && isPressed:
+			added = append(added, xproto.Keycode(index))
+		case wasPressed && !isPressed:
+			removed = append(removed, xproto.Keycode(index))
+		}
+	}
+	return added, removed
+}
+
+func x11CrashFindPressedKeysym(
+	connection *xgb.Conn,
+	setup *xproto.SetupInfo,
+	pressed []byte,
+	want xproto.Keysym,
+) xproto.Keycode {
+	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
+	mapping, err := xproto.GetKeyboardMapping(connection, setup.MinKeycode, byte(count)).Reply()
+	if err != nil || mapping == nil || mapping.KeysymsPerKeycode == 0 {
+		return 0
+	}
+	per := int(mapping.KeysymsPerKeycode)
+	for offset := 0; offset+per <= len(mapping.Keysyms); offset += per {
+		code := setup.MinKeycode + xproto.Keycode(offset/per)
+		if int(code)/8 >= len(pressed) || pressed[int(code)/8]&(1<<uint(code%8)) == 0 {
+			continue
+		}
+		for _, keysym := range mapping.Keysyms[offset : offset+per] {
+			if keysym == want {
+				return code
+			}
+		}
+	}
+	return 0
+}
+
+func x11CrashAwaitRestoration(
+	beforeKeyboard x11KeyboardState,
+	beforeKeyboardBytes []byte,
+	beforeInput x11InputState,
+	beforeXKB []byte,
+	compareXKB bool,
+) error {
+	deadline := time.Now().Add(x11CrashRestoreTimeout)
+	var lastDifference string
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return errors.New(lastDifference)
+		}
+		observerTimeout := x11CrashObserverTimeout
+		if observerTimeout > remaining {
+			observerTimeout = remaining
+		}
+		afterKeyboard, afterInput, snapshotErr := x11CrashObserveState(observerTimeout)
+		if snapshotErr != nil {
+			lastDifference = fmt.Sprintf("bounded X11 state snapshot failed: %v", snapshotErr)
+			x11CrashWaitForNextPoll(deadline)
+			continue
+		}
+		keyboardEqual := bytes.Equal(x11CrashKeyboardBytes(afterKeyboard), beforeKeyboardBytes)
+		inputEqual := x11CrashInputEqual(afterInput, beforeInput)
+		if keyboardEqual && inputEqual {
+			if !compareXKB {
+				return nil
+			}
+			remaining = time.Until(deadline)
+			if remaining <= 0 {
+				return errors.New(lastDifference)
+			}
+			xkbTimeout := x11CrashXKBCompTimeout
+			if xkbTimeout > remaining {
+				xkbTimeout = remaining
+			}
+			afterXKB, xkbErr := x11CrashXKBCompSnapshotRaw(xkbTimeout)
+			if xkbErr == nil && bytes.Equal(afterXKB, beforeXKB) {
+				return nil
+			}
+			if xkbErr != nil {
+				lastDifference = fmt.Sprintf("xkbcomp snapshot failed while polling restoration: %v", xkbErr)
+			} else {
+				lastDifference = fmt.Sprintf(
+					"core/input restored but xkbcomp differs: before=%x after=%x",
+					sha256.Sum256(beforeXKB),
+					sha256.Sum256(afterXKB),
+				)
+			}
+		} else {
+			keyboardDifference := "equal"
+			if !keyboardEqual {
+				keyboardDifference = x11KeyboardStateDifference(beforeKeyboard, afterKeyboard)
+			}
+			lastDifference = fmt.Sprintf(
+				"keyboard=%s input_before=%+v input_after=%+v",
+				keyboardDifference,
+				beforeInput,
+				afterInput,
+			)
+		}
+		x11CrashWaitForNextPoll(deadline)
+	}
+}
+
+func x11CrashObserveState(timeout time.Duration) (x11KeyboardState, x11InputState, error) {
+	if timeout <= 0 {
+		return x11KeyboardState{}, x11InputState{}, errors.New("X11 state snapshot timeout is exhausted")
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("resolve observer executable: %w", err)
+	}
+	resultRead, resultWrite, err := os.Pipe()
+	if err != nil {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("create observer result pipe: %w", err)
+	}
+	defer func() { _ = resultRead.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	command := exec.CommandContext(
+		ctx,
+		executable,
+		"-test.run="+x11CrashTestPattern,
+		"-test.count=1",
+		"-test.timeout="+(timeout+x11CrashObserverShutdownWindow).String(),
+	)
+	command.Env = x11CrashObserverEnvironment(os.Environ())
+	command.ExtraFiles = []*os.File{resultWrite}
+	command.WaitDelay = x11CrashObserverShutdownWindow
+	var log bytes.Buffer
+	command.Stdout = &log
+	command.Stderr = &log
+	if err := command.Start(); err != nil {
+		_ = resultWrite.Close()
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("start isolated X11 observer: %w", err)
+	}
+	if err := resultWrite.Close(); err != nil {
+		_ = command.Process.Kill()
+		_ = command.Wait()
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("close parent observer result writer: %w", err)
+	}
+	payload, readErr := io.ReadAll(resultRead)
+	waitErr := command.Wait()
+	if ctx.Err() != nil {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("X11 state snapshot timed out after %s: %w", timeout, ctx.Err())
+	}
+	if waitErr != nil {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("isolated X11 observer failed: %w: %s", waitErr, strings.TrimSpace(log.String()))
+	}
+	if readErr != nil {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("read isolated X11 observer result: %w", readErr)
+	}
+	var wire x11CrashObservedWire
+	if err := json.Unmarshal(payload, &wire); err != nil {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("decode isolated X11 observer result: %w", err)
+	}
+	observed := wire.observedState()
+	return observed.keyboard, observed.input, nil
+}
+
+func x11CrashWriteObserverSnapshot(t *testing.T) {
+	t.Helper()
+	resultFile := os.NewFile(x11CrashReadyFD, "robotgo-x11-crash-observer-result")
+	if resultFile == nil {
+		t.Fatalf("crash observer has no result fd %d", x11CrashReadyFD)
+	}
+	defer func() { _ = resultFile.Close() }()
+	connection, err := x11CrashOpenObserver()
+	if err != nil {
+		t.Fatalf("open isolated X11 observer: %v", err)
+	}
+	defer connection.Close()
+	keyboard, input, err := x11CrashObserveStateOnConnection(connection)
+	if err != nil {
+		t.Fatalf("take isolated X11 observer snapshot: %v", err)
+	}
+	if err := json.NewEncoder(resultFile).Encode(x11CrashWireState(keyboard, input)); err != nil {
+		t.Fatalf("write isolated X11 observer snapshot: %v", err)
+	}
+	if err := resultFile.Close(); err != nil {
+		t.Fatalf("close isolated X11 observer result: %v", err)
+	}
+}
+
+func x11CrashWireState(keyboard x11KeyboardState, input x11InputState) x11CrashObservedWire {
+	return x11CrashObservedWire{
+		MinKeycode:          keyboard.minKeycode,
+		KeysymsPerKeycode:   keyboard.keysymsPerKeycode,
+		Keysyms:             keyboard.keysyms,
+		KeycodesPerModifier: keyboard.keycodesPerModifier,
+		ModifierKeycodes:    keyboard.modifierKeycodes,
+		PressedKeys:         input.pressedKeys,
+		PointerX:            input.pointerX,
+		PointerY:            input.pointerY,
+		PointerMask:         input.pointerMask,
+	}
+}
+
+func (wire x11CrashObservedWire) observedState() x11CrashObservedState {
+	return x11CrashObservedState{
+		keyboard: x11KeyboardState{
+			minKeycode:          wire.MinKeycode,
+			keysymsPerKeycode:   wire.KeysymsPerKeycode,
+			keysyms:             append([]xproto.Keysym(nil), wire.Keysyms...),
+			keycodesPerModifier: wire.KeycodesPerModifier,
+			modifierKeycodes:    append([]xproto.Keycode(nil), wire.ModifierKeycodes...),
+		},
+		input: x11InputState{
+			pressedKeys: append([]byte(nil), wire.PressedKeys...),
+			pointerX:    wire.PointerX,
+			pointerY:    wire.PointerY,
+			pointerMask: wire.PointerMask,
+		},
+	}
+}
+
+func x11CrashOpenObserver() (*xgb.Conn, error) {
+	connection, err := xgb.NewConnDisplay(os.Getenv(x11CrashDisplayEnv))
+	if err != nil {
+		return nil, err
+	}
+	return connection, nil
+}
+
+func x11CrashObserveStateOnConnection(connection *xgb.Conn) (x11KeyboardState, x11InputState, error) {
+	setup := xproto.Setup(connection)
+	if setup == nil {
+		return x11KeyboardState{}, x11InputState{}, errors.New("X11 observer has no setup")
+	}
+	screen := setup.DefaultScreen(connection)
+	if screen == nil {
+		return x11KeyboardState{}, x11InputState{}, errors.New("X11 observer has no default screen")
+	}
+	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
+	keyboard, err := xproto.GetKeyboardMapping(connection, setup.MinKeycode, byte(count)).Reply()
+	if err != nil || keyboard == nil || keyboard.KeysymsPerKeycode == 0 {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("query observer keyboard map: reply=%+v err=%v", keyboard, err)
+	}
+	modifiers, err := xproto.GetModifierMapping(connection).Reply()
+	if err != nil || modifiers == nil {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("query observer modifier map: reply=%+v err=%v", modifiers, err)
+	}
+	keys, err := xproto.QueryKeymap(connection).Reply()
+	if err != nil || keys == nil {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("query observer pressed keys: reply=%+v err=%v", keys, err)
+	}
+	pointer, err := xproto.QueryPointer(connection, screen.Root).Reply()
+	if err != nil || pointer == nil {
+		return x11KeyboardState{}, x11InputState{}, fmt.Errorf("query observer pointer: reply=%+v err=%v", pointer, err)
+	}
+	return x11KeyboardState{
+			minKeycode:          setup.MinKeycode,
+			keysymsPerKeycode:   keyboard.KeysymsPerKeycode,
+			keysyms:             append([]xproto.Keysym(nil), keyboard.Keysyms...),
+			keycodesPerModifier: modifiers.KeycodesPerModifier,
+			modifierKeycodes:    append([]xproto.Keycode(nil), modifiers.Keycodes...),
+		}, x11InputState{
+			pressedKeys: append([]byte(nil), keys.Keys...),
+			pointerX:    int(pointer.RootX),
+			pointerY:    int(pointer.RootY),
+			pointerMask: pointer.Mask,
+		}, nil
+}
+
+func x11CrashWaitForNextPoll(deadline time.Time) {
+	delay := time.Until(deadline)
+	if delay > x11CrashPollInterval {
+		delay = x11CrashPollInterval
+	}
+	if delay <= 0 {
+		return
+	}
+	timer := time.NewTimer(delay)
+	<-timer.C
+}
+
+func x11CrashInputEqual(left, right x11InputState) bool {
+	return bytes.Equal(left.pressedKeys, right.pressedKeys) &&
+		left.pointerX == right.pointerX &&
+		left.pointerY == right.pointerY &&
+		left.pointerMask == right.pointerMask
+}
+
+func x11CrashXKBCompSnapshot(t *testing.T) ([]byte, bool) {
+	t.Helper()
+	output, err := x11CrashXKBCompSnapshotRaw(x11CrashXKBCompTimeout)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) && os.Getenv(x11RequiredEnv) != "1" {
+			t.Logf("xkbcomp snapshot unavailable: %v", err)
+			return nil, false
+		}
+		t.Fatalf("snapshot XKB map with xkbcomp: %v", err)
+	}
+	return output, true
+}
+
+func x11CrashXKBCompSnapshotRaw(timeout time.Duration) ([]byte, error) {
+	path, err := exec.LookPath("xkbcomp")
+	if err != nil {
+		return nil, err
+	}
+	if timeout <= 0 {
+		return nil, errors.New("xkbcomp timeout is exhausted")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	var stderr bytes.Buffer
+	command := exec.CommandContext(ctx, path, "-xkb", os.Getenv(x11CrashDisplayEnv), "-")
+	command.Stderr = &stderr
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("run xkbcomp: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return bytes.TrimSpace(output), nil
+}
+
+func x11CrashEmergencyRestore(
+	harness *x11InputHarness,
+	claim x11CrashWorkloadClaim,
+) (restoreErr error) {
+	keys, err := xproto.QueryKeymap(harness.conn).Reply()
+	if err != nil {
+		restoreErr = errors.Join(restoreErr, fmt.Errorf("query held keys for emergency cleanup: %w", err))
+	} else if keys == nil {
+		restoreErr = errors.Join(restoreErr, errors.New("query held keys for emergency cleanup returned no reply"))
+	} else if x11CrashKeyPressed(keys.Keys, claim.heldKeycode) {
+		if err := xtest.FakeInputChecked(
+			harness.conn,
+			byte(xproto.KeyRelease),
+			byte(claim.heldKeycode),
+			0,
+			harness.root,
+			0,
+			0,
+			0,
+		).Check(); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("release claimed emergency keycode %d: %w", claim.heldKeycode, err))
+		}
+	}
+	pointer, err := xproto.QueryPointer(harness.conn, harness.root).Reply()
+	if err != nil {
+		restoreErr = errors.Join(restoreErr, fmt.Errorf("query pointer for emergency cleanup: %w", err))
+	} else if pointer == nil {
+		restoreErr = errors.Join(restoreErr, errors.New("query pointer for emergency cleanup returned no reply"))
+	} else if pointer.Mask&claim.buttonMask != 0 {
+		if err := xtest.FakeInputChecked(
+			harness.conn,
+			byte(xproto.ButtonRelease),
+			claim.button,
+			0,
+			harness.root,
+			0,
+			0,
+			0,
+		).Check(); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("release claimed emergency button %d: %w", claim.button, err))
+		}
+	}
+
+	// Release only the two exact synthetic holds before grabbing the server.
+	// The mapping is restored only if its final image still exactly matches the
+	// recorded claim and the keycode is neither pressed nor a modifier.
+	if err := xproto.GrabServerChecked(harness.conn).Check(); err != nil {
+		return errors.Join(restoreErr, fmt.Errorf("grab server for emergency keymap restore: %w", err))
+	}
+	defer func() {
+		if err := xproto.UngrabServerChecked(harness.conn).Check(); err != nil {
+			restoreErr = errors.Join(restoreErr, fmt.Errorf("ungrab server after emergency keymap restore: %w", err))
+		}
+	}()
+	current, err := xproto.GetKeyboardMapping(harness.conn, claim.scratchCode, 1).Reply()
+	if err != nil {
+		return errors.Join(restoreErr, fmt.Errorf("query claimed emergency scratch mapping: %w", err))
+	}
+	if current == nil || current.KeysymsPerKeycode != byte(len(claim.scratchAfter)) || len(current.Keysyms) != len(claim.scratchAfter) {
+		return errors.Join(restoreErr, fmt.Errorf("query claimed emergency scratch mapping returned incompatible reply: %+v", current))
+	}
+	if x11CrashMappingsEqual(current.Keysyms, claim.scratchBefore) {
+		return restoreErr
+	}
+	if !x11CrashMappingsEqual(current.Keysyms, claim.scratchAfter) {
+		return errors.Join(restoreErr, fmt.Errorf("preserved foreign replacement of claimed scratch keycode %d: %#v", claim.scratchCode, current.Keysyms))
+	}
+	held, heldErr := xproto.QueryKeymap(harness.conn).Reply()
+	modifiers, modifierErr := xproto.GetModifierMapping(harness.conn).Reply()
+	if heldErr != nil || held == nil {
+		return errors.Join(restoreErr, fmt.Errorf("refuse emergency scratch restore: query pressed state for keycode %d: reply=%+v err=%v", claim.scratchCode, held, heldErr))
+	}
+	if modifierErr != nil || modifiers == nil {
+		return errors.Join(restoreErr, fmt.Errorf("refuse emergency scratch restore: query modifier state for keycode %d: reply=%+v err=%v", claim.scratchCode, modifiers, modifierErr))
+	}
+	if x11CrashKeyPressed(held.Keys, claim.scratchCode) {
+		return errors.Join(restoreErr, fmt.Errorf("refuse emergency scratch restore: claimed keycode %d is pressed", claim.scratchCode))
+	}
+	if x11CrashModifierContains(modifiers.Keycodes, claim.scratchCode) {
+		return errors.Join(restoreErr, fmt.Errorf("refuse emergency scratch restore: claimed keycode %d is assigned as a modifier", claim.scratchCode))
+	}
+	if err := xproto.ChangeKeyboardMappingChecked(
+		harness.conn,
+		1,
+		claim.scratchCode,
+		byte(len(claim.scratchBefore)),
+		claim.scratchBefore,
+	).Check(); err != nil {
+		return errors.Join(restoreErr, fmt.Errorf("restore claimed emergency scratch keycode %d: %w", claim.scratchCode, err))
+	}
+	verified, err := xproto.GetKeyboardMapping(harness.conn, claim.scratchCode, 1).Reply()
+	if err != nil || verified == nil || !x11CrashMappingsEqual(verified.Keysyms, claim.scratchBefore) {
+		return errors.Join(restoreErr, fmt.Errorf("verify claimed emergency scratch restore: reply=%+v err=%v", verified, err))
+	}
+	return restoreErr
+}
+
+func x11CrashModifierContains(keycodes []xproto.Keycode, keycode xproto.Keycode) bool {
+	for _, candidate := range keycodes {
+		if candidate == keycode {
+			return true
+		}
+	}
+	return false
+}
+
+func x11CrashVerifyBaseline(
+	keyboard []byte,
+	input x11InputState,
+	xkbSnapshot []byte,
+	compareXKB bool,
+) error {
+	var verifyErr error
+	afterKeyboard, afterInput, err := x11CrashObserveState(x11CrashObserverTimeout)
+	if err != nil {
+		return fmt.Errorf("verify emergency X11 baseline: %w", err)
+	}
+	if !bytes.Equal(x11CrashKeyboardBytes(afterKeyboard), keyboard) {
+		verifyErr = errors.Join(verifyErr, errors.New("emergency cleanup did not restore the canonical core/modifier map"))
+	}
+	if !x11CrashInputEqual(afterInput, input) {
+		verifyErr = errors.Join(verifyErr, fmt.Errorf(
+			"emergency cleanup input mismatch: before=%+v after=%+v",
+			input,
+			afterInput,
+		))
+	}
+	if compareXKB {
+		afterXKB, err := x11CrashXKBCompSnapshotRaw(x11CrashXKBCompTimeout)
+		if err != nil {
+			verifyErr = errors.Join(verifyErr, fmt.Errorf("verify emergency XKB snapshot: %w", err))
+		} else if !bytes.Equal(afterXKB, xkbSnapshot) {
+			verifyErr = errors.Join(verifyErr, fmt.Errorf(
+				"emergency XKB snapshot mismatch: before=%x after=%x",
+				sha256.Sum256(xkbSnapshot),
+				sha256.Sum256(afterXKB),
+			))
+		}
+	}
+	return verifyErr
+}

--- a/x11_input_integration_test.go
+++ b/x11_input_integration_test.go
@@ -44,6 +44,7 @@ func (h *x11InputHarness) findEmptyNonModifierKeycode() (xproto.Keycode, []xprot
 	setup := xproto.Setup(h.conn)
 	if setup == nil {
 		h.t.Fatal("X11 connection has no setup while finding an empty keycode")
+		return 0, nil
 	}
 	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
 	reply, err := xproto.GetKeyboardMapping(h.conn, setup.MinKeycode, byte(count)).Reply()
@@ -104,6 +105,7 @@ func (h *x11InputHarness) keymapContains(keysym uint32) bool {
 	setup := xproto.Setup(h.conn)
 	if setup == nil {
 		h.t.Fatal("X11 connection has no setup while scanning the keymap")
+		return false
 	}
 	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
 	reply, err := xproto.GetKeyboardMapping(h.conn, setup.MinKeycode, byte(count)).Reply()
@@ -155,6 +157,20 @@ func TestPureGoX11PointerInput(t *testing.T) {
 	if err := robotgo.Toggle("wheelLeft", "down"); !errors.Is(err, robotgo.ErrNotSupported) {
 		t.Fatalf("persistent horizontal-wheel toggle error = %v, want ErrNotSupported", err)
 	}
+	for _, operation := range []struct {
+		name string
+		run  func() error
+	}{
+		{name: "wheel-left click", run: func() error { return robotgo.ClickE("wheelLeft") }},
+		{name: "wheel-right click", run: func() error { return robotgo.ClickE("wheelRight") }},
+		{name: "horizontal scroll", run: func() error { return robotgo.ScrollE(1, 0, 0) }},
+		{name: "mixed-axis scroll", run: func() error { return robotgo.ScrollE(-1, 1, 0) }},
+	} {
+		if err := operation.run(); !errors.Is(err, robotgo.ErrNotSupported) {
+			t.Fatalf("%s error = %v, want ErrNotSupported", operation.name, err)
+		}
+	}
+	harness.assertNoInputEvent("input event from rejected Pure-Go horizontal-wheel operation", 100*time.Millisecond)
 	const targetX, targetY = 180, 170
 	if err := robotgo.MoveE(targetX, targetY); err != nil {
 		t.Fatalf("MoveE: %v", err)
@@ -219,16 +235,14 @@ func TestPureGoX11PointerInput(t *testing.T) {
 		t.Fatalf("right-button up events = %+v, want %+v", got, want)
 	}
 
-	if err := robotgo.ScrollE(1, 1, 0); err != nil {
+	if err := robotgo.ScrollE(0, 1, 0); err != nil {
 		t.Fatalf("ScrollE: %v", err)
 	}
-	if got, want := harness.waitForButtonEvents(4), []x11ButtonEvent{
-		{pressed: true, button: x11ButtonWheelLeft},
-		{button: x11ButtonWheelLeft},
+	if got, want := harness.waitForButtonEvents(2), []x11ButtonEvent{
 		{pressed: true, button: x11ButtonWheelUp},
 		{button: x11ButtonWheelUp},
 	}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("scroll events = %+v, want %+v", got, want)
+		t.Fatalf("vertical scroll events = %+v, want %+v", got, want)
 	}
 	if err := robotgo.Toggle("wheelUp", "down"); err != nil {
 		t.Fatalf("hold wheel button before ScrollE: %v", err)

--- a/x11_input_parity_integration_test.go
+++ b/x11_input_parity_integration_test.go
@@ -3,6 +3,7 @@
 package robotgo_test
 
 import (
+	"errors"
 	"fmt"
 	"image/color"
 	"os"
@@ -19,6 +20,7 @@ const (
 	envExpectedX11Implementation = "ROBOTGO_EXPECT_X11_IMPLEMENTATION"
 	x11KeysymControlL            = 0xffe3
 	x11KeysymControlR            = 0xffe4
+	x11ParityButtonWheelRight    = 7
 )
 
 type x11ObservedKeyEvent struct {
@@ -141,14 +143,54 @@ func TestX11BackendBehavioralParity(t *testing.T) {
 			{button: x11ButtonRight},
 		})
 
-		if err := robotgo.ScrollE(1, 1, 0); err != nil {
+		if err := robotgo.ScrollE(0, 1, 0); err != nil {
 			t.Fatalf("ScrollE: %v", err)
 		}
-		assertButtonEvents(t, harness.waitForButtonEvents(4), []x11ButtonEvent{
-			{pressed: true, button: x11ButtonWheelLeft},
-			{button: x11ButtonWheelLeft},
+		assertButtonEvents(t, harness.waitForButtonEvents(2), []x11ButtonEvent{
 			{pressed: true, button: x11ButtonWheelUp},
 			{button: x11ButtonWheelUp},
+		})
+	})
+
+	t.Run("horizontal wheel backend contract", func(t *testing.T) {
+		harness.drainEvents()
+		if err := robotgo.MoveE(x11WindowX+10, x11WindowY+10); err != nil {
+			t.Fatalf("position pointer for horizontal-wheel contract: %v", err)
+		}
+		harness.waitForEvent("pointer motion before horizontal-wheel contract", func(event xgb.Event) bool {
+			motion, ok := event.(xproto.MotionNotifyEvent)
+			return ok && int(motion.RootX) == x11WindowX+10 && int(motion.RootY) == x11WindowY+10
+		})
+		harness.drainEvents()
+		if robotgo.GetRuntimeBackendInfo().BuildImplementation == robotgo.RuntimeImplementationPureGo {
+			for _, operation := range []struct {
+				name string
+				run  func() error
+			}{
+				{name: "scroll", run: func() error { return robotgo.ScrollE(1, 0, 0) }},
+				{name: "wheel-left click", run: func() error { return robotgo.ClickE("wheelLeft") }},
+				{name: "wheel-right click", run: func() error { return robotgo.ClickE("wheelRight") }},
+			} {
+				if err := operation.run(); !errors.Is(err, robotgo.ErrNotSupported) {
+					t.Fatalf("Pure-Go %s error = %v, want ErrNotSupported", operation.name, err)
+				}
+			}
+			harness.assertNoInputEvent("input event from rejected Pure-Go horizontal-wheel operation", 100*time.Millisecond)
+			return
+		}
+		if err := robotgo.ScrollE(1, 0, 0); err != nil {
+			t.Fatalf("native horizontal ScrollE: %v", err)
+		}
+		assertButtonEvents(t, harness.waitForButtonEvents(2), []x11ButtonEvent{
+			{pressed: true, button: x11ButtonWheelLeft},
+			{button: x11ButtonWheelLeft},
+		})
+		if err := robotgo.ClickE("wheelRight"); err != nil {
+			t.Fatalf("native wheel-right ClickE: %v", err)
+		}
+		assertButtonEvents(t, harness.waitForButtonEvents(2), []x11ButtonEvent{
+			{pressed: true, button: x11ParityButtonWheelRight},
+			{button: x11ParityButtonWheelRight},
 		})
 	})
 
@@ -296,6 +338,7 @@ func (h *x11InputHarness) keyboardState() x11KeyboardState {
 	setup := xproto.Setup(h.conn)
 	if setup == nil {
 		h.t.Fatal("X11 connection has no setup while snapshotting keyboard state")
+		return x11KeyboardState{}
 	}
 	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
 	keyboard, err := xproto.GetKeyboardMapping(h.conn, setup.MinKeycode, byte(count)).Reply()

--- a/x11_input_test_harness_linux_test.go
+++ b/x11_input_test_harness_linux_test.go
@@ -95,6 +95,7 @@ func newX11InputHarness(t x11TestingT) *x11InputHarness {
 		conn.Close()
 		if version == nil {
 			x11Unavailable(t, "X11 integration test received no XTEST version reply")
+			return nil
 		}
 		x11Unavailable(
 			t,
@@ -110,6 +111,7 @@ func newX11InputHarness(t x11TestingT) *x11InputHarness {
 	if screen == nil {
 		conn.Close()
 		t.Fatal("X11 connection has no default screen")
+		return nil
 	}
 	windowID, err := xproto.NewWindowId(conn)
 	if err != nil {
@@ -412,6 +414,7 @@ func (h *x11InputHarness) findKeycode(keysym uint32) (xproto.Keycode, []xproto.K
 	setup := xproto.Setup(h.conn)
 	if setup == nil {
 		h.t.Fatal("X11 connection has no setup while finding a keysym")
+		return 0, nil
 	}
 	count := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
 	reply, err := xproto.GetKeyboardMapping(h.conn, setup.MinKeycode, byte(count)).Reply()


### PR DESCRIPTION
## Goal

Make the `CGO_ENABLED=0` Linux/X11 input backend race-testable and recover RobotGo-owned input and temporary Unicode scratch mappings when the application process exits unexpectedly or is killed with `SIGKILL`.

## What changed

- Extracted the stateful Pure-Go X11/XTEST implementation into `internal/x11input`, while keeping the public non-CGO adapter and API contracts stable.
- Added a separately re-executed guardian process that owns the live X11 connection.
- Replaced inherited control descriptors with a random token-authenticated Linux abstract Unix socket and exact kernel `SO_PEERCRED` PID/UID verification.
- Added bounded startup, display-dial, request-dispatch, cleanup, transport-close, process-exit, kill, and reap paths.
- Added conditional crash cleanup for RobotGo-owned keys, buttons, and scratch mappings.
- Made mapping ownership fail-safe when an X11 mutation succeeds but its reply or verification readback is lost: exact known state may be restored, while unresolved or foreign state is preserved and reported instead of overwritten.
- Kept Pure-Go horizontal wheel input explicitly unsupported because core X11 button 6/7 state cannot be observed safely; native CGO horizontal scrolling remains supported.
- Extended CI, the Xvfb integration manifest, benchmark smoke, README, testing guide, performance notes, and product roadmap.

## User and developer impact

Pure-Go X11 input remains opt-in through `CGO_ENABLED=0`, but its failure behavior is now explicit and crash-aware. Normal callers should still use `CloseMainDisplayE` after delayed consumers have processed text because it is the deterministic path that reports cleanup errors. Guardian startup requires executable `/proc/self/exe`, Linux abstract Unix sockets, and permission to re-execute the current binary; startup fails without silently falling back to an in-process X11 connection.

The guarantee covers application-process death while the guardian and a responsive X server survive. It cannot synchronously restore state after simultaneous guardian/container/host termination or an X11 transport that remains blocked beyond the cleanup deadline.

## Validation

- `go test -count=1 ./...`
- `CGO_ENABLED=0 go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go test -race -count=20 -timeout=2m ./internal/x11input`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run`
- `CGO_ENABLED=0 golangci-lint run --build-tags=x11integration .`
- `govulncheck ./...`
- Windows and macOS non-CGO cross-compilation
- All 20 required Pure-Go X11/Xvfb integration tests, including real application `SIGKILL` recovery
- Native X11 behavioral parity and missing-XTEST negative contract
- Native/Pure-Go behavior and 10-benchmark evidence smoke
- Targeted mapping ambiguity/foreign-state tests repeated 50 times under the race detector
- Helper kill/reap test repeated 100 times under the race detector
- GitHub Actions push run `29535333155` passed

## Review focus

- Guardian authentication and process lifecycle in `internal/x11input/guardian_linux.go`
- Mapping/input ownership and bounded cleanup in `internal/x11input/guardian_reexec_linux.go`
- Real crash proof in `x11_input_crash_*_integration_test.go`
