### PR TITLE
feat: add Pure-Go Windows input backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
 | macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture and display bounds with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
-| Windows | `CGO_ENABLED=0` | Pure-Go capture/bounds plus layout-aware `SendInput` keyboard/text, exact pointer movement/location, smooth movement/drag, buttons, horizontal/vertical scroll, live readiness, ownership checks, and deterministic in-process cleanup |
+| Windows | `CGO_ENABLED=0` | Pure-Go capture/bounds plus foreground-layout-aware `SendInput` keyboard/text, exact pointer movement/location, smooth movement/drag, buttons, horizontal/vertical scroll, live readiness, ownership checks, and deterministic in-process cleanup |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
 | Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds plus XTEST mouse, keyboard, text/Unicode, pointer-location, smooth-move/drag, vertical scroll, and live readiness probes; horizontal scroll is explicitly unsupported |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Current technical differences include:
   with partial operations reported honestly instead of universal support being
   implied.
 - A defined non-CGO contract: Pure-Go capture is available through CoreGraphics
-  on macOS, native APIs on Windows, and X11. Linux/X11 additionally has an XTEST
-  keyboard/pointer backend; Wayland capture uses the consent-aware Screenshot
-  portal, and unavailable GUI operations return `ErrNotSupported` rather than
-  plausible zero values.
+  on macOS, native APIs on Windows, and X11. Windows and Linux/X11 additionally
+  have keyboard/pointer backends; Wayland capture uses the consent-aware
+  Screenshot portal, and unavailable GUI operations return `ErrNotSupported`
+  rather than plausible zero values.
 - Hermetic portal/compositor tests, tagged Wayland integration suites, and CI
   coverage for Linux, macOS, Windows, Wayland, portal, lint, and non-CGO modes.
 - Open, auditable native and Go backend code, including explicit resource
@@ -75,10 +75,11 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
 | macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture and display bounds with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
+| Windows | `CGO_ENABLED=0` | Pure-Go capture/bounds plus layout-aware `SendInput` keyboard/text, exact pointer movement/location, smooth movement/drag, buttons, horizontal/vertical scroll, live readiness, ownership checks, and deterministic in-process cleanup |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
 | Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds plus XTEST mouse, keyboard, text/Unicode, pointer-location, smooth-move/drag, vertical scroll, and live readiness probes; horizontal scroll is explicitly unsupported |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |
-| Other supported platforms without CGO | `CGO_ENABLED=0` | Pure-Go capture works on macOS and Windows; Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
+| Other supported platforms without CGO | `CGO_ENABLED=0` | Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
 
 Wayland compositors intentionally restrict global automation. GNOME and KDE can
 use consent-aware Screenshot and RemoteDesktop portal paths. The explicit
@@ -583,6 +584,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Linux capabilities](examples/linux_capabilities/main.go)
 - [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
 - [Pure-Go X11 input probe and opt-in demo](examples/purego_x11_input/main.go)
+- [Pure-Go Windows input readiness and opt-in demo](examples/purego_windows_input/main.go)
 - [Consent-aware RemoteDesktop portal input](examples/remote_desktop_input/main.go)
 - [Persistent ScreenCast/PipeWire capture](examples/screencast_capture/main.go)
 - [Window and process helpers](examples/window/main.go)
@@ -602,6 +604,21 @@ CGO_ENABLED=0 go run ./examples/purego_x11_input -act -text "Hello"
 
 Keyboard actions keep scratch mappings alive for two seconds before verified
 cleanup. Increase `-settle` when the focused XKB client may process input later.
+
+On Windows, the Pure-Go example performs readiness checks only unless `-move`
+or `-text` is supplied:
+
+```powershell
+$env:CGO_ENABLED = "0"
+go run ./examples/purego_windows_input
+go run ./examples/purego_windows_input -move 400,300 -text "Hello"
+```
+
+`SendInput` is subject to Windows User Interface Privilege Isolation: a
+normal-integrity process cannot inject input into a higher-integrity target.
+Persistent `KeyDown`/`MouseDown` state is owned by the backend and released by
+`CloseMainDisplayE`; callers should still use balanced operations or `defer`
+cleanup because process termination cannot run in-process cleanup.
 
 ## Testing
 
@@ -626,7 +643,8 @@ the reported guardian is the exact child that exits and is reaped. The
 measures the guardian path and retains native CGO as the X11 default while
 Pure-Go remains the supported CGO-disabled backend. The earlier direct-path
 sample remains linked from the performance report as historical evidence.
-Protecting the resulting remote checks remains a roadmap exit criterion.
+The stable remote checks are required by `main` branch protection. Real
+GNOME/KDE/wlroots jobs remain opt-in until matching runners are registered.
 
 Wayland and portal code has additional tagged suites:
 
@@ -653,7 +671,7 @@ Real Wayland input results are tracked in the
 - [Product roadmap](docs/plan/product-roadmap.md)
 - [Wayland implementation history](docs/wayland-history.md)
 
-The active product slice remains selective Phase 3 Pure-Go hardening. The
+The active product slice remains selective Phase 3 Pure-Go expansion. The
 Linux/X11 evaluation is complete: shared behavior is blocking CI,
 current guardian-path decision evidence is versioned, and native CGO remains
 the default while Pure-Go supports CGO-disabled builds. The Pure-Go X11 core is
@@ -662,9 +680,11 @@ after an application-process crash. Its request transport now reuses bounded
 state and avoids double payload encoding, with versioned evidence showing lower
 allocation cost. Balanced transient press/release pairs now share one guardian
 request while preserving per-step crash-cleanup ownership and the existing
-preflight/server-grab policy. Protecting remote checks and evaluating further
-backends remain. Real GNOME/KDE/wlroots validation is an independent Wayland
-release gate.
+preflight/server-grab policy. Required remote checks now protect `main`.
+Pure-Go Windows input is the next delivered platform slice, with hermetic
+transaction tests and an opt-in real input-desktop probe. Further macOS and
+Windows backends remain selective work. Real GNOME/KDE/wlroots validation is an
+independent Wayland release gate.
 
 ## Upstream and attribution
 

--- a/TEST.md
+++ b/TEST.md
@@ -48,7 +48,7 @@ branch protection requires the stable three-OS, lint, vet, race, Wayland, and
 X11 evidence checks. Opt-in real-compositor jobs remain excluded until matching
 self-hosted runners are registered.
 
-Pure-Go Windows input has hermetic tests for Win32 `INPUT` layout, active-layout
+Pure-Go Windows input has hermetic tests for Win32 `INPUT` layout, foreground-layout
 key mapping, Unicode surrogate pairs, partial-injection rollback, ownership,
 buttons, scrolling, and movement. They run in the Windows non-CGO CI leg. A
 real input-desktop pointer probe is explicitly opt-in because it moves the

--- a/TEST.md
+++ b/TEST.md
@@ -44,7 +44,26 @@ every balanced-comparison benchmark once. The same job starts a reachable Xvfb w
 and verifies that native readiness rejects it without injecting input. Missing
 runtime prerequisites fail instead of turning these checks into successful
 skips. Performance numbers are report-only; correctness is blocking. Repository
-branch protection does not yet require the resulting remote checks.
+branch protection requires the stable three-OS, lint, vet, race, Wayland, and
+X11 evidence checks. Opt-in real-compositor jobs remain excluded until matching
+self-hosted runners are registered.
+
+Pure-Go Windows input has hermetic tests for Win32 `INPUT` layout, active-layout
+key mapping, Unicode surrogate pairs, partial-injection rollback, ownership,
+buttons, scrolling, and movement. They run in the Windows non-CGO CI leg. A
+real input-desktop pointer probe is explicitly opt-in because it moves the
+global cursor:
+
+```powershell
+$env:CGO_ENABLED = "0"
+$env:ROBOTGO_REQUIRE_WINDOWS_INPUT_INTEGRATION = "1"
+go test -tags windowsintegration -run "^TestPureGoWindowsInputRuntime$" -count=1 -v .
+```
+
+The runtime probe restores the original pointer position. Keyboard injection
+is kept hermetic in default CI because a generic hosted runner offers no
+trustworthy foreground target; the runnable example provides explicit manual
+validation.
 
 Opt-in macOS runtime capture benchmark:
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -138,12 +138,12 @@ display enumeration, Screen Recording preflight, RGBA conversion, and
 CoreGraphics ownership are covered hermetically on both supported
 architectures.
 
-Windows non-CGO builds now provide a layout-aware `SendInput` keyboard and text
+Windows non-CGO builds now provide a foreground-layout-aware `SendInput` keyboard and text
 backend plus exact pointer movement/location, smooth movement and drag,
 buttons, horizontal and vertical scrolling, live readiness checks, partial
 injection rollback, ownership conflicts, and deterministic in-process cleanup.
 Exact Unicode text is encoded as UTF-16, while `KeyTap` resolves characters
-through the active Windows keyboard layout instead of assuming US key
+through the foreground target's Windows keyboard layout instead of assuming US key
 positions. Hermetic tests validate 32/64-bit `INPUT` layout and transaction
 semantics; the real input-desktop pointer test remains opt-in because it moves a
 global resource.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -32,10 +32,10 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
-| Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs | Keep required jobs green and confirm repository branch protection |
+| Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | X11 hardening and measurement complete; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; lower-allocation request transport and safe balanced-input sequencing; three-OS CI; non-skipping multi-layout Xvfb input tests | Protect the remote CI checks, then assess further backends selectively |
+| 3. Pure-Go | X11 complete; Windows input implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Windows `SendInput` keyboard/pointer backend; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; lower-allocation request transport and safe balanced-input sequencing; protected three-OS CI; non-skipping multi-layout Xvfb input tests | Collect real Windows input-desktop evidence, then assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -138,6 +138,16 @@ display enumeration, Screen Recording preflight, RGBA conversion, and
 CoreGraphics ownership are covered hermetically on both supported
 architectures.
 
+Windows non-CGO builds now provide a layout-aware `SendInput` keyboard and text
+backend plus exact pointer movement/location, smooth movement and drag,
+buttons, horizontal and vertical scrolling, live readiness checks, partial
+injection rollback, ownership conflicts, and deterministic in-process cleanup.
+Exact Unicode text is encoded as UTF-16, while `KeyTap` resolves characters
+through the active Windows keyboard layout instead of assuming US key
+positions. Hermetic tests validate 32/64-bit `INPUT` layout and transaction
+semantics; the real input-desktop pointer test remains opt-in because it moves a
+global resource.
+
 Linux/X11 additionally has a Pure-Go XGB/XTEST keyboard and pointer backend for
 the error-returning input APIs, text/Unicode, pointer location, smooth
 movement/drag, scroll, live readiness probes, and deterministic connection and
@@ -155,9 +165,10 @@ X11 binaries pass one black-box public-API contract for capture, pointer,
 buttons, scroll, modifier order, and ASCII text without keyboard-map changes. A
 reproducible balanced benchmark script records raw observations, medians,
 quartiles, ratios, metadata, and runs a report-only CI smoke. The versioned
-decision-grade sample retains native CGO as the Linux/X11 default: Pure-Go wins
-pointer-movement latency and build portability, while native wins capture, most
-input operations and allocations. At the measured revision, native also had
+decision-grade sample retains native CGO as the Linux/X11 default: native wins
+the current measured capture and input latency/allocation comparisons, while
+Pure-Go provides CGO-disabled build portability. At the measured revision,
+native also had
 stronger Unicode crash isolation; the later Pure-Go guardian closes the targeted
 application-process-kill gap without changing that historical performance
 sample. The current guardian-path comparison shows native winning the measured
@@ -193,9 +204,9 @@ allocations by `24–33%` without weakening request correlation or cleanup.
 Balanced transient press/release pairs now share one guardian request while
 retaining per-step ownership, verified release, preflight, server-grab, timeout,
 and crash-recovery contracts. This reduces another `5–14%` of allocations for
-the affected click, scroll, key-press, and text benchmarks. Protecting the
-remote checks and selectively evaluating additional backends keep the broader
-Phase 3 partial.
+the affected click, scroll, key-press, and text benchmarks. Stable remote checks
+now protect `main`; selectively evaluating additional platform backends keeps
+the broader Phase 3 partial.
 
 Exit criteria:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -22,7 +22,7 @@ Current implementation baseline:
   scrolling, pointer location, explicit state errors, and deterministic
   cleanup/reconnect. It is selected only for X11-primary sessions and never as
   an implicit Xwayland fallback from Wayland.
-- Windows non-CGO builds provide layout-aware keyboard/text and pointer input
+- Windows non-CGO builds provide foreground-layout-aware keyboard/text and pointer input
   through user32, including exact Unicode, smooth movement/drag, horizontal and
   vertical scroll, ownership checks, partial-injection rollback, live
   readiness, and deterministic in-process cleanup.

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -22,6 +22,10 @@ Current implementation baseline:
   scrolling, pointer location, explicit state errors, and deterministic
   cleanup/reconnect. It is selected only for X11-primary sessions and never as
   an implicit Xwayland fallback from Wayland.
+- Windows non-CGO builds provide layout-aware keyboard/text and pointer input
+  through user32, including exact Unicode, smooth movement/drag, horizontal and
+  vertical scroll, ownership checks, partial-injection rollback, live
+  readiness, and deterministic in-process cleanup.
 - Non-CGO `CaptureImg`/`CaptureScreen`, their Go-bitmap/string variants, and
   pixel-color queries use the hardened screenshot portal on Wayland and the
   Pure-Go screenshot backend on X11/Windows; unsupported targets fail explicitly.
@@ -105,8 +109,8 @@ Window backend support matrix (current):
     contract. Current optimized guardian-path evidence retains native CGO as the
     X11 default while keeping Pure-Go supported for CGO-disabled builds. The
     lower-allocation request transport and balanced transient-input sequencing
-    preserve the crash contract. Protecting the checks and evaluating further
-    backends remain open. The Pure-Go core is now
+    preserve the crash contract. Stable checks now protect `main`; evaluating
+    further backends remains open. The Pure-Go core is now
     race-testable, and a separate X11 guardian uses an authenticated abstract
     Unix socket with kernel-verified peer credentials, bounded request dispatch,
     and deadline-bounded cleanup after an application-process `SIGKILL`. It
@@ -167,14 +171,14 @@ Window backend support matrix (current):
     enabling any of them as defaults.
 - CI/Testing:
   - Keep the current headless Weston, screencopy, portal, and non-CGO CI
-    commands green; eliminating unexpected hermetic skips and adding branch
-    protection remain open.
+    commands green; eliminate unexpected hermetic skips. Stable jobs are
+    required by `main` branch protection.
   - Keep the non-CGO Xvfb/XTEST input test on a configured `us,de` keymap in
     Linux CI; missing `DISPLAY` or XTEST must fail the matrix leg rather than
     skip. Keep the shared native/Pure-Go contract and report-only benchmark
     smoke green, including the native XTEST-disabled negative contract and
-    display-lifecycle stress; the resulting remote checks still need branch
-    protection.
+    display-lifecycle stress; the resulting stable remote checks are required
+    by `main` branch protection.
   - Keep the extracted Pure-Go X11 core in the blocking race job and its
     guardian-backed application-`SIGKILL` recovery in the non-skipping Xvfb
     manifest; guardian/host/X-server loss and X11 transport stalls beyond the
@@ -187,4 +191,6 @@ Window backend support matrix (current):
   - Keep `examples/purego_x11_input` side-effect-free by default; live
     readiness checks and global input must remain behind its explicit `-act`
     flag.
+  - Keep `examples/purego_windows_input` readiness-only by default; global
+    pointer or keyboard input requires explicit `-move` or `-text` flags.
   - Publish a versioned support matrix and troubleshooting guide.

--- a/examples/purego_windows_input/main.go
+++ b/examples/purego_windows_input/main.go
@@ -1,0 +1,78 @@
+//go:build windows
+
+// Command purego_windows_input demonstrates the non-CGO Windows input backend.
+//
+// Run a readiness-only check without injecting input:
+//
+//	CGO_ENABLED=0 go run ./examples/purego_windows_input
+//
+// Opt in to visible input with -move and/or -text:
+//
+//	CGO_ENABLED=0 go run ./examples/purego_windows_input -move 400,300 -text "Hello"
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	move := flag.String("move", "", "optional absolute pointer target as x,y")
+	text := flag.String("text", "", "optional text to type into the active application")
+	flag.Parse()
+
+	info := robotgo.GetRuntimeBackendInfo()
+	fmt.Printf("implementation=%s os=%s arch=%s\n", info.BuildImplementation, info.GOOS, info.GOARCH)
+	if info.BuildImplementation != robotgo.RuntimeImplementationPureGo {
+		fmt.Fprintln(os.Stderr, "re-run with CGO_ENABLED=0 to exercise the Pure-Go backend")
+		os.Exit(2)
+	}
+	if err := robotgo.KeyboardReady(); err != nil {
+		fmt.Fprintln(os.Stderr, "keyboard:", err)
+		os.Exit(1)
+	}
+	if err := robotgo.MouseReady(); err != nil {
+		fmt.Fprintln(os.Stderr, "mouse:", err)
+		os.Exit(1)
+	}
+	fmt.Println("Pure-Go Windows keyboard and mouse backends are ready")
+
+	if *move != "" {
+		x, y, err := coordinates(*move)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		if err := robotgo.MoveE(x, y); err != nil {
+			fmt.Fprintln(os.Stderr, "move:", err)
+			os.Exit(1)
+		}
+	}
+	if *text != "" {
+		if err := robotgo.TypeStrE(*text); err != nil {
+			fmt.Fprintln(os.Stderr, "text:", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func coordinates(value string) (int, int, error) {
+	parts := strings.Split(value, ",")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("move must be x,y, got %q", value)
+	}
+	x, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid x coordinate: %w", err)
+	}
+	y, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid y coordinate: %w", err)
+	}
+	return x, y, nil
+}

--- a/input_backend_default_nocgo.go
+++ b/input_backend_default_nocgo.go
@@ -1,4 +1,4 @@
-//go:build !cgo && !linux
+//go:build !cgo && !linux && !windows
 
 package robotgo
 

--- a/input_backend_nocgo.go
+++ b/input_backend_nocgo.go
@@ -8,11 +8,16 @@ import "fmt"
 // platform backends. A tap owns the complete press/release transaction; a
 // toggle changes only the requested state.
 type pureGoKeyEvent struct {
-	Key       string
-	Modifiers []string
-	PID       int
-	Down      bool
-	Tap       bool
+	Key string
+	// Modifiers contains the portable, backend-normalized modifiers used by
+	// X11 and portal-compatible backends. UserModifiers preserves only the
+	// modifiers supplied by the caller so layout-aware platforms can derive
+	// character modifiers from their active keyboard layout.
+	Modifiers     []string
+	UserModifiers []string
+	PID           int
+	Down          bool
+	Tap           bool
 }
 
 // pureGoTextEvent describes one UTF-8 text transaction. Delay is applied
@@ -82,6 +87,10 @@ func pureGoInputCapabilities() (keyboard, mouse FeatureCapability) {
 			keyboard.Available, keyboard.Reason = false, reason
 			mouse.Available, mouse.Reason = false, reason
 		}
+	}
+	if backendName == featureBackendPureGoWindows {
+		keyboard.Notes += "; SendInput follows the active keyboard layout and Windows UIPI; CloseMainDisplayE releases RobotGo-owned persistent holds"
+		mouse.Notes += "; pointer coordinates use the Windows virtual screen; CloseMainDisplayE releases RobotGo-owned persistent holds"
 	}
 	return keyboard, mouse
 }

