### PR TITLE
feat: add Pure-Go Windows window control

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -145,6 +145,16 @@ jobs:
           go test -tags windowsintegration
           -run "^TestPureGoWindowsInputRuntime$"
           -count=1 -timeout=30s -v .
+
+      - name: Test Pure-Go Windows window desktop
+        if: runner.os == 'Windows'
+        env:
+          CGO_ENABLED: "0"
+          ROBOTGO_REQUIRE_WINDOWS_WINDOW_INTEGRATION: "1"
+        run: >-
+          go test -tags windowsintegration
+          -run "^TestPureGoWindowsWindowRuntime$"
+          -count=1 -timeout=30s -v .
       - name: Test non-CGO OCR compatibility stubs
         if: runner.os == 'Linux'
         env:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
 | macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture and display bounds with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
-| Windows | `CGO_ENABLED=0` | Pure-Go capture/bounds plus foreground-layout-aware `SendInput` keyboard/text, exact pointer movement/location, smooth movement/drag, buttons, horizontal/vertical scroll, live readiness, ownership checks, and deterministic in-process cleanup |
+| Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds, foreground-layout-aware `SendInput` keyboard/text, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
 | Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds plus XTEST mouse, keyboard, text/Unicode, pointer-location, smooth-move/drag, vertical scroll, and live readiness probes; horizontal scroll is explicitly unsupported |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |
@@ -500,6 +500,13 @@ available in Wayland core. `LocationE` and unsupported window operations return
 window support through compositor-specific tools; inspect capabilities instead
 of assuming parity with X11.
 
+Pure-Go Windows builds provide window introspection and control through Win32:
+active handle/PID, title, outer/client bounds, activation, minimize/maximize,
+topmost state, and graceful close. PID lookup prefers a visible, unowned
+top-level window and falls back to another top-level window owned by the
+process. Windows may deny `SetActiveE` under its foreground-activation policy;
+the error is returned instead of reporting false success.
+
 ### Runtime diagnostics
 
 `GetRuntimeBackendInfo` is platform-neutral and reports whether the current
@@ -585,6 +592,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
 - [Pure-Go X11 input probe and opt-in demo](examples/purego_x11_input/main.go)
 - [Pure-Go Windows input readiness and opt-in demo](examples/purego_windows_input/main.go)
+- [Pure-Go Windows window inspection and opt-in control](examples/purego_windows_window/main.go)
 - [Consent-aware RemoteDesktop portal input](examples/remote_desktop_input/main.go)
 - [Persistent ScreenCast/PipeWire capture](examples/screencast_capture/main.go)
 - [Window and process helpers](examples/window/main.go)
@@ -619,6 +627,17 @@ normal-integrity process cannot inject input into a higher-integrity target.
 Persistent `KeyDown`/`MouseDown` state is owned by the backend and released by
 `CloseMainDisplayE`; callers should still use balanced operations or `defer`
 cleanup because process termination cannot run in-process cleanup.
+
+The Windows window example is read-only by default. `-activate` and `-minimize`
+are explicit opt-ins:
+
+```powershell
+$env:CGO_ENABLED = "0"
+go run ./examples/purego_windows_window
+go run ./examples/purego_windows_window -pid 1234
+go run ./examples/purego_windows_window -handle 123456 -activate
+go run ./examples/purego_windows_window -pid 1234 -minimize
+```
 
 ## Testing
 
@@ -683,7 +702,10 @@ request while preserving per-step crash-cleanup ownership and the existing
 preflight/server-grab policy. Required remote checks now protect `main`.
 Pure-Go Windows input is a delivered platform slice, with hermetic transaction
 tests and a blocking real input-desktop pointer probe on the Windows CI runner.
-Further macOS and Windows backends remain selective work. Real
+Pure-Go Windows window introspection/control is the next delivered slice, with
+a self-owned Win32 test window covering PID/handle resolution, title, geometry,
+state changes, activation, topmost state, and graceful close. Further macOS and
+Windows backends remain selective work. Real
 GNOME/KDE/wlroots validation is an independent Wayland release gate.
 
 ## Upstream and attribution

--- a/TEST.md
+++ b/TEST.md
@@ -65,6 +65,21 @@ Keyboard injection stays hermetic because a generic hosted runner offers no
 trustworthy foreground target; the runnable example provides explicit manual
 validation.
 
