### PR TITLE
ci: require Windows input desktop evidence

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -136,6 +136,15 @@ jobs:
         env:
           CGO_ENABLED: "0"
         run: go test -v ./...
+      - name: Test Pure-Go Windows input desktop
+        if: runner.os == 'Windows'
+        env:
+          CGO_ENABLED: "0"
+          ROBOTGO_REQUIRE_WINDOWS_INPUT_INTEGRATION: "1"
+        run: >-
+          go test -tags windowsintegration
+          -run "^TestPureGoWindowsInputRuntime$"
+          -count=1 -timeout=30s -v .
       - name: Test non-CGO OCR compatibility stubs
         if: runner.os == 'Linux'
         env:

--- a/README.md
+++ b/README.md
@@ -681,10 +681,10 @@ state and avoids double payload encoding, with versioned evidence showing lower
 allocation cost. Balanced transient press/release pairs now share one guardian
 request while preserving per-step crash-cleanup ownership and the existing
 preflight/server-grab policy. Required remote checks now protect `main`.
-Pure-Go Windows input is the next delivered platform slice, with hermetic
-transaction tests and an opt-in real input-desktop probe. Further macOS and
-Windows backends remain selective work. Real GNOME/KDE/wlroots validation is an
-independent Wayland release gate.
+Pure-Go Windows input is a delivered platform slice, with hermetic transaction
+tests and a blocking real input-desktop pointer probe on the Windows CI runner.
+Further macOS and Windows backends remain selective work. Real
+GNOME/KDE/wlroots validation is an independent Wayland release gate.
 
 ## Upstream and attribution
 

--- a/TEST.md
+++ b/TEST.md
@@ -48,11 +48,11 @@ branch protection requires the stable three-OS, lint, vet, race, Wayland, and
 X11 evidence checks. Opt-in real-compositor jobs remain excluded until matching
 self-hosted runners are registered.
 
-Pure-Go Windows input has hermetic tests for Win32 `INPUT` layout, foreground-layout
-key mapping, Unicode surrogate pairs, partial-injection rollback, ownership,
-buttons, scrolling, and movement. They run in the Windows non-CGO CI leg. A
-real input-desktop pointer probe is explicitly opt-in because it moves the
-global cursor:
+Pure-Go Windows input has hermetic tests for Win32 `INPUT` layout,
+foreground-layout key mapping, Unicode surrogate pairs, partial-injection
+rollback, ownership, buttons, scrolling, and movement. They run in the Windows
+non-CGO CI leg. The same leg runs a real input-desktop pointer probe and restores
+the original global cursor position:
 
 ```powershell
 $env:CGO_ENABLED = "0"
@@ -60,8 +60,8 @@ $env:ROBOTGO_REQUIRE_WINDOWS_INPUT_INTEGRATION = "1"
 go test -tags windowsintegration -run "^TestPureGoWindowsInputRuntime$" -count=1 -v .
 ```
 
-The runtime probe restores the original pointer position. Keyboard injection
-is kept hermetic in default CI because a generic hosted runner offers no
+The environment variable remains an explicit safety gate for local execution.
+Keyboard injection stays hermetic because a generic hosted runner offers no
 trustworthy foreground target; the runnable example provides explicit manual
 validation.
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -35,7 +35,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | X11 complete; Windows input implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Windows `SendInput` keyboard/pointer backend; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; lower-allocation request transport and safe balanced-input sequencing; protected three-OS CI; non-skipping multi-layout Xvfb input tests | Collect real Windows input-desktop evidence, then assess further backends selectively |
+| 3. Pure-Go | X11 complete; Windows input CI-evidenced; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Windows `SendInput` keyboard/pointer backend with a blocking input-desktop probe; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; lower-allocation request transport and safe balanced-input sequencing; protected three-OS CI; non-skipping multi-layout Xvfb input tests | Assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -145,8 +145,8 @@ injection rollback, ownership conflicts, and deterministic in-process cleanup.
 Exact Unicode text is encoded as UTF-16, while `KeyTap` resolves characters
 through the foreground target's Windows keyboard layout instead of assuming US key
 positions. Hermetic tests validate 32/64-bit `INPUT` layout and transaction
-semantics; the real input-desktop pointer test remains opt-in because it moves a
-global resource.
+semantics. The Windows non-CGO CI leg runs the explicitly gated real
+input-desktop pointer test and restores the original global cursor position.
 
 Linux/X11 additionally has a Pure-Go XGB/XTEST keyboard and pointer backend for
 the error-returning input APIs, text/Unicode, pointer location, smooth

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -193,4 +193,6 @@ Window backend support matrix (current):
     flag.
   - Keep `examples/purego_windows_input` readiness-only by default; global
     pointer or keyboard input requires explicit `-move` or `-text` flags.
+  - Keep the explicitly gated real Windows input-desktop pointer probe blocking
+    in the non-CGO Windows CI leg; it must restore the original cursor position.
   - Publish a versioned support matrix and troubleshooting guide.


### PR DESCRIPTION
## Goal

Make the real Pure-Go Windows input-desktop pointer probe blocking evidence for Phase 3 without requiring a local Windows machine.

## Changes

- run the explicitly gated windowsintegration probe in the Windows non-CGO matrix leg
- keep the probe bounded to 30 seconds
- document that the global cursor is restored and keyboard injection remains hermetic
- update the Phase 3 roadmap status once the runner evidence is enforced

## Validation

- go test ./...
- CGO_ENABLED=0 go test ./...
- git diff --check

## Risk

The hosted Windows runner must expose a functional input desktop. The probe attempts one-pixel moves in both directions and restores the original cursor position through test cleanup.