--- a/input_backend_nocgo.go
+++ b/input_backend_nocgo.go
@@ -12,7 +12,7 @@ type pureGoKeyEvent struct {
 	// Modifiers contains the portable, backend-normalized modifiers used by
 	// X11 and portal-compatible backends. UserModifiers preserves only the
 	// modifiers supplied by the caller so layout-aware platforms can derive
-	// character modifiers from their active keyboard layout.
+	// character modifiers from their target keyboard layout.
 	Modifiers     []string
 	UserModifiers []string
 	PID           int
@@ -89,7 +89,7 @@ func pureGoInputCapabilities() (keyboard, mouse FeatureCapability) {
 		}
 	}
 	if backendName == featureBackendPureGoWindows {
-		keyboard.Notes += "; SendInput follows the active keyboard layout and Windows UIPI; CloseMainDisplayE releases RobotGo-owned persistent holds"
+		keyboard.Notes += "; SendInput follows the foreground target's keyboard layout and Windows UIPI; CloseMainDisplayE releases RobotGo-owned persistent holds"
 		mouse.Notes += "; pointer coordinates use the Windows virtual screen; CloseMainDisplayE releases RobotGo-owned persistent holds"
 	}
 	return keyboard, mouse

--- a/input_backend_windows_nocgo.go
+++ b/input_backend_windows_nocgo.go
@@ -14,6 +14,8 @@ type windowsInputBackend struct {
 	core *windowsinput.Backend
 }
 
+const maxWindowsTextDelayMilliseconds = int64(^uint64(0)>>1) / int64(time.Millisecond)
+
 var pureGoWindowsInput = &windowsInputBackend{core: windowsinput.New()}
 
 func platformPureGoInputBackend() pureGoInputBackend { return pureGoWindowsInput }
@@ -51,6 +53,12 @@ func (backend *windowsInputBackend) Key(event pureGoKeyEvent) error {
 }
 
 func (backend *windowsInputBackend) Text(event pureGoTextEvent) error {
+	if int64(event.Delay) > maxWindowsTextDelayMilliseconds {
+		return fmt.Errorf(
+			"robotgo: Windows text delay %dms exceeds time.Duration",
+			event.Delay,
+		)
+	}
 	return translatePureGoWindowsInputError(backend.core.Text(windowsinput.TextEvent{
 		Text: event.Text, PID: event.PID,
 		Delay: time.Duration(event.Delay) * time.Millisecond,

--- a/input_backend_windows_nocgo.go
+++ b/input_backend_windows_nocgo.go
@@ -1,0 +1,95 @@
+//go:build windows && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/marang/robotgo/internal/windowsinput"
+)
+
+type windowsInputBackend struct {
+	core *windowsinput.Backend
+}
+
+var pureGoWindowsInput = &windowsInputBackend{core: windowsinput.New()}
+
+func platformPureGoInputBackend() pureGoInputBackend { return pureGoWindowsInput }
+
+func closePureGoPlatformInput() error { return pureGoWindowsInput.Close() }
+
+func (*windowsInputBackend) Name() string { return featureBackendPureGoWindows }
+
+func translatePureGoWindowsInputError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, windowsinput.ErrUnsupported):
+		return fmt.Errorf("%w: %w", ErrNotSupported, err)
+	case errors.Is(err, windowsinput.ErrOwnership):
+		return fmt.Errorf("%w: %w", ErrInputOwnership, err)
+	default:
+		return err
+	}
+}
+
+func (backend *windowsInputBackend) KeyboardReady() error {
+	return translatePureGoWindowsInputError(backend.core.KeyboardReady())
+}
+
+func (backend *windowsInputBackend) MouseReady() error {
+	return translatePureGoWindowsInputError(backend.core.MouseReady())
+}
+
+func (backend *windowsInputBackend) Key(event pureGoKeyEvent) error {
+	return translatePureGoWindowsInputError(backend.core.Key(windowsinput.KeyEvent{
+		Key: event.Key, Modifiers: append([]string(nil), event.UserModifiers...),
+		PID: event.PID, Down: event.Down, Tap: event.Tap,
+	}))
+}
+
+func (backend *windowsInputBackend) Text(event pureGoTextEvent) error {
+	return translatePureGoWindowsInputError(backend.core.Text(windowsinput.TextEvent{
+		Text: event.Text, PID: event.PID,
+		Delay: time.Duration(event.Delay) * time.Millisecond,
+	}))
+}
+
+func (backend *windowsInputBackend) MoveAbsolute(x, y int, displayID []int) error {
+	return translatePureGoWindowsInputError(backend.core.MoveAbsolute(x, y, displayID))
+}
+
+func (backend *windowsInputBackend) MoveRelative(x, y int) error {
+	return translatePureGoWindowsInputError(backend.core.MoveRelative(x, y))
+}
+
+func (backend *windowsInputBackend) MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error {
+	return translatePureGoWindowsInputError(backend.core.MoveSmooth(x, y, relative, lowDelay, highDelay))
+}
+
+func (backend *windowsInputBackend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
+	return translatePureGoWindowsInputError(backend.core.DragSmooth(x, y, lowDelay, highDelay))
+}
+
+func (backend *windowsInputBackend) Location() (int, int, error) {
+	x, y, err := backend.core.Location()
+	return x, y, translatePureGoWindowsInputError(err)
+}
+
+func (backend *windowsInputBackend) Click(button string, double bool) error {
+	return translatePureGoWindowsInputError(backend.core.Click(button, double))
+}
+
+func (backend *windowsInputBackend) Toggle(button string, down bool) error {
+	return translatePureGoWindowsInputError(backend.core.Toggle(button, down))
+}
+
+func (backend *windowsInputBackend) Scroll(x, y int) error {
+	return translatePureGoWindowsInputError(backend.core.Scroll(x, y))
+}
+
+func (backend *windowsInputBackend) Close() error {
+	return translatePureGoWindowsInputError(backend.core.Close())
+}

--- a/input_backend_windows_nocgo_test.go
+++ b/input_backend_windows_nocgo_test.go
@@ -4,6 +4,7 @@ package robotgo
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/marang/robotgo/internal/windowsinput"
@@ -23,6 +24,15 @@ func TestPureGoWindowsInputBackendSelection(t *testing.T) {
 			t.Fatalf("%s capability = %+v", name, capability)
 		}
 	}
+	runtimeCapabilities := GetRuntimeCapabilities()
+	for name, capability := range map[string]FeatureCapability{
+		"keyboard": runtimeCapabilities.Keyboard,
+		"mouse":    runtimeCapabilities.Mouse,
+	} {
+		if !capability.Available || capability.Backend != featureBackendPureGoWindows {
+			t.Fatalf("runtime %s capability = %+v", name, capability)
+		}
+	}
 }
 
 func TestTranslatePureGoWindowsInputErrors(t *testing.T) {
@@ -31,5 +41,17 @@ func TestTranslatePureGoWindowsInputErrors(t *testing.T) {
 	}
 	if err := translatePureGoWindowsInputError(windowsinput.ErrOwnership); !errors.Is(err, ErrInputOwnership) {
 		t.Fatalf("ownership translation = %v", err)
+	}
+}
+
+func TestPureGoWindowsTextDelayRejectsDurationOverflow(t *testing.T) {
+	if strconv.IntSize != 64 {
+		t.Skip("int cannot exceed time.Duration milliseconds on 32-bit Windows")
+	}
+	overflow := maxWindowsTextDelayMilliseconds + 1
+	backend := &windowsInputBackend{core: windowsinput.New()}
+	err := backend.Text(pureGoTextEvent{Text: "a", Delay: int(overflow)})
+	if err == nil {
+		t.Fatal("Text accepted a delay that overflows time.Duration")
 	}
 }

--- a/input_backend_windows_nocgo_test.go
+++ b/input_backend_windows_nocgo_test.go
@@ -1,0 +1,35 @@
+//go:build windows && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marang/robotgo/internal/windowsinput"
+)
+
+func TestPureGoWindowsInputBackendSelection(t *testing.T) {
+	backend := platformPureGoInputBackend()
+	if backend == nil || backend.Name() != featureBackendPureGoWindows {
+		t.Fatalf("platform backend = %#v, want %q", backend, featureBackendPureGoWindows)
+	}
+	keyboard, mouse := pureGoInputCapabilities()
+	for name, capability := range map[string]FeatureCapability{
+		"keyboard": keyboard,
+		"mouse":    mouse,
+	} {
+		if !capability.Available || capability.Backend != featureBackendPureGoWindows {
+			t.Fatalf("%s capability = %+v", name, capability)
+		}
+	}
+}
+
+func TestTranslatePureGoWindowsInputErrors(t *testing.T) {
+	if err := translatePureGoWindowsInputError(windowsinput.ErrUnsupported); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("unsupported translation = %v", err)
+	}
+	if err := translatePureGoWindowsInputError(windowsinput.ErrOwnership); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("ownership translation = %v", err)
+	}
+}