+Pure-Go Windows window control uses a self-owned Win32 top-level window, so the
+hosted runner can validate the full contract without touching another
+application. The test covers capability reporting, PID/handle resolution,
+title, outer/client bounds, minimize/maximize, foreground activation, topmost
+state, and `WM_CLOSE`:
+
+```powershell
+$env:CGO_ENABLED = "0"
+$env:ROBOTGO_REQUIRE_WINDOWS_WINDOW_INTEGRATION = "1"
+go test -tags windowsintegration -run "^TestPureGoWindowsWindowRuntime$" -count=1 -v .
+```
+
+The environment variable is an explicit local safety gate. CI runs this command
+as a blocking Windows non-CGO check.
+
 Opt-in macOS runtime capture benchmark:
 
 ```bash

--- a/api_contract_nocgo_test.go
+++ b/api_contract_nocgo_test.go
@@ -4,6 +4,7 @@ package robotgo
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 )
 
@@ -12,15 +13,28 @@ func TestNonCGOPortableAPIContract(t *testing.T) {
 	_ = capabilities.Hook
 	_ = capabilities.Events
 
-	unsupported := []error{
-		CloseWindowE(),
-		MinWindowE(0),
-		MaxWindowE(0),
-		SetTopMostE(true),
-	}
-	for _, err := range unsupported {
-		if !errors.Is(err, ErrNotSupported) {
-			t.Fatalf("non-CGO operation error = %v, want ErrNotSupported", err)
+	if runtime.GOOS == "windows" {
+		invalidTargets := []error{
+			SetActiveE(0),
+			MinWindowE(0),
+			MaxWindowE(0),
+		}
+		for _, err := range invalidTargets {
+			if err == nil || errors.Is(err, ErrNotSupported) {
+				t.Fatalf("Pure-Go Windows invalid-target error = %v, want explicit backend error", err)
+			}
+		}
+	} else {
+		unsupported := []error{
+			CloseWindowE(),
+			MinWindowE(0),
+			MaxWindowE(0),
+			SetTopMostE(true),
+		}
+		for _, err := range unsupported {
+			if !errors.Is(err, ErrNotSupported) {
+				t.Fatalf("non-CGO operation error = %v, want ErrNotSupported", err)
+			}
 		}
 	}
 	if err := MinWindowE(0, "invalid"); err == nil || errors.Is(err, ErrNotSupported) {

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -35,7 +35,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | X11 complete; Windows input CI-evidenced; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Windows `SendInput` keyboard/pointer backend with a blocking input-desktop probe; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; lower-allocation request transport and safe balanced-input sequencing; protected three-OS CI; non-skipping multi-layout Xvfb input tests | Assess further backends selectively |
+| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Windows `SendInput` keyboard/pointer backend with a blocking input-desktop probe; Win32 window introspection/control with a self-owned runtime window; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; lower-allocation request transport and safe balanced-input sequencing; protected three-OS CI; non-skipping multi-layout Xvfb input tests | Assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -147,6 +147,11 @@ through the foreground target's Windows keyboard layout instead of assuming US k
 positions. Hermetic tests validate 32/64-bit `INPUT` layout and transaction
 semantics. The Windows non-CGO CI leg runs the explicitly gated real
 input-desktop pointer test and restores the original global cursor position.
+The same build provides Win32 window capability reporting, active handle/PID,
+PID-to-window resolution, titles, outer/client geometry, activation,
+minimize/maximize, topmost state, and graceful close. Its blocking runtime test
+creates and owns the target window, exercises each operation, and never mutates
+an unrelated application.
 
 Linux/X11 additionally has a Pure-Go XGB/XTEST keyboard and pointer backend for
 the error-returning input APIs, text/Unicode, pointer location, smooth
@@ -205,8 +210,9 @@ Balanced transient press/release pairs now share one guardian request while
 retaining per-step ownership, verified release, preflight, server-grab, timeout,
 and crash-recovery contracts. This reduces another `5–14%` of allocations for
 the affected click, scroll, key-press, and text benchmarks. Stable remote checks
-now protect `main`; selectively evaluating additional platform backends keeps
-the broader Phase 3 partial.
+now protect `main`; Windows input and self-owned window runtime evidence are
+blocking. Selectively evaluating additional platform backends keeps the broader
+Phase 3 partial.
 
 Exit criteria:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -110,7 +110,10 @@ Window backend support matrix (current):
     X11 default while keeping Pure-Go supported for CGO-disabled builds. The
     lower-allocation request transport and balanced transient-input sequencing
     preserve the crash contract. Stable checks now protect `main`; evaluating
-    further backends remains open. The Pure-Go core is now
+    further backends remains open. Pure-Go Windows also provides Win32 window
+    introspection/control, backed by a blocking self-owned runtime-window test
+    for PID/handle resolution, geometry, state, activation, topmost, and close.
+    The Pure-Go X11 core is now
     race-testable, and a separate X11 guardian uses an authenticated abstract
     Unix socket with kernel-verified peer credentials, bounded request dispatch,
     and deadline-bounded cleanup after an application-process `SIGKILL`. It

--- a/examples/purego_windows_window/main.go
+++ b/examples/purego_windows_window/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	pid := flag.Int("pid", 0, "inspect a process window by PID")
+	handle := flag.Int("handle", 0, "inspect a window by HWND")
+	activate := flag.Bool("activate", false, "activate the selected window")
+	minimize := flag.Bool("minimize", false, "minimize, then restore, the selected window")
+	flag.Parse()
+
+	if runtime.GOOS != "windows" {
+		fmt.Fprintln(os.Stderr, "this example requires Windows")
+		os.Exit(2)
+	}
+	capability := robotgo.GetRuntimeCapabilities().Window
+	fmt.Printf("window backend: available=%v backend=%s reason=%s\n",
+		capability.Available, capability.Backend, capability.Reason)
+	if !capability.Available {
+		os.Exit(1)
+	}
+
+	target, isHandle := selectedTarget(*pid, *handle)
+	if target == 0 {
+		target = robotgo.GetHandle()
+		isHandle = true
+	}
+	if target == 0 {
+		fmt.Fprintln(os.Stderr, "no active window is available")
+		os.Exit(1)
+	}
+
+	args := []int(nil)
+	if isHandle {
+		args = []int{1}
+	}
+	titleArgs := append([]int{target}, args...)
+	title, err := robotgo.GetTitleE(titleArgs...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "title:", err)
+		os.Exit(1)
+	}
+	x, y, width, height := robotgo.GetBounds(target, args...)
+	fmt.Printf("target=%d handle=%v title=%q bounds=(%d,%d %dx%d)\n",
+		target, isHandle, title, x, y, width, height)
+
+	resolved := robotgo.GetHandByPid(target, args...)
+	if *activate {
+		if err := robotgo.SetActiveE(resolved); err != nil {
+			fmt.Fprintln(os.Stderr, "activate:", err)
+			os.Exit(1)
+		}
+	}
+	if *minimize {
+		stateArgs := []interface{}{true}
+		if isHandle {
+			stateArgs = append(stateArgs, 1)
+		}
+		if err := robotgo.MinWindowE(target, stateArgs...); err != nil {
+			fmt.Fprintln(os.Stderr, "minimize:", err)
+			os.Exit(1)
+		}
+		time.Sleep(time.Second)
+		stateArgs[0] = false
+		if err := robotgo.MinWindowE(target, stateArgs...); err != nil {
+			fmt.Fprintln(os.Stderr, "restore:", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func selectedTarget(pid, handle int) (target int, isHandle bool) {
+	if pid > 0 && handle > 0 {
+		fmt.Fprintln(os.Stderr, "use either -pid or -handle, not both")
+		os.Exit(2)
+	}
+	if handle > 0 {
+		return handle, true
+	}
+	return pid, false
+}

--- a/internal/windowswindow/backend.go
+++ b/internal/windowswindow/backend.go
@@ -1,0 +1,251 @@
+package windowswindow
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	// ErrWindowNotFound reports that no window matched the requested target.
+	ErrWindowNotFound = errors.New("windows window not found")
+	// ErrInvalidWindow reports a zero, stale, or otherwise invalid HWND.
+	ErrInvalidWindow = errors.New("invalid Windows window handle")
+	// ErrOperation reports a failed Win32 window operation.
+	ErrOperation = errors.New("windows window operation failed")
+)
+
+// Handle is a platform-neutral representation of a Windows HWND.
+type Handle uintptr
+
+// Rect contains screen-relative window geometry.
+type Rect struct {
+	X      int
+	Y      int
+	Width  int
+	Height int
+}
+
+// State identifies a queryable and mutable Windows presentation state.
+type State uint8
+
+const (
+	// StateMinimized identifies the minimized/iconic state.
+	StateMinimized State = iota
+	// StateMaximized identifies the maximized/zoomed state.
+	StateMaximized
+)
+
+// System abstracts the Win32 calls used by Backend.
+type System interface {
+	ForegroundWindow() Handle
+	IsWindow(Handle) bool
+	FindWindowByPID(uint32) (Handle, error)
+	WindowProcessID(Handle) (uint32, error)
+	WindowText(Handle) (string, error)
+	WindowRect(Handle) (Rect, error)
+	ClientRect(Handle) (Rect, error)
+	SetForegroundWindow(Handle) error
+	SetWindowState(Handle, State, bool) error
+	WindowState(Handle, State) (bool, error)
+	IsTopMost(Handle) (bool, error)
+	SetTopMost(Handle, bool) error
+	CloseWindow(Handle) error
+}
+
+// Backend resolves window targets and enforces the public operation contract.
+type Backend struct {
+	system System
+
+	mu       sync.RWMutex
+	selected Handle
+}
+
+// New constructs a Backend around a Win32 system implementation.
+func New(system System) *Backend {
+	return &Backend{system: system}
+}
+
+// Active returns the current valid foreground window.
+func (backend *Backend) Active() (Handle, error) {
+	handle := backend.system.ForegroundWindow()
+	if err := backend.validate(handle); err != nil {
+		return 0, fmt.Errorf("%w: foreground window", err)
+	}
+	return handle, nil
+}
+
+// Resolve maps either a PID or an explicit HWND to a valid window.
+func (backend *Backend) Resolve(target int, isHandle bool) (Handle, error) {
+	if target <= 0 {
+		return 0, fmt.Errorf("%w: target must be positive, got %d", ErrWindowNotFound, target)
+	}
+	if isHandle {
+		handle := Handle(uintptr(target))
+		if err := backend.validate(handle); err != nil {
+			return 0, err
+		}
+		return handle, nil
+	}
+	if uint64(target) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("%w: pid %d exceeds the Windows DWORD range", ErrWindowNotFound, target)
+	}
+	handle, err := backend.system.FindWindowByPID(uint32(target))
+	if err != nil {
+		return 0, fmt.Errorf("%w: pid %d: %v", ErrWindowNotFound, target, err)
+	}
+	if err := backend.validate(handle); err != nil {
+		return 0, fmt.Errorf("%w: pid %d resolved to %#x", err, target, uintptr(handle))
+	}
+	return handle, nil
+}
+
+// Select stores a successfully resolved compatibility handle.
+func (backend *Backend) Select(target int, isHandle bool) error {
+	handle, err := backend.Resolve(target, isHandle)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	backend.selected = handle
+	backend.mu.Unlock()
+	return nil
+}
+
+// Selected returns the compatibility handle stored by Select.
+func (backend *Backend) Selected() Handle {
+	backend.mu.RLock()
+	defer backend.mu.RUnlock()
+	return backend.selected
+}
+
+// PID returns the owning process ID for a valid window.
+func (backend *Backend) PID(handle Handle) (int, error) {
+	if err := backend.validate(handle); err != nil {
+		return 0, err
+	}
+	pid, err := backend.system.WindowProcessID(handle)
+	if err != nil {
+		return 0, fmt.Errorf("%w: get pid for handle %#x: %v", ErrOperation, uintptr(handle), err)
+	}
+	if pid == 0 {
+		return 0, fmt.Errorf("%w: handle %#x has no process", ErrWindowNotFound, uintptr(handle))
+	}
+	if uint64(pid) > uint64(^uint(0)>>1) {
+		return 0, fmt.Errorf("%w: pid %d exceeds the Go int range", ErrOperation, pid)
+	}
+	return int(pid), nil
+}
+
+// Title returns a non-empty title for a valid window.
+func (backend *Backend) Title(handle Handle) (string, error) {
+	if err := backend.validate(handle); err != nil {
+		return "", err
+	}
+	title, err := backend.system.WindowText(handle)
+	if err != nil {
+		return "", fmt.Errorf("%w: get title for handle %#x: %v", ErrOperation, uintptr(handle), err)
+	}
+	if title == "" {
+		return "", fmt.Errorf("%w: handle %#x has no title", ErrWindowNotFound, uintptr(handle))
+	}
+	return title, nil
+}
+
+// Bounds returns outer or client geometry for a valid window.
+func (backend *Backend) Bounds(handle Handle, client bool) (Rect, error) {
+	if err := backend.validate(handle); err != nil {
+		return Rect{}, err
+	}
+	var (
+		rect Rect
+		err  error
+	)
+	if client {
+		rect, err = backend.system.ClientRect(handle)
+	} else {
+		rect, err = backend.system.WindowRect(handle)
+	}
+	if err != nil {
+		return Rect{}, fmt.Errorf("%w: get bounds for handle %#x: %v", ErrOperation, uintptr(handle), err)
+	}
+	if rect.Width <= 0 || rect.Height <= 0 {
+		return Rect{}, fmt.Errorf("%w: handle %#x returned invalid bounds %+v", ErrOperation, uintptr(handle), rect)
+	}
+	return rect, nil
+}
+
+// Activate requests foreground activation for a valid window.
+func (backend *Backend) Activate(handle Handle) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := backend.system.SetForegroundWindow(handle); err != nil {
+		return fmt.Errorf("%w: activate handle %#x: %v", ErrOperation, uintptr(handle), err)
+	}
+	return nil
+}
+
+// SetState changes a minimized or maximized window state.
+func (backend *Backend) SetState(handle Handle, state State, enabled bool) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := backend.system.SetWindowState(handle, state, enabled); err != nil {
+		return fmt.Errorf("%w: change state for handle %#x: %v", ErrOperation, uintptr(handle), err)
+	}
+	return nil
+}
+
+// State queries a minimized or maximized window state.
+func (backend *Backend) State(handle Handle, state State) (bool, error) {
+	if err := backend.validate(handle); err != nil {
+		return false, err
+	}
+	enabled, err := backend.system.WindowState(handle, state)
+	if err != nil {
+		return false, fmt.Errorf("%w: query state for handle %#x: %v", ErrOperation, uintptr(handle), err)
+	}
+	return enabled, nil
+}
+
+// TopMost reports whether a window has topmost extended style.
+func (backend *Backend) TopMost(handle Handle) (bool, error) {
+	if err := backend.validate(handle); err != nil {
+		return false, err
+	}
+	enabled, err := backend.system.IsTopMost(handle)
+	if err != nil {
+		return false, fmt.Errorf("%w: query topmost for handle %#x: %v", ErrOperation, uintptr(handle), err)
+	}
+	return enabled, nil
+}
+
+// SetTopMost changes a window's topmost state without moving or resizing it.
+func (backend *Backend) SetTopMost(handle Handle, enabled bool) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := backend.system.SetTopMost(handle, enabled); err != nil {
+		return fmt.Errorf("%w: set topmost for handle %#x: %v", ErrOperation, uintptr(handle), err)
+	}
+	return nil
+}
+
+// Close posts WM_CLOSE to a valid window.
+func (backend *Backend) Close(handle Handle) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := backend.system.CloseWindow(handle); err != nil {
+		return fmt.Errorf("%w: close handle %#x: %v", ErrOperation, uintptr(handle), err)
+	}
+	return nil
+}
+
+func (backend *Backend) validate(handle Handle) error {
+	if handle == 0 || !backend.system.IsWindow(handle) {
+		return fmt.Errorf("%w: %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	return nil
+}

--- a/internal/windowswindow/backend_test.go
+++ b/internal/windowswindow/backend_test.go
@@ -1,0 +1,232 @@
+package windowswindow
+
+import (
+	"errors"
+	"testing"
+)
+
+type fakeSystem struct {
+	foreground Handle
+	valid      map[Handle]bool
+	byPID      map[uint32]Handle
+	pids       map[Handle]uint32
+	titles     map[Handle]string
+	windowRect Rect
+	clientRect Rect
+	style      map[State]bool
+	topMost    bool
+	activated  Handle
+	stateSet   State
+	stateValue bool
+	topSet     bool
+	closed     Handle
+	err        error
+}
+
+func (system *fakeSystem) ForegroundWindow() Handle { return system.foreground }
+func (system *fakeSystem) IsWindow(handle Handle) bool {
+	return system.valid[handle]
+}
+func (system *fakeSystem) FindWindowByPID(pid uint32) (Handle, error) {
+	if system.err != nil {
+		return 0, system.err
+	}
+	return system.byPID[pid], nil
+}
+func (system *fakeSystem) WindowProcessID(handle Handle) (uint32, error) {
+	return system.pids[handle], system.err
+}
+func (system *fakeSystem) WindowText(handle Handle) (string, error) {
+	return system.titles[handle], system.err
+}
+func (system *fakeSystem) WindowRect(Handle) (Rect, error) {
+	return system.windowRect, system.err
+}
+func (system *fakeSystem) ClientRect(Handle) (Rect, error) {
+	return system.clientRect, system.err
+}
+func (system *fakeSystem) SetForegroundWindow(handle Handle) error {
+	system.activated = handle
+	return system.err
+}
+func (system *fakeSystem) SetWindowState(_ Handle, state State, enabled bool) error {
+	system.stateSet = state
+	system.stateValue = enabled
+	return system.err
+}
+func (system *fakeSystem) WindowState(_ Handle, state State) (bool, error) {
+	return system.style[state], system.err
+}
+func (system *fakeSystem) IsTopMost(Handle) (bool, error) {
+	return system.topMost, system.err
+}
+func (system *fakeSystem) SetTopMost(_ Handle, enabled bool) error {
+	system.topSet = enabled
+	return system.err
+}
+func (system *fakeSystem) CloseWindow(handle Handle) error {
+	system.closed = handle
+	return system.err
+}
+
+func newFakeBackend() (*Backend, *fakeSystem) {
+	system := &fakeSystem{
+		foreground: 7,
+		valid:      map[Handle]bool{7: true, 8: true},
+		byPID:      map[uint32]Handle{42: 8},
+		pids:       map[Handle]uint32{7: 41, 8: 42},
+		titles:     map[Handle]string{7: "active", 8: "target"},
+		windowRect: Rect{X: 1, Y: 2, Width: 300, Height: 200},
+		clientRect: Rect{X: 3, Y: 4, Width: 280, Height: 160},
+		style:      map[State]bool{StateMinimized: true},
+		topMost:    true,
+	}
+	return New(system), system
+}
+
+func TestBackendResolvesActivePIDAndHandle(t *testing.T) {
+	t.Parallel()
+	backend, _ := newFakeBackend()
+
+	active, err := backend.Active()
+	if err != nil || active != 7 {
+		t.Fatalf("Active() = %#x, %v", active, err)
+	}
+	byPID, err := backend.Resolve(42, false)
+	if err != nil || byPID != 8 {
+		t.Fatalf("Resolve(pid) = %#x, %v", byPID, err)
+	}
+	byHandle, err := backend.Resolve(8, true)
+	if err != nil || byHandle != 8 {
+		t.Fatalf("Resolve(handle) = %#x, %v", byHandle, err)
+	}
+	pid, err := backend.PID(active)
+	if err != nil || pid != 41 {
+		t.Fatalf("PID() = %d, %v", pid, err)
+	}
+}
+
+func TestBackendRejectsMissingAndInvalidTargets(t *testing.T) {
+	t.Parallel()
+	backend, system := newFakeBackend()
+
+	if _, err := backend.Resolve(0, false); !errors.Is(err, ErrWindowNotFound) {
+		t.Fatalf("Resolve(0) error = %v", err)
+	}
+	if _, err := backend.Resolve(99, true); !errors.Is(err, ErrInvalidWindow) {
+		t.Fatalf("Resolve(invalid handle) error = %v", err)
+	}
+	system.err = errors.New("enumeration failed")
+	if _, err := backend.Resolve(99, false); !errors.Is(err, ErrWindowNotFound) {
+		t.Fatalf("Resolve(missing pid) error = %v", err)
+	}
+}
+
+func TestBackendRejectsPIDOutsideDWORDOn64Bit(t *testing.T) {
+	if ^uint(0)>>32 == 0 {
+		t.Skip("Go int cannot represent a value above DWORD on this architecture")
+	}
+	t.Parallel()
+	backend, _ := newFakeBackend()
+	overflow := uint64(^uint32(0))
+	overflow++
+
+	if _, err := backend.Resolve(int(overflow), false); !errors.Is(err, ErrWindowNotFound) {
+		t.Fatalf("Resolve(overflow pid) error = %v", err)
+	}
+}
+
+func TestBackendReadsTitleAndBounds(t *testing.T) {
+	t.Parallel()
+	backend, _ := newFakeBackend()
+
+	title, err := backend.Title(8)
+	if err != nil || title != "target" {
+		t.Fatalf("Title() = %q, %v", title, err)
+	}
+	window, err := backend.Bounds(8, false)
+	if err != nil || window.Width != 300 {
+		t.Fatalf("Bounds(window) = %+v, %v", window, err)
+	}
+	client, err := backend.Bounds(8, true)
+	if err != nil || client.X != 3 || client.Height != 160 {
+		t.Fatalf("Bounds(client) = %+v, %v", client, err)
+	}
+}
+
+func TestBackendRejectsEmptyTitleAndInvalidBounds(t *testing.T) {
+	t.Parallel()
+	backend, system := newFakeBackend()
+
+	system.titles[8] = ""
+	if _, err := backend.Title(8); !errors.Is(err, ErrWindowNotFound) {
+		t.Fatalf("empty title error = %v", err)
+	}
+	system.windowRect = Rect{}
+	if _, err := backend.Bounds(8, false); !errors.Is(err, ErrOperation) {
+		t.Fatalf("empty bounds error = %v", err)
+	}
+}
+
+func TestBackendControlsResolvedWindow(t *testing.T) {
+	t.Parallel()
+	backend, system := newFakeBackend()
+
+	if err := backend.Activate(8); err != nil || system.activated != 8 {
+		t.Fatalf("Activate() error = %v, target = %#x", err, system.activated)
+	}
+	if err := backend.SetState(8, StateMaximized, true); err != nil {
+		t.Fatalf("SetState() error = %v", err)
+	}
+	if system.stateSet != StateMaximized || !system.stateValue {
+		t.Fatalf("state mutation = %v, %v", system.stateSet, system.stateValue)
+	}
+	minimized, err := backend.State(8, StateMinimized)
+	if err != nil || !minimized {
+		t.Fatalf("State() = %v, %v", minimized, err)
+	}
+	topMost, err := backend.TopMost(8)
+	if err != nil || !topMost {
+		t.Fatalf("TopMost() = %v, %v", topMost, err)
+	}
+	if err := backend.SetTopMost(8, false); err != nil || system.topSet {
+		t.Fatalf("SetTopMost(false) error = %v, value = %v", err, system.topSet)
+	}
+	if err := backend.Close(8); err != nil || system.closed != 8 {
+		t.Fatalf("Close() error = %v, target = %#x", err, system.closed)
+	}
+}
+
+func TestBackendPreservesOperationErrors(t *testing.T) {
+	t.Parallel()
+	backend, system := newFakeBackend()
+	system.err = errors.New("denied")
+
+	if err := backend.Activate(8); !errors.Is(err, ErrOperation) {
+		t.Fatalf("Activate() error = %v", err)
+	}
+	if _, err := backend.State(8, StateMaximized); !errors.Is(err, ErrOperation) {
+		t.Fatalf("State() error = %v", err)
+	}
+	if err := backend.Close(8); !errors.Is(err, ErrOperation) {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestBackendSelectionOnlyChangesAfterSuccessfulResolution(t *testing.T) {
+	t.Parallel()
+	backend, _ := newFakeBackend()
+
+	if err := backend.Select(42, false); err != nil {
+		t.Fatalf("Select(pid): %v", err)
+	}
+	if got := backend.Selected(); got != 8 {
+		t.Fatalf("Selected() = %#x, want 8", got)
+	}
+	if err := backend.Select(99, true); err == nil {
+		t.Fatal("Select(invalid) succeeded")
+	}
+	if got := backend.Selected(); got != 8 {
+		t.Fatalf("failed Select changed selection to %#x", got)
+	}
+}

--- a/internal/windowswindow/system_windows.go
+++ b/internal/windowswindow/system_windows.go
@@ -1,0 +1,208 @@
+//go:build windows
+
+package windowswindow
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+
+	"github.com/tailscale/win"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	user32DLL           = windows.NewLazySystemDLL("user32.dll")
+	procEnumWindows     = user32DLL.NewProc("EnumWindows")
+	procIsIconic        = user32DLL.NewProc("IsIconic")
+	procIsWindow        = user32DLL.NewProc("IsWindow")
+	procIsZoomed        = user32DLL.NewProc("IsZoomed")
+	errNoMatchingWindow = errors.New("no top-level window belongs to the process")
+)
+
+type nativeSystem struct{}
+
+// NewNative constructs a backend that calls User32 directly.
+func NewNative() *Backend {
+	return New(nativeSystem{})
+}
+
+func (nativeSystem) ForegroundWindow() Handle {
+	return Handle(win.GetForegroundWindow())
+}
+
+func (nativeSystem) IsWindow(handle Handle) bool {
+	result, _, _ := procIsWindow.Call(uintptr(handle))
+	return result != 0
+}
+
+func (nativeSystem) FindWindowByPID(pid uint32) (Handle, error) {
+	if pid == 0 {
+		return 0, errNoMatchingWindow
+	}
+
+	var fallback, preferred Handle
+	callback := syscall.NewCallback(func(rawHandle, _ uintptr) uintptr {
+		handle := win.HWND(rawHandle)
+		var ownerPID uint32
+		win.GetWindowThreadProcessId(handle, &ownerPID)
+		if ownerPID != pid {
+			return 1
+		}
+		if fallback == 0 {
+			fallback = Handle(rawHandle)
+		}
+		if preferred == 0 && win.IsWindowVisible(handle) &&
+			win.GetWindow(handle, win.GW_OWNER) == 0 {
+			preferred = Handle(rawHandle)
+		}
+		return 1
+	})
+	result, _, callErr := procEnumWindows.Call(callback, 0)
+	if result == 0 {
+		return 0, windowsCallError("EnumWindows", callErr)
+	}
+	if preferred != 0 {
+		return preferred, nil
+	}
+	if fallback != 0 {
+		return fallback, nil
+	}
+	return 0, errNoMatchingWindow
+}
+
+func (nativeSystem) WindowProcessID(handle Handle) (uint32, error) {
+	var pid uint32
+	if threadID := win.GetWindowThreadProcessId(win.HWND(handle), &pid); threadID == 0 || pid == 0 {
+		return 0, errors.New("GetWindowThreadProcessId returned no process")
+	}
+	return pid, nil
+}
+
+func (nativeSystem) WindowText(handle Handle) (string, error) {
+	hwnd := win.HWND(handle)
+	length := win.GetWindowTextLength(hwnd)
+	if length == 0 {
+		return "", nil
+	}
+	buffer := make([]uint16, int(length)+1)
+	written := win.GetWindowText(hwnd, &buffer[0], int32(len(buffer)))
+	if written == 0 {
+		return "", errors.New("GetWindowTextW returned no title")
+	}
+	return windows.UTF16ToString(buffer[:written]), nil
+}
+
+func (nativeSystem) WindowRect(handle Handle) (Rect, error) {
+	var native win.RECT
+	if !win.GetWindowRect(win.HWND(handle), &native) {
+		return Rect{}, errors.New("GetWindowRect failed")
+	}
+	return rectFromNative(native, win.POINT{X: native.Left, Y: native.Top}), nil
+}
+
+func (nativeSystem) ClientRect(handle Handle) (Rect, error) {
+	hwnd := win.HWND(handle)
+	var native win.RECT
+	if !win.GetClientRect(hwnd, &native) {
+		return Rect{}, errors.New("GetClientRect failed")
+	}
+	origin := win.POINT{X: native.Left, Y: native.Top}
+	if !win.ClientToScreen(hwnd, &origin) {
+		return Rect{}, errors.New("ClientToScreen failed")
+	}
+	return rectFromNative(native, origin), nil
+}
+
+func (nativeSystem) SetForegroundWindow(handle Handle) error {
+	if !win.SetForegroundWindow(win.HWND(handle)) {
+		return errors.New("SetForegroundWindow was denied")
+	}
+	return nil
+}
+
+func (nativeSystem) SetWindowState(handle Handle, state State, enabled bool) error {
+	var command int32
+	switch state {
+	case StateMinimized:
+		if enabled {
+			command = win.SW_MINIMIZE
+		} else {
+			command = win.SW_RESTORE
+		}
+	case StateMaximized:
+		if enabled {
+			command = win.SW_MAXIMIZE
+		} else {
+			command = win.SW_RESTORE
+		}
+	default:
+		return fmt.Errorf("unknown window state %d", state)
+	}
+	// ShowWindow reports the previous visibility state, not operation success.
+	win.ShowWindow(win.HWND(handle), command)
+	actual, err := (nativeSystem{}).WindowState(handle, state)
+	if err != nil {
+		return err
+	}
+	if actual != enabled {
+		return fmt.Errorf("ShowWindow did not apply state %d=%t", state, enabled)
+	}
+	return nil
+}
+
+func (nativeSystem) WindowState(handle Handle, state State) (bool, error) {
+	var procedure *windows.LazyProc
+	switch state {
+	case StateMinimized:
+		procedure = procIsIconic
+	case StateMaximized:
+		procedure = procIsZoomed
+	default:
+		return false, fmt.Errorf("unknown window state %d", state)
+	}
+	result, _, _ := procedure.Call(uintptr(handle))
+	return result != 0, nil
+}
+
+func (nativeSystem) IsTopMost(handle Handle) (bool, error) {
+	style := win.GetWindowLongPtr(win.HWND(handle), win.GWL_EXSTYLE)
+	return style&uintptr(win.WS_EX_TOPMOST) != 0, nil
+}
+
+func (nativeSystem) SetTopMost(handle Handle, enabled bool) error {
+	insertAfter := win.HWND_NOTOPMOST
+	if enabled {
+		insertAfter = win.HWND_TOPMOST
+	}
+	if !win.SetWindowPos(
+		win.HWND(handle), insertAfter,
+		0, 0, 0, 0, win.SWP_NOMOVE|win.SWP_NOSIZE,
+	) {
+		return errors.New("SetWindowPos failed")
+	}
+	return nil
+}
+
+func (nativeSystem) CloseWindow(handle Handle) error {
+	if win.PostMessage(win.HWND(handle), win.WM_CLOSE, 0, 0) == 0 {
+		return errors.New("PostMessage(WM_CLOSE) failed")
+	}
+	return nil
+}
+
+func rectFromNative(native win.RECT, origin win.POINT) Rect {
+	return Rect{
+		X:      int(origin.X),
+		Y:      int(origin.Y),
+		Width:  int(native.Right - native.Left),
+		Height: int(native.Bottom - native.Top),
+	}
+}
+
+func windowsCallError(operation string, callErr error) error {
+	if callErr == nil || errors.Is(callErr, syscall.Errno(0)) {
+		return errors.New(operation + " failed")
+	}
+	return fmt.Errorf("%s failed: %w", operation, callErr)
+}

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/marang/robotgo/clipboard"
 	inputportal "github.com/marang/robotgo/input/portal"
+	"github.com/marang/robotgo/internal/windowswindow"
 )
 
 const Version = "v1.00.0.1189, MT. Baker!"
@@ -322,13 +323,47 @@ func alertArgs(args ...string) (string, string) {
 
 func SysScale(...int) float64 { return 1 }
 
-func GetBounds(int, ...int) (int, int, int, int) { return 0, 0, 0, 0 }
-func GetClient(int, ...int) (int, int, int, int) { return 0, 0, 0, 0 }
-func GetTitle(...int) string                     { return "" }
-func SetActive(Handle)                           {}
-func SetActiveE(Handle) error                    { return ErrNotSupported }
-func ActivePid(int, ...int) error                { return ErrNotSupported }
-func ActiveName(string) error                    { return ErrNotSupported }
+func GetBounds(target int, args ...int) (int, int, int, int) {
+	return pureGoWindowBounds(target, len(args) > 0 || currentTreatAsHandle(), false)
+}
+func GetClient(target int, args ...int) (int, int, int, int) {
+	return pureGoWindowBounds(target, len(args) > 0 || currentTreatAsHandle(), true)
+}
+func GetTitle(args ...int) string {
+	title, _ := GetTitleE(args...)
+	return title
+}
+func SetActive(handle Handle) { _ = SetActiveE(handle) }
+func SetActiveE(handle Handle) error {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return err
+	}
+	return backend.Activate(windowswindow.Handle(handle))
+}
+func ActivePid(target int, args ...int) error {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return err
+	}
+	handle, err := backend.Resolve(target, len(args) > 0 || currentTreatAsHandle())
+	if err != nil {
+		return err
+	}
+	return backend.Activate(handle)
+}
+func ActiveName(name string) error {
+	pids, err := FindIds(name)
+	if err != nil {
+		return err
+	}
+	for _, pid := range pids {
+		if err := ActivePid(pid); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: no window found for process name %q", windowswindow.ErrWindowNotFound, name)
+}
 
 const (
 	KeyA           = "a"
@@ -827,10 +862,24 @@ func U8ToHex(rgb *uint8) uint32 {
 		*(*uint8)(unsafe.Add(unsafe.Pointer(rgb), 2)),
 	)
 }
-func GetActive() Handle             { return 0 }
-func GetHandle() int                { return 0 }
-func GetPid() int                   { return os.Getpid() }
-func MinWindow(int, ...interface{}) {}
-func MaxWindow(int, ...interface{}) {}
-func CloseWindow(...int)            {}
-func CloseWindowKill(...int) error  { return ErrNotSupported }
+func GetActive() Handle {
+	handle, _ := pureGoWindowActive()
+	return Handle(handle)
+}
+func GetHandle() int { return int(GetActive()) }
+func GetPid() int {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return 0
+	}
+	handle, err := backend.Active()
+	if err != nil {
+		return 0
+	}
+	pid, _ := backend.PID(handle)
+	return pid
+}
+func MinWindow(target int, args ...interface{}) { _ = MinWindowE(target, args...) }
+func MaxWindow(target int, args ...interface{}) { _ = MaxWindowE(target, args...) }
+func CloseWindow(args ...int)                   { _ = CloseWindowE(args...) }
+func CloseWindowKill(...int) error              { return ErrNotSupported }

--- a/robotgo_nocgo_parity.go
+++ b/robotgo_nocgo_parity.go
@@ -7,14 +7,31 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/marang/robotgo/internal/windowswindow"
 )
 
 // The functions in this file preserve the portable public surface for builds
 // without CGO. Native operations return ErrNotSupported instead of disappearing
 // from the package API.
 
-func ActivePidC(int, ...int) error { return ErrNotSupported }
-func CloseWindowE(...int) error    { return ErrNotSupported }
+func ActivePidC(target int, args ...int) error { return ActivePid(target, args...) }
+func CloseWindowE(args ...int) error {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return err
+	}
+	var handle windowswindow.Handle
+	if len(args) == 0 {
+		handle, err = backend.Active()
+	} else {
+		handle, err = backend.Resolve(args[0], len(args) > 1 || currentTreatAsHandle())
+	}
+	if err != nil {
+		return err
+	}
+	return backend.Close(handle)
+}
 
 func CmdCtrl() string {
 	if runtime.GOOS == "darwin" {
@@ -46,29 +63,106 @@ func FreeBitmapArr(bits ...CBitmap) {
 		FreeBitmap(bit)
 	}
 }
-func GetBHandle() int                                 { return GetHandle() }
-func GetHWNDByPid(int) int                            { return 0 }
-func GetLocationColor(...int) (string, error)         { return "", ErrNotSupported }
-func GetMousePos() (int, int)                         { return Location() }
-func GetTitleE(...int) (string, error)                { return "", ErrNotSupported }
-func GetXDisplayName() string                         { return "" }
-func SetXDisplayName(string) error                    { return ErrNotSupported }
-func Is64Bit() bool                                   { return strconv.IntSize == 64 }
-func IsMain(displayID int) bool                       { return displayID == GetMainId() }
-func IsValid() bool                                   { return false }
-func IsTopMost() bool                                 { return false }
-func IsTopMostE() (bool, error)                       { return false, ErrNotSupported }
-func IsMinimized() bool                               { return false }
-func IsMinimizedE() (bool, error)                     { return false, ErrNotSupported }
-func IsMaximized() bool                               { return false }
-func IsMaximizedE() (bool, error)                     { return false, ErrNotSupported }
-func SetTopMost(bool)                                 {}
-func SetTopMostE(bool) error                          { return ErrNotSupported }
-func SetHandle(int)                                   {}
-func SetHandlePid(int, ...int)                        {}
-func GetHandById(int, ...int) Handle                  { return 0 }
-func GetHandByPid(int, ...int) Handle                 { return 0 }
-func GetHandPid(int, ...int) Handle                   { return 0 }
+func GetBHandle() int {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return 0
+	}
+	if selected := backend.Selected(); selected != 0 {
+		return int(selected)
+	}
+	return GetHandle()
+}
+func GetHWNDByPid(pid int) int {
+	handle, err := pureGoWindowResolve(pid, false)
+	if err != nil {
+		return 0
+	}
+	return int(handle)
+}
+func GetLocationColor(...int) (string, error) { return "", ErrNotSupported }
+func GetMousePos() (int, int)                 { return Location() }
+func GetTitleE(args ...int) (string, error)   { return pureGoWindowTitle(args...) }
+func GetXDisplayName() string                 { return "" }
+func SetXDisplayName(string) error            { return ErrNotSupported }
+func Is64Bit() bool                           { return strconv.IntSize == 64 }
+func IsMain(displayID int) bool               { return displayID == GetMainId() }
+func IsValid() bool {
+	_, err := pureGoWindowActive()
+	return err == nil
+}
+func IsTopMost() bool {
+	state, _ := IsTopMostE()
+	return state
+}
+func IsTopMostE() (bool, error) {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return false, err
+	}
+	handle, err := backend.Active()
+	if err != nil {
+		return false, err
+	}
+	return backend.TopMost(handle)
+}
+func IsMinimized() bool {
+	state, _ := IsMinimizedE()
+	return state
+}
+func IsMinimizedE() (bool, error) {
+	return pureGoActiveWindowState(windowswindow.StateMinimized)
+}
+func IsMaximized() bool {
+	state, _ := IsMaximizedE()
+	return state
+}
+func IsMaximizedE() (bool, error) {
+	return pureGoActiveWindowState(windowswindow.StateMaximized)
+}
+func SetTopMost(state bool) { _ = SetTopMostE(state) }
+func SetTopMostE(state bool) error {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return err
+	}
+	handle, err := backend.Active()
+	if err != nil {
+		return err
+	}
+	return backend.SetTopMost(handle, state)
+}
+func SetHandle(handle int) {
+	backend, err := pureGoWindowBackend()
+	if err == nil {
+		_ = backend.Select(handle, true)
+	}
+}
+func SetHandlePid(target int, args ...int) {
+	backend, err := pureGoWindowBackend()
+	if err == nil {
+		_ = backend.Select(target, len(args) > 0 || currentTreatAsHandle())
+	}
+}
+func GetHandById(id int, args ...int) Handle {
+	isHandle := true
+	if len(args) > 0 {
+		isHandle = args[0] != 0
+	}
+	handle, err := pureGoWindowResolve(id, isHandle)
+	if err != nil {
+		return 0
+	}
+	return Handle(handle)
+}
+func GetHandByPid(target int, args ...int) Handle {
+	handle, err := pureGoWindowResolve(target, len(args) > 0 || currentTreatAsHandle())
+	if err != nil {
+		return 0
+	}
+	return Handle(handle)
+}
+func GetHandPid(target int, args ...int) Handle       { return GetHandByPid(target, args...) }
 func MicroSleep(tm float64)                           { time.Sleep(time.Duration(tm * float64(time.Millisecond))) }
 func PadHexs(hex CHex) string                         { return PadHex(uint32(hex)) }
 func UintToHex(value uint32) CHex                     { return CHex(value) }
@@ -162,15 +256,41 @@ func Try(fn func(), handler func(interface{})) {
 }
 func TypeStringDelayed(text string, delay int) { TypeStrDelay(text, delay) }
 
-func MinWindowE(_ int, args ...interface{}) error {
-	if _, err := parseWindowStateArguments(args); err != nil {
+func MinWindowE(target int, args ...interface{}) error {
+	state, err := parseWindowStateArguments(args)
+	if err != nil {
 		return err
 	}
-	return ErrNotSupported
+	return pureGoSetWindowState(target, state, len(args) > 1 || currentTreatAsHandle(), windowswindow.StateMinimized)
 }
-func MaxWindowE(_ int, args ...interface{}) error {
-	if _, err := parseWindowStateArguments(args); err != nil {
+func MaxWindowE(target int, args ...interface{}) error {
+	state, err := parseWindowStateArguments(args)
+	if err != nil {
 		return err
 	}
-	return ErrNotSupported
+	return pureGoSetWindowState(target, state, len(args) > 1 || currentTreatAsHandle(), windowswindow.StateMaximized)
+}
+
+func pureGoActiveWindowState(state windowswindow.State) (bool, error) {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return false, err
+	}
+	handle, err := backend.Active()
+	if err != nil {
+		return false, err
+	}
+	return backend.State(handle, state)
+}
+
+func pureGoSetWindowState(target int, enabled, isHandle bool, state windowswindow.State) error {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return err
+	}
+	handle, err := backend.Resolve(target, isHandle)
+	if err != nil {
+		return err
+	}
+	return backend.SetState(handle, state, enabled)
 }

--- a/runtime_capabilities_nocgo.go
+++ b/runtime_capabilities_nocgo.go
@@ -50,5 +50,6 @@ func runtimeCapabilities() RuntimeCapabilities {
 	if mouse.Backend != "" {
 		result.Mouse = mouse
 	}
+	result.Window = pureGoWindowCapability()
 	return result
 }

--- a/runtime_config_nocgo.go
+++ b/runtime_config_nocgo.go
@@ -1,0 +1,5 @@
+//go:build !cgo
+
+package robotgo
+
+func currentTreatAsHandle() bool { return GetRuntimeConfig().TreatAsHandle }

--- a/window_backend_default_nocgo.go
+++ b/window_backend_default_nocgo.go
@@ -1,0 +1,9 @@
+//go:build !windows && !cgo
+
+package robotgo
+
+import "github.com/marang/robotgo/internal/windowswindow"
+
+func platformPureGoWindowBackend() *windowswindow.Backend {
+	return nil
+}

--- a/window_backend_nocgo.go
+++ b/window_backend_nocgo.go
@@ -1,0 +1,83 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"fmt"
+
+	"github.com/marang/robotgo/internal/windowswindow"
+)
+
+func pureGoWindowBackend() (*windowswindow.Backend, error) {
+	backend := platformPureGoWindowBackend()
+	if backend == nil {
+		return nil, fmt.Errorf("%w: no Pure-Go window backend is active", ErrNotSupported)
+	}
+	return backend, nil
+}
+
+func pureGoWindowCapability() FeatureCapability {
+	if platformPureGoWindowBackend() == nil {
+		return FeatureCapability{
+			Reason: ErrNotSupported.Error(),
+			Notes:  "no matching Pure-Go window backend is active in this build",
+		}
+	}
+	return FeatureCapability{
+		Available: true,
+		Backend:   featureBackendPureGoWindows,
+		Reason:    "Pure-Go Win32 window introspection and control are available",
+		Notes:     "PID targets prefer visible unowned top-level windows; Windows foreground-activation policy still applies",
+	}
+}
+
+func pureGoWindowActive() (windowswindow.Handle, error) {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return 0, err
+	}
+	return backend.Active()
+}
+
+func pureGoWindowResolve(target int, isHandle bool) (windowswindow.Handle, error) {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return 0, err
+	}
+	return backend.Resolve(target, isHandle)
+}
+
+func pureGoWindowTitle(args ...int) (string, error) {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return "", err
+	}
+	if len(args) == 0 {
+		handle, activeErr := backend.Active()
+		if activeErr != nil {
+			return "", activeErr
+		}
+		return backend.Title(handle)
+	}
+	handle, err := backend.Resolve(args[0], len(args) > 1 || currentTreatAsHandle())
+	if err != nil {
+		return "", err
+	}
+	return backend.Title(handle)
+}
+
+func pureGoWindowBounds(target int, isHandle, client bool) (int, int, int, int) {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return 0, 0, 0, 0
+	}
+	handle, err := backend.Resolve(target, isHandle)
+	if err != nil {
+		return 0, 0, 0, 0
+	}
+	rect, err := backend.Bounds(handle, client)
+	if err != nil {
+		return 0, 0, 0, 0
+	}
+	return rect.X, rect.Y, rect.Width, rect.Height
+}

--- a/window_backend_windows_nocgo.go
+++ b/window_backend_windows_nocgo.go
@@ -1,0 +1,11 @@
+//go:build windows && !cgo
+
+package robotgo
+
+import "github.com/marang/robotgo/internal/windowswindow"
+
+var pureGoWindowsWindowBackend = windowswindow.NewNative()
+
+func platformPureGoWindowBackend() *windowswindow.Backend {
+	return pureGoWindowsWindowBackend
+}

--- a/windows_window_integration_test.go
+++ b/windows_window_integration_test.go
@@ -1,0 +1,216 @@
+//go:build windows && !cgo && windowsintegration
+
+package robotgo
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/tailscale/win"
+)
+
+const envRequireWindowsWindowIntegration = "ROBOTGO_REQUIRE_WINDOWS_WINDOW_INTEGRATION"
+
+func TestPureGoWindowsWindowRuntime(t *testing.T) {
+	if os.Getenv(envRequireWindowsWindowIntegration) != "1" {
+		t.Skip("set " + envRequireWindowsWindowIntegration + "=1 to exercise a real Windows desktop window")
+	}
+
+	handle, stopped := startWindowsIntegrationWindow(t)
+	pid := os.Getpid()
+
+	capability := GetRuntimeCapabilities().Window
+	if !capability.Available || capability.Backend != featureBackendPureGoWindows {
+		t.Fatalf("window capability = %+v", capability)
+	}
+
+	title, err := GetTitleE(int(handle), 1)
+	if err != nil || title != "RobotGo Pure-Go window integration" {
+		t.Fatalf("GetTitleE(handle) = %q, %v", title, err)
+	}
+	title, err = GetTitleE(pid)
+	if err != nil || title != "RobotGo Pure-Go window integration" {
+		t.Fatalf("GetTitleE(pid) = %q, %v", title, err)
+	}
+	if resolved := GetHWNDByPid(pid); resolved != int(handle) {
+		t.Fatalf("GetHWNDByPid(%d) = %#x, want %#x", pid, resolved, handle)
+	}
+	if resolved := GetHandByPid(pid); resolved != Handle(handle) {
+		t.Fatalf("GetHandByPid(%d) = %#x, want %#x", pid, resolved, handle)
+	}
+
+	x, y, width, height := GetBounds(int(handle), 1)
+	if width <= 0 || height <= 0 {
+		t.Fatalf("GetBounds(handle) = (%d, %d, %d, %d)", x, y, width, height)
+	}
+	clientX, clientY, clientWidth, clientHeight := GetClient(int(handle), 1)
+	if clientWidth <= 0 || clientHeight <= 0 || clientWidth > width || clientHeight > height {
+		t.Fatalf("GetClient(handle) = (%d, %d, %d, %d), window=(%d, %d, %d, %d)",
+			clientX, clientY, clientWidth, clientHeight, x, y, width, height)
+	}
+
+	if err := MinWindowE(int(handle), true, 1); err != nil {
+		t.Fatalf("MinWindowE(true): %v", err)
+	}
+	waitForWindowsCondition(t, "window to minimize", func() bool {
+		return win.GetWindowLongPtr(handle, win.GWL_STYLE)&uintptr(win.WS_MINIMIZE) != 0
+	})
+	if err := MinWindowE(int(handle), false, 1); err != nil {
+		t.Fatalf("MinWindowE(false): %v", err)
+	}
+	if err := MaxWindowE(int(handle), true, 1); err != nil {
+		t.Fatalf("MaxWindowE(true): %v", err)
+	}
+	waitForWindowsCondition(t, "window to maximize", func() bool {
+		return win.GetWindowLongPtr(handle, win.GWL_STYLE)&uintptr(win.WS_MAXIMIZE) != 0
+	})
+	if err := MaxWindowE(int(handle), false, 1); err != nil {
+		t.Fatalf("MaxWindowE(false): %v", err)
+	}
+
+	if err := SetActiveE(Handle(handle)); err != nil {
+		t.Fatalf("SetActiveE: %v", err)
+	}
+	waitForWindowsCondition(t, "window to become foreground", func() bool {
+		return GetActive() == Handle(handle)
+	})
+	if got := GetPid(); got != pid {
+		t.Fatalf("GetPid() = %d, want %d", got, pid)
+	}
+	if minimized, err := IsMinimizedE(); err != nil || minimized {
+		t.Fatalf("IsMinimizedE() = %v, %v after restore", minimized, err)
+	}
+	if maximized, err := IsMaximizedE(); err != nil || maximized {
+		t.Fatalf("IsMaximizedE() = %v, %v after restore", maximized, err)
+	}
+	if err := SetTopMostE(true); err != nil {
+		t.Fatalf("SetTopMostE(true): %v", err)
+	}
+	topMost, err := IsTopMostE()
+	if err != nil || !topMost {
+		t.Fatalf("IsTopMostE() = %v, %v", topMost, err)
+	}
+	if err := SetTopMostE(false); err != nil {
+		t.Fatalf("SetTopMostE(false): %v", err)
+	}
+
+	if err := CloseWindowE(int(handle), 1); err != nil {
+		t.Fatalf("CloseWindowE(handle): %v", err)
+	}
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("window did not process WM_CLOSE")
+	}
+}
+
+func startWindowsIntegrationWindow(t *testing.T) (win.HWND, <-chan struct{}) {
+	t.Helper()
+	created := make(chan win.HWND, 1)
+	failed := make(chan error, 1)
+	stopped := make(chan struct{})
+
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		defer close(stopped)
+
+		instance := win.GetModuleHandle(nil)
+		className, err := syscall.UTF16PtrFromString(fmt.Sprintf("RobotGoPureGoWindow%d", os.Getpid()))
+		if err != nil {
+			failed <- err
+			return
+		}
+		title, err := syscall.UTF16PtrFromString("RobotGo Pure-Go window integration")
+		if err != nil {
+			failed <- err
+			return
+		}
+		windowProc := syscall.NewCallback(func(handle uintptr, message uint32, wParam, lParam uintptr) uintptr {
+			switch message {
+			case win.WM_DESTROY:
+				win.PostQuitMessage(0)
+				return 0
+			default:
+				return win.DefWindowProc(win.HWND(handle), message, wParam, lParam)
+			}
+		})
+		class := win.WNDCLASSEX{
+			CbSize:        uint32(unsafe.Sizeof(win.WNDCLASSEX{})),
+			LpfnWndProc:   windowProc,
+			HInstance:     instance,
+			LpszClassName: className,
+		}
+		if atom := win.RegisterClassEx(&class); atom == 0 {
+			failed <- errorsFromWindowsCall("RegisterClassEx")
+			return
+		}
+		defer win.UnregisterClass(className)
+
+		handle := win.CreateWindowEx(
+			0, className, title, win.WS_OVERLAPPEDWINDOW,
+			80, 90, 420, 300, 0, 0, instance, nil,
+		)
+		if handle == 0 {
+			failed <- errorsFromWindowsCall("CreateWindowEx")
+			return
+		}
+		win.ShowWindow(handle, win.SW_SHOW)
+		created <- handle
+
+		var message win.MSG
+		for {
+			result := win.GetMessage(&message, 0, 0, 0)
+			if result == 0 {
+				break
+			}
+			if int32(result) == -1 {
+				failed <- errorsFromWindowsCall("GetMessage")
+				return
+			}
+			win.TranslateMessage(&message)
+			win.DispatchMessage(&message)
+		}
+		runtime.KeepAlive(windowProc)
+	}()
+
+	select {
+	case handle := <-created:
+		t.Cleanup(func() {
+			if win.GetWindowThreadProcessId(handle, nil) != 0 {
+				win.PostMessage(handle, win.WM_CLOSE, 0, 0)
+			}
+		})
+		return handle, stopped
+	case err := <-failed:
+		t.Fatalf("create integration window: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out creating integration window")
+	}
+	return 0, stopped
+}
+
+func waitForWindowsCondition(t *testing.T, description string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for " + description)
+}
+
+func errorsFromWindowsCall(operation string) error {
+	err := syscall.GetLastError()
+	if err == nil || err == syscall.Errno(0) {
+		return fmt.Errorf("%s failed", operation)
+	}
+	return fmt.Errorf("%s failed: %w", operation, err)
+}


### PR DESCRIPTION
## Goal

Complete the next selective Phase 3 slice by making the non-CGO Windows window APIs useful and explicit instead of returning placeholder zero values or unsupported errors.

## Changes

- add a Pure-Go Win32 window backend with validated PID/handle resolution
- prefer visible unowned top-level windows for PID targets, with a deterministic fallback
- support active handle/PID, title, outer/client bounds, activation, minimize/maximize, topmost state, and graceful close
- report the `pure-go-windows` window capability
- add hermetic backend tests and a self-owned real Win32 integration window
- make the real desktop contract blocking in the Windows non-CGO CI leg
- add a safe-by-default runnable example and update README, TEST, and roadmap status

## Risk and contracts

- Windows foreground policy may deny activation; `SetActiveE` returns that failure explicitly
- target mutation in CI is confined to a window created and owned by the test process
- legacy non-error APIs retain their compatibility behavior; error-returning APIs expose failures
- no default backend switch is involved

## Local validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./internal/windowswindow`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run`
- `CGO_ENABLED=0 golangci-lint run`
- Windows amd64/386 cross-compilation with `windowsintegration`
