### PR TITLE
docs: record guardian X11 performance evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,10 +622,10 @@ X11 runtime support fails instead of skipping; see
 the exact commands and prerequisites. The crash proof additionally inspects
 `/proc/<pid>/task/<tid>/children` under a Linux child subreaper to verify that
 the reported guardian is the exact child that exits and is reaped. The
-[versioned decision-grade comparison](docs/performance/data/x11-2026-07-16-d5fd51c/summary.md)
-retains native CGO as the X11 default and Pure-Go as the supported CGO-disabled
-backend. That sample predates the guardian IPC layer; it remains the
-default-selection record, not a current guardian performance measurement.
+[current decision-grade comparison](docs/performance/data/x11-2026-07-17-6c06469/summary.md)
+measures the guardian path and retains native CGO as the X11 default while
+Pure-Go remains the supported CGO-disabled backend. The earlier direct-path
+sample remains linked from the performance report as historical evidence.
 Protecting the resulting remote checks remains a roadmap exit criterion.
 
 Wayland and portal code has additional tagged suites:
@@ -655,12 +655,12 @@ Real Wayland input results are tracked in the
 
 The active product slice remains selective Phase 3 Pure-Go hardening. The
 Linux/X11 evaluation is complete: shared behavior is blocking CI,
-decision-grade evidence is versioned, and native CGO remains the default while
-Pure-Go supports CGO-disabled builds. The Pure-Go X11 core is race-testable and
-its separate guardian performs bounded, claim-checked cleanup after an
-application-process crash. Protecting remote checks and evaluating further
-backends remain. Real GNOME/KDE/wlroots validation is an independent Wayland
-release gate.
+current guardian-path decision evidence is versioned, and native CGO remains
+the default while Pure-Go supports CGO-disabled builds. The Pure-Go X11 core is
+race-testable and its separate guardian performs bounded, claim-checked cleanup
+after an application-process crash. Safe guardian-cost optimization,
+protecting remote checks, and evaluating further backends remain. Real
+GNOME/KDE/wlroots validation is an independent Wayland release gate.
 
 ## Upstream and attribution
 

--- a/docs/performance/data/x11-2026-07-16-d5fd51c/summary.md
+++ b/docs/performance/data/x11-2026-07-16-d5fd51c/summary.md
@@ -7,7 +7,8 @@
 - Observations per benchmark and implementation: `10`
 - Go benchtime: `500ms`
 - GOMAXPROCS / `-test.cpu`: `1`
-- Balanced two-order cycles: `1`
+- Benchmark cycles: `5`
+- Balanced two-order mode: `enabled`
 
 | Benchmark | Metric | native CGO median [Q1–Q3] | Pure-Go median [Q1–Q3] | Pure-Go / native CGO | N (native CGO / Pure-Go) |
 |---|---:|---:|---:|---:|---:|