--- a/internal/windowsinput/backend_windows.go
+++ b/internal/windowsinput/backend_windows.go
@@ -1,0 +1,601 @@
+//go:build windows
+
+// Package windowsinput provides RobotGo's Pure-Go Windows input backend.
+package windowsinput
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+const (
+	doubleClickGap         = 200 * time.Millisecond
+	dragStartDelay         = 50 * time.Millisecond
+	maximumSmoothDelay     = 10_000
+	maximumScrollMagnitude = math.MaxInt32 / wheelDelta
+)
+
+var (
+	// ErrUnsupported reports an operation that Win32 cannot safely provide.
+	ErrUnsupported = errors.New("Pure-Go Windows input operation is unsupported")
+	// ErrOwnership reports an attempt to release or overwrite foreign input.
+	ErrOwnership = errors.New("Pure-Go Windows input state is not owned by RobotGo")
+)
+
+// KeyEvent is one normalized keyboard operation.
+type KeyEvent struct {
+	Key       string
+	Modifiers []string
+	PID       int
+	Down      bool
+	Tap       bool
+}
+
+// TextEvent is one exact Unicode text operation.
+type TextEvent struct {
+	Text  string
+	PID   int
+	Delay time.Duration
+}
+
+// Backend serializes Win32 input transactions and tracks persistent holds.
+type Backend struct {
+	mu sync.Mutex
+
+	system inputSystem
+	sleep  func(time.Duration)
+
+	ownedKeys        map[uint16]struct{}
+	ownedKeyExtended map[uint16]bool
+	ownedKeyOrder    []uint16
+	ownedButtons     map[uint32]struct{}
+	ownedButtonOrder []uint32
+	ownedUnicode     []uint16
+}
+
+// New creates a backend backed by user32.dll.
+func New() *Backend {
+	return newBackend(newWin32System(), time.Sleep)
+}
+
+func newBackend(system inputSystem, sleep func(time.Duration)) *Backend {
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	return &Backend{
+		system:           system,
+		sleep:            sleep,
+		ownedKeys:        make(map[uint16]struct{}),
+		ownedKeyExtended: make(map[uint16]bool),
+		ownedButtons:     make(map[uint32]struct{}),
+	}
+}
+
+// KeyboardReady verifies that the required Win32 keyboard entry points exist.
+func (backend *Backend) KeyboardReady() error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	return backend.system.KeyboardReady()
+}
+
+// MouseReady verifies the pointer entry points and access to the input desktop.
+func (backend *Backend) MouseReady() error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.system.MouseReady(); err != nil {
+		return err
+	}
+	_, _, err := backend.system.CursorPosition()
+	return err
+}
+
+func namedVirtualKey(key string) (uint16, bool) {
+	named := map[string]uint16{
+		"backspace": vkBack, "delete": vkDelete,
+		"enter": vkReturn, "tab": vkTab,
+		"esc": vkEscape, "escape": vkEscape,
+		"up": vkUp, "down": vkDown, "right": vkRight, "left": vkLeft,
+		"home": vkHome, "end": vkEnd, "pageup": vkPrior, "pagedown": vkNext,
+		"cmd": vkLWin, "command": vkLWin, "lcmd": vkLWin, "rcmd": vkRWin,
+		"alt": vkMenu, "lalt": vkLMenu, "ralt": vkRMenu,
+		"ctrl": vkControl, "control": vkControl, "lctrl": vkLControl, "rctrl": vkRControl,
+		"shift": vkShift, "lshift": vkLShift, "rshift": vkRShift, "right_shift": vkRShift,
+		"capslock": vkCapital, "space": vkSpace,
+		"print": vkSnapshot, "printscreen": vkSnapshot,
+		"insert": vkInsert, "menu": vkApps,
+		"num0": vkNumpad0, "numpad_0": vkNumpad0,
+		"num1": vkNumpad1, "numpad_1": vkNumpad1,
+		"num2": vkNumpad2, "numpad_2": vkNumpad2,
+		"num3": vkNumpad3, "numpad_3": vkNumpad3,
+		"num4": vkNumpad4, "numpad_4": vkNumpad4,
+		"num5": vkNumpad5, "numpad_5": vkNumpad5,
+		"num6": vkNumpad6, "numpad_6": vkNumpad6,
+		"num7": vkNumpad7, "numpad_7": vkNumpad7,
+		"num8": vkNumpad8, "numpad_8": vkNumpad8,
+		"num9": vkNumpad9, "numpad_9": vkNumpad9,
+		"num_lock": vkNumLock, "numpad_lock": vkNumLock,
+		"num.": vkDecimal, "num+": vkAdd, "num-": vkSubtract,
+		"num*": vkMultiply, "num/": vkDivide, "num_enter": vkReturn,
+		"num_equal":   vkOEMPlus,
+		"scroll_lock": vkScroll, "pause_break": vkPause,
+		"audio_mute": vkVolumeMute, "audio_vol_down": vkVolumeDown,
+		"audio_vol_up": vkVolumeUp, "audio_play": vkMediaPlayPause,
+		"audio_pause": vkMediaPlayPause, "audio_stop": vkMediaStop,
+		"audio_prev": vkMediaPrevTrack, "audio_next": vkMediaNextTrack,
+	}
+	value, ok := named[strings.ToLower(key)]
+	return value, ok
+}
+
+func functionVirtualKey(key string) (uint16, bool) {
+	lower := strings.ToLower(key)
+	if !strings.HasPrefix(lower, "f") {
+		return 0, false
+	}
+	number, err := strconv.Atoi(strings.TrimPrefix(lower, "f"))
+	if err != nil || number < 1 || number > 24 {
+		return 0, false
+	}
+	return vkF1 + uint16(number-1), true
+}
+
+func modifierVirtualKey(name string) (uint16, error) {
+	if strings.EqualFold(name, "none") {
+		return 0, nil
+	}
+	key, ok := namedVirtualKey(name)
+	if !ok {
+		return 0, fmt.Errorf("%w: unknown modifier %q", ErrUnsupported, name)
+	}
+	switch key {
+	case vkMenu, vkLMenu, vkRMenu,
+		vkControl, vkLControl, vkRControl,
+		vkShift, vkLShift, vkRShift,
+		vkLWin, vkRWin:
+		return key, nil
+	default:
+		return 0, fmt.Errorf("%w: %q is not a modifier", ErrUnsupported, name)
+	}
+}
+
+func (backend *Backend) resolveKeyLocked(key string) (uint16, []uint16, error) {
+	switch key {
+	case "\n", "\r":
+		return vkReturn, nil, nil
+	case "\t":
+		return vkTab, nil, nil
+	case "\b":
+		return vkBack, nil, nil
+	}
+	if named, ok := namedVirtualKey(key); ok {
+		return named, nil, nil
+	}
+	if function, ok := functionVirtualKey(key); ok {
+		return function, nil, nil
+	}
+	if !utf8.ValidString(key) || utf8.RuneCountInString(key) != 1 {
+		return 0, nil, fmt.Errorf("%w: invalid key %q", ErrUnsupported, key)
+	}
+	value, _ := utf8.DecodeRuneInString(key)
+	if value > math.MaxUint16 {
+		return 0, nil, fmt.Errorf("%w: %U has no single Windows virtual key; use text input", ErrUnsupported, value)
+	}
+	virtualKey, shiftState, ok := backend.system.VirtualKeyForRune(uint16(value))
+	if !ok {
+		return 0, nil, fmt.Errorf("%w: active Windows keyboard layout cannot map %U; use text input", ErrUnsupported, value)
+	}
+	if virtualKey == 0 {
+		return 0, nil, fmt.Errorf("%w: active Windows keyboard layout returned no virtual key for %U", ErrUnsupported, value)
+	}
+	if shiftState&^uint8(shiftStateShift|shiftStateControl|shiftStateAlt) != 0 {
+		return 0, nil, fmt.Errorf("%w: active Windows keyboard layout requires unsupported shift state %#x for %U", ErrUnsupported, shiftState, value)
+	}
+	modifiers := make([]uint16, 0, 3)
+	if shiftState&shiftStateShift != 0 {
+		modifiers = append(modifiers, vkShift)
+	}
+	if shiftState&shiftStateControl != 0 {
+		modifiers = append(modifiers, vkControl)
+	}
+	if shiftState&shiftStateAlt != 0 {
+		modifiers = append(modifiers, vkMenu)
+	}
+	return virtualKey, modifiers, nil
+}
+
+func appendUniqueKey(keys []uint16, key uint16) []uint16 {
+	if key == 0 {
+		return keys
+	}
+	for _, existing := range keys {
+		if existing == key {
+			return keys
+		}
+	}
+	return append(keys, key)
+}
+
+func (backend *Backend) resolveModifiersLocked(names []string, implicit []uint16) ([]uint16, error) {
+	result := append([]uint16(nil), implicit...)
+	for _, name := range names {
+		key, err := modifierVirtualKey(name)
+		if err != nil {
+			return nil, err
+		}
+		result = appendUniqueKey(result, key)
+	}
+	return result, nil
+}
+
+func (backend *Backend) temporaryModifierInputsLocked(modifiers []uint16, main uint16) (down, up []trackedInput) {
+	for _, modifier := range modifiers {
+		if modifier == main {
+			continue
+		}
+		if _, owned := backend.ownedKeys[modifier]; owned || backend.system.KeyDown(modifier) {
+			continue
+		}
+		down = append(down, trackedKeyInput(modifier, true))
+		up = append([]trackedInput{trackedKeyInput(modifier, false)}, up...)
+	}
+	return down, up
+}
+
+// Key injects one layout-aware key transaction.
+func (backend *Backend) Key(event KeyEvent) error {
+	if event.PID != 0 {
+		return fmt.Errorf("%w: Windows SendInput cannot target a process", ErrUnsupported)
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.system.KeyboardReady(); err != nil {
+		return err
+	}
+	main, implicit, err := backend.resolveKeyLocked(event.Key)
+	if err != nil {
+		return err
+	}
+	modifiers, err := backend.resolveModifiersLocked(event.Modifiers, implicit)
+	if err != nil {
+		return err
+	}
+	modifierDown, modifierUp := backend.temporaryModifierInputsLocked(modifiers, main)
+	mainExtended := strings.EqualFold(event.Key, "num_enter")
+	mainInput := func(down bool) trackedInput {
+		return trackedKeyInputExtended(main, down, mainExtended)
+	}
+	if event.Tap {
+		if _, owned := backend.ownedKeys[main]; owned || backend.system.KeyDown(main) {
+			return fmt.Errorf("%w: key %q is already down", ErrOwnership, event.Key)
+		}
+		inputs := append(modifierDown, mainInput(true))
+		inputs = append(inputs, mainInput(false))
+		inputs = append(inputs, modifierUp...)
+		return backend.sendTrackedLocked(inputs)
+	}
+	if event.Down {
+		if _, owned := backend.ownedKeys[main]; owned || backend.system.KeyDown(main) {
+			return fmt.Errorf("%w: key %q is already down", ErrOwnership, event.Key)
+		}
+		inputs := append(modifierDown, mainInput(true))
+		inputs = append(inputs, modifierUp...)
+		return backend.sendTrackedLocked(inputs)
+	}
+	if _, owned := backend.ownedKeys[main]; !owned {
+		return fmt.Errorf("%w: key %q was not pressed by this backend", ErrOwnership, event.Key)
+	}
+	inputs := append(modifierDown, mainInput(false))
+	inputs = append(inputs, modifierUp...)
+	return backend.sendTrackedLocked(inputs)
+}
+
+// Text injects exact UTF-16 code units through KEYEVENTF_UNICODE.
+func (backend *Backend) Text(event TextEvent) error {
+	if event.PID != 0 {
+		return fmt.Errorf("%w: Windows SendInput cannot target a process", ErrUnsupported)
+	}
+	if event.Delay < 0 {
+		return errors.New("Pure-Go Windows text delay must be non-negative")
+	}
+	if !utf8.ValidString(event.Text) {
+		return errors.New("Pure-Go Windows text is not valid UTF-8")
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.system.KeyboardReady(); err != nil {
+		return err
+	}
+	runes := []rune(event.Text)
+	for index, value := range runes {
+		units := utf16.Encode([]rune{value})
+		inputs := make([]trackedInput, 0, len(units)*2)
+		for _, unit := range units {
+			inputs = append(inputs,
+				trackedUnicodeInput(unit, true),
+				trackedUnicodeInput(unit, false),
+			)
+		}
+		if err := backend.sendTrackedLocked(inputs); err != nil {
+			return fmt.Errorf("type %U: %w", value, err)
+		}
+		if event.Delay > 0 && index+1 < len(runes) {
+			backend.sleep(event.Delay)
+		}
+	}
+	return nil
+}
+
+func validateCoordinate(value int) error {
+	if int(int32(value)) != value {
+		return fmt.Errorf("Pure-Go Windows coordinate %d is outside [%d,%d]", value, math.MinInt32, math.MaxInt32)
+	}
+	return nil
+}
+
+// MoveAbsolute moves the pointer in virtual-screen coordinates.
+func (backend *Backend) MoveAbsolute(x, y int, _ []int) error {
+	if err := validateCoordinate(x); err != nil {
+		return err
+	}
+	if err := validateCoordinate(y); err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	return backend.system.SetCursorPosition(int32(x), int32(y))
+}
+
+// MoveRelative moves from the current pointer location without acceleration.
+func (backend *Backend) MoveRelative(x, y int) error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	currentX, currentY, err := backend.system.CursorPosition()
+	if err != nil {
+		return err
+	}
+	targetX, targetY := int64(currentX)+int64(x), int64(currentY)+int64(y)
+	if targetX < math.MinInt32 || targetX > math.MaxInt32 ||
+		targetY < math.MinInt32 || targetY > math.MaxInt32 {
+		return errors.New("Pure-Go Windows relative pointer target exceeds Win32 coordinates")
+	}
+	return backend.system.SetCursorPosition(int32(targetX), int32(targetY))
+}
+
+func validSmoothDelayRange(lowDelay, highDelay float64) bool {
+	return !math.IsNaN(lowDelay) && !math.IsNaN(highDelay) &&
+		!math.IsInf(lowDelay, 0) && !math.IsInf(highDelay, 0) &&
+		lowDelay >= 0 && highDelay >= lowDelay && highDelay <= maximumSmoothDelay
+}
+
+func (backend *Backend) moveSmoothLocked(x, y int, relative bool, lowDelay, highDelay float64) error {
+	if !validSmoothDelayRange(lowDelay, highDelay) {
+		return fmt.Errorf("Pure-Go Windows invalid smooth-move delay range %g..%g ms", lowDelay, highDelay)
+	}
+	startX, startY, err := backend.system.CursorPosition()
+	if err != nil {
+		return err
+	}
+	targetX, targetY := int64(x), int64(y)
+	if relative {
+		targetX += int64(startX)
+		targetY += int64(startY)
+	}
+	if targetX < math.MinInt32 || targetX > math.MaxInt32 ||
+		targetY < math.MinInt32 || targetY > math.MaxInt32 {
+		return errors.New("Pure-Go Windows smooth pointer target exceeds Win32 coordinates")
+	}
+	distance := math.Hypot(float64(targetX-int64(startX)), float64(targetY-int64(startY)))
+	steps := int(math.Ceil(distance / 8))
+	if steps < 1 {
+		steps = 1
+	}
+	if steps > 240 {
+		steps = 240
+	}
+	delay := time.Duration((lowDelay + highDelay) / 2 * float64(time.Millisecond))
+	lastX, lastY := int64(startX), int64(startY)
+	for step := 1; step <= steps; step++ {
+		progress := float64(step) / float64(steps)
+		if progress < 0.5 {
+			progress = 4 * progress * progress * progress
+		} else {
+			inverse := -2*progress + 2
+			progress = 1 - inverse*inverse*inverse/2
+		}
+		currentX := int64(math.Round(float64(startX) + float64(targetX-int64(startX))*progress))
+		currentY := int64(math.Round(float64(startY) + float64(targetY-int64(startY))*progress))
+		if currentX == lastX && currentY == lastY && step != steps {
+			continue
+		}
+		if err := backend.system.SetCursorPosition(int32(currentX), int32(currentY)); err != nil {
+			return err
+		}
+		lastX, lastY = currentX, currentY
+		if delay > 0 && step != steps {
+			backend.sleep(delay)
+		}
+	}
+	return nil
+}
+
+// MoveSmooth performs a bounded eased movement.
+func (backend *Backend) MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	return backend.moveSmoothLocked(x, y, relative, lowDelay, highDelay)
+}
+
+func mouseButton(name string) (flags uint32, virtualKey uint16, err error) {
+	switch name {
+	case "", "left":
+		return mouseEventLeftDown, vkLButton, nil
+	case "center", "middle":
+		return mouseEventMiddleDown, vkMButton, nil
+	case "right":
+		return mouseEventRightDown, vkRButton, nil
+	case "wheelUp", "wheelDown", "wheelLeft", "wheelRight":
+		return 0, 0, fmt.Errorf("%w: use Scroll for wheel input instead of button %q", ErrUnsupported, name)
+	default:
+		return 0, 0, fmt.Errorf("invalid Pure-Go Windows pointer button %q", name)
+	}
+}
+
+func mouseButtonUpFlag(downFlag uint32) uint32 {
+	switch downFlag {
+	case mouseEventLeftDown:
+		return mouseEventLeftUp
+	case mouseEventMiddleDown:
+		return mouseEventMiddleUp
+	default:
+		return mouseEventRightUp
+	}
+}
+
+func (backend *Backend) buttonAvailableLocked(flag uint32, virtualKey uint16) error {
+	if _, owned := backend.ownedButtons[flag]; owned || backend.system.KeyDown(virtualKey) {
+		return fmt.Errorf("%w: pointer button is already down", ErrOwnership)
+	}
+	return nil
+}
+
+// Click injects one or two complete button pulses.
+func (backend *Backend) Click(name string, double bool) error {
+	flag, virtualKey, err := mouseButton(name)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.system.MouseReady(); err != nil {
+		return err
+	}
+	if err := backend.buttonAvailableLocked(flag, virtualKey); err != nil {
+		return err
+	}
+	count := 1
+	if double {
+		count = 2
+	}
+	for click := 0; click < count; click++ {
+		if err := backend.sendTrackedLocked([]trackedInput{
+			trackedButtonInput(flag, true),
+			trackedButtonInput(flag, false),
+		}); err != nil {
+			return err
+		}
+		if click+1 < count {
+			backend.sleep(doubleClickGap)
+		}
+	}
+	return nil
+}
+
+// Toggle changes a persistent pointer-button state with ownership checks.
+func (backend *Backend) Toggle(name string, down bool) error {
+	flag, virtualKey, err := mouseButton(name)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.system.MouseReady(); err != nil {
+		return err
+	}
+	if down {
+		if err := backend.buttonAvailableLocked(flag, virtualKey); err != nil {
+			return err
+		}
+	} else if _, owned := backend.ownedButtons[flag]; !owned {
+		return fmt.Errorf("%w: pointer button was not pressed by this backend", ErrOwnership)
+	}
+	return backend.sendTrackedLocked([]trackedInput{trackedButtonInput(flag, down)})
+}
+
+// DragSmooth owns the left button for the complete drag transaction.
+func (backend *Backend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.system.MouseReady(); err != nil {
+		return err
+	}
+	if err := backend.buttonAvailableLocked(mouseEventLeftDown, vkLButton); err != nil {
+		return err
+	}
+	downErr := backend.sendTrackedLocked([]trackedInput{trackedButtonInput(mouseEventLeftDown, true)})
+	if downErr != nil {
+		return downErr
+	}
+	backend.sleep(dragStartDelay)
+	moveErr := backend.moveSmoothLocked(x, y, false, lowDelay, highDelay)
+	upErr := backend.sendTrackedLocked([]trackedInput{trackedButtonInput(mouseEventLeftDown, false)})
+	return errors.Join(moveErr, upErr)
+}
+
+// Location returns the pointer location in virtual-screen coordinates.
+func (backend *Backend) Location() (int, int, error) {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	x, y, err := backend.system.CursorPosition()
+	return int(x), int(y), err
+}
+
+// Scroll injects horizontal and vertical wheel deltas.
+func (backend *Backend) Scroll(x, y int) error {
+	if x < -maximumScrollMagnitude || x > maximumScrollMagnitude ||
+		y < -maximumScrollMagnitude || y > maximumScrollMagnitude {
+		return fmt.Errorf("Pure-Go Windows scroll magnitude exceeds %d", maximumScrollMagnitude)
+	}
+	inputs := make([]trackedInput, 0, 2)
+	if x != 0 {
+		// RobotGo positive x means left; Win32 positive HWHEEL means right.
+		inputs = append(inputs, trackedMouseInput(mouseEventHWheel, int32(-x*wheelDelta)))
+	}
+	if y != 0 {
+		inputs = append(inputs, trackedMouseInput(mouseEventWheel, int32(y*wheelDelta)))
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if err := backend.system.MouseReady(); err != nil {
+		return err
+	}
+	return backend.sendTrackedLocked(inputs)
+}
+
+// Close releases every key, Unicode unit, and button still owned by RobotGo.
+func (backend *Backend) Close() error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	var closeErr error
+	for index := len(backend.ownedUnicode) - 1; index >= 0; index-- {
+		closeErr = errors.Join(closeErr, backend.sendTrackedLocked(
+			[]trackedInput{trackedUnicodeInput(backend.ownedUnicode[index], false)},
+		))
+	}
+	for index := len(backend.ownedKeyOrder) - 1; index >= 0; index-- {
+		key := backend.ownedKeyOrder[index]
+		if _, owned := backend.ownedKeys[key]; owned {
+			closeErr = errors.Join(closeErr, backend.sendTrackedLocked(
+				[]trackedInput{trackedKeyInputExtended(key, false, backend.ownedKeyExtended[key])},
+			))
+		}
+	}
+	for index := len(backend.ownedButtonOrder) - 1; index >= 0; index-- {
+		button := backend.ownedButtonOrder[index]
+		if _, owned := backend.ownedButtons[button]; owned {
+			closeErr = errors.Join(closeErr, backend.sendTrackedLocked(
+				[]trackedInput{trackedButtonInput(button, false)},
+			))
+		}
+	}
+	return closeErr
+}

