### PR TITLE
perf(x11): reduce guardian request allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ X11 runtime support fails instead of skipping; see
 the exact commands and prerequisites. The crash proof additionally inspects
 `/proc/<pid>/task/<tid>/children` under a Linux child subreaper to verify that
 the reported guardian is the exact child that exits and is reaped. The
-[current decision-grade comparison](docs/performance/data/x11-2026-07-17-6c06469/summary.md)
+[current decision-grade comparison](docs/performance/data/x11-2026-07-17-817656f/summary.md)
 measures the guardian path and retains native CGO as the X11 default while
 Pure-Go remains the supported CGO-disabled backend. The earlier direct-path
 sample remains linked from the performance report as historical evidence.
@@ -658,9 +658,11 @@ Linux/X11 evaluation is complete: shared behavior is blocking CI,
 current guardian-path decision evidence is versioned, and native CGO remains
 the default while Pure-Go supports CGO-disabled builds. The Pure-Go X11 core is
 race-testable and its separate guardian performs bounded, claim-checked cleanup
-after an application-process crash. Safe guardian-cost optimization,
-protecting remote checks, and evaluating further backends remain. Real
-GNOME/KDE/wlroots validation is an independent Wayland release gate.
+after an application-process crash. Its request transport now reuses bounded
+state and avoids double payload encoding, with versioned evidence showing lower
+allocation cost. Safe round-trip optimization, protecting remote checks, and
+evaluating further backends remain. Real GNOME/KDE/wlroots validation is an
+independent Wayland release gate.
 
 ## Upstream and attribution
 