--- a/docs/performance/data/x11-2026-07-17-6c06469/behavior-native.txt
+++ b/docs/performance/data/x11-2026-07-17-6c06469/behavior-native.txt
@@ -1,0 +1,101 @@
+=== RUN   TestNativeX11StatefulInputDoesNotSwitchToPortalOnUp
+--- PASS: TestNativeX11StatefulInputDoesNotSwitchToPortalOnUp (0.00s)
+=== RUN   TestNativeX11UnicodeFailsBeforeMutation
+=== RUN   TestNativeX11UnicodeFailsBeforeMutation/text_preflight
+=== RUN   TestNativeX11UnicodeFailsBeforeMutation/code_point
+--- PASS: TestNativeX11UnicodeFailsBeforeMutation (0.21s)
+    --- PASS: TestNativeX11UnicodeFailsBeforeMutation/text_preflight (0.10s)
+    --- PASS: TestNativeX11UnicodeFailsBeforeMutation/code_point (0.10s)
+=== RUN   TestNativeX11UnmappedKeyFailsBeforeModifierInput
+--- PASS: TestNativeX11UnmappedKeyFailsBeforeModifierInput (0.10s)
+=== RUN   TestNativeX11KeyPressKeepsResolvedKeycodesAcrossKeymapChange
+--- PASS: TestNativeX11KeyPressKeepsResolvedKeycodesAcrossKeymapChange (0.02s)
+=== RUN   TestNativeX11TextKeymapFailureIsAtomic
+--- PASS: TestNativeX11TextKeymapFailureIsAtomic (0.21s)
+=== RUN   TestNativeX11TextUsesActiveGermanKeymap
+--- PASS: TestNativeX11TextUsesActiveGermanKeymap (0.08s)
+=== RUN   TestNativeX11TextRejectsMidStreamKeymapChange
+--- PASS: TestNativeX11TextRejectsMidStreamKeymapChange (0.36s)
+=== RUN   TestNativeX11ForeignHeldKeysNeverReleased
+=== RUN   TestNativeX11ForeignHeldKeysNeverReleased/text_main_key_and_full_string_preflight
+=== RUN   TestNativeX11ForeignHeldKeysNeverReleased/compound_key_modifier
+=== RUN   TestNativeX11ForeignHeldKeysNeverReleased/unowned_key-up
+--- PASS: TestNativeX11ForeignHeldKeysNeverReleased (0.31s)
+    --- PASS: TestNativeX11ForeignHeldKeysNeverReleased/text_main_key_and_full_string_preflight (0.10s)
+    --- PASS: TestNativeX11ForeignHeldKeysNeverReleased/compound_key_modifier (0.10s)
+    --- PASS: TestNativeX11ForeignHeldKeysNeverReleased/unowned_key-up (0.10s)
+=== RUN   TestNativeX11TextHonorsActiveXKBState
+=== RUN   TestNativeX11TextHonorsActiveXKBState/foreign_Shift_is_reused_but_never_released
+=== RUN   TestNativeX11TextHonorsActiveXKBState/foreign_Level3_selector_is_reused
+=== RUN   TestNativeX11TextHonorsActiveXKBState/Caps_Lock_state_is_preserved
+=== RUN   TestNativeX11TextHonorsActiveXKBState/shortcut_modifier_fails_closed
+--- PASS: TestNativeX11TextHonorsActiveXKBState (0.26s)
+    --- PASS: TestNativeX11TextHonorsActiveXKBState/foreign_Shift_is_reused_but_never_released (0.05s)
+    --- PASS: TestNativeX11TextHonorsActiveXKBState/foreign_Level3_selector_is_reused (0.05s)
+    --- PASS: TestNativeX11TextHonorsActiveXKBState/Caps_Lock_state_is_preserved (0.05s)
+    --- PASS: TestNativeX11TextHonorsActiveXKBState/shortcut_modifier_fails_closed (0.10s)
+=== RUN   TestNativeX11KeyToggleOwnershipSurvivesKeymapChange
+--- PASS: TestNativeX11KeyToggleOwnershipSurvivesKeymapChange (0.03s)
+=== RUN   TestNativeX11KeyToggleSharesOnlyOwnedModifiers
+--- PASS: TestNativeX11KeyToggleSharesOnlyOwnedModifiers (0.09s)
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/close_releases_and_invalidates_ownership
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/retarget_releases_and_invalidates_ownership
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/close_releases_and_invalidates_mouse_ownership
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/stateful_unobservable_wheel_buttons_are_unsupported
+--- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle (0.07s)
+    --- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/close_releases_and_invalidates_ownership (0.03s)
+    --- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/retarget_releases_and_invalidates_ownership (0.03s)
+    --- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/close_releases_and_invalidates_mouse_ownership (0.00s)
+    --- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/stateful_unobservable_wheel_buttons_are_unsupported (0.00s)
+=== RUN   TestNativeX11ExplicitInvalidDisplayNeverFallsBack
+--- PASS: TestNativeX11ExplicitInvalidDisplayNeverFallsBack (0.11s)
+=== RUN   TestNativeX11PixelColorOutOfBoundsReturnsError
+--- PASS: TestNativeX11PixelColorOutOfBoundsReturnsError (0.00s)
+=== RUN   TestNativeX11DisplayLifecycleConcurrent
+--- PASS: TestNativeX11DisplayLifecycleConcurrent (0.82s)
+=== RUN   TestNativeX11EnvironmentToggleLifecycleConcurrent
+--- PASS: TestNativeX11EnvironmentToggleLifecycleConcurrent (0.09s)
+=== RUN   TestX11BackendBehavioralParity
+=== RUN   TestX11BackendBehavioralParity/capture
+=== RUN   TestX11BackendBehavioralParity/pointer
+=== RUN   TestX11BackendBehavioralParity/buttons_and_scroll
+=== RUN   TestX11BackendBehavioralParity/horizontal_wheel_backend_contract
+=== RUN   TestX11BackendBehavioralParity/named_key
+=== RUN   TestX11BackendBehavioralParity/modifier_order
+=== RUN   TestX11BackendBehavioralParity/text_and_keyboard_state
+--- PASS: TestX11BackendBehavioralParity (0.19s)
+    --- PASS: TestX11BackendBehavioralParity/capture (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/pointer (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/buttons_and_scroll (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/horizontal_wheel_backend_contract (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/named_key (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/modifier_order (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/text_and_keyboard_state (0.06s)
+=== RUN   TestX11XTestVersionAtLeast
+=== PAUSE TestX11XTestVersionAtLeast
+=== RUN   TestNativeX11ConfiguredTargetAppliesToWindowAndScale
+--- PASS: TestNativeX11ConfiguredTargetAppliesToWindowAndScale (0.00s)
+=== RUN   TestNativeX11ClientCoordinatesThroughReparenting
+--- PASS: TestNativeX11ClientCoordinatesThroughReparenting (0.00s)
+=== RUN   TestNativeX11DestroyedWindowDoesNotAbort
+--- PASS: TestNativeX11DestroyedWindowDoesNotAbort (3.02s)
+=== CONT  TestX11XTestVersionAtLeast
+=== RUN   TestX11XTestVersionAtLeast/missing_reply
+=== PAUSE TestX11XTestVersionAtLeast/missing_reply
+=== RUN   TestX11XTestVersionAtLeast/older_minor
+=== PAUSE TestX11XTestVersionAtLeast/older_minor
+=== RUN   TestX11XTestVersionAtLeast/minimum
+=== PAUSE TestX11XTestVersionAtLeast/minimum
+=== RUN   TestX11XTestVersionAtLeast/newer_major
+=== PAUSE TestX11XTestVersionAtLeast/newer_major
+=== CONT  TestX11XTestVersionAtLeast/missing_reply
+=== CONT  TestX11XTestVersionAtLeast/newer_major
+=== CONT  TestX11XTestVersionAtLeast/minimum
+=== CONT  TestX11XTestVersionAtLeast/older_minor
+--- PASS: TestX11XTestVersionAtLeast (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/missing_reply (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/newer_major (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/minimum (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/older_minor (0.00s)
+PASS

--- a/docs/performance/data/x11-2026-07-17-6c06469/behavior-purego.txt
+++ b/docs/performance/data/x11-2026-07-17-6c06469/behavior-purego.txt
@@ -1,0 +1,77 @@
+=== RUN   TestPureGoX11RejectsImplicitDependencyPortalFallback
+--- PASS: TestPureGoX11RejectsImplicitDependencyPortalFallback (0.00s)
+=== RUN   TestPureGoX11CrashRestoresScratchAndOwnedInput
+--- PASS: TestPureGoX11CrashRestoresScratchAndOwnedInput (2.05s)
+=== RUN   TestPureGoX11MultiLayoutConfiguration
+--- PASS: TestPureGoX11MultiLayoutConfiguration (0.00s)
+=== RUN   TestPureGoX11Capabilities
+--- PASS: TestPureGoX11Capabilities (0.01s)
+=== RUN   TestPureGoX11PointerInput
+--- PASS: TestPureGoX11PointerInput (0.25s)
+=== RUN   TestPureGoX11KeyboardInput
+--- PASS: TestPureGoX11KeyboardInput (0.70s)
+=== RUN   TestPureGoX11TextReachesDelayedXKBClient
+--- PASS: TestPureGoX11TextReachesDelayedXKBClient (0.05s)
+=== RUN   TestPureGoX11ExplicitShiftReachesXKBClient
+--- PASS: TestPureGoX11ExplicitShiftReachesXKBClient (0.07s)
+=== RUN   TestPureGoX11ScratchReservationSkipsPressedEmptyKeycode
+--- PASS: TestPureGoX11ScratchReservationSkipsPressedEmptyKeycode (0.02s)
+=== RUN   TestPureGoX11ScratchCleanupCanRetryAfterForeignRelease
+--- PASS: TestPureGoX11ScratchCleanupCanRetryAfterForeignRelease (0.02s)
+=== RUN   TestPureGoX11RejectsNonModifierBeforeScratchMutation
+--- PASS: TestPureGoX11RejectsNonModifierBeforeScratchMutation (0.11s)
+=== RUN   TestPureGoX11ScratchCleanupCanRetryAfterModifierRestore
+--- PASS: TestPureGoX11ScratchCleanupCanRetryAfterModifierRestore (0.02s)
+=== RUN   TestPureGoX11TextCapacityFailsBeforeInput
+--- PASS: TestPureGoX11TextCapacityFailsBeforeInput (0.11s)
+=== RUN   TestPureGoX11RejectsScratchReplacementBeforeTextTap
+--- PASS: TestPureGoX11RejectsScratchReplacementBeforeTextTap (0.11s)
+=== RUN   TestPureGoX11ClosePreservesForeignScratchReplacement
+--- PASS: TestPureGoX11ClosePreservesForeignScratchReplacement (0.17s)
+=== RUN   TestPureGoX11ClosePreservesForeignModifierScratchReplacement
+--- PASS: TestPureGoX11ClosePreservesForeignModifierScratchReplacement (0.02s)
+=== RUN   TestPureGoX11PreservesForeignInputState
+--- PASS: TestPureGoX11PreservesForeignInputState (0.25s)
+=== RUN   TestPureGoX11EventDrainDoesNotStall
+--- PASS: TestPureGoX11EventDrainDoesNotStall (0.04s)
+=== RUN   TestPureGoX11CloseMainDisplayReconnects
+--- PASS: TestPureGoX11CloseMainDisplayReconnects (0.28s)
+=== RUN   TestPureGoX11SessionSwitchReleasesOwnedInput
+--- PASS: TestPureGoX11SessionSwitchReleasesOwnedInput (0.02s)
+=== RUN   TestX11BackendBehavioralParity
+=== RUN   TestX11BackendBehavioralParity/capture
+=== RUN   TestX11BackendBehavioralParity/pointer
+=== RUN   TestX11BackendBehavioralParity/buttons_and_scroll
+=== RUN   TestX11BackendBehavioralParity/horizontal_wheel_backend_contract
+=== RUN   TestX11BackendBehavioralParity/named_key
+=== RUN   TestX11BackendBehavioralParity/modifier_order
+=== RUN   TestX11BackendBehavioralParity/text_and_keyboard_state
+--- PASS: TestX11BackendBehavioralParity (0.34s)
+    --- PASS: TestX11BackendBehavioralParity/capture (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/pointer (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/buttons_and_scroll (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/horizontal_wheel_backend_contract (0.10s)
+    --- PASS: TestX11BackendBehavioralParity/named_key (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/modifier_order (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/text_and_keyboard_state (0.10s)
+=== RUN   TestX11XTestVersionAtLeast
+=== PAUSE TestX11XTestVersionAtLeast
+=== CONT  TestX11XTestVersionAtLeast
+=== RUN   TestX11XTestVersionAtLeast/missing_reply
+=== PAUSE TestX11XTestVersionAtLeast/missing_reply
+=== RUN   TestX11XTestVersionAtLeast/older_minor
+=== PAUSE TestX11XTestVersionAtLeast/older_minor
+=== RUN   TestX11XTestVersionAtLeast/minimum
+=== PAUSE TestX11XTestVersionAtLeast/minimum
+=== RUN   TestX11XTestVersionAtLeast/newer_major
+=== PAUSE TestX11XTestVersionAtLeast/newer_major
+=== CONT  TestX11XTestVersionAtLeast/missing_reply
+=== CONT  TestX11XTestVersionAtLeast/minimum
+=== CONT  TestX11XTestVersionAtLeast/older_minor
+=== CONT  TestX11XTestVersionAtLeast/newer_major
+--- PASS: TestX11XTestVersionAtLeast (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/missing_reply (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/minimum (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/older_minor (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/newer_major (0.00s)
+PASS

--- a/docs/performance/data/x11-2026-07-17-6c06469/metadata.txt
+++ b/docs/performance/data/x11-2026-07-17-6c06469/metadata.txt
@@ -1,0 +1,159 @@
+timestamp_utc=2026-07-17T06:20:27Z
+git_commit=6c064690be8ba6e8e57934298f394f224aba30a9
+source_fingerprint=9b9cba4599fa1b01d114a5a77d1dfcd6d96f48e5
+allow_dirty=0
+source_mode=detached-clean-worktree
+git_status_begin
+
+git_status_end
+go_version=go version go1.26.5-X:nodwarf5 linux/amd64
+go_env_begin
+{
+	"AR": "ar",
+	"CC": "gcc",
+	"CGO_CFLAGS": "-O2 -g",
+	"CGO_CPPFLAGS": "",
+	"CGO_CXXFLAGS": "-O2 -g",
+	"CGO_LDFLAGS": "-O2 -g",
+	"CXX": "g++",
+	"GO386": "",
+	"GOAMD64": "v1",
+	"GOARCH": "amd64",
+	"GOARM": "",
+	"GOARM64": "",
+	"GOEXPERIMENT": "nodwarf5",
+	"GOFLAGS": "-mod=readonly",
+	"GOMIPS": "",
+	"GOMIPS64": "",
+	"GOOS": "linux",
+	"GOPPC64": "",
+	"GORISCV64": "",
+	"GOTOOLCHAIN": "auto",
+	"GOVERSION": "go1.26.5-X:nodwarf5",
+	"GOWORK": "off",
+	"PKG_CONFIG": "pkg-config"
+}
+go_env_end
+runtime_env_begin
+GOGC=100
+GOMEMLIMIT=off
+GODEBUG=
+runtime_env_end
+pkg_config_env_begin
+PKG_CONFIG_PATH=
+PKG_CONFIG_LIBDIR=
+PKG_CONFIG_SYSROOT_DIR=
+LD_LIBRARY_PATH=
+pkg_config_env_end
+x11_pkg_config_begin
+x11_version=1.8.13
+xtst_version=1.2.5
+ -lXtst -lX11
+x11_pkg_config_end
+native_binary_build_info_begin
+/tmp/robotgo-x11-evidence.7hojUc/robotgo-native.test: go1.26.5-X:nodwarf5
+	path	github.com/marang/robotgo.test
+	mod	github.com/marang/robotgo	(devel)
+	build	-buildmode=exe
+	build	-compiler=gc
+	build	-tags=x11integration
+	build	DefaultGODEBUG=cryptocustomrand=1,tlssecpmlkem=0,urlstrictcolons=0
+	build	CGO_ENABLED=1
+	build	CGO_CFLAGS=
+	build	CGO_CPPFLAGS=
+	build	CGO_CXXFLAGS=
+	build	CGO_LDFLAGS=
+	build	GOARCH=amd64
+	build	GOEXPERIMENT=nodwarf5
+	build	GOOS=linux
+	build	GOAMD64=v1
+native_binary_build_info_end
+purego_binary_build_info_begin
+/tmp/robotgo-x11-evidence.7hojUc/robotgo-purego.test: go1.26.5-X:nodwarf5
+	path	github.com/marang/robotgo.test
+	mod	github.com/marang/robotgo	(devel)
+	build	-buildmode=exe
+	build	-compiler=gc
+	build	-tags=x11integration
+	build	DefaultGODEBUG=cryptocustomrand=1,tlssecpmlkem=0,urlstrictcolons=0
+	build	CGO_ENABLED=0
+	build	GOARCH=amd64
+	build	GOEXPERIMENT=nodwarf5
+	build	GOOS=linux
+	build	GOAMD64=v1
+purego_binary_build_info_end
+native_binary_dependencies_begin
+	linux-vdso.so.1 (0x00007fb369e7d000)
+	libm.so.6 => /usr/lib/libm.so.6 (0x00007fb369d0d000)
+	libX11.so.6 => /usr/lib/libX11.so.6 (0x00007fb369bcb000)
+	libXtst.so.6 => /usr/lib/libXtst.so.6 (0x00007fb369bc3000)
+	libresolv.so.2 => /usr/lib/libresolv.so.2 (0x00007fb369baf000)
+	libc.so.6 => /usr/lib/libc.so.6 (0x00007fb369800000)
+	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fb369e7f000)
+	libxcb.so.1 => /usr/lib/libxcb.so.1 (0x00007fb369b84000)
+	libXext.so.6 => /usr/lib/libXext.so.6 (0x00007fb369b6e000)
+	libXau.so.6 => /usr/lib/libXau.so.6 (0x00007fb369b69000)
+	libXdmcp.so.6 => /usr/lib/libXdmcp.so.6 (0x00007fb369b61000)
+native_binary_dependencies_end
+cc_version=gcc (GCC) 16.1.1 20260625
+pkg_config_version=2.5.1
+benchmark_cycles=5
+benchmark_balanced=1
+benchmark_benchtime=500ms
+behavior_cpu=4
+benchmark_cpu=1
+uname=Linux 7.1.3-arch2-1 x86_64
+Architecture:                            x86_64
+CPU op-mode(s):                          32-bit, 64-bit
+Address sizes:                           39 bits physical, 48 bits virtual
+Byte Order:                              Little Endian
+CPU(s):                                  12
+On-line CPU(s) list:                     0-11
+Vendor ID:                               GenuineIntel
+Model name:                              Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+CPU family:                              6
+Model:                                   158
+Thread(s) per core:                      2
+Core(s) per socket:                      6
+Socket(s):                               1
+Stepping:                                10
+Microcode version:                       0xf8
+CPU(s) scaling MHz:                      95%
+CPU max MHz:                             4100.0000
+CPU min MHz:                             800.0000
+BogoMIPS:                                4399.99
+Flags:                                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb pti ssbd ibrs ibpb stibp tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust sgx bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp vnmi sgx_lc md_clear flush_l1d arch_capabilities
+Virtualization:                          VT-x
+L1d cache:                               192 KiB (6 instances)
+L1i cache:                               192 KiB (6 instances)
+L2 cache:                                1.5 MiB (6 instances)
+L3 cache:                                9 MiB (1 instance)
+NUMA node(s):                            1
+NUMA node0 CPU(s):                       0-11
+Vulnerability Gather data sampling:      Mitigation; Microcode
+Vulnerability Ghostwrite:                Not affected
+Vulnerability Indirect target selection: Not affected
+Vulnerability Itlb multihit:             KVM: Mitigation: Split huge pages
+Vulnerability L1tf:                      Mitigation; PTE Inversion; VMX conditional cache flushes, SMT vulnerable
+Vulnerability Mds:                       Mitigation; Clear CPU buffers; SMT vulnerable
+Vulnerability Meltdown:                  Mitigation; PTI
+Vulnerability Mmio stale data:           Mitigation; Clear CPU buffers; SMT vulnerable
+Vulnerability Old microcode:             Vulnerable
+Vulnerability Reg file data sampling:    Not affected
+Vulnerability Retbleed:                  Mitigation; IBRS
+Vulnerability Spec rstack overflow:      Not affected
+Vulnerability Spec store bypass:         Mitigation; Speculative Store Bypass disabled via prctl
+Vulnerability Spectre v1:                Mitigation; usercopy/swapgs barriers and __user pointer sanitization
+Vulnerability Spectre v2:                Mitigation; IBRS; IBPB conditional; STIBP conditional; RSB filling; PBRSB-eIBRS Not affected; BHI Not affected
+Vulnerability Srbds:                     Mitigation; Microcode
+Vulnerability Tsa:                       Not affected
+Vulnerability Tsx async abort:           Not affected
+Vulnerability Vmscape:                   Mitigation; IBPB before exit to userspace
+xvfb_path=/tmp/robotgo-xvfb.23tKHQ/usr/bin/Xvfb
+xvfb_package=unknown
+xtest_requirement=2.2 (enforced by behavioral harness)
+x11_keymap_begin
+rules:      evdev
+model:      pc105
+layout:     us,de
+x11_keymap_end

--- a/docs/performance/data/x11-2026-07-17-6c06469/native.txt
+++ b/docs/performance/data/x11-2026-07-17-6c06469/native.txt
@@ -1,0 +1,160 @@
+# implementation=native-cgo sample=1 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     643	    955593 ns/op	1285.90 MB/s	 1228864 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   43574	     14072 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17090	     34923 ns/op	      86 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     50539 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5560	    100548 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5406219 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13891	     43026 ns/op	     181 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4950	    154515 ns/op	     209 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     170	   3471105 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  43520021 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=1 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     580	   1007549 ns/op	1219.59 MB/s	 1228873 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   44322	     13986 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17780	     34211 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     50241 ns/op	      86 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    7632	    101480 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5477510 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   14380	     42196 ns/op	     182 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4728	    151813 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     172	   3488431 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      12	  44886559 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=2 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     602	    974889 ns/op	1260.45 MB/s	 1228864 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   44870	     13820 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17388	     33764 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   12154	     50235 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    6328	     99117 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5471495 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13416	     41774 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    3907	    155650 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     176	   3465653 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44810808 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=2 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     572	    973324 ns/op	1262.48 MB/s	 1228873 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   44871	     14959 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17199	     34216 ns/op	      85 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     51186 ns/op	      88 B/op	       4 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    6204	     97573 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5461624 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   14002	     42238 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    3962	    151135 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     172	   3443048 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44334675 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=3 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     566	   1000398 ns/op	1228.31 MB/s	 1228873 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   43747	     13965 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17498	     34471 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     50544 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    6549	     97769 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5483444 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   14690	     41400 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4026	    154756 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     171	   3446616 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44488412 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=3 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     646	    895299 ns/op	1372.50 MB/s	 1228872 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   42642	     13475 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17942	     33663 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     50202 ns/op	      86 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    7780	    101332 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5446965 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   14642	     41473 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4150	    151907 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     174	   3476410 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44661544 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=4 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     625	    975917 ns/op	1259.12 MB/s	 1228872 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   45354	     13499 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17767	     33763 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     50162 ns/op	      86 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    7732	    100995 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5491251 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13683	     41081 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    5080	    148554 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     171	   3474816 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  43373294 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=4 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     648	    933769 ns/op	1315.96 MB/s	 1228872 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   43905	     13641 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17457	     34388 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     51688 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5672	    100452 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5443882 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   14547	     41885 ns/op	     182 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4850	    148721 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     174	   3472053 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44375437 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=5 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     592	   1006340 ns/op	1221.06 MB/s	 1228873 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   43885	     13780 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17487	     34505 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   12255	     50311 ns/op	      88 B/op	       4 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5958	    104512 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5408666 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13903	     41437 ns/op	     181 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4815	    153185 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     174	   3452799 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44427984 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=5 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     592	    995597 ns/op	1234.23 MB/s	 1228864 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   42769	     14352 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17470	     34527 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     52006 ns/op	      88 B/op	       4 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5274	     98531 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5412873 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   14342	     42368 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4564	    149233 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     175	   3464105 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44895219 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS

--- a/docs/performance/data/x11-2026-07-17-6c06469/purego.txt
+++ b/docs/performance/data/x11-2026-07-17-6c06469/purego.txt
@@ -1,0 +1,160 @@
+# implementation=pure-go sample=1 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     174	   3498122 ns/op	 351.27 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    8294	     79122 ns/op	    1528 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    7375	     86292 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    8754	     81315 ns/op	    1248 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1135	    546731 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	      98	   6024133 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1598	    361600 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     388	   1679423 ns/op	   75824 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      81	   7272016 ns/op	   73679 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59330150 ns/op	   0.00 MB/s	  672568 B/op	    2020 allocs/op
+PASS
+# implementation=pure-go sample=1 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     182	   3318169 ns/op	 370.32 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    7074	     77495 ns/op	    1528 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    6369	     86819 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    6613	     80548 ns/op	    1248 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1296	    500993 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5974413 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1334	    412216 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     440	   1442822 ns/op	   75825 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      84	   6957938 ns/op	   73679 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  61347060 ns/op	   0.00 MB/s	  672568 B/op	    2020 allocs/op
+PASS
+# implementation=pure-go sample=2 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     183	   3242592 ns/op	 378.96 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    9240	     79465 ns/op	    1528 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    7723	     81164 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    8828	     83271 ns/op	    1248 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1255	    530563 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5890301 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1443	    424298 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     380	   1918789 ns/op	   75825 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      82	   7343347 ns/op	   73679 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59238707 ns/op	   0.00 MB/s	  672568 B/op	    2020 allocs/op
+PASS
+# implementation=pure-go sample=2 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     178	   3292457 ns/op	 373.22 MB/s	 1342658 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    6698	     83227 ns/op	    1528 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    8803	     80755 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    7180	     87582 ns/op	    1248 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1147	    563745 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   6005506 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1443	    395200 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     370	   1727558 ns/op	   75824 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      93	   7307496 ns/op	   73678 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59500177 ns/op	   0.00 MB/s	  673159 B/op	    2021 allocs/op
+PASS
+# implementation=pure-go sample=3 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     182	   3292673 ns/op	 373.19 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    9176	     79857 ns/op	    1528 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    7759	     79791 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    5970	     91721 ns/op	    1249 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	     952	    546766 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	      97	   6021026 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1756	    381251 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     370	   1776080 ns/op	   75825 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      87	   7189688 ns/op	   73678 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59231218 ns/op	   0.00 MB/s	  672568 B/op	    2020 allocs/op
+PASS
+# implementation=pure-go sample=3 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     176	   3383451 ns/op	 363.18 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    6885	     75202 ns/op	    1528 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    8467	     80719 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    6415	     79651 ns/op	    1248 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1161	    632658 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5951396 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1414	    395626 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     334	   1654195 ns/op	   75840 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      79	   7240622 ns/op	   73679 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  62078833 ns/op	   0.00 MB/s	  672568 B/op	    2020 allocs/op
+PASS
+# implementation=pure-go sample=4 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     183	   3472058 ns/op	 353.91 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    7094	     83043 ns/op	    1528 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    6970	     86715 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    8722	     86019 ns/op	    1248 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1095	    514442 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5986911 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1452	    396979 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     376	   1562748 ns/op	   75825 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      91	   7183363 ns/op	   73678 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  58430109 ns/op	   0.00 MB/s	  672568 B/op	    2020 allocs/op
+PASS
+# implementation=pure-go sample=4 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     181	   3370631 ns/op	 364.56 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    9003	     75877 ns/op	    1529 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    7302	     78059 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    7336	     80500 ns/op	    1248 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1273	    512966 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   6074058 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1641	    393080 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     422	   1477789 ns/op	   75824 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      84	   7142626 ns/op	   73679 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  60311317 ns/op	   0.00 MB/s	  672568 B/op	    2020 allocs/op
+PASS
+# implementation=pure-go sample=5 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     174	   3545229 ns/op	 346.61 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    7198	     80127 ns/op	    1528 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    7030	     85824 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    8103	     80473 ns/op	    1248 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1075	    531486 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	      96	   6007031 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1623	    402656 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     338	   1683229 ns/op	   75824 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      81	   7100699 ns/op	   73679 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59059555 ns/op	   0.00 MB/s	  672568 B/op	    2020 allocs/op
+PASS
+# implementation=pure-go sample=5 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     180	   3473614 ns/op	 353.75 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    8439	     80935 ns/op	    1528 B/op	      29 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    6188	     83582 ns/op	    1272 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    6451	     83700 ns/op	    1248 B/op	      21 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1102	    556113 ns/op	    8361 B/op	     140 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	      99	   6106091 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1520	    384010 ns/op	    6216 B/op	     106 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     356	   1588603 ns/op	   75824 B/op	     241 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      88	   7062553 ns/op	   73678 B/op	     207 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  61228314 ns/op	   0.00 MB/s	  672568 B/op	    2020 allocs/op
+PASS

--- a/docs/performance/data/x11-2026-07-17-6c06469/run-status.txt
+++ b/docs/performance/data/x11-2026-07-17-6c06469/run-status.txt
@@ -1,0 +1,6 @@
+status=complete
+git_commit=6c064690be8ba6e8e57934298f394f224aba30a9
+source_fingerprint=9b9cba4599fa1b01d114a5a77d1dfcd6d96f48e5
+allow_dirty=0
+snapshot_verified=1
+decision_grade=1

--- a/docs/performance/data/x11-2026-07-17-6c06469/summary.md
+++ b/docs/performance/data/x11-2026-07-17-6c06469/summary.md
@@ -1,0 +1,44 @@
+# X11 native CGO vs Pure-Go benchmark report
+
+> Report-only evidence: correctness is blocking; timing ratios never fail CI. A 1x CI smoke validates this measurement path only and is not decision-grade performance data.
+
+- Git commit: `6c064690be8ba6e8e57934298f394f224aba30a9`
+- Source fingerprint: `9b9cba4599fa1b01d114a5a77d1dfcd6d96f48e5`
+- Observations per benchmark and implementation: `10`
+- Go benchtime: `500ms`
+- GOMAXPROCS / `-test.cpu`: `1`
+- Benchmark cycles: `5`
+- Balanced two-order mode: `enabled`
+
+| Benchmark | Metric | native CGO median [Q1–Q3] | Pure-Go median [Q1–Q3] | Pure-Go / native CGO | N (native CGO / Pure-Go) |
+|---|---:|---:|---:|---:|---:|
+| BenchmarkCaptureImgRuntime | ns/op | 975403 [960025.75–999197.75] | 3.377041e+06 [3.299047e+06–3.473225e+06] | 3.462x | 10 / 10 |
+| BenchmarkCaptureImgRuntime | B/op | 1.228872e+06 [1.228866e+06–1.228873e+06] | 1.342656e+06 [1.342656e+06–1.342656e+06] | 1.093x | 10 / 10 |
+| BenchmarkCaptureImgRuntime | allocs/op | 2 [2–2] | 116 [116–116] | 58.000x | 10 / 10 |
+| BenchmarkX11InputRuntime/ButtonTogglePair | ns/op | 100500 [98677.5–101247.75] | 539108.5 [518472.25–553776.25] | 5.364x | 10 / 10 |
+| BenchmarkX11InputRuntime/ButtonTogglePair | B/op | 207 [207–208] | 8361 [8361–8361] | 40.391x | 10 / 10 |
+| BenchmarkX11InputRuntime/ButtonTogglePair | allocs/op | 8 [8–9] | 140 [140–140] | 17.500x | 10 / 10 |
+| BenchmarkX11InputRuntime/ClickLeft | ns/op | 5.4542945e+06 [5.42062525e+06–5.47600625e+06] | 6.0062685e+06 [5.9775375e+06–6.02335625e+06] | 1.101x | 10 / 10 |
+| BenchmarkX11InputRuntime/ClickLeft | B/op | 184 [184–184] | 6216 [6216–6216] | 33.783x | 10 / 10 |
+| BenchmarkX11InputRuntime/ClickLeft | allocs/op | 7 [7–7] | 106 [106–106] | 15.143x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyPressEnter | ns/op | 3.468379e+06 [3.4556255e+06–3.47412525e+06] | 7.1865255e+06 [7.11118075e+06–7.2641675e+06] | 2.072x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyPressEnter | B/op | 184 [184–184] | 73679 [73678–73679] | 400.429x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyPressEnter | allocs/op | 7 [7–7] | 207 [207–207] | 29.571x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyTogglePairEnter | ns/op | 151860 [149708.5–154182.5] | 1.666809e+06 [1.56921175e+06–1.71647575e+06] | 10.976x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyTogglePairEnter | B/op | 208 [208–208] | 75824.5 [75824–75825] | 364.541x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyTogglePairEnter | allocs/op | 9 [9–9] | 241 [241–241] | 26.778x | 10 / 10 |
+| BenchmarkX11InputRuntime/Location | ns/op | 13892.5 [13675.75–14050.5] | 79661 [77901.75–80733] | 5.734x | 10 / 10 |
+| BenchmarkX11InputRuntime/Location | B/op | 0 [0–0] | 1528 [1528–1528] | n/a | 10 / 10 |
+| BenchmarkX11InputRuntime/Location | allocs/op | 0 [0–0] | 29 [29–29] | n/a | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveAbsolute | ns/op | 34302 [33875.75–34496.5] | 82373 [80728–86175] | 2.401x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveAbsolute | B/op | 87 [87–87] | 1272 [1272–1272] | 14.621x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveAbsolute | allocs/op | 3 [3–3] | 21 [21–21] | 7.000x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveRelative | ns/op | 50425 [50236.5–51025.5] | 82293 [80512–85439.25] | 1.632x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveRelative | B/op | 87 [86.25–87.75] | 1248 [1248–1248] | 14.345x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveRelative | allocs/op | 3 [3–3.75] | 21 [21–21] | 7.000x | 10 / 10 |
+| BenchmarkX11InputRuntime/ScrollVertical1 | ns/op | 41829.5 [41446–42227.5] | 395413 [386277.5–401236.75] | 9.453x | 10 / 10 |
+| BenchmarkX11InputRuntime/ScrollVertical1 | B/op | 183 [182–183] | 6216 [6216–6216] | 33.967x | 10 / 10 |
+| BenchmarkX11InputRuntime/ScrollVertical1 | allocs/op | 6 [6–6] | 106 [106–106] | 17.667x | 10 / 10 |
+| BenchmarkX11InputRuntime/TypeASCII8 | ns/op | 4.4458198e+07 [4.43448655e+07–4.4773492e+07] | 5.94151635e+07 [5.923309025e+07–6.099906475e+07] | 1.336x | 10 / 10 |
+| BenchmarkX11InputRuntime/TypeASCII8 | B/op | 2040 [2040–2040] | 672568 [672568–672568] | 329.690x | 10 / 10 |
+| BenchmarkX11InputRuntime/TypeASCII8 | allocs/op | 81 [81–81] | 2020 [2020–2020] | 24.938x | 10 / 10 |

--- a/docs/performance/x11-native-vs-purego.md
+++ b/docs/performance/x11-native-vs-purego.md
@@ -94,37 +94,47 @@ negative contract with the command in [TEST.md](../../TEST.md#x11integration-nat
 
 ## Current decision
 
-The decision-grade sample for commit `d5fd51c72702a719fd60fb06e0ef246018dc8b4e`
-is stored with its raw output, behavior logs, metadata, and completion record in
-[data/x11-2026-07-16-d5fd51c](data/x11-2026-07-16-d5fd51c/summary.md). Both
+The current decision-grade sample measures commit
+`6c064690be8ba6e8e57934298f394f224aba30a9`, including the re-executed Pure-Go
+guardian. Its raw output, behavior logs, metadata, and completion record are in
+[data/x11-2026-07-17-6c06469](data/x11-2026-07-17-6c06469/summary.md). Both
 implementations passed the complete shared contract and their exact
-backend-specific safety manifests.
+backend-specific safety manifests; the Pure-Go manifest includes a real
+application-process `SIGKILL` and verified guardian cleanup.
 
-The table below is historical evidence for that exact commit. The current
-Pure-Go backend subsequently moved its X11 connection into a re-executed
-guardian and moved its state machine into a race-testable internal package.
-Those changes close the targeted application-process-crash gap but add IPC, so
-the stored measurements must not be presented as guardian-path performance.
+The measurement used a user-local extraction of the official Arch Linux
+`xorg-server-xvfb` package `21.1.24-1` because the host did not have Xvfb
+installed and system package installation was unavailable. The package archive
+SHA-256 was
+`7f2116f869aedf51eb899dcfee4cf1f3bf6f9f42c71e089dcdbc0907d529e985`.
+Consequently, the exact temporary binary path is retained in metadata and the
+system-package field is `unknown`; this does not affect the clean detached
+source snapshot or the balanced same-server comparison.
 
 | Criterion | Evidence | Decision impact |
 |---|---|---|
-| Capture | Pure-Go/native median latency ratio `3.493x`; 115 versus 2 Go allocations per operation | Native has a material throughput and allocation advantage |
-| Stateful buttons and keys | Pure-Go/native median latency ratios `1.395x` for button toggles, `1.347x` for key toggles, and `1.627x` for key presses | Native remains preferable for common input sequences |
-| Scroll at sampled commit | Pure-Go/native median latency ratios `2.017x` horizontal and `2.083x` vertical; the current shared comparison retains vertical only because Pure-Go now rejects unobservable horizontal button state explicitly | Native remains preferable; do not present the historical horizontal number as current supported behavior |
-| Pointer queries and moves | Location is effectively equal at `1.016x`; Pure-Go absolute and relative move ratios are `0.565x` and `0.398x` | Pure-Go has a real pointer-movement advantage, but not enough to outweigh the broader default-path costs |
-| Delayed click and ASCII text | Ratios are `1.016x` and `1.012x`; configured user-visible delays dominate | No meaningful default-selection signal |
+| Capture | Pure-Go/native median latency ratio `3.462x`; 116 versus 2 Go allocations per operation | Native retains a material throughput and allocation advantage; guardian IPC is not involved in capture |
+| Stateful buttons and keys | Pure-Go/native median latency ratios `5.364x` for button toggles, `10.976x` for key toggles, and `2.072x` for delayed key presses | The per-request guardian safety boundary is measurable and native remains preferable for common input sequences |
+| Scroll | Pure-Go/native median latency ratio `9.453x` for vertical scroll; Pure-Go horizontal scroll remains explicitly unsupported because X11 does not expose reliable wheel-button state | Native remains preferable for scrolling |
+| Pointer queries and moves | Pure-Go/native median latency ratios are `5.734x` for location, `2.401x` for absolute movement, and `1.632x` for relative movement | The guardian reverses the earlier direct-connection movement advantage; native is now faster for all measured pointer operations |
+| Delayed click and ASCII text | Ratios are `1.101x` and `1.336x`; configured user-visible delays dominate much of the end-to-end result | Keep the operations supported, but do not use their ratios alone for backend selection |
 | Build and Unicode behavior | Pure-Go removes the C/Xlib build dependency and retains managed Unicode scratch mappings; native avoids server-global temporary mappings | Keep Pure-Go useful and supported for CGO-disabled builds |
-| Lifecycle risk at sampled commit | Pure-Go scratch mappings were conflict-aware, but abnormal process termination still lacked a scoped or crash-safe cleanup mechanism | Do not use this historical sample to claim guardian crash behavior or performance |
+| Lifecycle behavior | The Pure-Go safety manifest passes real application-process `SIGKILL` recovery with claim-checked, deadline-bounded guardian cleanup | The measured IPC cost buys a concrete crash-isolation guarantee absent from the historical direct-connection sample |
 
 **Decision:** retain native CGO as the Linux/X11 default when CGO is enabled.
 Keep the Pure-Go X11 backend as the supported CGO-disabled implementation. This
-is not a rejection of Pure-Go: it already wins pointer-movement latency and
-build portability, while native currently wins capture, most input operations,
-and allocation cost. Native also avoids server-global Unicode mappings
-entirely; the Pure-Go guardian now restores those mappings after a targeted
-application-process kill while it and a responsive X server survive. Its
-cleanup is deadline-bounded and restores only an exact unchanged, unpressed,
-non-modifier final image; foreign final images are preserved, while an
-exact-image ABA replacement is not observable in X11. Revisit the default only
-after a new decision-grade sample measures the guardian path and passes the
-same behavioral, race, and crash-recovery contracts.
+is not a rejection of Pure-Go: it preserves useful X11 automation without CGO
+and now provides measured crash isolation, while native wins every current
+latency comparison and most Go allocation comparisons. Native also avoids
+server-global Unicode mappings entirely. The Pure-Go guardian restores those
+mappings after a targeted application-process kill while it and a responsive
+X server survive. Its cleanup is deadline-bounded and restores only an exact
+unchanged, unpressed, non-modifier final image; foreign final images are
+preserved, while an exact-image ABA replacement is not observable in X11.
+
+The earlier pre-guardian sample remains available in
+[data/x11-2026-07-16-d5fd51c](data/x11-2026-07-16-d5fd51c/summary.md) as
+historical evidence. It must not be presented as current performance. Future
+work may reduce guardian round trips or allocations only if the same behavior,
+race, and crash-recovery contracts remain blocking; the evidence does not
+justify weakening the safety boundary or changing the default.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -28,14 +28,14 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
   Weston integration, race, and vet variants.
 
-## Execution Status (2026-07-16)
+## Execution Status (2026-07-17)
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
-| Current baseline | Complete in branch | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Confirm all required jobs after the branch is pushed and protect them |
+| Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Keep required jobs green and confirm repository branch protection |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | X11 hardening complete; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; versioned decision-grade evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; three-OS CI; non-skipping multi-layout Xvfb input tests | Protect the remote CI checks, collect current guardian performance evidence, then assess further backends selectively |
+| 3. Pure-Go | X11 hardening and measurement complete; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; current guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; three-OS CI; non-skipping multi-layout Xvfb input tests | Protect the remote CI checks, evaluate safe guardian round-trip/allocation reductions, then assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -183,9 +183,11 @@ the same exact image. The blocking Xvfb contract sends a real `SIGKILL` to the
 application workload and compares core, modifier, XKB, key, pointer, and button
 state. The guarantee requires the guardian and responsive X server to survive;
 guardian/host loss or a transport blocked beyond the cleanup deadline still
-needs later reconciliation. Protecting the remote checks, refreshing
-performance evidence for the guardian path, and selectively evaluating
-additional backends keep the broader Phase 3 partial.
+needs later reconciliation. Current decision-grade evidence measures the
+guardian path and confirms that its crash isolation adds material IPC latency
+and allocations, so native CGO remains the default. Protecting the remote
+checks, evaluating optimizations without weakening the safety contract, and
+selectively evaluating additional backends keep the broader Phase 3 partial.
 
 Exit criteria:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -102,9 +102,9 @@ Window backend support matrix (current):
     behavioral contract run in non-skipping Xvfb/XTEST CI. A balanced benchmark
     smoke is report-only. Native X11 now has atomic input preflight, one shared
     configured-display lifecycle/target, live XTEST readiness, and an XTEST-disabled negative
-    contract. A versioned decision-grade sample retains native CGO as the X11
-    default while keeping Pure-Go supported for CGO-disabled builds. Protecting
-    the checks, collecting current guardian-path performance evidence, and
+    contract. Current decision-grade guardian-path evidence retains native CGO
+    as the X11 default while keeping Pure-Go supported for CGO-disabled builds.
+    Protecting the checks, evaluating safe IPC/allocation reductions, and
     evaluating further backends remain open. The Pure-Go core is now
     race-testable, and a separate X11 guardian uses an authenticated abstract
     Unix socket with kernel-verified peer credentials, bounded request dispatch,

--- a/scripts/benchmark-x11-backends.sh
+++ b/scripts/benchmark-x11-backends.sh
@@ -437,7 +437,11 @@ run_inside_xvfb() {
 
 	local summary_tmp="${ROBOTGO_X11_EVIDENCE_OUTPUT}/summary.md.tmp"
 	local decision_grade
+	local balanced_mode="disabled"
 	decision_grade="$(decision_grade_for_run)"
+	if [[ "${ROBOTGO_X11_EVIDENCE_BALANCED}" == "1" ]]; then
+		balanced_mode="enabled"
+	fi
 	{
 		printf '# X11 native CGO vs Pure-Go benchmark report\n\n'
 		printf '> Report-only evidence: correctness is blocking; timing ratios never fail CI. '
@@ -454,7 +458,8 @@ run_inside_xvfb() {
 		printf -- '- Observations per benchmark and implementation: `%s`\n' "${observations_per_implementation}"
 		printf -- '- Go benchtime: `%s`\n' "${ROBOTGO_X11_EVIDENCE_BENCHTIME}"
 		printf -- '- GOMAXPROCS / `-test.cpu`: `%s`\n' "${ROBOTGO_X11_EVIDENCE_CPU}"
-		printf -- '- Balanced two-order cycles: `%s`\n\n' "${ROBOTGO_X11_EVIDENCE_BALANCED}"
+		printf -- '- Benchmark cycles: `%s`\n' "${ROBOTGO_X11_EVIDENCE_COUNT}"
+		printf -- '- Balanced two-order mode: `%s`\n\n' "${balanced_mode}"
 		cat "${ROBOTGO_X11_EVIDENCE_OUTPUT}/summary-table.md"
 	} >"${summary_tmp}"
 	mv -- "${summary_tmp}" "${ROBOTGO_X11_EVIDENCE_OUTPUT}/summary.md"


### PR DESCRIPTION
## What changed

- version the first decision-grade native-CGO versus Pure-Go X11 benchmark that includes the crash-safe guardian path
- retain raw benchmark output, behavior logs, environment metadata, and completion evidence
- update the performance decision, README, product roadmap, and Wayland backlog
- fix the generated summary so benchmark cycle count and balanced-order mode are reported separately and clearly

## Why

The previous versioned sample predated the guardian IPC boundary and could not support claims about current Pure-Go performance. The new balanced sample measures the actual guardian path after all behavioral and crash-recovery contracts pass.

## Impact

Native CGO remains the Linux/X11 default. Pure-Go remains the supported CGO-disabled backend with measured application-crash isolation. The data makes the guardian latency and Go-allocation trade-off explicit and identifies safe round-trip/allocation reduction as follow-up work without weakening cleanup guarantees.

## Validation

- full decision-grade X11 evidence run: five balanced cycles, ten observations per benchmark and implementation
- real application-process SIGKILL recovery contract
- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- targeted race tests for X11 input and benchmark tooling
- CGO and non-CGO `go vet ./...`
- `golangci-lint run`
- dirty reporter smoke proving corrected cycle/mode output