--- a/internal/windowsinput/backend_windows.go
+++ b/internal/windowsinput/backend_windows.go
@@ -27,6 +27,40 @@ var (
 	ErrUnsupported = errors.New("Pure-Go Windows input operation is unsupported")
 	// ErrOwnership reports an attempt to release or overwrite foreign input.
 	ErrOwnership = errors.New("Pure-Go Windows input state is not owned by RobotGo")
+
+	namedVirtualKeys = map[string]uint16{
+		"backspace": vkBack, "delete": vkDelete,
+		"enter": vkReturn, "tab": vkTab,
+		"esc": vkEscape, "escape": vkEscape,
+		"up": vkUp, "down": vkDown, "right": vkRight, "left": vkLeft,
+		"home": vkHome, "end": vkEnd, "pageup": vkPrior, "pagedown": vkNext,
+		"cmd": vkLWin, "command": vkLWin, "lcmd": vkLWin, "rcmd": vkRWin,
+		"alt": vkMenu, "lalt": vkLMenu, "ralt": vkRMenu,
+		"ctrl": vkControl, "control": vkControl, "lctrl": vkLControl, "rctrl": vkRControl,
+		"shift": vkShift, "lshift": vkLShift, "rshift": vkRShift, "right_shift": vkRShift,
+		"capslock": vkCapital, "space": vkSpace,
+		"print": vkSnapshot, "printscreen": vkSnapshot,
+		"insert": vkInsert, "menu": vkApps,
+		"num0": vkNumpad0, "numpad_0": vkNumpad0,
+		"num1": vkNumpad1, "numpad_1": vkNumpad1,
+		"num2": vkNumpad2, "numpad_2": vkNumpad2,
+		"num3": vkNumpad3, "numpad_3": vkNumpad3,
+		"num4": vkNumpad4, "numpad_4": vkNumpad4,
+		"num5": vkNumpad5, "numpad_5": vkNumpad5,
+		"num6": vkNumpad6, "numpad_6": vkNumpad6,
+		"num7": vkNumpad7, "numpad_7": vkNumpad7,
+		"num8": vkNumpad8, "numpad_8": vkNumpad8,
+		"num9": vkNumpad9, "numpad_9": vkNumpad9,
+		"num_lock": vkNumLock, "numpad_lock": vkNumLock,
+		"num.": vkDecimal, "num+": vkAdd, "num-": vkSubtract,
+		"num*": vkMultiply, "num/": vkDivide, "num_enter": vkReturn,
+		"num_equal":   vkOEMPlus,
+		"scroll_lock": vkScroll, "pause_break": vkPause,
+		"audio_mute": vkVolumeMute, "audio_vol_down": vkVolumeDown,
+		"audio_vol_up": vkVolumeUp, "audio_play": vkMediaPlayPause,
+		"audio_pause": vkMediaPlayPause, "audio_stop": vkMediaStop,
+		"audio_prev": vkMediaPrevTrack, "audio_next": vkMediaNextTrack,
+	}
 )
 
 // KeyEvent is one normalized keyboard operation.