--- a/docs/performance/data/x11-2026-07-17-817656f/behavior-native.txt
+++ b/docs/performance/data/x11-2026-07-17-817656f/behavior-native.txt
@@ -1,0 +1,101 @@
+=== RUN   TestNativeX11StatefulInputDoesNotSwitchToPortalOnUp
+--- PASS: TestNativeX11StatefulInputDoesNotSwitchToPortalOnUp (0.00s)
+=== RUN   TestNativeX11UnicodeFailsBeforeMutation
+=== RUN   TestNativeX11UnicodeFailsBeforeMutation/text_preflight
+=== RUN   TestNativeX11UnicodeFailsBeforeMutation/code_point
+--- PASS: TestNativeX11UnicodeFailsBeforeMutation (0.21s)
+    --- PASS: TestNativeX11UnicodeFailsBeforeMutation/text_preflight (0.10s)
+    --- PASS: TestNativeX11UnicodeFailsBeforeMutation/code_point (0.10s)
+=== RUN   TestNativeX11UnmappedKeyFailsBeforeModifierInput
+--- PASS: TestNativeX11UnmappedKeyFailsBeforeModifierInput (0.10s)
+=== RUN   TestNativeX11KeyPressKeepsResolvedKeycodesAcrossKeymapChange
+--- PASS: TestNativeX11KeyPressKeepsResolvedKeycodesAcrossKeymapChange (0.02s)
+=== RUN   TestNativeX11TextKeymapFailureIsAtomic
+--- PASS: TestNativeX11TextKeymapFailureIsAtomic (0.21s)
+=== RUN   TestNativeX11TextUsesActiveGermanKeymap
+--- PASS: TestNativeX11TextUsesActiveGermanKeymap (0.07s)
+=== RUN   TestNativeX11TextRejectsMidStreamKeymapChange
+--- PASS: TestNativeX11TextRejectsMidStreamKeymapChange (0.36s)
+=== RUN   TestNativeX11ForeignHeldKeysNeverReleased
+=== RUN   TestNativeX11ForeignHeldKeysNeverReleased/text_main_key_and_full_string_preflight
+=== RUN   TestNativeX11ForeignHeldKeysNeverReleased/compound_key_modifier
+=== RUN   TestNativeX11ForeignHeldKeysNeverReleased/unowned_key-up
+--- PASS: TestNativeX11ForeignHeldKeysNeverReleased (0.31s)
+    --- PASS: TestNativeX11ForeignHeldKeysNeverReleased/text_main_key_and_full_string_preflight (0.10s)
+    --- PASS: TestNativeX11ForeignHeldKeysNeverReleased/compound_key_modifier (0.10s)
+    --- PASS: TestNativeX11ForeignHeldKeysNeverReleased/unowned_key-up (0.10s)
+=== RUN   TestNativeX11TextHonorsActiveXKBState
+=== RUN   TestNativeX11TextHonorsActiveXKBState/foreign_Shift_is_reused_but_never_released
+=== RUN   TestNativeX11TextHonorsActiveXKBState/foreign_Level3_selector_is_reused
+=== RUN   TestNativeX11TextHonorsActiveXKBState/Caps_Lock_state_is_preserved
+=== RUN   TestNativeX11TextHonorsActiveXKBState/shortcut_modifier_fails_closed
+--- PASS: TestNativeX11TextHonorsActiveXKBState (0.26s)
+    --- PASS: TestNativeX11TextHonorsActiveXKBState/foreign_Shift_is_reused_but_never_released (0.05s)
+    --- PASS: TestNativeX11TextHonorsActiveXKBState/foreign_Level3_selector_is_reused (0.05s)
+    --- PASS: TestNativeX11TextHonorsActiveXKBState/Caps_Lock_state_is_preserved (0.06s)
+    --- PASS: TestNativeX11TextHonorsActiveXKBState/shortcut_modifier_fails_closed (0.10s)
+=== RUN   TestNativeX11KeyToggleOwnershipSurvivesKeymapChange
+--- PASS: TestNativeX11KeyToggleOwnershipSurvivesKeymapChange (0.03s)
+=== RUN   TestNativeX11KeyToggleSharesOnlyOwnedModifiers
+--- PASS: TestNativeX11KeyToggleSharesOnlyOwnedModifiers (0.09s)
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/close_releases_and_invalidates_ownership
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/retarget_releases_and_invalidates_ownership
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/close_releases_and_invalidates_mouse_ownership
+=== RUN   TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/stateful_unobservable_wheel_buttons_are_unsupported
+--- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle (0.07s)
+    --- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/close_releases_and_invalidates_ownership (0.03s)
+    --- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/retarget_releases_and_invalidates_ownership (0.03s)
+    --- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/close_releases_and_invalidates_mouse_ownership (0.00s)
+    --- PASS: TestNativeX11ToggleOwnershipFollowsDisplayLifecycle/stateful_unobservable_wheel_buttons_are_unsupported (0.00s)
+=== RUN   TestNativeX11ExplicitInvalidDisplayNeverFallsBack
+--- PASS: TestNativeX11ExplicitInvalidDisplayNeverFallsBack (0.11s)
+=== RUN   TestNativeX11PixelColorOutOfBoundsReturnsError
+--- PASS: TestNativeX11PixelColorOutOfBoundsReturnsError (0.00s)
+=== RUN   TestNativeX11DisplayLifecycleConcurrent
+--- PASS: TestNativeX11DisplayLifecycleConcurrent (0.82s)
+=== RUN   TestNativeX11EnvironmentToggleLifecycleConcurrent
+--- PASS: TestNativeX11EnvironmentToggleLifecycleConcurrent (0.09s)
+=== RUN   TestX11BackendBehavioralParity
+=== RUN   TestX11BackendBehavioralParity/capture
+=== RUN   TestX11BackendBehavioralParity/pointer
+=== RUN   TestX11BackendBehavioralParity/buttons_and_scroll
+=== RUN   TestX11BackendBehavioralParity/horizontal_wheel_backend_contract
+=== RUN   TestX11BackendBehavioralParity/named_key
+=== RUN   TestX11BackendBehavioralParity/modifier_order
+=== RUN   TestX11BackendBehavioralParity/text_and_keyboard_state
+--- PASS: TestX11BackendBehavioralParity (0.20s)
+    --- PASS: TestX11BackendBehavioralParity/capture (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/pointer (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/buttons_and_scroll (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/horizontal_wheel_backend_contract (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/named_key (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/modifier_order (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/text_and_keyboard_state (0.06s)
+=== RUN   TestX11XTestVersionAtLeast
+=== PAUSE TestX11XTestVersionAtLeast
+=== RUN   TestNativeX11ConfiguredTargetAppliesToWindowAndScale
+--- PASS: TestNativeX11ConfiguredTargetAppliesToWindowAndScale (0.00s)
+=== RUN   TestNativeX11ClientCoordinatesThroughReparenting
+--- PASS: TestNativeX11ClientCoordinatesThroughReparenting (0.00s)
+=== RUN   TestNativeX11DestroyedWindowDoesNotAbort
+--- PASS: TestNativeX11DestroyedWindowDoesNotAbort (3.02s)
+=== CONT  TestX11XTestVersionAtLeast
+=== RUN   TestX11XTestVersionAtLeast/missing_reply
+=== PAUSE TestX11XTestVersionAtLeast/missing_reply
+=== RUN   TestX11XTestVersionAtLeast/older_minor
+=== PAUSE TestX11XTestVersionAtLeast/older_minor
+=== RUN   TestX11XTestVersionAtLeast/minimum
+=== PAUSE TestX11XTestVersionAtLeast/minimum
+=== RUN   TestX11XTestVersionAtLeast/newer_major
+=== PAUSE TestX11XTestVersionAtLeast/newer_major
+=== CONT  TestX11XTestVersionAtLeast/missing_reply
+=== CONT  TestX11XTestVersionAtLeast/newer_major
+=== CONT  TestX11XTestVersionAtLeast/minimum
+=== CONT  TestX11XTestVersionAtLeast/older_minor
+--- PASS: TestX11XTestVersionAtLeast (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/missing_reply (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/newer_major (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/minimum (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/older_minor (0.00s)
+PASS

--- a/docs/performance/data/x11-2026-07-17-817656f/behavior-purego.txt
+++ b/docs/performance/data/x11-2026-07-17-817656f/behavior-purego.txt
@@ -1,0 +1,77 @@
+=== RUN   TestPureGoX11RejectsImplicitDependencyPortalFallback
+--- PASS: TestPureGoX11RejectsImplicitDependencyPortalFallback (0.00s)
+=== RUN   TestPureGoX11CrashRestoresScratchAndOwnedInput
+--- PASS: TestPureGoX11CrashRestoresScratchAndOwnedInput (2.05s)
+=== RUN   TestPureGoX11MultiLayoutConfiguration
+--- PASS: TestPureGoX11MultiLayoutConfiguration (0.00s)
+=== RUN   TestPureGoX11Capabilities
+--- PASS: TestPureGoX11Capabilities (0.01s)
+=== RUN   TestPureGoX11PointerInput
+--- PASS: TestPureGoX11PointerInput (0.25s)
+=== RUN   TestPureGoX11KeyboardInput
+--- PASS: TestPureGoX11KeyboardInput (0.70s)
+=== RUN   TestPureGoX11TextReachesDelayedXKBClient
+--- PASS: TestPureGoX11TextReachesDelayedXKBClient (0.05s)
+=== RUN   TestPureGoX11ExplicitShiftReachesXKBClient
+--- PASS: TestPureGoX11ExplicitShiftReachesXKBClient (0.07s)
+=== RUN   TestPureGoX11ScratchReservationSkipsPressedEmptyKeycode
+--- PASS: TestPureGoX11ScratchReservationSkipsPressedEmptyKeycode (0.02s)
+=== RUN   TestPureGoX11ScratchCleanupCanRetryAfterForeignRelease
+--- PASS: TestPureGoX11ScratchCleanupCanRetryAfterForeignRelease (0.02s)
+=== RUN   TestPureGoX11RejectsNonModifierBeforeScratchMutation
+--- PASS: TestPureGoX11RejectsNonModifierBeforeScratchMutation (0.11s)
+=== RUN   TestPureGoX11ScratchCleanupCanRetryAfterModifierRestore
+--- PASS: TestPureGoX11ScratchCleanupCanRetryAfterModifierRestore (0.01s)
+=== RUN   TestPureGoX11TextCapacityFailsBeforeInput
+--- PASS: TestPureGoX11TextCapacityFailsBeforeInput (0.11s)
+=== RUN   TestPureGoX11RejectsScratchReplacementBeforeTextTap
+--- PASS: TestPureGoX11RejectsScratchReplacementBeforeTextTap (0.11s)
+=== RUN   TestPureGoX11ClosePreservesForeignScratchReplacement
+--- PASS: TestPureGoX11ClosePreservesForeignScratchReplacement (0.17s)
+=== RUN   TestPureGoX11ClosePreservesForeignModifierScratchReplacement
+--- PASS: TestPureGoX11ClosePreservesForeignModifierScratchReplacement (0.02s)
+=== RUN   TestPureGoX11PreservesForeignInputState
+--- PASS: TestPureGoX11PreservesForeignInputState (0.26s)
+=== RUN   TestPureGoX11EventDrainDoesNotStall
+--- PASS: TestPureGoX11EventDrainDoesNotStall (0.04s)
+=== RUN   TestPureGoX11CloseMainDisplayReconnects
+--- PASS: TestPureGoX11CloseMainDisplayReconnects (0.28s)
+=== RUN   TestPureGoX11SessionSwitchReleasesOwnedInput
+--- PASS: TestPureGoX11SessionSwitchReleasesOwnedInput (0.02s)
+=== RUN   TestX11BackendBehavioralParity
+=== RUN   TestX11BackendBehavioralParity/capture
+=== RUN   TestX11BackendBehavioralParity/pointer
+=== RUN   TestX11BackendBehavioralParity/buttons_and_scroll
+=== RUN   TestX11BackendBehavioralParity/horizontal_wheel_backend_contract
+=== RUN   TestX11BackendBehavioralParity/named_key
+=== RUN   TestX11BackendBehavioralParity/modifier_order
+=== RUN   TestX11BackendBehavioralParity/text_and_keyboard_state
+--- PASS: TestX11BackendBehavioralParity (0.34s)
+    --- PASS: TestX11BackendBehavioralParity/capture (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/pointer (0.00s)
+    --- PASS: TestX11BackendBehavioralParity/buttons_and_scroll (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/horizontal_wheel_backend_contract (0.10s)
+    --- PASS: TestX11BackendBehavioralParity/named_key (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/modifier_order (0.01s)
+    --- PASS: TestX11BackendBehavioralParity/text_and_keyboard_state (0.09s)
+=== RUN   TestX11XTestVersionAtLeast
+=== PAUSE TestX11XTestVersionAtLeast
+=== CONT  TestX11XTestVersionAtLeast
+=== RUN   TestX11XTestVersionAtLeast/missing_reply
+=== PAUSE TestX11XTestVersionAtLeast/missing_reply
+=== RUN   TestX11XTestVersionAtLeast/older_minor
+=== PAUSE TestX11XTestVersionAtLeast/older_minor
+=== RUN   TestX11XTestVersionAtLeast/minimum
+=== PAUSE TestX11XTestVersionAtLeast/minimum
+=== RUN   TestX11XTestVersionAtLeast/newer_major
+=== PAUSE TestX11XTestVersionAtLeast/newer_major
+=== CONT  TestX11XTestVersionAtLeast/missing_reply
+=== CONT  TestX11XTestVersionAtLeast/minimum
+=== CONT  TestX11XTestVersionAtLeast/older_minor
+=== CONT  TestX11XTestVersionAtLeast/newer_major
+--- PASS: TestX11XTestVersionAtLeast (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/missing_reply (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/older_minor (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/minimum (0.00s)
+    --- PASS: TestX11XTestVersionAtLeast/newer_major (0.00s)
+PASS

--- a/docs/performance/data/x11-2026-07-17-817656f/metadata.txt
+++ b/docs/performance/data/x11-2026-07-17-817656f/metadata.txt
@@ -1,0 +1,159 @@
+timestamp_utc=2026-07-17T06:48:35Z
+git_commit=817656f2d52140581f7f6c5535d86f050ee6663b
+source_fingerprint=c982022e8255b2a1773e452b5c45a7c0a0aa98da
+allow_dirty=0
+source_mode=detached-clean-worktree
+git_status_begin
+
+git_status_end
+go_version=go version go1.26.5-X:nodwarf5 linux/amd64
+go_env_begin
+{
+	"AR": "ar",
+	"CC": "gcc",
+	"CGO_CFLAGS": "-O2 -g",
+	"CGO_CPPFLAGS": "",
+	"CGO_CXXFLAGS": "-O2 -g",
+	"CGO_LDFLAGS": "-O2 -g",
+	"CXX": "g++",
+	"GO386": "",
+	"GOAMD64": "v1",
+	"GOARCH": "amd64",
+	"GOARM": "",
+	"GOARM64": "",
+	"GOEXPERIMENT": "nodwarf5",
+	"GOFLAGS": "-mod=readonly",
+	"GOMIPS": "",
+	"GOMIPS64": "",
+	"GOOS": "linux",
+	"GOPPC64": "",
+	"GORISCV64": "",
+	"GOTOOLCHAIN": "auto",
+	"GOVERSION": "go1.26.5-X:nodwarf5",
+	"GOWORK": "off",
+	"PKG_CONFIG": "pkg-config"
+}
+go_env_end
+runtime_env_begin
+GOGC=100
+GOMEMLIMIT=off
+GODEBUG=
+runtime_env_end
+pkg_config_env_begin
+PKG_CONFIG_PATH=
+PKG_CONFIG_LIBDIR=
+PKG_CONFIG_SYSROOT_DIR=
+LD_LIBRARY_PATH=
+pkg_config_env_end
+x11_pkg_config_begin
+x11_version=1.8.13
+xtst_version=1.2.5
+ -lXtst -lX11
+x11_pkg_config_end
+native_binary_build_info_begin
+/tmp/robotgo-x11-evidence.hwO6AR/robotgo-native.test: go1.26.5-X:nodwarf5
+	path	github.com/marang/robotgo.test
+	mod	github.com/marang/robotgo	(devel)
+	build	-buildmode=exe
+	build	-compiler=gc
+	build	-tags=x11integration
+	build	DefaultGODEBUG=cryptocustomrand=1,tlssecpmlkem=0,urlstrictcolons=0
+	build	CGO_ENABLED=1
+	build	CGO_CFLAGS=
+	build	CGO_CPPFLAGS=
+	build	CGO_CXXFLAGS=
+	build	CGO_LDFLAGS=
+	build	GOARCH=amd64
+	build	GOEXPERIMENT=nodwarf5
+	build	GOOS=linux
+	build	GOAMD64=v1
+native_binary_build_info_end
+purego_binary_build_info_begin
+/tmp/robotgo-x11-evidence.hwO6AR/robotgo-purego.test: go1.26.5-X:nodwarf5
+	path	github.com/marang/robotgo.test
+	mod	github.com/marang/robotgo	(devel)
+	build	-buildmode=exe
+	build	-compiler=gc
+	build	-tags=x11integration
+	build	DefaultGODEBUG=cryptocustomrand=1,tlssecpmlkem=0,urlstrictcolons=0
+	build	CGO_ENABLED=0
+	build	GOARCH=amd64
+	build	GOEXPERIMENT=nodwarf5
+	build	GOOS=linux
+	build	GOAMD64=v1
+purego_binary_build_info_end
+native_binary_dependencies_begin
+	linux-vdso.so.1 (0x00007fbb9475b000)
+	libm.so.6 => /usr/lib/libm.so.6 (0x00007fbb945eb000)
+	libX11.so.6 => /usr/lib/libX11.so.6 (0x00007fbb944a9000)
+	libXtst.so.6 => /usr/lib/libXtst.so.6 (0x00007fbb944a1000)
+	libresolv.so.2 => /usr/lib/libresolv.so.2 (0x00007fbb9448d000)
+	libc.so.6 => /usr/lib/libc.so.6 (0x00007fbb94200000)
+	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fbb9475d000)
+	libxcb.so.1 => /usr/lib/libxcb.so.1 (0x00007fbb94462000)
+	libXext.so.6 => /usr/lib/libXext.so.6 (0x00007fbb9444c000)
+	libXau.so.6 => /usr/lib/libXau.so.6 (0x00007fbb94447000)
+	libXdmcp.so.6 => /usr/lib/libXdmcp.so.6 (0x00007fbb9443f000)
+native_binary_dependencies_end
+cc_version=gcc (GCC) 16.1.1 20260625
+pkg_config_version=2.5.1
+benchmark_cycles=5
+benchmark_balanced=1
+benchmark_benchtime=500ms
+behavior_cpu=4
+benchmark_cpu=1
+uname=Linux 7.1.3-arch2-1 x86_64
+Architecture:                            x86_64
+CPU op-mode(s):                          32-bit, 64-bit
+Address sizes:                           39 bits physical, 48 bits virtual
+Byte Order:                              Little Endian
+CPU(s):                                  12
+On-line CPU(s) list:                     0-11
+Vendor ID:                               GenuineIntel
+Model name:                              Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+CPU family:                              6
+Model:                                   158
+Thread(s) per core:                      2
+Core(s) per socket:                      6
+Socket(s):                               1
+Stepping:                                10
+Microcode version:                       0xf8
+CPU(s) scaling MHz:                      95%
+CPU max MHz:                             4100.0000
+CPU min MHz:                             800.0000
+BogoMIPS:                                4399.99
+Flags:                                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb pti ssbd ibrs ibpb stibp tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust sgx bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp vnmi sgx_lc md_clear flush_l1d arch_capabilities
+Virtualization:                          VT-x
+L1d cache:                               192 KiB (6 instances)
+L1i cache:                               192 KiB (6 instances)
+L2 cache:                                1.5 MiB (6 instances)
+L3 cache:                                9 MiB (1 instance)
+NUMA node(s):                            1
+NUMA node0 CPU(s):                       0-11
+Vulnerability Gather data sampling:      Mitigation; Microcode
+Vulnerability Ghostwrite:                Not affected
+Vulnerability Indirect target selection: Not affected
+Vulnerability Itlb multihit:             KVM: Mitigation: Split huge pages
+Vulnerability L1tf:                      Mitigation; PTE Inversion; VMX conditional cache flushes, SMT vulnerable
+Vulnerability Mds:                       Mitigation; Clear CPU buffers; SMT vulnerable
+Vulnerability Meltdown:                  Mitigation; PTI
+Vulnerability Mmio stale data:           Mitigation; Clear CPU buffers; SMT vulnerable
+Vulnerability Old microcode:             Vulnerable
+Vulnerability Reg file data sampling:    Not affected
+Vulnerability Retbleed:                  Mitigation; IBRS
+Vulnerability Spec rstack overflow:      Not affected
+Vulnerability Spec store bypass:         Mitigation; Speculative Store Bypass disabled via prctl
+Vulnerability Spectre v1:                Mitigation; usercopy/swapgs barriers and __user pointer sanitization
+Vulnerability Spectre v2:                Mitigation; IBRS; IBPB conditional; STIBP conditional; RSB filling; PBRSB-eIBRS Not affected; BHI Not affected
+Vulnerability Srbds:                     Mitigation; Microcode
+Vulnerability Tsa:                       Not affected
+Vulnerability Tsx async abort:           Not affected
+Vulnerability Vmscape:                   Mitigation; IBPB before exit to userspace
+xvfb_path=/tmp/robotgo-xvfb.23tKHQ/usr/bin/Xvfb
+xvfb_package=unknown
+xtest_requirement=2.2 (enforced by behavioral harness)
+x11_keymap_begin
+rules:      evdev
+model:      pc105
+layout:     us,de
+x11_keymap_end

--- a/docs/performance/data/x11-2026-07-17-817656f/native.txt
+++ b/docs/performance/data/x11-2026-07-17-817656f/native.txt
@@ -1,0 +1,160 @@
+# implementation=native-cgo sample=1 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     579	   1060192 ns/op	1159.04 MB/s	 1228873 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   42438	     14158 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17018	     34279 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     51670 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5719	    102245 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5470263 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13974	     42681 ns/op	     179 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4543	    152739 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     174	   3462639 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44872370 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=1 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     572	   1038885 ns/op	1182.81 MB/s	 1228864 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   38995	     13598 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   16994	     34613 ns/op	      86 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     51962 ns/op	      88 B/op	       4 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5832	    103824 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5439035 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13954	     43224 ns/op	     182 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4803	    153560 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     171	   3480058 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44554170 ns/op	   0.00 MB/s	    2048 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=2 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     607	    961095 ns/op	1278.54 MB/s	 1228864 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   43970	     14439 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17001	     34969 ns/op	      86 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     51788 ns/op	      88 B/op	       4 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5684	    104105 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5447792 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   12954	     45942 ns/op	     182 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4990	    154182 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     172	   3445244 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44222161 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=2 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     621	    991499 ns/op	1239.34 MB/s	 1228872 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   44529	     13953 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   16902	     34759 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     52447 ns/op	      88 B/op	       4 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5836	    103574 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5438717 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   12771	     45007 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4779	    153327 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     172	   3417496 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44648270 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=3 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     592	    996695 ns/op	1232.88 MB/s	 1228873 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   44562	     13782 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17156	     35942 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     52837 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    7498	    100996 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5439557 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13585	     43934 ns/op	     182 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    5007	    150847 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     172	   3425090 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44641702 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=3 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     595	   1001546 ns/op	1226.90 MB/s	 1228864 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   42128	     14147 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17383	     35438 ns/op	      88 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     51299 ns/op	      88 B/op	       4 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5820	    103492 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5416421 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13514	     44998 ns/op	     182 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4914	    152383 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     175	   3446432 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44285960 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=4 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     586	   1007428 ns/op	1219.74 MB/s	 1228873 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   39916	     13844 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17244	     34767 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   12045	     49665 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    6597	    104923 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5428700 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13945	     44652 ns/op	     178 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    5042	    148792 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     175	   3465720 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44430425 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=4 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     638	    986609 ns/op	1245.48 MB/s	 1228864 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   44544	     13431 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17620	     34437 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     52002 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    6907	    102594 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5369251 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13846	     44462 ns/op	     180 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4156	    149578 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     172	   3463021 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44739653 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=5 order=native-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     601	   1000966 ns/op	1227.61 MB/s	 1228864 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   41293	     14184 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17391	     34637 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     51823 ns/op	      88 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    5682	    104573 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5472313 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13808	     43599 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4687	    153075 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     172	   3484895 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44333414 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS
+# implementation=native-cgo sample=5 order=purego-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     620	    956645 ns/op	1284.49 MB/s	 1228872 B/op	       2 allocs/op
+BenchmarkX11InputRuntime/Location         	   41044	     13452 ns/op	       0 B/op	       0 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	   17728	     34944 ns/op	      87 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	   10000	     50578 ns/op	      86 B/op	       3 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    6002	    101532 ns/op	     207 B/op	       8 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5358168 ns/op	     184 B/op	       7 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	   13248	     43936 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	    4910	    153205 ns/op	     208 B/op	       9 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	     174	   3470750 ns/op	     183 B/op	       6 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	      13	  44379567 ns/op	   0.00 MB/s	    2040 B/op	      81 allocs/op
+PASS

--- a/docs/performance/data/x11-2026-07-17-817656f/purego.txt
+++ b/docs/performance/data/x11-2026-07-17-817656f/purego.txt
@@ -1,0 +1,160 @@
+# implementation=pure-go sample=1 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     175	   3458718 ns/op	 355.28 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    8311	     79030 ns/op	     896 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    7902	     83112 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    7609	     83551 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1183	    525729 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   6047348 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1564	    411719 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     462	   1567488 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      88	   7164429 ns/op	   59411 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  58774863 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS
+# implementation=pure-go sample=1 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     176	   3385020 ns/op	 363.01 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    6858	     81694 ns/op	     896 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    6078	     86088 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    6799	     84076 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1102	    562000 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   6002379 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1585	    386014 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     394	   1486152 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      75	   7332967 ns/op	   59410 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59776592 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS
+# implementation=pure-go sample=2 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     177	   3279395 ns/op	 374.70 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    7056	     76897 ns/op	     896 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    6416	     84828 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    7226	     81329 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1124	    531062 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	      98	   5994272 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1498	    395634 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     374	   1570088 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      78	   7257783 ns/op	   59410 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59219699 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS
+# implementation=pure-go sample=2 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     177	   3392359 ns/op	 362.23 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    6936	     77388 ns/op	     896 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    7226	     82324 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    7434	     84908 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1129	    538907 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	      97	   6010517 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1579	    399573 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     384	   1617726 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      90	   6968197 ns/op	   59411 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59529391 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS
+# implementation=pure-go sample=3 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     178	   3443349 ns/op	 356.86 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    7734	     72384 ns/op	     896 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    6674	     85681 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    8432	     82440 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1080	    524356 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5942739 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1509	    379692 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     391	   1444675 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      81	   7384365 ns/op	   59411 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  58523709 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS
+# implementation=pure-go sample=3 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     178	   3562050 ns/op	 344.97 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    7640	     77249 ns/op	     896 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    6176	     83747 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    8613	     82738 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1009	    516437 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	      99	   6063734 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1441	    384537 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     409	   1737184 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      80	   7050175 ns/op	   59411 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59182575 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS
+# implementation=pure-go sample=4 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     177	   3384328 ns/op	 363.09 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    7462	     80426 ns/op	     897 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    6465	     81363 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    6976	     83338 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1041	    527218 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	      98	   6015880 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1486	    396682 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     337	   1552183 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      85	   7095967 ns/op	   59411 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  58643981 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS
+# implementation=pure-go sample=4 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     177	   3394449 ns/op	 362.00 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    8370	     79410 ns/op	     896 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    6229	     81247 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    7981	     78536 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1227	    522195 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   5924590 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1586	    380890 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     392	   1562032 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      84	   7205337 ns/op	   59411 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  59269453 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS
+# implementation=pure-go sample=5 order=native-first.2
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     177	   3438179 ns/op	 357.40 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    7642	     78508 ns/op	     896 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    8331	     81409 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    6447	     83286 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1116	    525778 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	      94	   6044216 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1448	    393748 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     378	   1453361 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      85	   7023336 ns/op	   59411 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  58051226 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS
+# implementation=pure-go sample=5 order=purego-first.1
+goos: linux
+goarch: amd64
+pkg: github.com/marang/robotgo
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkCaptureImgRuntime 	     177	   3439691 ns/op	 357.24 MB/s	 1342656 B/op	     116 allocs/op
+BenchmarkX11InputRuntime/Location         	    7830	     75146 ns/op	     896 B/op	      22 allocs/op
+BenchmarkX11InputRuntime/MoveAbsolute     	    8043	     83843 ns/op	     640 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/MoveRelative     	    7390	     80327 ns/op	     624 B/op	      14 allocs/op
+BenchmarkX11InputRuntime/ButtonTogglePair 	    1114	    525251 ns/op	    4192 B/op	      95 allocs/op
+BenchmarkX11InputRuntime/ClickLeft        	     100	   6017165 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/ScrollVertical1  	    1622	    385282 ns/op	    3184 B/op	      73 allocs/op
+BenchmarkX11InputRuntime/KeyTogglePairEnter         	     356	   1470818 ns/op	   60419 B/op	     178 allocs/op
+BenchmarkX11InputRuntime/KeyPressEnter              	      93	   7029797 ns/op	   59411 B/op	     156 allocs/op
+BenchmarkX11InputRuntime/TypeASCII8                 	       9	  61364875 ns/op	   0.00 MB/s	  540368 B/op	    1527 allocs/op
+PASS

--- a/docs/performance/data/x11-2026-07-17-817656f/run-status.txt
+++ b/docs/performance/data/x11-2026-07-17-817656f/run-status.txt
@@ -1,0 +1,6 @@
+status=complete
+git_commit=817656f2d52140581f7f6c5535d86f050ee6663b
+source_fingerprint=c982022e8255b2a1773e452b5c45a7c0a0aa98da
+allow_dirty=0
+snapshot_verified=1
+decision_grade=1

--- a/docs/performance/data/x11-2026-07-17-817656f/summary.md
+++ b/docs/performance/data/x11-2026-07-17-817656f/summary.md
@@ -1,0 +1,44 @@
+# X11 native CGO vs Pure-Go benchmark report
+
+> Report-only evidence: correctness is blocking; timing ratios never fail CI. A 1x CI smoke validates this measurement path only and is not decision-grade performance data.
+
+- Git commit: `817656f2d52140581f7f6c5535d86f050ee6663b`
+- Source fingerprint: `c982022e8255b2a1773e452b5c45a7c0a0aa98da`
+- Observations per benchmark and implementation: `10`
+- Go benchtime: `500ms`
+- GOMAXPROCS / `-test.cpu`: `1`
+- Benchmark cycles: `5`
+- Balanced two-order mode: `enabled`
+
+| Benchmark | Metric | native CGO median [Q1–Q3] | Pure-Go median [Q1–Q3] | Pure-Go / native CGO | N (native CGO / Pure-Go) |
+|---|---:|---:|---:|---:|---:|
+| BenchmarkCaptureImgRuntime | ns/op | 998830.5 [987831.5–1.0059575e+06] | 3.416314e+06 [3.38685475e+06–3.4424345e+06] | 3.420x | 10 / 10 |
+| BenchmarkCaptureImgRuntime | B/op | 1.228868e+06 [1.228864e+06–1.22887275e+06] | 1.342656e+06 [1.342656e+06–1.342656e+06] | 1.093x | 10 / 10 |
+| BenchmarkCaptureImgRuntime | allocs/op | 2 [2–2] | 116 [116–116] | 58.000x | 10 / 10 |
+| BenchmarkX11InputRuntime/ButtonTogglePair | ns/op | 103533 [102332.25–104034.75] | 525753.5 [524579.75–530101] | 5.078x | 10 / 10 |
+| BenchmarkX11InputRuntime/ButtonTogglePair | B/op | 207 [207–208] | 4192 [4192–4192] | 20.251x | 10 / 10 |
+| BenchmarkX11InputRuntime/ButtonTogglePair | allocs/op | 8 [8–9] | 95 [95–95] | 11.875x | 10 / 10 |
+| BenchmarkX11InputRuntime/ClickLeft | ns/op | 5.438876e+06 [5.41949075e+06–5.44573325e+06] | 6.0131985e+06 [5.99629875e+06–6.03745325e+06] | 1.106x | 10 / 10 |
+| BenchmarkX11InputRuntime/ClickLeft | B/op | 184 [183.25–184] | 3184 [3184–3184] | 17.304x | 10 / 10 |
+| BenchmarkX11InputRuntime/ClickLeft | allocs/op | 7 [6.25–7] | 73 [73–73] | 10.429x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyPressEnter | ns/op | 3.46283e+06 [3.445541e+06–3.4694925e+06] | 7.130198e+06 [7.0348915e+06–7.2446715e+06] | 2.059x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyPressEnter | B/op | 184 [184–184] | 59411 [59411–59411] | 322.886x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyPressEnter | allocs/op | 7 [7–7] | 156 [156–156] | 22.286x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyTogglePairEnter | ns/op | 152907 [151231–153296.5] | 1.5571075e+06 [1.4746515e+06–1.569438e+06] | 10.183x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyTogglePairEnter | B/op | 208 [208–208] | 60419 [60419–60419] | 290.476x | 10 / 10 |
+| BenchmarkX11InputRuntime/KeyTogglePairEnter | allocs/op | 9 [9–9] | 178 [178–178] | 19.778x | 10 / 10 |
+| BenchmarkX11InputRuntime/Location | ns/op | 13898.5 [13644–14155.25] | 77948 [76985–79315] | 5.608x | 10 / 10 |
+| BenchmarkX11InputRuntime/Location | B/op | 0 [0–0] | 896 [896–896] | n/a | 10 / 10 |
+| BenchmarkX11InputRuntime/Location | allocs/op | 0 [0–0] | 22 [22–22] | n/a | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveAbsolute | ns/op | 34763 [34619–34962.75] | 83429.5 [81637.75–84581.75] | 2.400x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveAbsolute | B/op | 87 [87–87] | 640 [640–640] | 7.356x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveAbsolute | allocs/op | 3 [3–3] | 14 [14–14] | 4.667x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveRelative | ns/op | 51805.5 [51391.75–51992] | 83012 [81606.75–83497.75] | 1.602x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveRelative | B/op | 87.5 [87–88] | 624 [624–624] | 7.131x | 10 / 10 |
+| BenchmarkX11InputRuntime/MoveRelative | allocs/op | 3 [3–4] | 14 [14–14] | 4.667x | 10 / 10 |
+| BenchmarkX11InputRuntime/ScrollVertical1 | ns/op | 44199 [43682.75–44911.5] | 389881 [384723.25–396420] | 8.821x | 10 / 10 |
+| BenchmarkX11InputRuntime/ScrollVertical1 | B/op | 182 [180.5–182.75] | 3184 [3184–3184] | 17.495x | 10 / 10 |
+| BenchmarkX11InputRuntime/ScrollVertical1 | allocs/op | 6 [6–6] | 73 [73–73] | 12.167x | 10 / 10 |
+| BenchmarkX11InputRuntime/TypeASCII8 | ns/op | 4.44922975e+07 [4.434495225e+07–4.4646628e+07] | 5.9201137e+07 [5.86767015e+07–5.94644065e+07] | 1.331x | 10 / 10 |
+| BenchmarkX11InputRuntime/TypeASCII8 | B/op | 2040 [2040–2040] | 540368 [540368–540368] | 264.886x | 10 / 10 |
+| BenchmarkX11InputRuntime/TypeASCII8 | allocs/op | 81 [81–81] | 1527 [1527–1527] | 18.852x | 10 / 10 |

--- a/docs/performance/x11-native-vs-purego.md
+++ b/docs/performance/x11-native-vs-purego.md
@@ -95,9 +95,9 @@ negative contract with the command in [TEST.md](../../TEST.md#x11integration-nat
 ## Current decision
 
 The current decision-grade sample measures commit
-`6c064690be8ba6e8e57934298f394f224aba30a9`, including the re-executed Pure-Go
+`817656f2d52140581f7f6c5535d86f050ee6663b`, including the re-executed Pure-Go
 guardian. Its raw output, behavior logs, metadata, and completion record are in
-[data/x11-2026-07-17-6c06469](data/x11-2026-07-17-6c06469/summary.md). Both
+[data/x11-2026-07-17-817656f](data/x11-2026-07-17-817656f/summary.md). Both
 implementations passed the complete shared contract and their exact
 backend-specific safety manifests; the Pure-Go manifest includes a real
 application-process `SIGKILL` and verified guardian cleanup.
@@ -113,11 +113,11 @@ source snapshot or the balanced same-server comparison.
 
 | Criterion | Evidence | Decision impact |
 |---|---|---|
-| Capture | Pure-Go/native median latency ratio `3.462x`; 116 versus 2 Go allocations per operation | Native retains a material throughput and allocation advantage; guardian IPC is not involved in capture |
-| Stateful buttons and keys | Pure-Go/native median latency ratios `5.364x` for button toggles, `10.976x` for key toggles, and `2.072x` for delayed key presses | The per-request guardian safety boundary is measurable and native remains preferable for common input sequences |
-| Scroll | Pure-Go/native median latency ratio `9.453x` for vertical scroll; Pure-Go horizontal scroll remains explicitly unsupported because X11 does not expose reliable wheel-button state | Native remains preferable for scrolling |
-| Pointer queries and moves | Pure-Go/native median latency ratios are `5.734x` for location, `2.401x` for absolute movement, and `1.632x` for relative movement | The guardian reverses the earlier direct-connection movement advantage; native is now faster for all measured pointer operations |
-| Delayed click and ASCII text | Ratios are `1.101x` and `1.336x`; configured user-visible delays dominate much of the end-to-end result | Keep the operations supported, but do not use their ratios alone for backend selection |
+| Capture | Pure-Go/native median latency ratio `3.420x`; 116 versus 2 Go allocations per operation | Native retains a material throughput and allocation advantage; guardian IPC is not involved in capture |
+| Stateful buttons and keys | Pure-Go/native median latency ratios `5.078x` for button toggles, `10.183x` for key toggles, and `2.059x` for delayed key presses | The per-request guardian safety boundary remains measurable and native remains preferable for common input sequences |
+| Scroll | Pure-Go/native median latency ratio `8.821x` for vertical scroll; Pure-Go horizontal scroll remains explicitly unsupported because X11 does not expose reliable wheel-button state | Native remains preferable for scrolling |
+| Pointer queries and moves | Pure-Go/native median latency ratios are `5.608x` for location, `2.400x` for absolute movement, and `1.602x` for relative movement | IPC round trips dominate the remaining gap; native remains faster for all measured pointer operations |
+| Delayed click and ASCII text | Ratios are `1.106x` and `1.331x`; configured user-visible delays dominate much of the end-to-end result | Keep the operations supported, but do not use their ratios alone for backend selection |
 | Build and Unicode behavior | Pure-Go removes the C/Xlib build dependency and retains managed Unicode scratch mappings; native avoids server-global temporary mappings | Keep Pure-Go useful and supported for CGO-disabled builds |
 | Lifecycle behavior | The Pure-Go safety manifest passes real application-process `SIGKILL` recovery with claim-checked, deadline-bounded guardian cleanup | The measured IPC cost buys a concrete crash-isolation guarantee absent from the historical direct-connection sample |
 
@@ -125,16 +125,26 @@ source snapshot or the balanced same-server comparison.
 Keep the Pure-Go X11 backend as the supported CGO-disabled implementation. This
 is not a rejection of Pure-Go: it preserves useful X11 automation without CGO
 and now provides measured crash isolation, while native wins every current
-latency comparison and most Go allocation comparisons. Native also avoids
+latency and reported Go-allocation comparison. Native also avoids
 server-global Unicode mappings entirely. The Pure-Go guardian restores those
 mappings after a targeted application-process kill while it and a responsive
 X server survive. Its cleanup is deadline-bounded and restores only an exact
 unchanged, unpressed, non-modifier final image; foreign final images are
 preserved, while an exact-image ABA replacement is not observable in X11.
 
-The earlier pre-guardian sample remains available in
+Compared with the immediately preceding guardian sample at
+[data/x11-2026-07-17-6c06469](data/x11-2026-07-17-6c06469/summary.md), reusing
+the request timer, response channel, and frame-read buffer while avoiding
+double payload marshaling reduces Pure-Go input allocations by `24–33%`.
+Allocated Go bytes fall by `41–50%` for pointer/mouse operations and about
+`19–20%` for keyboard/text operations. Balanced median latencies remain in the
+same range, confirming that round trips—not these removed allocations—dominate
+the remaining gap. The optimization preserves request correlation, fail-closed
+response-ID handling, timeout teardown, and the full crash-recovery manifest.
+
+The pre-guardian sample remains available in
 [data/x11-2026-07-16-d5fd51c](data/x11-2026-07-16-d5fd51c/summary.md) as
-historical evidence. It must not be presented as current performance. Future
-work may reduce guardian round trips or allocations only if the same behavior,
-race, and crash-recovery contracts remain blocking; the evidence does not
-justify weakening the safety boundary or changing the default.
+historical evidence. Neither older sample may be presented as current
+performance. Future work may reduce guardian round trips only if the same
+behavior, race, and crash-recovery contracts remain blocking; the evidence does
+not justify weakening the safety boundary or changing the default.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -35,7 +35,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Keep required jobs green and confirm repository branch protection |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | X11 hardening and measurement complete; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; current guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; three-OS CI; non-skipping multi-layout Xvfb input tests | Protect the remote CI checks, evaluate safe guardian round-trip/allocation reductions, then assess further backends selectively |
+| 3. Pure-Go | X11 hardening and measurement complete; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; lower-allocation request transport; three-OS CI; non-skipping multi-layout Xvfb input tests | Protect the remote CI checks, evaluate safe guardian round-trip reductions, then assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -184,9 +184,11 @@ application workload and compares core, modifier, XKB, key, pointer, and button
 state. The guarantee requires the guardian and responsive X server to survive;
 guardian/host loss or a transport blocked beyond the cleanup deadline still
 needs later reconciliation. Current decision-grade evidence measures the
-guardian path and confirms that its crash isolation adds material IPC latency
-and allocations, so native CGO remains the default. Protecting the remote
-checks, evaluating optimizations without weakening the safety contract, and
+guardian path and confirms that its crash isolation adds material IPC latency,
+so native CGO remains the default. Reusing bounded request state, reading frames
+through a reusable buffer, and avoiding double payload marshaling reduce input
+allocations by `24–33%` without weakening request correlation or cleanup.
+Protecting the remote checks, evaluating safe round-trip reductions, and
 selectively evaluating additional backends keep the broader Phase 3 partial.
 
 Exit criteria:

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -102,10 +102,11 @@ Window backend support matrix (current):
     behavioral contract run in non-skipping Xvfb/XTEST CI. A balanced benchmark
     smoke is report-only. Native X11 now has atomic input preflight, one shared
     configured-display lifecycle/target, live XTEST readiness, and an XTEST-disabled negative
-    contract. Current decision-grade guardian-path evidence retains native CGO
-    as the X11 default while keeping Pure-Go supported for CGO-disabled builds.
-    Protecting the checks, evaluating safe IPC/allocation reductions, and
-    evaluating further backends remain open. The Pure-Go core is now
+    contract. Current optimized guardian-path evidence retains native CGO as the
+    X11 default while keeping Pure-Go supported for CGO-disabled builds. The
+    lower-allocation request transport preserves the crash contract. Protecting
+    the checks, evaluating safe round-trip reductions, and evaluating further
+    backends remain open. The Pure-Go core is now
     race-testable, and a separate X11 guardian uses an authenticated abstract
     Unix socket with kernel-verified peer credentials, bounded request dispatch,
     and deadline-bounded cleanup after an application-process `SIGKILL`. It

--- a/internal/x11input/guardian_linux.go
+++ b/internal/x11input/guardian_linux.go
@@ -74,9 +74,14 @@ type guardianConnection struct {
 	requestTimeout time.Duration
 	cleanupTimeout time.Duration
 
+	// The guardian dispatches requests sequentially. Matching that ordering here
+	// permits one reusable response channel and timer without changing outcomes.
+	requestMu         sync.Mutex
+	response          chan guardianResponse
+	requestTimer      *time.Timer
 	mu                sync.Mutex
 	nextID            uint64
-	pending           map[uint64]chan guardianResponse
+	activeRequestID   uint64
 	readErr           error
 	controlErr        error
 	terminalEvent     guardianEvent
@@ -268,12 +273,14 @@ func newGuardianConnection(control io.ReadWriteCloser, process *exec.Cmd, option
 		process:        process,
 		requestTimeout: options.RequestTimeout,
 		cleanupTimeout: options.CleanupTimeout,
-		pending:        make(map[uint64]chan guardianResponse),
+		response:       make(chan guardianResponse, 1),
+		requestTimer:   time.NewTimer(time.Hour),
 		events:         make(chan guardianEvent, 256),
 		done:           make(chan struct{}),
 		terminalSignal: make(chan struct{}),
 		processDone:    make(chan error, 1),
 	}
+	stopAndDrainGuardianTimer(connection.requestTimer)
 	go connection.readFrames()
 	if process != nil {
 		go func() {
@@ -287,8 +294,9 @@ func newGuardianConnection(control io.ReadWriteCloser, process *exec.Cmd, option
 }
 
 func (connection *guardianConnection) readFrames() {
+	reader := guardianFramedReader{reader: connection.control}
 	for {
-		envelope, err := readGuardianEnvelope(connection.control)
+		envelope, err := reader.read()
 		if err != nil {
 			connection.finish(err)
 			return
@@ -296,12 +304,19 @@ func (connection *guardianConnection) readFrames() {
 		switch envelope.Kind {
 		case guardianFrameResponse:
 			connection.mu.Lock()
-			response := connection.pending[envelope.ID]
-			delete(connection.pending, envelope.ID)
-			connection.mu.Unlock()
-			if response != nil {
-				response <- guardianResponse{envelope: envelope}
+			activeRequestID := connection.activeRequestID
+			if envelope.ID == activeRequestID {
+				connection.activeRequestID = 0
 			}
+			connection.mu.Unlock()
+			if activeRequestID == 0 || envelope.ID != activeRequestID {
+				connection.finish(fmt.Errorf(
+					"unexpected X11 guardian response ID %d (active request %d)",
+					envelope.ID, activeRequestID,
+				))
+				return
+			}
+			connection.response <- guardianResponse{envelope: envelope}
 		case guardianFrameEvent:
 			var event guardianEvent
 			if err := decodeGuardianPayload(envelope.Payload, &event); err != nil {
@@ -339,11 +354,11 @@ func (connection *guardianConnection) finish(err error) {
 		connection.recordTerminalEvent(terminal)
 		connection.mu.Lock()
 		connection.readErr = err
-		pending := connection.pending
-		connection.pending = make(map[uint64]chan guardianResponse)
+		activeRequestID := connection.activeRequestID
+		connection.activeRequestID = 0
 		connection.mu.Unlock()
-		for _, response := range pending {
-			response <- guardianResponse{err: err}
+		if activeRequestID != 0 {
+			connection.response <- guardianResponse{err: err}
 		}
 		// Shutdown wakes both the local reader and the guardian peer before Close.
 		var controlErr error
@@ -420,10 +435,9 @@ func (connection *guardianConnection) request(operation string, request, respons
 }
 
 func (connection *guardianConnection) requestWithTimeout(operation string, request, response any, timeout time.Duration) error {
-	payload, err := guardianPayload(request)
-	if err != nil {
-		return err
-	}
+	connection.requestMu.Lock()
+	defer connection.requestMu.Unlock()
+
 	connection.mu.Lock()
 	if connection.readErr != nil {
 		err := connection.readErr
@@ -432,8 +446,7 @@ func (connection *guardianConnection) requestWithTimeout(operation string, reque
 	}
 	connection.nextID++
 	id := connection.nextID
-	result := make(chan guardianResponse, 1)
-	connection.pending[id] = result
+	connection.activeRequestID = id
 	connection.mu.Unlock()
 
 	envelope := guardianEnvelope{
@@ -441,20 +454,20 @@ func (connection *guardianConnection) requestWithTimeout(operation string, reque
 		Kind:      guardianFrameRequest,
 		ID:        id,
 		Operation: operation,
-		Payload:   payload,
 	}
-	if err := connection.writer.write(envelope); err != nil {
-		connection.removePending(id)
+	if err := connection.writer.writePayload(envelope, request); err != nil {
+		connection.clearActiveRequest(id)
 		connection.finish(err)
 		return err
 	}
 	if timeout <= 0 {
 		timeout = guardianDefaultRequestTimeout
 	}
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
+	stopAndDrainGuardianTimer(connection.requestTimer)
+	connection.requestTimer.Reset(timeout)
 	select {
-	case received := <-result:
+	case received := <-connection.response:
+		stopAndDrainGuardianTimer(connection.requestTimer)
 		if received.err != nil {
 			return received.err
 		}
@@ -462,8 +475,8 @@ func (connection *guardianConnection) requestWithTimeout(operation string, reque
 			return errors.New(received.envelope.Error)
 		}
 		return decodeGuardianPayload(received.envelope.Payload, response)
-	case <-timer.C:
-		connection.removePending(id)
+	case <-connection.requestTimer.C:
+		connection.clearActiveRequest(id)
 		timeoutErr := fmt.Errorf("X11 guardian %s timed out after %s", operation, timeout)
 		// A timed-out state-changing request has an unknowable outcome. Tear down
 		// the control channel so the helper performs its crash-safe cleanup rather
@@ -473,10 +486,22 @@ func (connection *guardianConnection) requestWithTimeout(operation string, reque
 	}
 }
 
-func (connection *guardianConnection) removePending(id uint64) {
+func (connection *guardianConnection) clearActiveRequest(id uint64) {
 	connection.mu.Lock()
-	delete(connection.pending, id)
+	if connection.activeRequestID == id {
+		connection.activeRequestID = 0
+	}
 	connection.mu.Unlock()
+}
+
+func stopAndDrainGuardianTimer(timer *time.Timer) {
+	if timer == nil || timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
 }
 
 func (connection *guardianConnection) WaitForEvent() (bool, error) {

--- a/internal/x11input/guardian_linux_test.go
+++ b/internal/x11input/guardian_linux_test.go
@@ -381,6 +381,120 @@ func TestGuardianConnectionProxiesAndMultiplexesEvents(t *testing.T) {
 	}
 }
 
+func TestGuardianConcurrentRequestsRemainCorrelated(t *testing.T) {
+	transport := newGuardianTestConnection()
+	connection, done := newInProcessGuardian(t, transport)
+
+	const workers = 64
+	start := make(chan struct{})
+	failures := make(chan error, workers)
+	var group sync.WaitGroup
+	group.Add(workers)
+	for worker := range workers {
+		go func() {
+			defer group.Done()
+			<-start
+			if worker%2 == 0 {
+				setup, err := connection.Setup()
+				if err != nil {
+					failures <- fmt.Errorf("worker %d Setup: %w", worker, err)
+				} else if setup != transport.setup {
+					failures <- fmt.Errorf("worker %d Setup = %+v, want %+v", worker, setup, transport.setup)
+				}
+				return
+			}
+			state, err := connection.QueryPointer(transport.setup.Root)
+			if err != nil {
+				failures <- fmt.Errorf("worker %d QueryPointer: %w", worker, err)
+			} else if state != transport.pointer {
+				failures <- fmt.Errorf("worker %d QueryPointer = %+v, want %+v", worker, state, transport.pointer)
+			}
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(failures)
+	for err := range failures {
+		t.Error(err)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("Close after concurrent requests: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("guardian server after concurrent requests: %v", err)
+	}
+}
+
+func TestGuardianFramedWriterPayloadRoundTrips(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		payload any
+		check   func(*testing.T, guardianEnvelope)
+	}{
+		{
+			name: "omitted payload",
+			check: func(t *testing.T, envelope guardianEnvelope) {
+				t.Helper()
+				if len(envelope.Payload) != 0 {
+					t.Fatalf("nil payload encoded as %q, want omitted", envelope.Payload)
+				}
+			},
+		},
+		{
+			name: "typed payload",
+			payload: guardianFakeInputRequest{
+				EventType: byte(xproto.MotionNotify),
+				Detail:    x11RelativeMotion,
+				Root:      42,
+				X:         -17,
+				Y:         23,
+			},
+			check: func(t *testing.T, envelope guardianEnvelope) {
+				t.Helper()
+				var got guardianFakeInputRequest
+				if err := decodeGuardianPayload(envelope.Payload, &got); err != nil {
+					t.Fatalf("decode typed payload: %v", err)
+				}
+				want := guardianFakeInputRequest{
+					EventType: byte(xproto.MotionNotify),
+					Detail:    x11RelativeMotion,
+					Root:      42,
+					X:         -17,
+					Y:         23,
+				}
+				if got != want {
+					t.Fatalf("typed payload = %+v, want %+v", got, want)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var framed strings.Builder
+			writer := guardianFramedWriter{writer: &framed}
+			wantEnvelope := guardianEnvelope{
+				Version:   guardianProtocolVersion,
+				Kind:      guardianFrameRequest,
+				ID:        27,
+				Operation: guardianOperationFakeInput,
+			}
+			if err := writer.writePayload(wantEnvelope, test.payload); err != nil {
+				t.Fatalf("write payload frame: %v", err)
+			}
+			gotEnvelope, err := readGuardianEnvelope(strings.NewReader(framed.String()))
+			if err != nil {
+				t.Fatalf("read payload frame: %v", err)
+			}
+			if gotEnvelope.Version != wantEnvelope.Version ||
+				gotEnvelope.Kind != wantEnvelope.Kind ||
+				gotEnvelope.ID != wantEnvelope.ID ||
+				gotEnvelope.Operation != wantEnvelope.Operation {
+				t.Fatalf("frame envelope = %+v, want metadata %+v", gotEnvelope, wantEnvelope)
+			}
+			test.check(t, gotEnvelope)
+		})
+	}
+}
+
 func TestGuardianEOFReleasesOwnedInputAndRestoresMapping(t *testing.T) {
 	transport := newGuardianTestConnection()
 	connection, done := newInProcessGuardian(t, transport)
@@ -1015,6 +1129,41 @@ func TestGuardianRequestTimeoutTerminatesAmbiguousConnection(t *testing.T) {
 	}
 	if err := peer.Close(); err != nil {
 		t.Fatalf("close timeout peer: %v", err)
+	}
+}
+
+func TestGuardianUnexpectedResponseIDTerminatesConnection(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("create socketpair: %v", err)
+	}
+	parent := os.NewFile(uintptr(fds[0]), "guardian-response-id-parent")
+	peer := os.NewFile(uintptr(fds[1]), "guardian-response-id-peer")
+	connection := newGuardianConnection(parent, nil, GuardianOptions{RequestTimeout: time.Second})
+	peerDone := make(chan error, 1)
+	go func() {
+		request, readErr := readGuardianEnvelope(peer)
+		if readErr != nil {
+			peerDone <- readErr
+			return
+		}
+		writer := guardianFramedWriter{writer: peer}
+		writeErr := writer.writePayload(guardianEnvelope{
+			Version:   guardianProtocolVersion,
+			Kind:      guardianFrameResponse,
+			ID:        request.ID + 1,
+			Operation: request.Operation,
+		}, guardianSetupResponse{Setup: Setup{Root: 99}})
+		peerDone <- writeErr
+	}()
+	if _, err := connection.Setup(); err == nil || !strings.Contains(err.Error(), "unexpected X11 guardian response ID") {
+		t.Fatalf("Setup with unexpected response ID = %v, want protocol error", err)
+	}
+	if err := <-peerDone; err != nil {
+		t.Fatalf("write unexpected response: %v", err)
+	}
+	if err := peer.Close(); err != nil {
+		t.Fatalf("close unexpected-response peer: %v", err)
 	}
 }
 

--- a/internal/x11input/guardian_protocol_linux.go
+++ b/internal/x11input/guardian_protocol_linux.go
@@ -49,6 +49,18 @@ type guardianEnvelope struct {
 	Error     string          `json:"error,omitempty"`
 }
 
+// guardianOutboundEnvelope accepts typed payloads so a frame and its payload
+// are marshaled once. The receiving envelope retains RawMessage for strict
+// operation-specific decoding.
+type guardianOutboundEnvelope struct {
+	Version   uint16 `json:"version"`
+	Kind      string `json:"kind"`
+	ID        uint64 `json:"id,omitempty"`
+	Operation string `json:"operation,omitempty"`
+	Payload   any    `json:"payload,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
 type guardianHelloRequest struct {
 	Token              string `json:"token"`
 	Display            string `json:"display"`
@@ -119,19 +131,43 @@ type guardianFramedWriter struct {
 	writer io.Writer
 }
 
+type guardianFramedReader struct {
+	reader io.Reader
+	buffer []byte
+}
+
 func (writer *guardianFramedWriter) write(envelope guardianEnvelope) error {
 	encoded, err := json.Marshal(envelope)
 	if err != nil {
 		return fmt.Errorf("encode guardian frame: %w", err)
 	}
+	return writer.writeEncoded(encoded)
+}
+
+func (writer *guardianFramedWriter) writePayload(envelope guardianEnvelope, payload any) error {
+	encoded, err := json.Marshal(guardianOutboundEnvelope{
+		Version:   envelope.Version,
+		Kind:      envelope.Kind,
+		ID:        envelope.ID,
+		Operation: envelope.Operation,
+		Payload:   payload,
+		Error:     envelope.Error,
+	})
+	if err != nil {
+		return fmt.Errorf("encode guardian frame: %w", err)
+	}
+	return writer.writeEncoded(encoded)
+}
+
+func (writer *guardianFramedWriter) writeEncoded(encoded []byte) error {
 	if len(encoded) == 0 || len(encoded) > guardianMaximumFrame {
 		return fmt.Errorf("guardian frame size %d exceeds limit %d", len(encoded), guardianMaximumFrame)
 	}
-	header := make([]byte, 4)
-	binary.BigEndian.PutUint32(header, uint32(len(encoded)))
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], uint32(len(encoded)))
 	writer.mu.Lock()
 	defer writer.mu.Unlock()
-	if err := writeAll(writer.writer, header); err != nil {
+	if err := writeAll(writer.writer, header[:]); err != nil {
 		return fmt.Errorf("write guardian frame header: %w", err)
 	}
 	if err := writeAll(writer.writer, encoded); err != nil {
@@ -141,16 +177,24 @@ func (writer *guardianFramedWriter) write(envelope guardianEnvelope) error {
 }
 
 func readGuardianEnvelope(reader io.Reader) (guardianEnvelope, error) {
+	framedReader := guardianFramedReader{reader: reader}
+	return framedReader.read()
+}
+
+func (reader *guardianFramedReader) read() (guardianEnvelope, error) {
 	var header [4]byte
-	if _, err := io.ReadFull(reader, header[:]); err != nil {
+	if _, err := io.ReadFull(reader.reader, header[:]); err != nil {
 		return guardianEnvelope{}, err
 	}
 	size := binary.BigEndian.Uint32(header[:])
 	if size == 0 || size > guardianMaximumFrame {
 		return guardianEnvelope{}, fmt.Errorf("invalid guardian frame size %d", size)
 	}
-	encoded := make([]byte, int(size))
-	if _, err := io.ReadFull(reader, encoded); err != nil {
+	if cap(reader.buffer) < int(size) {
+		reader.buffer = make([]byte, int(size))
+	}
+	encoded := reader.buffer[:int(size)]
+	if _, err := io.ReadFull(reader.reader, encoded); err != nil {
 		return guardianEnvelope{}, fmt.Errorf("read guardian frame body: %w", err)
 	}
 	var envelope guardianEnvelope

--- a/internal/x11input/guardian_reexec_linux.go
+++ b/internal/x11input/guardian_reexec_linux.go
@@ -88,7 +88,8 @@ func runGuardianReexecChild() int {
 
 func serveGuardian(control io.ReadWriteCloser, expectedToken string, dialer Dialer) error {
 	writer := &guardianFramedWriter{writer: control}
-	helloEnvelope, err := readGuardianEnvelope(control)
+	reader := guardianFramedReader{reader: control}
+	helloEnvelope, err := reader.read()
 	if err != nil {
 		return err
 	}
@@ -130,7 +131,7 @@ func serveGuardian(control io.ReadWriteCloser, expectedToken string, dialer Dial
 	go server.forwardEvents()
 
 	for {
-		envelope, readErr := readGuardianEnvelope(control)
+		envelope, readErr := reader.read()
 		if readErr != nil {
 			server.stopForwardingEvents()
 			if errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
@@ -259,20 +260,15 @@ func (server *guardianServer) forwardEvents() {
 		if err != nil {
 			event.Error = err.Error()
 		}
-		payload, payloadErr := guardianPayload(event)
-		if payloadErr != nil {
-			return
-		}
 		server.eventsMu.RLock()
 		if server.closing {
 			server.eventsMu.RUnlock()
 			return
 		}
-		writeErr := server.writer.write(guardianEnvelope{
+		writeErr := server.writer.writePayload(guardianEnvelope{
 			Version: guardianProtocolVersion,
 			Kind:    guardianFrameEvent,
-			Payload: payload,
-		})
+		}, event)
 		server.eventsMu.RUnlock()
 		if writeErr != nil || !open || err != nil {
 			return
@@ -360,21 +356,16 @@ func (server *guardianServer) dispatch(envelope guardianEnvelope) (any, error) {
 }
 
 func writeGuardianResponse(writer *guardianFramedWriter, request guardianEnvelope, response any, responseErr error) error {
-	payload, err := guardianPayload(response)
-	if err != nil {
-		return err
-	}
 	envelope := guardianEnvelope{
 		Version:   guardianProtocolVersion,
 		Kind:      guardianFrameResponse,
 		ID:        request.ID,
 		Operation: request.Operation,
-		Payload:   payload,
 	}
 	if responseErr != nil {
 		envelope.Error = responseErr.Error()
 	}
-	return writer.write(envelope)
+	return writer.writePayload(envelope, response)
 }
 
 func (server *guardianServer) changeKeyboardMapping(request guardianChangeKeyboardMappingRequest) error {


### PR DESCRIPTION
## What changed

- serialize Guardian requests to match the already-sequential helper dispatch
- reuse one bounded response channel and request timer per connection
- marshal typed outbound payloads once instead of building a separate RawMessage first
- reuse frame-read buffers in the long-lived parent and helper loops
- keep the frame header on the stack
- reject unexpected response IDs by terminating the ambiguous connection
- add concurrent correlation, wire-format, and fail-closed response-ID tests
- version a new decision-grade native-CGO versus optimized Pure-Go benchmark

## Why

The first Guardian-path evidence showed that the crash-safe IPC boundary added substantial Go allocation cost. Profiles identified per-request timers/channels, double JSON marshaling, and frame buffers as safe targets that do not require moving X11 state transitions or weakening cleanup.

## Impact

Across the current decision-grade sample, Pure-Go input allocations fall by about 24–33%. Allocated Go bytes fall by 41–50% for pointer/mouse operations and roughly 19–20% for keyboard/text operations. Median latency remains in the same range because IPC/X11 round trips still dominate. Native CGO remains the default; Pure-Go retains the same crash-isolation contract.

## Safety properties retained

- authenticated re-exec helper and verified peer credentials
- one correlated response per request; unexpected IDs fail closed
- bounded request, cleanup, and process-reap deadlines
- ambiguous timeout teardown
- claim-checked mapping restoration and foreign-state preservation
- real application-process SIGKILL recovery

## Validation

- decision-grade five-cycle balanced X11 evidence run, ten observations per benchmark/backend
- full native and Pure-Go behavioral manifests
- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- targeted new Guardian tests 100 times under `-race`
- complete Guardian suite 20 times under `-race`
- CGO and non-CGO `go vet ./...`
- `golangci-lint run`