@@ -89,6 +123,10 @@ func (backend *Backend) KeyboardReady() error {
 func (backend *Backend) MouseReady() error {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
+	return backend.mouseReadyLocked()
+}
+
+func (backend *Backend) mouseReadyLocked() error {
 	if err := backend.system.MouseReady(); err != nil {
 		return err
 	}
@@ -97,40 +135,7 @@ func (backend *Backend) MouseReady() error {
 }
 
 func namedVirtualKey(key string) (uint16, bool) {
-	named := map[string]uint16{
-		"backspace": vkBack, "delete": vkDelete,
-		"enter": vkReturn, "tab": vkTab,
-		"esc": vkEscape, "escape": vkEscape,
-		"up": vkUp, "down": vkDown, "right": vkRight, "left": vkLeft,
-		"home": vkHome, "end": vkEnd, "pageup": vkPrior, "pagedown": vkNext,
-		"cmd": vkLWin, "command": vkLWin, "lcmd": vkLWin, "rcmd": vkRWin,
-		"alt": vkMenu, "lalt": vkLMenu, "ralt": vkRMenu,
-		"ctrl": vkControl, "control": vkControl, "lctrl": vkLControl, "rctrl": vkRControl,
-		"shift": vkShift, "lshift": vkLShift, "rshift": vkRShift, "right_shift": vkRShift,
-		"capslock": vkCapital, "space": vkSpace,
-		"print": vkSnapshot, "printscreen": vkSnapshot,
-		"insert": vkInsert, "menu": vkApps,
-		"num0": vkNumpad0, "numpad_0": vkNumpad0,
-		"num1": vkNumpad1, "numpad_1": vkNumpad1,
-		"num2": vkNumpad2, "numpad_2": vkNumpad2,
-		"num3": vkNumpad3, "numpad_3": vkNumpad3,
-		"num4": vkNumpad4, "numpad_4": vkNumpad4,
-		"num5": vkNumpad5, "numpad_5": vkNumpad5,
-		"num6": vkNumpad6, "numpad_6": vkNumpad6,
-		"num7": vkNumpad7, "numpad_7": vkNumpad7,
-		"num8": vkNumpad8, "numpad_8": vkNumpad8,
-		"num9": vkNumpad9, "numpad_9": vkNumpad9,
-		"num_lock": vkNumLock, "numpad_lock": vkNumLock,
-		"num.": vkDecimal, "num+": vkAdd, "num-": vkSubtract,
-		"num*": vkMultiply, "num/": vkDivide, "num_enter": vkReturn,
-		"num_equal":   vkOEMPlus,
-		"scroll_lock": vkScroll, "pause_break": vkPause,
-		"audio_mute": vkVolumeMute, "audio_vol_down": vkVolumeDown,
-		"audio_vol_up": vkVolumeUp, "audio_play": vkMediaPlayPause,
-		"audio_pause": vkMediaPlayPause, "audio_stop": vkMediaStop,
-		"audio_prev": vkMediaPrevTrack, "audio_next": vkMediaNextTrack,
-	}
-	value, ok := named[strings.ToLower(key)]
+	value, ok := namedVirtualKeys[strings.ToLower(key)]
 	return value, ok
 }
 
@@ -187,15 +192,18 @@ func (backend *Backend) resolveKeyLocked(key string) (uint16, []uint16, error) {
 	if value > math.MaxUint16 {
 		return 0, nil, fmt.Errorf("%w: %U has no single Windows virtual key; use text input", ErrUnsupported, value)
 	}
-	virtualKey, shiftState, ok := backend.system.VirtualKeyForRune(uint16(value))
+	virtualKey, shiftState, ok, err := backend.system.VirtualKeyForRune(uint16(value))
+	if err != nil {
+		return 0, nil, err
+	}
 	if !ok {
-		return 0, nil, fmt.Errorf("%w: active Windows keyboard layout cannot map %U; use text input", ErrUnsupported, value)
+		return 0, nil, fmt.Errorf("%w: foreground Windows keyboard layout cannot map %U; use text input", ErrUnsupported, value)
 	}
 	if virtualKey == 0 {
-		return 0, nil, fmt.Errorf("%w: active Windows keyboard layout returned no virtual key for %U", ErrUnsupported, value)
+		return 0, nil, fmt.Errorf("%w: foreground Windows keyboard layout returned no virtual key for %U", ErrUnsupported, value)
 	}
 	if shiftState&^uint8(shiftStateShift|shiftStateControl|shiftStateAlt) != 0 {
-		return 0, nil, fmt.Errorf("%w: active Windows keyboard layout requires unsupported shift state %#x for %U", ErrUnsupported, shiftState, value)
+		return 0, nil, fmt.Errorf("%w: foreground Windows keyboard layout requires unsupported shift state %#x for %U", ErrUnsupported, shiftState, value)
 	}
 	modifiers := make([]uint16, 0, 3)
 	if shiftState&shiftStateShift != 0 {
@@ -248,7 +256,7 @@ func (backend *Backend) temporaryModifierInputsLocked(modifiers []uint16, main u
 	return down, up
 }
 
-// Key injects one layout-aware key transaction.
+// Key injects one foreground-layout-aware key transaction.
 func (backend *Backend) Key(event KeyEvent) error {
 	if event.PID != 0 {
 		return fmt.Errorf("%w: Windows SendInput cannot target a process", ErrUnsupported)
@@ -288,8 +296,19 @@ func (backend *Backend) Key(event KeyEvent) error {
 		inputs = append(inputs, modifierUp...)
 		return backend.sendTrackedLocked(inputs)
 	}
-	if _, owned := backend.ownedKeys[main]; !owned {
+	ownedExtended, owned := backend.ownedKeyExtended[main]
+	if !owned {
 		return fmt.Errorf("%w: key %q was not pressed by this backend", ErrOwnership, event.Key)
+	}
+	if ownedExtended != mainExtended {
+		ownedKind := "standard"
+		if ownedExtended {
+			ownedKind = "extended"
+		}
+		return fmt.Errorf(
+			"%w: key %q does not match the owned %s key",
+			ErrOwnership, event.Key, ownedKind,
+		)
 	}
 	inputs := append(modifierDown, mainInput(false))
 	inputs = append(inputs, modifierUp...)
@@ -312,11 +331,18 @@ func (backend *Backend) Text(event TextEvent) error {
 	if err := backend.system.KeyboardReady(); err != nil {
 		return err
 	}
-	runes := []rune(event.Text)
-	for index, value := range runes {
-		units := utf16.Encode([]rune{value})
-		inputs := make([]trackedInput, 0, len(units)*2)
-		for _, unit := range units {
+	for index, value := range event.Text {
+		var units [2]uint16
+		unitCount := 1
+		if value <= math.MaxUint16 {
+			units[0] = uint16(value)
+		} else {
+			high, low := utf16.EncodeRune(value)
+			units[0], units[1] = uint16(high), uint16(low)
+			unitCount = 2
+		}
+		inputs := make([]trackedInput, 0, unitCount*2)
+		for _, unit := range units[:unitCount] {
 			inputs = append(inputs,
 				trackedUnicodeInput(unit, true),
 				trackedUnicodeInput(unit, false),
@@ -325,7 +351,7 @@ func (backend *Backend) Text(event TextEvent) error {
 		if err := backend.sendTrackedLocked(inputs); err != nil {
 			return fmt.Errorf("type %U: %w", value, err)
 		}
-		if event.Delay > 0 && index+1 < len(runes) {
+		if event.Delay > 0 && index+utf8.RuneLen(value) < len(event.Text) {
 			backend.sleep(event.Delay)
 		}
 	}
@@ -349,6 +375,9 @@ func (backend *Backend) MoveAbsolute(x, y int, _ []int) error {
 	}
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
+	if err := backend.mouseReadyLocked(); err != nil {
+		return err
+	}
 	return backend.system.SetCursorPosition(int32(x), int32(y))
 }
 
@@ -356,6 +385,9 @@ func (backend *Backend) MoveAbsolute(x, y int, _ []int) error {
 func (backend *Backend) MoveRelative(x, y int) error {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
+	if err := backend.system.MouseReady(); err != nil {
+		return err
+	}
 	currentX, currentY, err := backend.system.CursorPosition()
 	if err != nil {
 		return err
@@ -374,13 +406,27 @@ func validSmoothDelayRange(lowDelay, highDelay float64) bool {
 		lowDelay >= 0 && highDelay >= lowDelay && highDelay <= maximumSmoothDelay
 }
 
-func (backend *Backend) moveSmoothLocked(x, y int, relative bool, lowDelay, highDelay float64) error {
+type smoothMovePlan struct {
+	startX, startY   int64
+	targetX, targetY int64
+	steps            int
+	delay            time.Duration
+}
+
+func (backend *Backend) planSmoothMoveLocked(
+	x, y int,
+	relative bool,
+	lowDelay, highDelay float64,
+) (smoothMovePlan, error) {
 	if !validSmoothDelayRange(lowDelay, highDelay) {
-		return fmt.Errorf("Pure-Go Windows invalid smooth-move delay range %g..%g ms", lowDelay, highDelay)
+		return smoothMovePlan{}, fmt.Errorf(
+			"Pure-Go Windows invalid smooth-move delay range %g..%g ms",
+			lowDelay, highDelay,
+		)
 	}
 	startX, startY, err := backend.system.CursorPosition()
 	if err != nil {
-		return err
+		return smoothMovePlan{}, err
 	}
 	targetX, targetY := int64(x), int64(y)
 	if relative {
@@ -389,7 +435,7 @@ func (backend *Backend) moveSmoothLocked(x, y int, relative bool, lowDelay, high
 	}
 	if targetX < math.MinInt32 || targetX > math.MaxInt32 ||
 		targetY < math.MinInt32 || targetY > math.MaxInt32 {
-		return errors.New("Pure-Go Windows smooth pointer target exceeds Win32 coordinates")
+		return smoothMovePlan{}, errors.New("Pure-Go Windows smooth pointer target exceeds Win32 coordinates")
 	}
 	distance := math.Hypot(float64(targetX-int64(startX)), float64(targetY-int64(startY)))
 	steps := int(math.Ceil(distance / 8))
@@ -399,36 +445,55 @@ func (backend *Backend) moveSmoothLocked(x, y int, relative bool, lowDelay, high
 	if steps > 240 {
 		steps = 240
 	}
-	delay := time.Duration((lowDelay + highDelay) / 2 * float64(time.Millisecond))
-	lastX, lastY := int64(startX), int64(startY)
-	for step := 1; step <= steps; step++ {
-		progress := float64(step) / float64(steps)
+	return smoothMovePlan{
+		startX: int64(startX), startY: int64(startY),
+		targetX: targetX, targetY: targetY,
+		steps: steps,
+		delay: time.Duration((lowDelay + highDelay) / 2 * float64(time.Millisecond)),
+	}, nil
+}
+
+func (backend *Backend) executeSmoothMoveLocked(plan smoothMovePlan) error {
+	lastX, lastY := plan.startX, plan.startY
+	for step := 1; step <= plan.steps; step++ {
+		progress := float64(step) / float64(plan.steps)
 		if progress < 0.5 {
 			progress = 4 * progress * progress * progress
 		} else {
 			inverse := -2*progress + 2
 			progress = 1 - inverse*inverse*inverse/2
 		}
-		currentX := int64(math.Round(float64(startX) + float64(targetX-int64(startX))*progress))
-		currentY := int64(math.Round(float64(startY) + float64(targetY-int64(startY))*progress))
-		if currentX == lastX && currentY == lastY && step != steps {
+		currentX := int64(math.Round(float64(plan.startX) + float64(plan.targetX-plan.startX)*progress))
+		currentY := int64(math.Round(float64(plan.startY) + float64(plan.targetY-plan.startY)*progress))
+		if currentX == lastX && currentY == lastY && step != plan.steps {
 			continue
 		}
 		if err := backend.system.SetCursorPosition(int32(currentX), int32(currentY)); err != nil {
 			return err
 		}
 		lastX, lastY = currentX, currentY
-		if delay > 0 && step != steps {
-			backend.sleep(delay)
+		if plan.delay > 0 && step != plan.steps {
+			backend.sleep(plan.delay)
 		}
 	}
 	return nil
+}
+
+func (backend *Backend) moveSmoothLocked(x, y int, relative bool, lowDelay, highDelay float64) error {
+	plan, err := backend.planSmoothMoveLocked(x, y, relative, lowDelay, highDelay)
+	if err != nil {
+		return err
+	}
+	return backend.executeSmoothMoveLocked(plan)
 }
 
 // MoveSmooth performs a bounded eased movement.
 func (backend *Backend) MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
+	if err := backend.system.MouseReady(); err != nil {
+		return err
+	}
 	return backend.moveSmoothLocked(x, y, relative, lowDelay, highDelay)
 }
 
@@ -473,10 +538,7 @@ func (backend *Backend) Click(name string, double bool) error {
 	}
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
-	if err := backend.system.MouseReady(); err != nil {
-		return err
-	}
-	if err := backend.buttonAvailableLocked(flag, virtualKey); err != nil {
+	if err := backend.mouseReadyLocked(); err != nil {
 		return err
 	}
 	count := 1
@@ -484,6 +546,9 @@ func (backend *Backend) Click(name string, double bool) error {
 		count = 2
 	}
 	for click := 0; click < count; click++ {
+		if err := backend.buttonAvailableLocked(flag, virtualKey); err != nil {
+			return err
+		}
 		if err := backend.sendTrackedLocked([]trackedInput{
 			trackedButtonInput(flag, true),
 			trackedButtonInput(flag, false),
@@ -505,7 +570,7 @@ func (backend *Backend) Toggle(name string, down bool) error {
 	}
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
-	if err := backend.system.MouseReady(); err != nil {
+	if err := backend.mouseReadyLocked(); err != nil {
 		return err
 	}
 	if down {
@@ -520,9 +585,22 @@ func (backend *Backend) Toggle(name string, down bool) error {
 
 // DragSmooth owns the left button for the complete drag transaction.
 func (backend *Backend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
+	if !validSmoothDelayRange(lowDelay, highDelay) {
+		return fmt.Errorf("Pure-Go Windows invalid smooth-move delay range %g..%g ms", lowDelay, highDelay)
+	}
+	if err := validateCoordinate(x); err != nil {
+		return err
+	}
+	if err := validateCoordinate(y); err != nil {
+		return err
+	}
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 	if err := backend.system.MouseReady(); err != nil {
+		return err
+	}
+	plan, err := backend.planSmoothMoveLocked(x, y, false, lowDelay, highDelay)
+	if err != nil {
 		return err
 	}
 	if err := backend.buttonAvailableLocked(mouseEventLeftDown, vkLButton); err != nil {
@@ -533,7 +611,7 @@ func (backend *Backend) DragSmooth(x, y int, lowDelay, highDelay float64) error 
 		return downErr
 	}
 	backend.sleep(dragStartDelay)
-	moveErr := backend.moveSmoothLocked(x, y, false, lowDelay, highDelay)
+	moveErr := backend.executeSmoothMoveLocked(plan)
 	upErr := backend.sendTrackedLocked([]trackedInput{trackedButtonInput(mouseEventLeftDown, false)})
 	return errors.Join(moveErr, upErr)
 }
@@ -542,6 +620,9 @@ func (backend *Backend) DragSmooth(x, y int, lowDelay, highDelay float64) error 
 func (backend *Backend) Location() (int, int, error) {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
+	if err := backend.system.MouseReady(); err != nil {
+		return 0, 0, err
+	}
 	x, y, err := backend.system.CursorPosition()
 	return int(x), int(y), err
 }
@@ -565,7 +646,7 @@ func (backend *Backend) Scroll(x, y int) error {
 	}
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
-	if err := backend.system.MouseReady(); err != nil {
+	if err := backend.mouseReadyLocked(); err != nil {
 		return err
 	}
 	return backend.sendTrackedLocked(inputs)

--- a/internal/windowsinput/backend_windows_test.go
+++ b/internal/windowsinput/backend_windows_test.go
@@ -4,6 +4,8 @@ package windowsinput
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"testing"
@@ -21,6 +23,7 @@ type fakeSystem struct {
 	mouseErr    error
 	cursorErr   error
 	setErr      error
+	layoutErr   error
 
 	x int32
 	y int32
@@ -63,12 +66,10 @@ func (system *fakeSystem) KeyDown(key uint16) bool {
 	return system.down[key]
 }
 
-func (system *fakeSystem) VirtualKeyForRune(value uint16) (uint16, uint8, bool) {
+func (system *fakeSystem) VirtualKeyForRune(value uint16) (uint16, uint8, bool, error) {
 	key, ok := system.layout[value]
-	return key, system.shiftState[value], ok
+	return key, system.shiftState[value], ok, system.layoutErr
 }
-
-func (*fakeSystem) ScanCodeForVirtualKey(uint16) uint16 { return 0 }
 
 func newFakeBackend(system *fakeSystem, sleeps *[]time.Duration) *Backend {
 	if system.down == nil {
@@ -117,7 +118,18 @@ func TestInputRecordMatchesWin32Layout(t *testing.T) {
 	}
 }
 
-func TestKeyUsesActiveLayoutAndCallerModifiers(t *testing.T) {
+func TestRequiredUser32ProceduresResolve(t *testing.T) {
+	t.Parallel()
+	system := newWin32System()
+	if err := system.KeyboardReady(); err != nil {
+		t.Fatalf("keyboard procedures: %v", err)
+	}
+	if err := system.MouseReady(); err != nil {
+		t.Fatalf("pointer procedures: %v", err)
+	}
+}
+
+func TestKeyUsesForegroundLayoutAndCallerModifiers(t *testing.T) {
 	system := &fakeSystem{
 		layout:     map[uint16]uint16{'@': 0x51},
 		shiftState: map[uint16]uint8{'@': shiftStateControl | shiftStateAlt},
@@ -146,6 +158,18 @@ func TestKeyUsesActiveLayoutAndCallerModifiers(t *testing.T) {
 	}
 	if len(backend.ownedKeys) != 0 {
 		t.Fatalf("tap left owned keys: %#v", backend.ownedKeys)
+	}
+}
+
+func TestKeyPreservesForegroundLayoutFailure(t *testing.T) {
+	layoutErr := fmt.Errorf("%w: no foreground window", ErrUnsupported)
+	system := &fakeSystem{layoutErr: layoutErr}
+	backend := newFakeBackend(system, nil)
+	if err := backend.Key(KeyEvent{Key: "a", Tap: true}); !errors.Is(err, layoutErr) {
+		t.Fatalf("Key error = %v, want foreground-layout error", err)
+	}
+	if len(system.sends) != 0 {
+		t.Fatalf("layout failure injected %d input transactions", len(system.sends))
 	}
 }
 
@@ -188,6 +212,28 @@ func TestKeyHoldRequiresOwnershipAndCloseReleases(t *testing.T) {
 		{vkReturn, 0, keyEventKeyUp},
 	}) {
 		t.Fatalf("Close transaction = %#v", got)
+	}
+}
+
+func TestKeyReleasePreservesExtendedIdentity(t *testing.T) {
+	system := &fakeSystem{}
+	backend := newFakeBackend(system, nil)
+	if err := backend.Key(KeyEvent{Key: "num_enter", Down: true}); err != nil {
+		t.Fatalf("numpad enter down: %v", err)
+	}
+	if err := backend.Key(KeyEvent{Key: "enter", Down: false}); !errors.Is(err, ErrOwnership) {
+		t.Fatalf("standard enter release error = %v, want ErrOwnership", err)
+	}
+	if len(system.sends) != 1 {
+		t.Fatalf("mismatched release performed %d SendInput calls, want 1", len(system.sends))
+	}
+	if err := backend.Key(KeyEvent{Key: "num_enter", Down: false}); err != nil {
+		t.Fatalf("numpad enter up: %v", err)
+	}
+	release := decodeKeyboard(system.sends[1][0])
+	if release.VirtualKey != vkReturn ||
+		release.Flags != keyEventExtended|keyEventKeyUp {
+		t.Fatalf("numpad enter release = %+v", release)
 	}
 }
 
@@ -267,6 +313,25 @@ func TestPartialUnicodeTransactionReleasesPressedUnit(t *testing.T) {
 	}
 }
 
+func TestPartialButtonTransactionReleasesPressedButton(t *testing.T) {
+	injectionErr := errors.New("button partial")
+	system := &fakeSystem{sendPlan: []sendResult{
+		{inserted: 1, err: injectionErr},
+		{inserted: 1},
+	}}
+	backend := newFakeBackend(system, nil)
+	if err := backend.Click("left", false); !errors.Is(err, injectionErr) {
+		t.Fatalf("Click error = %v, want injection error", err)
+	}
+	if len(backend.ownedButtons) != 0 {
+		t.Fatalf("rollback left owned buttons: %#v", backend.ownedButtons)
+	}
+	if len(system.sends) != 2 ||
+		system.sends[1][0].Payload.Flags != mouseEventLeftUp {
+		t.Fatalf("button rollback transactions = %#v", system.sends)
+	}
+}
+
 func TestClickDoubleAndScrollDirections(t *testing.T) {
 	system := &fakeSystem{}
 	var sleeps []time.Duration
@@ -296,6 +361,23 @@ func TestClickDoubleAndScrollDirections(t *testing.T) {
 	}
 	if got := int32(scroll[1].Payload.MouseData); scroll[1].Payload.Flags != mouseEventWheel || got != -3*wheelDelta {
 		t.Fatalf("vertical scroll = flags %#x data %d", scroll[1].Payload.Flags, got)
+	}
+}
+
+func TestDoubleClickRechecksForeignButtonState(t *testing.T) {
+	system := &fakeSystem{}
+	backend := newBackend(system, func(time.Duration) {
+		system.down[vkLButton] = true
+	})
+	system.down = make(map[uint16]bool)
+	if err := backend.Click("left", true); !errors.Is(err, ErrOwnership) {
+		t.Fatalf("Click error = %v, want ownership conflict", err)
+	}
+	if len(system.sends) != 1 {
+		t.Fatalf("double click injected %d pulses, want only the first", len(system.sends))
+	}
+	if len(backend.ownedButtons) != 0 {
+		t.Fatalf("double click left owned buttons: %#v", backend.ownedButtons)
 	}
 }
 
@@ -333,5 +415,67 @@ func TestReadyErrorsArePreserved(t *testing.T) {
 	}
 	if err := backend.MouseReady(); !errors.Is(err, mouseErr) {
 		t.Fatalf("MouseReady = %v", err)
+	}
+}
+
+func TestPointerOperationsCheckReadinessBeforeSideEffects(t *testing.T) {
+	mouseErr := errors.New("input desktop unavailable")
+	system := &fakeSystem{mouseErr: mouseErr}
+	backend := newFakeBackend(system, nil)
+	operations := map[string]func() error{
+		"move absolute": func() error { return backend.MoveAbsolute(1, 2, nil) },
+		"move relative": func() error { return backend.MoveRelative(1, 2) },
+		"move smooth":   func() error { return backend.MoveSmooth(1, 2, false, 0, 0) },
+		"drag smooth":   func() error { return backend.DragSmooth(1, 2, 0, 0) },
+		"location": func() error {
+			_, _, err := backend.Location()
+			return err
+		},
+		"click":  func() error { return backend.Click("left", false) },
+		"toggle": func() error { return backend.Toggle("left", true) },
+		"scroll": func() error { return backend.Scroll(0, 1) },
+	}
+	for name, operation := range operations {
+		if err := operation(); !errors.Is(err, mouseErr) {
+			t.Errorf("%s error = %v, want readiness error", name, err)
+		}
+	}
+	if len(system.sends) != 0 {
+		t.Fatalf("readiness failures injected %d input transactions", len(system.sends))
+	}
+	if len(system.positions) != 0 {
+		t.Fatalf("readiness failures moved the pointer: %#v", system.positions)
+	}
+}
+
+func TestInvalidDragIsSideEffectFree(t *testing.T) {
+	system := &fakeSystem{}
+	backend := newFakeBackend(system, nil)
+	if err := backend.DragSmooth(10, 20, 0, maximumSmoothDelay+1); err == nil {
+		t.Fatal("DragSmooth accepted an excessive delay")
+	}
+	if strconv.IntSize == 64 {
+		outOfRange := int64(math.MaxInt32) + 1
+		if err := backend.DragSmooth(int(outOfRange), 20, 0, 0); err == nil {
+			t.Fatal("DragSmooth accepted an out-of-range coordinate")
+		}
+	}
+	if len(system.sends) != 0 {
+		t.Fatalf("invalid drag injected %d input transactions", len(system.sends))
+	}
+	if len(system.positions) != 0 {
+		t.Fatalf("invalid drag moved the pointer: %#v", system.positions)
+	}
+}
+
+func TestDragPlanningFailureIsSideEffectFree(t *testing.T) {
+	cursorErr := errors.New("cursor query failed")
+	system := &fakeSystem{cursorErr: cursorErr}
+	backend := newFakeBackend(system, nil)
+	if err := backend.DragSmooth(10, 20, 0, 0); !errors.Is(err, cursorErr) {
+		t.Fatalf("DragSmooth error = %v, want cursor error", err)
+	}
+	if len(system.sends) != 0 {
+		t.Fatalf("failed drag planning injected %d input transactions", len(system.sends))
 	}
 }

--- a/internal/windowsinput/backend_windows_test.go
+++ b/internal/windowsinput/backend_windows_test.go
@@ -1,0 +1,337 @@
+//go:build windows
+
+package windowsinput
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+type sendResult struct {
+	inserted int
+	err      error
+}
+
+type fakeSystem struct {
+	keyboardErr error
+	mouseErr    error
+	cursorErr   error
+	setErr      error
+
+	x int32
+	y int32
+
+	down       map[uint16]bool
+	layout     map[uint16]uint16
+	shiftState map[uint16]uint8
+	sendPlan   []sendResult
+	sends      [][]inputRecord
+	positions  [][2]int32
+}
+
+func (system *fakeSystem) KeyboardReady() error { return system.keyboardErr }
+func (system *fakeSystem) MouseReady() error    { return system.mouseErr }
+
+func (system *fakeSystem) SendInput(records []inputRecord) (int, error) {
+	system.sends = append(system.sends, append([]inputRecord(nil), records...))
+	if len(system.sendPlan) == 0 {
+		return len(records), nil
+	}
+	result := system.sendPlan[0]
+	system.sendPlan = system.sendPlan[1:]
+	return result.inserted, result.err
+}
+
+func (system *fakeSystem) CursorPosition() (int32, int32, error) {
+	return system.x, system.y, system.cursorErr
+}
+
+func (system *fakeSystem) SetCursorPosition(x, y int32) error {
+	if system.setErr != nil {
+		return system.setErr
+	}
+	system.x, system.y = x, y
+	system.positions = append(system.positions, [2]int32{x, y})
+	return nil
+}
+
+func (system *fakeSystem) KeyDown(key uint16) bool {
+	return system.down[key]
+}
+
+func (system *fakeSystem) VirtualKeyForRune(value uint16) (uint16, uint8, bool) {
+	key, ok := system.layout[value]
+	return key, system.shiftState[value], ok
+}
+
+func (*fakeSystem) ScanCodeForVirtualKey(uint16) uint16 { return 0 }
+
+func newFakeBackend(system *fakeSystem, sleeps *[]time.Duration) *Backend {
+	if system.down == nil {
+		system.down = make(map[uint16]bool)
+	}
+	if system.layout == nil {
+		system.layout = map[uint16]uint16{
+			'a': 0x41,
+			'A': 0x41,
+		}
+	}
+	if system.shiftState == nil {
+		system.shiftState = map[uint16]uint8{'A': shiftStateShift}
+	}
+	return newBackend(system, func(delay time.Duration) {
+		if sleeps != nil {
+			*sleeps = append(*sleeps, delay)
+		}
+	})
+}
+
+func decodeKeyboard(record inputRecord) keyboardInput {
+	return *(*keyboardInput)(unsafe.Pointer(&record.Payload))
+}
+
+func keyboardSummary(records []inputRecord) [][3]uint32 {
+	result := make([][3]uint32, len(records))
+	for index, record := range records {
+		key := decodeKeyboard(record)
+		result[index] = [3]uint32{uint32(key.VirtualKey), uint32(key.ScanCode), key.Flags}
+	}
+	return result
+}
+
+func TestInputRecordMatchesWin32Layout(t *testing.T) {
+	t.Parallel()
+	want := uintptr(40)
+	if strconv.IntSize == 32 {
+		want = 28
+	}
+	if got := unsafe.Sizeof(inputRecord{}); got != want {
+		t.Fatalf("sizeof(INPUT) = %d, want %d", got, want)
+	}
+	if got := unsafe.Offsetof(inputRecord{}.Payload); got != unsafe.Alignof(uintptr(0)) {
+		t.Fatalf("INPUT union offset = %d, want %d", got, unsafe.Alignof(uintptr(0)))
+	}
+}
+
+func TestKeyUsesActiveLayoutAndCallerModifiers(t *testing.T) {
+	system := &fakeSystem{
+		layout:     map[uint16]uint16{'@': 0x51},
+		shiftState: map[uint16]uint8{'@': shiftStateControl | shiftStateAlt},
+	}
+	backend := newFakeBackend(system, nil)
+	if err := backend.Key(KeyEvent{
+		Key: "@", Modifiers: []string{"shift"}, Down: true, Tap: true,
+	}); err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if len(system.sends) != 1 {
+		t.Fatalf("SendInput calls = %d, want 1", len(system.sends))
+	}
+	want := [][3]uint32{
+		{vkControl, 0, 0},
+		{vkMenu, 0, 0},
+		{vkShift, 0, 0},
+		{0x51, 0, 0},
+		{0x51, 0, keyEventKeyUp},
+		{vkShift, 0, keyEventKeyUp},
+		{vkMenu, 0, keyEventKeyUp},
+		{vkControl, 0, keyEventKeyUp},
+	}
+	if got := keyboardSummary(system.sends[0]); !reflect.DeepEqual(got, want) {
+		t.Fatalf("keyboard transaction = %#v, want %#v", got, want)
+	}
+	if len(backend.ownedKeys) != 0 {
+		t.Fatalf("tap left owned keys: %#v", backend.ownedKeys)
+	}
+}
+
+func TestKeyPreservesAlreadyHeldModifier(t *testing.T) {
+	system := &fakeSystem{down: map[uint16]bool{vkControl: true}}
+	backend := newFakeBackend(system, nil)
+	if err := backend.Key(KeyEvent{
+		Key: "a", Modifiers: []string{"ctrl"}, Down: true, Tap: true,
+	}); err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	want := [][3]uint32{
+		{0x41, 0, 0},
+		{0x41, 0, keyEventKeyUp},
+	}
+	if got := keyboardSummary(system.sends[0]); !reflect.DeepEqual(got, want) {
+		t.Fatalf("keyboard transaction = %#v, want %#v", got, want)
+	}
+}
+
+func TestKeyHoldRequiresOwnershipAndCloseReleases(t *testing.T) {
+	system := &fakeSystem{}
+	backend := newFakeBackend(system, nil)
+	if err := backend.Key(KeyEvent{Key: "enter", Down: false}); !errors.Is(err, ErrOwnership) {
+		t.Fatalf("orphan key up error = %v, want ErrOwnership", err)
+	}
+	if err := backend.Key(KeyEvent{Key: "enter", Down: true}); err != nil {
+		t.Fatalf("key down: %v", err)
+	}
+	if _, owned := backend.ownedKeys[vkReturn]; !owned {
+		t.Fatal("key down was not tracked")
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(backend.ownedKeys) != 0 {
+		t.Fatalf("Close left owned keys: %#v", backend.ownedKeys)
+	}
+	if got := keyboardSummary(system.sends[len(system.sends)-1]); !reflect.DeepEqual(got, [][3]uint32{
+		{vkReturn, 0, keyEventKeyUp},
+	}) {
+		t.Fatalf("Close transaction = %#v", got)
+	}
+}
+
+func TestPartialKeyTransactionRollsBackNewHolds(t *testing.T) {
+	injectionErr := errors.New("partial injection")
+	system := &fakeSystem{sendPlan: []sendResult{
+		{inserted: 2, err: injectionErr},
+		{inserted: 1},
+		{inserted: 1},
+	}}
+	backend := newFakeBackend(system, nil)
+	err := backend.Key(KeyEvent{
+		Key: "a", Modifiers: []string{"ctrl"}, Down: true,
+	})
+	if !errors.Is(err, injectionErr) {
+		t.Fatalf("Key error = %v, want injection error", err)
+	}
+	if len(backend.ownedKeys) != 0 {
+		t.Fatalf("rollback left owned keys: %#v", backend.ownedKeys)
+	}
+	if len(system.sends) != 3 {
+		t.Fatalf("SendInput calls = %d, want transaction plus two releases", len(system.sends))
+	}
+	gotReleaseKeys := []uint16{
+		decodeKeyboard(system.sends[1][0]).VirtualKey,
+		decodeKeyboard(system.sends[2][0]).VirtualKey,
+	}
+	if want := []uint16{0x41, vkControl}; !reflect.DeepEqual(gotReleaseKeys, want) {
+		t.Fatalf("rollback keys = %#v, want %#v", gotReleaseKeys, want)
+	}
+}
+
+func TestTextUsesUTF16PairsAndRuneDelay(t *testing.T) {
+	system := &fakeSystem{}
+	var sleeps []time.Duration
+	backend := newFakeBackend(system, &sleeps)
+	if err := backend.Text(TextEvent{
+		Text: "😀A", Delay: 7 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("Text: %v", err)
+	}
+	if len(system.sends) != 2 {
+		t.Fatalf("SendInput calls = %d, want one per rune", len(system.sends))
+	}
+	first := keyboardSummary(system.sends[0])
+	wantFirst := [][3]uint32{
+		{0, 0xd83d, keyEventUnicode},
+		{0, 0xd83d, keyEventUnicode | keyEventKeyUp},
+		{0, 0xde00, keyEventUnicode},
+		{0, 0xde00, keyEventUnicode | keyEventKeyUp},
+	}
+	if !reflect.DeepEqual(first, wantFirst) {
+		t.Fatalf("surrogate transaction = %#v, want %#v", first, wantFirst)
+	}
+	if !reflect.DeepEqual(sleeps, []time.Duration{7 * time.Millisecond}) {
+		t.Fatalf("text sleeps = %#v", sleeps)
+	}
+}
+
+func TestPartialUnicodeTransactionReleasesPressedUnit(t *testing.T) {
+	injectionErr := errors.New("unicode partial")
+	system := &fakeSystem{sendPlan: []sendResult{
+		{inserted: 1, err: injectionErr},
+		{inserted: 1},
+	}}
+	backend := newFakeBackend(system, nil)
+	err := backend.Text(TextEvent{Text: "A"})
+	if !errors.Is(err, injectionErr) {
+		t.Fatalf("Text error = %v, want injection error", err)
+	}
+	if len(backend.ownedUnicode) != 0 {
+		t.Fatalf("rollback left Unicode units: %#v", backend.ownedUnicode)
+	}
+	release := decodeKeyboard(system.sends[1][0])
+	if release.ScanCode != 'A' || release.Flags != keyEventUnicode|keyEventKeyUp {
+		t.Fatalf("Unicode rollback = %+v", release)
+	}
+}
+
+func TestClickDoubleAndScrollDirections(t *testing.T) {
+	system := &fakeSystem{}
+	var sleeps []time.Duration
+	backend := newFakeBackend(system, &sleeps)
+	if err := backend.Click("right", true); err != nil {
+		t.Fatalf("Click: %v", err)
+	}
+	if !reflect.DeepEqual(sleeps, []time.Duration{doubleClickGap}) {
+		t.Fatalf("double-click sleeps = %#v", sleeps)
+	}
+	for index, records := range system.sends[:2] {
+		if len(records) != 2 ||
+			records[0].Payload.Flags != mouseEventRightDown ||
+			records[1].Payload.Flags != mouseEventRightUp {
+			t.Fatalf("click %d records = %#v", index, records)
+		}
+	}
+	if err := backend.Scroll(2, -3); err != nil {
+		t.Fatalf("Scroll: %v", err)
+	}
+	scroll := system.sends[2]
+	if len(scroll) != 2 {
+		t.Fatalf("scroll records = %d, want 2", len(scroll))
+	}
+	if got := int32(scroll[0].Payload.MouseData); scroll[0].Payload.Flags != mouseEventHWheel || got != -2*wheelDelta {
+		t.Fatalf("horizontal scroll = flags %#x data %d", scroll[0].Payload.Flags, got)
+	}
+	if got := int32(scroll[1].Payload.MouseData); scroll[1].Payload.Flags != mouseEventWheel || got != -3*wheelDelta {
+		t.Fatalf("vertical scroll = flags %#x data %d", scroll[1].Payload.Flags, got)
+	}
+}
+
+func TestPointerOwnershipAndSmoothMovement(t *testing.T) {
+	system := &fakeSystem{x: -10, y: 20}
+	var sleeps []time.Duration
+	backend := newFakeBackend(system, &sleeps)
+	if err := backend.Toggle("left", false); !errors.Is(err, ErrOwnership) {
+		t.Fatalf("orphan button up error = %v, want ErrOwnership", err)
+	}
+	if err := backend.MoveRelative(5, -8); err != nil {
+		t.Fatalf("MoveRelative: %v", err)
+	}
+	if system.x != -5 || system.y != 12 {
+		t.Fatalf("relative position = (%d,%d), want (-5,12)", system.x, system.y)
+	}
+	if err := backend.MoveSmooth(11, 12, false, 0, 0); err != nil {
+		t.Fatalf("MoveSmooth: %v", err)
+	}
+	if system.x != 11 || system.y != 12 {
+		t.Fatalf("smooth position = (%d,%d), want (11,12)", system.x, system.y)
+	}
+	if len(sleeps) != 0 {
+		t.Fatalf("zero-delay smooth move slept: %#v", sleeps)
+	}
+}
+
+func TestReadyErrorsArePreserved(t *testing.T) {
+	keyboardErr := errors.New("keyboard unavailable")
+	mouseErr := errors.New("mouse unavailable")
+	system := &fakeSystem{keyboardErr: keyboardErr, mouseErr: mouseErr}
+	backend := newFakeBackend(system, nil)
+	if err := backend.KeyboardReady(); !errors.Is(err, keyboardErr) {
+		t.Fatalf("KeyboardReady = %v", err)
+	}
+	if err := backend.MouseReady(); !errors.Is(err, mouseErr) {
+		t.Fatalf("MouseReady = %v", err)
+	}
+}

--- a/internal/windowsinput/syscall_windows.go
+++ b/internal/windowsinput/syscall_windows.go
@@ -5,6 +5,7 @@ package windowsinput
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -28,8 +29,6 @@ const (
 	mouseEventHWheel     = 0x1000
 
 	wheelDelta = 120
-
-	mapVirtualKeyToScanCode = 0
 
 	shiftStateShift   = 1
 	shiftStateControl = 2
@@ -219,42 +218,52 @@ type inputSystem interface {
 	CursorPosition() (int32, int32, error)
 	SetCursorPosition(int32, int32) error
 	KeyDown(uint16) bool
-	VirtualKeyForRune(uint16) (uint16, uint8, bool)
-	ScanCodeForVirtualKey(uint16) uint16
+	VirtualKeyForRune(uint16) (uint16, uint8, bool, error)
 }
 
 type win32System struct {
-	sendInput        *windows.LazyProc
-	getCursorPos     *windows.LazyProc
-	setCursorPos     *windows.LazyProc
-	getAsyncKeyState *windows.LazyProc
-	vkKeyScanW       *windows.LazyProc
-	mapVirtualKeyW   *windows.LazyProc
+	sendInput                *windows.LazyProc
+	getCursorPos             *windows.LazyProc
+	setCursorPos             *windows.LazyProc
+	getAsyncKeyState         *windows.LazyProc
+	getForegroundWindow      *windows.LazyProc
+	getWindowThreadProcessID *windows.LazyProc
+	getKeyboardLayout        *windows.LazyProc
+	vkKeyScanExW             *windows.LazyProc
 }
 
 func newWin32System() *win32System {
 	user32 := windows.NewLazySystemDLL("user32.dll")
 	return &win32System{
-		sendInput:        user32.NewProc("SendInput"),
-		getCursorPos:     user32.NewProc("GetCursorPos"),
-		setCursorPos:     user32.NewProc("SetCursorPos"),
-		getAsyncKeyState: user32.NewProc("GetAsyncKeyState"),
-		vkKeyScanW:       user32.NewProc("VkKeyScanW"),
-		mapVirtualKeyW:   user32.NewProc("MapVirtualKeyW"),
+		sendInput:                user32.NewProc("SendInput"),
+		getCursorPos:             user32.NewProc("GetCursorPos"),
+		setCursorPos:             user32.NewProc("SetCursorPos"),
+		getAsyncKeyState:         user32.NewProc("GetAsyncKeyState"),
+		getForegroundWindow:      user32.NewProc("GetForegroundWindow"),
+		getWindowThreadProcessID: user32.NewProc("GetWindowThreadProcessId"),
+		getKeyboardLayout:        user32.NewProc("GetKeyboardLayout"),
+		vkKeyScanExW:             user32.NewProc("VkKeyScanExW"),
 	}
 }
 
 func findProcedures(procedures ...*windows.LazyProc) error {
 	for _, procedure := range procedures {
 		if err := procedure.Find(); err != nil {
-			return fmt.Errorf("resolve user32.%s: %w", procedure.Name, err)
+			return fmt.Errorf("%w: resolve user32.%s: %w", ErrUnsupported, procedure.Name, err)
 		}
 	}
 	return nil
 }
 
 func (system *win32System) KeyboardReady() error {
-	return findProcedures(system.sendInput, system.getAsyncKeyState, system.vkKeyScanW, system.mapVirtualKeyW)
+	return findProcedures(
+		system.sendInput,
+		system.getAsyncKeyState,
+		system.getForegroundWindow,
+		system.getWindowThreadProcessID,
+		system.getKeyboardLayout,
+		system.vkKeyScanExW,
+	)
 }
 
 func (system *win32System) MouseReady() error {
@@ -277,6 +286,7 @@ func (system *win32System) SendInput(records []inputRecord) (int, error) {
 		uintptr(unsafe.Pointer(&records[0])),
 		unsafe.Sizeof(records[0]),
 	)
+	runtime.KeepAlive(records)
 	count := int(inserted)
 	if count == len(records) {
 		return count, nil
@@ -320,18 +330,25 @@ func (system *win32System) KeyDown(key uint16) bool {
 	return int16(uint16(result)) < 0
 }
 
-func (system *win32System) VirtualKeyForRune(value uint16) (uint16, uint8, bool) {
-	result, _, _ := system.vkKeyScanW.Call(uintptr(value))
+func (system *win32System) VirtualKeyForRune(value uint16) (uint16, uint8, bool, error) {
+	foreground, _, _ := system.getForegroundWindow.Call()
+	if foreground == 0 {
+		return 0, 0, false, fmt.Errorf("%w: Windows has no foreground window whose keyboard layout can be queried", ErrUnsupported)
+	}
+	threadID, _, _ := system.getWindowThreadProcessID.Call(foreground, 0)
+	if threadID == 0 {
+		return 0, 0, false, fmt.Errorf("%w: foreground Windows thread is unavailable", ErrUnsupported)
+	}
+	layout, _, _ := system.getKeyboardLayout.Call(threadID)
+	if layout == 0 {
+		return 0, 0, false, fmt.Errorf("%w: foreground Windows keyboard layout is unavailable", ErrUnsupported)
+	}
+	result, _, _ := system.vkKeyScanExW.Call(uintptr(value), layout)
 	translated := uint16(result)
 	if translated == mathMaxUint16 {
-		return 0, 0, false
+		return 0, 0, false, nil
 	}
-	return translated & 0xff, uint8(translated >> 8), true
-}
-
-func (system *win32System) ScanCodeForVirtualKey(value uint16) uint16 {
-	result, _, _ := system.mapVirtualKeyW.Call(uintptr(value), mapVirtualKeyToScanCode)
-	return uint16(result)
+	return translated & 0xff, uint8(translated >> 8), true, nil
 }
 
 const mathMaxUint16 = ^uint16(0)
@@ -405,14 +422,6 @@ func copyUint32Set(source map[uint32]struct{}) map[uint32]struct{} {
 	return result
 }
 
-func (backend *Backend) prepareRecord(input *trackedInput) inputRecord {
-	if input.kind == trackedKey {
-		keyboard := (*keyboardInput)(unsafe.Pointer(&input.record.Payload))
-		keyboard.ScanCode = backend.system.ScanCodeForVirtualKey(uint16(input.code))
-	}
-	return input.record
-}
-
 func (backend *Backend) rollbackNewOwnershipLocked(
 	keysBefore map[uint16]struct{},
 	buttonsBefore map[uint32]struct{},
@@ -422,9 +431,7 @@ func (backend *Backend) rollbackNewOwnershipLocked(
 	for index := len(backend.ownedUnicode) - 1; index >= unicodeCountBefore; index-- {
 		unit := backend.ownedUnicode[index]
 		release := trackedUnicodeInput(unit, false)
-		inserted, err := backend.system.SendInput([]inputRecord{
-			backend.prepareRecord(&release),
-		})
+		inserted, err := backend.system.SendInput([]inputRecord{release.record})
 		if inserted == 1 {
 			backend.applyTrackedInput(release)
 		}
@@ -436,7 +443,7 @@ func (backend *Backend) rollbackNewOwnershipLocked(
 			continue
 		}
 		release := trackedKeyInputExtended(key, false, backend.ownedKeyExtended[key])
-		inserted, err := backend.system.SendInput([]inputRecord{backend.prepareRecord(&release)})
+		inserted, err := backend.system.SendInput([]inputRecord{release.record})
 		if inserted == 1 {
 			backend.applyTrackedInput(release)
 		}
@@ -448,7 +455,7 @@ func (backend *Backend) rollbackNewOwnershipLocked(
 			continue
 		}
 		release := trackedButtonInput(button, false)
-		inserted, err := backend.system.SendInput([]inputRecord{backend.prepareRecord(&release)})
+		inserted, err := backend.system.SendInput([]inputRecord{release.record})
 		if inserted == 1 {
 			backend.applyTrackedInput(release)
 		}
@@ -463,7 +470,7 @@ func (backend *Backend) sendTrackedLocked(inputs []trackedInput) error {
 	}
 	records := make([]inputRecord, len(inputs))
 	for index := range inputs {
-		records[index] = backend.prepareRecord(&inputs[index])
+		records[index] = inputs[index].record
 	}
 	keysBefore := copyUint16Set(backend.ownedKeys)
 	buttonsBefore := copyUint32Set(backend.ownedButtons)

--- a/internal/windowsinput/syscall_windows.go
+++ b/internal/windowsinput/syscall_windows.go
@@ -1,0 +1,492 @@
+//go:build windows
+
+package windowsinput
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	inputMouse    = 0
+	inputKeyboard = 1
+
+	keyEventExtended = 0x0001
+	keyEventKeyUp    = 0x0002
+	keyEventUnicode  = 0x0004
+
+	mouseEventLeftDown   = 0x0002
+	mouseEventLeftUp     = 0x0004
+	mouseEventRightDown  = 0x0008
+	mouseEventRightUp    = 0x0010
+	mouseEventMiddleDown = 0x0020
+	mouseEventMiddleUp   = 0x0040
+	mouseEventWheel      = 0x0800
+	mouseEventHWheel     = 0x1000
+
+	wheelDelta = 120
+
+	mapVirtualKeyToScanCode = 0
+
+	shiftStateShift   = 1
+	shiftStateControl = 2
+	shiftStateAlt     = 4
+)
+
+const (
+	vkLButton        = 0x01
+	vkRButton        = 0x02
+	vkMButton        = 0x04
+	vkBack           = 0x08
+	vkTab            = 0x09
+	vkReturn         = 0x0d
+	vkShift          = 0x10
+	vkControl        = 0x11
+	vkMenu           = 0x12
+	vkPause          = 0x13
+	vkCapital        = 0x14
+	vkEscape         = 0x1b
+	vkSpace          = 0x20
+	vkPrior          = 0x21
+	vkNext           = 0x22
+	vkEnd            = 0x23
+	vkHome           = 0x24
+	vkLeft           = 0x25
+	vkUp             = 0x26
+	vkRight          = 0x27
+	vkDown           = 0x28
+	vkSnapshot       = 0x2c
+	vkInsert         = 0x2d
+	vkDelete         = 0x2e
+	vkLWin           = 0x5b
+	vkRWin           = 0x5c
+	vkApps           = 0x5d
+	vkNumpad0        = 0x60
+	vkNumpad1        = 0x61
+	vkNumpad2        = 0x62
+	vkNumpad3        = 0x63
+	vkNumpad4        = 0x64
+	vkNumpad5        = 0x65
+	vkNumpad6        = 0x66
+	vkNumpad7        = 0x67
+	vkNumpad8        = 0x68
+	vkNumpad9        = 0x69
+	vkMultiply       = 0x6a
+	vkAdd            = 0x6b
+	vkSubtract       = 0x6d
+	vkDecimal        = 0x6e
+	vkDivide         = 0x6f
+	vkF1             = 0x70
+	vkNumLock        = 0x90
+	vkScroll         = 0x91
+	vkLShift         = 0xa0
+	vkRShift         = 0xa1
+	vkLControl       = 0xa2
+	vkRControl       = 0xa3
+	vkLMenu          = 0xa4
+	vkRMenu          = 0xa5
+	vkVolumeMute     = 0xad
+	vkVolumeDown     = 0xae
+	vkVolumeUp       = 0xaf
+	vkMediaNextTrack = 0xb0
+	vkMediaPrevTrack = 0xb1
+	vkMediaStop      = 0xb2
+	vkMediaPlayPause = 0xb3
+	vkOEMPlus        = 0xbb
+)
+
+type mouseInput struct {
+	X         int32
+	Y         int32
+	MouseData uint32
+	Flags     uint32
+	Time      uint32
+	ExtraInfo uintptr
+}
+
+type keyboardInput struct {
+	VirtualKey uint16
+	ScanCode   uint16
+	Flags      uint32
+	Time       uint32
+	ExtraInfo  uintptr
+}
+
+// inputRecord uses MOUSEINPUT as the union backing because it is the largest
+// INPUT payload on both 32-bit and 64-bit Windows. Go's alignment then matches
+// INPUT: 28 bytes on 32-bit and 40 bytes on 64-bit.
+type inputRecord struct {
+	Type    uint32
+	Payload mouseInput
+}
+
+type trackedKind uint8
+
+const (
+	trackedNone trackedKind = iota
+	trackedKey
+	trackedButton
+	trackedUnicode
+)
+
+type trackedInput struct {
+	record   inputRecord
+	kind     trackedKind
+	code     uint32
+	down     bool
+	extended bool
+}
+
+func keyboardRecord(virtualKey, scanCode uint16, flags uint32) inputRecord {
+	record := inputRecord{Type: inputKeyboard}
+	keyboard := (*keyboardInput)(unsafe.Pointer(&record.Payload))
+	keyboard.VirtualKey = virtualKey
+	keyboard.ScanCode = scanCode
+	keyboard.Flags = flags
+	return record
+}
+
+func trackedKeyInput(key uint16, down bool) trackedInput {
+	return trackedKeyInputExtended(key, down, extendedVirtualKey(key))
+}
+
+func trackedKeyInputExtended(key uint16, down, extended bool) trackedInput {
+	flags := uint32(0)
+	if extended {
+		flags |= keyEventExtended
+	}
+	if !down {
+		flags |= keyEventKeyUp
+	}
+	return trackedInput{
+		record: keyboardRecord(key, 0, flags),
+		kind:   trackedKey, code: uint32(key), down: down,
+		extended: extended,
+	}
+}
+
+func trackedUnicodeInput(unit uint16, down bool) trackedInput {
+	flags := uint32(keyEventUnicode)
+	if !down {
+		flags |= keyEventKeyUp
+	}
+	return trackedInput{
+		record: keyboardRecord(0, unit, flags),
+		kind:   trackedUnicode, code: uint32(unit), down: down,
+	}
+}
+
+func trackedButtonInput(downFlag uint32, down bool) trackedInput {
+	flags := downFlag
+	if !down {
+		flags = mouseButtonUpFlag(downFlag)
+	}
+	return trackedInput{
+		record: inputRecord{Type: inputMouse, Payload: mouseInput{Flags: flags}},
+		kind:   trackedButton, code: downFlag, down: down,
+	}
+}
+
+func trackedMouseInput(flags uint32, data int32) trackedInput {
+	return trackedInput{
+		record: inputRecord{
+			Type:    inputMouse,
+			Payload: mouseInput{Flags: flags, MouseData: uint32(data)},
+		},
+	}
+}
+
+func extendedVirtualKey(key uint16) bool {
+	switch key {
+	case vkRControl, vkSnapshot, vkRMenu, vkPause,
+		vkHome, vkUp, vkPrior, vkLeft, vkRight, vkEnd, vkDown, vkNext,
+		vkInsert, vkDelete, vkLWin, vkRWin, vkApps, vkDivide, vkNumLock,
+		vkVolumeMute, vkVolumeDown, vkVolumeUp,
+		vkMediaNextTrack, vkMediaPrevTrack, vkMediaStop, vkMediaPlayPause:
+		return true
+	default:
+		return false
+	}
+}
+
+type inputSystem interface {
+	KeyboardReady() error
+	MouseReady() error
+	SendInput([]inputRecord) (int, error)
+	CursorPosition() (int32, int32, error)
+	SetCursorPosition(int32, int32) error
+	KeyDown(uint16) bool
+	VirtualKeyForRune(uint16) (uint16, uint8, bool)
+	ScanCodeForVirtualKey(uint16) uint16
+}
+
+type win32System struct {
+	sendInput        *windows.LazyProc
+	getCursorPos     *windows.LazyProc
+	setCursorPos     *windows.LazyProc
+	getAsyncKeyState *windows.LazyProc
+	vkKeyScanW       *windows.LazyProc
+	mapVirtualKeyW   *windows.LazyProc
+}
+
+func newWin32System() *win32System {
+	user32 := windows.NewLazySystemDLL("user32.dll")
+	return &win32System{
+		sendInput:        user32.NewProc("SendInput"),
+		getCursorPos:     user32.NewProc("GetCursorPos"),
+		setCursorPos:     user32.NewProc("SetCursorPos"),
+		getAsyncKeyState: user32.NewProc("GetAsyncKeyState"),
+		vkKeyScanW:       user32.NewProc("VkKeyScanW"),
+		mapVirtualKeyW:   user32.NewProc("MapVirtualKeyW"),
+	}
+}
+
+func findProcedures(procedures ...*windows.LazyProc) error {
+	for _, procedure := range procedures {
+		if err := procedure.Find(); err != nil {
+			return fmt.Errorf("resolve user32.%s: %w", procedure.Name, err)
+		}
+	}
+	return nil
+}
+
+func (system *win32System) KeyboardReady() error {
+	return findProcedures(system.sendInput, system.getAsyncKeyState, system.vkKeyScanW, system.mapVirtualKeyW)
+}
+
+func (system *win32System) MouseReady() error {
+	return findProcedures(system.sendInput, system.getCursorPos, system.setCursorPos, system.getAsyncKeyState)
+}
+
+func callFailure(operation string, callErr error) error {
+	if callErr == nil || errors.Is(callErr, windows.ERROR_SUCCESS) {
+		return fmt.Errorf("%s failed without Win32 error information", operation)
+	}
+	return fmt.Errorf("%s: %w", operation, callErr)
+}
+
+func (system *win32System) SendInput(records []inputRecord) (int, error) {
+	if len(records) == 0 {
+		return 0, nil
+	}
+	inserted, _, callErr := system.sendInput.Call(
+		uintptr(len(records)),
+		uintptr(unsafe.Pointer(&records[0])),
+		unsafe.Sizeof(records[0]),
+	)
+	count := int(inserted)
+	if count == len(records) {
+		return count, nil
+	}
+	if count < 0 || count > len(records) {
+		return 0, fmt.Errorf("SendInput returned invalid insertion count %d for %d events", count, len(records))
+	}
+	return count, fmt.Errorf(
+		"SendInput inserted %d of %d events: %w; Windows UIPI can block injection into higher-integrity applications",
+		count, len(records), callFailure("SendInput", callErr),
+	)
+}
+
+type point struct {
+	X int32
+	Y int32
+}
+
+func (system *win32System) CursorPosition() (int32, int32, error) {
+	var position point
+	result, _, callErr := system.getCursorPos.Call(uintptr(unsafe.Pointer(&position)))
+	if result == 0 {
+		return 0, 0, callFailure("GetCursorPos", callErr)
+	}
+	return position.X, position.Y, nil
+}
+
+func (system *win32System) SetCursorPosition(x, y int32) error {
+	result, _, callErr := system.setCursorPos.Call(
+		uintptr(uint32(x)),
+		uintptr(uint32(y)),
+	)
+	if result == 0 {
+		return callFailure("SetCursorPos", callErr)
+	}
+	return nil
+}
+
+func (system *win32System) KeyDown(key uint16) bool {
+	result, _, _ := system.getAsyncKeyState.Call(uintptr(key))
+	return int16(uint16(result)) < 0
+}
+
+func (system *win32System) VirtualKeyForRune(value uint16) (uint16, uint8, bool) {
+	result, _, _ := system.vkKeyScanW.Call(uintptr(value))
+	translated := uint16(result)
+	if translated == mathMaxUint16 {
+		return 0, 0, false
+	}
+	return translated & 0xff, uint8(translated >> 8), true
+}
+
+func (system *win32System) ScanCodeForVirtualKey(value uint16) uint16 {
+	result, _, _ := system.mapVirtualKeyW.Call(uintptr(value), mapVirtualKeyToScanCode)
+	return uint16(result)
+}
+
+const mathMaxUint16 = ^uint16(0)
+
+func removeUint16(values []uint16, target uint16) []uint16 {
+	for index := len(values) - 1; index >= 0; index-- {
+		if values[index] == target {
+			return append(values[:index], values[index+1:]...)
+		}
+	}
+	return values
+}
+
+func removeUint32(values []uint32, target uint32) []uint32 {
+	for index := len(values) - 1; index >= 0; index-- {
+		if values[index] == target {
+			return append(values[:index], values[index+1:]...)
+		}
+	}
+	return values
+}
+
+func (backend *Backend) applyTrackedInput(input trackedInput) {
+	switch input.kind {
+	case trackedKey:
+		key := uint16(input.code)
+		if input.down {
+			if _, exists := backend.ownedKeys[key]; !exists {
+				backend.ownedKeys[key] = struct{}{}
+				backend.ownedKeyExtended[key] = input.extended
+				backend.ownedKeyOrder = append(backend.ownedKeyOrder, key)
+			}
+		} else {
+			delete(backend.ownedKeys, key)
+			delete(backend.ownedKeyExtended, key)
+			backend.ownedKeyOrder = removeUint16(backend.ownedKeyOrder, key)
+		}
+	case trackedButton:
+		if input.down {
+			if _, exists := backend.ownedButtons[input.code]; !exists {
+				backend.ownedButtons[input.code] = struct{}{}
+				backend.ownedButtonOrder = append(backend.ownedButtonOrder, input.code)
+			}
+		} else {
+			delete(backend.ownedButtons, input.code)
+			backend.ownedButtonOrder = removeUint32(backend.ownedButtonOrder, input.code)
+		}
+	case trackedUnicode:
+		unit := uint16(input.code)
+		if input.down {
+			backend.ownedUnicode = append(backend.ownedUnicode, unit)
+		} else {
+			backend.ownedUnicode = removeUint16(backend.ownedUnicode, unit)
+		}
+	}
+}
+
+func copyUint16Set(source map[uint16]struct{}) map[uint16]struct{} {
+	result := make(map[uint16]struct{}, len(source))
+	for value := range source {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func copyUint32Set(source map[uint32]struct{}) map[uint32]struct{} {
+	result := make(map[uint32]struct{}, len(source))
+	for value := range source {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func (backend *Backend) prepareRecord(input *trackedInput) inputRecord {
+	if input.kind == trackedKey {
+		keyboard := (*keyboardInput)(unsafe.Pointer(&input.record.Payload))
+		keyboard.ScanCode = backend.system.ScanCodeForVirtualKey(uint16(input.code))
+	}
+	return input.record
+}
+
+func (backend *Backend) rollbackNewOwnershipLocked(
+	keysBefore map[uint16]struct{},
+	buttonsBefore map[uint32]struct{},
+	unicodeCountBefore int,
+) error {
+	var rollbackErr error
+	for index := len(backend.ownedUnicode) - 1; index >= unicodeCountBefore; index-- {
+		unit := backend.ownedUnicode[index]
+		release := trackedUnicodeInput(unit, false)
+		inserted, err := backend.system.SendInput([]inputRecord{
+			backend.prepareRecord(&release),
+		})
+		if inserted == 1 {
+			backend.applyTrackedInput(release)
+		}
+		rollbackErr = errors.Join(rollbackErr, err)
+	}
+	for index := len(backend.ownedKeyOrder) - 1; index >= 0; index-- {
+		key := backend.ownedKeyOrder[index]
+		if _, existed := keysBefore[key]; existed {
+			continue
+		}
+		release := trackedKeyInputExtended(key, false, backend.ownedKeyExtended[key])
+		inserted, err := backend.system.SendInput([]inputRecord{backend.prepareRecord(&release)})
+		if inserted == 1 {
+			backend.applyTrackedInput(release)
+		}
+		rollbackErr = errors.Join(rollbackErr, err)
+	}
+	for index := len(backend.ownedButtonOrder) - 1; index >= 0; index-- {
+		button := backend.ownedButtonOrder[index]
+		if _, existed := buttonsBefore[button]; existed {
+			continue
+		}
+		release := trackedButtonInput(button, false)
+		inserted, err := backend.system.SendInput([]inputRecord{backend.prepareRecord(&release)})
+		if inserted == 1 {
+			backend.applyTrackedInput(release)
+		}
+		rollbackErr = errors.Join(rollbackErr, err)
+	}
+	return rollbackErr
+}
+
+func (backend *Backend) sendTrackedLocked(inputs []trackedInput) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+	records := make([]inputRecord, len(inputs))
+	for index := range inputs {
+		records[index] = backend.prepareRecord(&inputs[index])
+	}
+	keysBefore := copyUint16Set(backend.ownedKeys)
+	buttonsBefore := copyUint32Set(backend.ownedButtons)
+	unicodeCountBefore := len(backend.ownedUnicode)
+	inserted, sendErr := backend.system.SendInput(records)
+	if inserted < 0 {
+		inserted = 0
+	}
+	if inserted > len(inputs) {
+		inserted = len(inputs)
+	}
+	for index := 0; index < inserted; index++ {
+		backend.applyTrackedInput(inputs[index])
+	}
+	if sendErr == nil && inserted == len(inputs) {
+		return nil
+	}
+	if sendErr == nil {
+		sendErr = fmt.Errorf("SendInput inserted %d of %d events", inserted, len(inputs))
+	}
+	rollbackErr := backend.rollbackNewOwnershipLocked(keysBefore, buttonsBefore, unicodeCountBefore)
+	if rollbackErr != nil {
+		rollbackErr = fmt.Errorf("release partially injected Windows input: %w", rollbackErr)
+	}
+	return errors.Join(sendErr, rollbackErr)
+}

--- a/remote_desktop_input_nocgo_test.go
+++ b/remote_desktop_input_nocgo_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestNonCGOHighLevelPortalInput(t *testing.T) {
+	// Exercise the portal fallback itself even on non-CGO platforms that have
+	// gained a preferred local input backend (currently Windows and X11).
+	installFakePureGoInputBackend(t, nil)
 	t.Setenv(envWaylandDisplay, "robotgo-test-wayland")
 	t.Setenv(envDisplay, "")
 	oldMouseSleep, oldKeySleep := MouseSleep, KeySleep

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -363,8 +363,9 @@ func KeyTap(key string, args ...interface{}) error {
 	}
 	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
 		return backend.Key(pureGoKeyEvent{
-			Key: key, Modifiers: platformModifiers, PID: pid,
-			Down: true, Tap: true,
+			Key: key, Modifiers: platformModifiers,
+			UserModifiers: append([]string(nil), modifiers...),
+			PID:           pid, Down: true, Tap: true,
 		})
 	})
 	if used {
@@ -413,8 +414,9 @@ func KeyToggle(key string, args ...interface{}) error {
 	}
 	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
 		return backend.Key(pureGoKeyEvent{
-			Key: key, Modifiers: platformModifiers, PID: pid,
-			Down: down,
+			Key: key, Modifiers: platformModifiers,
+			UserModifiers: append([]string(nil), modifiers...),
+			PID:           pid, Down: down,
 		})
 	})
 	if used {

--- a/robotgo_nocgo_parity.go
+++ b/robotgo_nocgo_parity.go
@@ -34,7 +34,9 @@ func CloseMainDisplay() { _ = CloseMainDisplayE() }
 // server-global scratch mappings, so call it only after targets have processed
 // all prior keyboard input. Abnormal process termination can leave mappings
 // behind. If cleanup reports a pressed-key or modifier-map conflict, remove
-// that conflict and retry CloseMainDisplayE.
+// that conflict and retry CloseMainDisplayE. On Pure-Go Windows it releases
+// RobotGo-owned persistent key and button holds; process termination cannot run
+// this in-process cleanup.
 func CloseMainDisplayE() error { return closePureGoPlatformInput() }
 
 func InvalidateScreenBoundsCache() {}

--- a/windows_input_integration_test.go
+++ b/windows_input_integration_test.go
@@ -1,0 +1,47 @@
+//go:build windows && !cgo && windowsintegration
+
+package robotgo_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/marang/robotgo"
+)
+
+const requireWindowsInputIntegration = "ROBOTGO_REQUIRE_WINDOWS_INPUT_INTEGRATION"
+
+func TestPureGoWindowsInputRuntime(t *testing.T) {
+	if os.Getenv(requireWindowsInputIntegration) != "1" {
+		t.Skip("set " + requireWindowsInputIntegration + "=1 to inject global Windows pointer input")
+	}
+	if err := robotgo.KeyboardReady(); err != nil {
+		t.Fatalf("KeyboardReady: %v", err)
+	}
+	if err := robotgo.MouseReady(); err != nil {
+		t.Fatalf("MouseReady: %v", err)
+	}
+	startX, startY, err := robotgo.LocationE()
+	if err != nil {
+		t.Fatalf("initial LocationE: %v", err)
+	}
+	t.Cleanup(func() {
+		if restoreErr := robotgo.MoveE(startX, startY); restoreErr != nil {
+			t.Errorf("restore pointer: %v", restoreErr)
+		}
+	})
+
+	for _, delta := range []int{1, -1} {
+		if err := robotgo.MoveE(startX+delta, startY); err != nil {
+			t.Fatalf("MoveE(%d,%d): %v", startX+delta, startY, err)
+		}
+		x, y, err := robotgo.LocationE()
+		if err != nil {
+			t.Fatalf("LocationE after move: %v", err)
+		}
+		if x == startX+delta && y == startY {
+			return
+		}
+	}
+	t.Fatal("Windows input desktop accepted no observable one-pixel pointer move")
+}


### PR DESCRIPTION
## What changed

- add a non-CGO Windows keyboard and pointer backend through `user32.dll`
- use layout-aware `VkKeyScanW` key mapping and exact UTF-16 `KEYEVENTF_UNICODE` text input
- support absolute/relative/smooth pointer movement, drag, buttons, double-click, pointer location, and horizontal/vertical scrolling
- serialize compound input, track RobotGo-owned holds, roll back partial `SendInput` calls, and release retained state through `CloseMainDisplayE`
- expose Windows input through runtime capabilities without changing the CGO default
- add hermetic Win32 transaction tests, 32/64-bit `INPUT` layout checks, an opt-in real input-desktop probe, and a readiness-only-by-default example
- record active `main` branch protection and update the Phase 3 roadmap

## Why

Windows non-CGO builds previously supported capture but returned `ErrNotSupported` for keyboard and pointer automation. This adds a useful Pure-Go platform backend while preserving explicit unsupported, ownership, and UIPI failure contracts.

## User impact

`CGO_ENABLED=0` Windows binaries can now use RobotGo's error-returning keyboard and mouse APIs. Character key taps follow the active keyboard layout instead of assuming US positions. Exact text uses UTF-16 input packets. Persistent holds remain process-owned and should be balanced or closed explicitly.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- default and non-CGO `golangci-lint`
- Windows non-CGO cross-build/tests for amd64 and 386
- Windows arm64 cross-build
- macOS amd64 non-CGO cross-build

The hosted Windows non-CGO job is expected to execute the new hermetic tests. The real global-pointer integration test remains opt-in via `ROBOTGO_REQUIRE_WINDOWS_INPUT_INTEGRATION=1`.