### PR TITLE
feat: add Pure-Go paste and pointer color parity

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -146,7 +146,7 @@ jobs:
           -run "^TestPureGoWindowsInputRuntime$"
           -count=1 -timeout=30s -v .
 
-      - name: Test Pure-Go Windows window desktop
+      - name: Test Pure-Go Windows window and paste desktop
         if: runner.os == 'Windows'
         env:
           CGO_ENABLED: "0"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
 | macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture and display bounds with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
-| Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds, foreground-layout-aware `SendInput` keyboard/text, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
+| Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds and pixel-at-pointer queries, foreground-layout-aware `SendInput` keyboard/text plus clipboard paste, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
 | Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds plus XTEST mouse, keyboard, text/Unicode, pointer-location, smooth-move/drag, vertical scroll, and live readiness probes; horizontal scroll is explicitly unsupported |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |
@@ -613,13 +613,15 @@ CGO_ENABLED=0 go run ./examples/purego_x11_input -act -text "Hello"
 Keyboard actions keep scratch mappings alive for two seconds before verified
 cleanup. Increase `-settle` when the focused XKB client may process input later.
 
-On Windows, the Pure-Go example performs readiness checks only unless `-move`
-or `-text` is supplied:
+On Windows, the Pure-Go example performs readiness checks only unless `-move`,
+`-text`, `-paste`, or `-color` is supplied. `-paste` replaces the text
+clipboard before sending Control+V:
 
 ```powershell
 $env:CGO_ENABLED = "0"
 go run ./examples/purego_windows_input
 go run ./examples/purego_windows_input -move 400,300 -text "Hello"
+go run ./examples/purego_windows_input -color -paste "Hello from the clipboard"
 ```
 
 `SendInput` is subject to Windows User Interface Privilege Isolation: a

--- a/TEST.md
+++ b/TEST.md
@@ -50,9 +50,10 @@ self-hosted runners are registered.
 
 Pure-Go Windows input has hermetic tests for Win32 `INPUT` layout,
 foreground-layout key mapping, Unicode surrogate pairs, partial-injection
-rollback, ownership, buttons, scrolling, and movement. They run in the Windows
-non-CGO CI leg. The same leg runs a real input-desktop pointer probe and restores
-the original global cursor position:
+rollback, ownership, buttons, scrolling, movement, clipboard-paste sequencing,
+and pixel-at-pointer dispatch. They run in the Windows non-CGO CI leg. The same
+leg runs a real input-desktop pointer and pixel-color probe and restores the
+original global cursor position:
 
 ```powershell
 $env:CGO_ENABLED = "0"
@@ -61,15 +62,13 @@ go test -tags windowsintegration -run "^TestPureGoWindowsInputRuntime$" -count=1
 ```
 
 The environment variable remains an explicit safety gate for local execution.
-Keyboard injection stays hermetic because a generic hosted runner offers no
-trustworthy foreground target; the runnable example provides explicit manual
-validation.
 
 Pure-Go Windows window control uses a self-owned Win32 top-level window, so the
-hosted runner can validate the full contract without touching another
-application. The test covers capability reporting, PID/handle resolution,
-title, outer/client bounds, minimize/maximize, foreground activation, topmost
-state, and `WM_CLOSE`:
+hosted runner can validate the full window contract and clipboard-assisted
+keyboard injection without typing into another application. The test covers
+capability reporting, PID/handle resolution, title, outer/client bounds,
+minimize/maximize, foreground activation, Unicode `PasteStr` into an owned edit
+control, topmost state, and `WM_CLOSE`:
 
 ```powershell
 $env:CGO_ENABLED = "0"
@@ -77,8 +76,9 @@ $env:ROBOTGO_REQUIRE_WINDOWS_WINDOW_INTEGRATION = "1"
 go test -tags windowsintegration -run "^TestPureGoWindowsWindowRuntime$" -count=1 -v .
 ```
 
-The environment variable is an explicit local safety gate. CI runs this command
-as a blocking Windows non-CGO check.
+The environment variable is an explicit local safety gate because the test
+temporarily changes the text clipboard; it restores the previous readable text
+value during cleanup. CI runs this command as a blocking Windows non-CGO check.
 
 Opt-in macOS runtime capture benchmark:
 

--- a/clipboard/clipboard_windows.go
+++ b/clipboard/clipboard_windows.go
@@ -96,8 +96,10 @@ func readAllContext(ctx context.Context, selection Selection) (string, error) {
 	text := syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(l))[:])
 
 	r, _, err := globalUnlock.Call(h)
-	if r == 0 {
-		return "", err
+	if r == 0 && err != nil {
+		if errno, ok := err.(syscall.Errno); !ok || errno != 0 {
+			return "", err
+		}
 	}
 
 	return text, nil

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -139,19 +139,21 @@ CoreGraphics ownership are covered hermetically on both supported
 architectures.
 
 Windows non-CGO builds now provide a foreground-layout-aware `SendInput` keyboard and text
-backend plus exact pointer movement/location, smooth movement and drag,
+backend, clipboard-assisted Unicode paste, pixel-at-pointer queries, plus exact pointer movement/location, smooth movement and drag,
 buttons, horizontal and vertical scrolling, live readiness checks, partial
 injection rollback, ownership conflicts, and deterministic in-process cleanup.
 Exact Unicode text is encoded as UTF-16, while `KeyTap` resolves characters
 through the foreground target's Windows keyboard layout instead of assuming US key
 positions. Hermetic tests validate 32/64-bit `INPUT` layout and transaction
 semantics. The Windows non-CGO CI leg runs the explicitly gated real
-input-desktop pointer test and restores the original global cursor position.
+input-desktop pointer/pixel test and restores the original global cursor position.
 The same build provides Win32 window capability reporting, active handle/PID,
 PID-to-window resolution, titles, outer/client geometry, activation,
 minimize/maximize, topmost state, and graceful close. Its blocking runtime test
 creates and owns the target window, exercises each operation, and never mutates
-an unrelated application.
+an unrelated application. The owned runtime window also contains an edit
+control that provides blocking evidence for clipboard-assisted Unicode paste
+and restores the previous readable text clipboard value.
 
 Linux/X11 additionally has a Pure-Go XGB/XTEST keyboard and pointer backend for
 the error-returning input APIs, text/Unicode, pointer location, smooth

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -25,7 +25,8 @@ Current implementation baseline:
 - Windows non-CGO builds provide foreground-layout-aware keyboard/text and pointer input
   through user32, including exact Unicode, smooth movement/drag, horizontal and
   vertical scroll, ownership checks, partial-injection rollback, live
-  readiness, and deterministic in-process cleanup.
+  readiness, deterministic in-process cleanup, clipboard-assisted paste, and
+  pixel-at-pointer queries.
 - Non-CGO `CaptureImg`/`CaptureScreen`, their Go-bitmap/string variants, and
   pixel-color queries use the hardened screenshot portal on Wayland and the
   Pure-Go screenshot backend on X11/Windows; unsupported targets fail explicitly.
@@ -195,7 +196,8 @@ Window backend support matrix (current):
     readiness checks and global input must remain behind its explicit `-act`
     flag.
   - Keep `examples/purego_windows_input` readiness-only by default; global
-    pointer or keyboard input requires explicit `-move` or `-text` flags.
+    pointer, keyboard, clipboard, or capture actions require explicit `-move`,
+    `-text`, `-paste`, or `-color` flags.
   - Keep the explicitly gated real Windows input-desktop pointer probe blocking
     in the non-CGO Windows CI leg; it must restore the original cursor position.
   - Publish a versioned support matrix and troubleshooting guide.

--- a/examples/purego_windows_input/main.go
+++ b/examples/purego_windows_input/main.go
@@ -6,9 +6,10 @@
 //
 //	CGO_ENABLED=0 go run ./examples/purego_windows_input
 //
-// Opt in to visible input with -move and/or -text:
+// Opt in to visible input with -move, -text, or -paste. Use -color to inspect
+// the pixel under the pointer:
 //
-//	CGO_ENABLED=0 go run ./examples/purego_windows_input -move 400,300 -text "Hello"
+//	CGO_ENABLED=0 go run ./examples/purego_windows_input -move 400,300 -color -paste "Hello"
 package main
 
 import (
@@ -24,6 +25,8 @@ import (
 func main() {
 	move := flag.String("move", "", "optional absolute pointer target as x,y")
 	text := flag.String("text", "", "optional text to type into the active application")
+	paste := flag.String("paste", "", "optional text to copy and paste into the active application")
+	color := flag.Bool("color", false, "print the RGB color under the current pointer")
 	flag.Parse()
 
 	info := robotgo.GetRuntimeBackendInfo()
@@ -58,6 +61,20 @@ func main() {
 			fmt.Fprintln(os.Stderr, "text:", err)
 			os.Exit(1)
 		}
+	}
+	if *paste != "" {
+		if err := robotgo.PasteStr(*paste); err != nil {
+			fmt.Fprintln(os.Stderr, "paste:", err)
+			os.Exit(1)
+		}
+	}
+	if *color {
+		value, err := robotgo.GetLocationColor()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "pointer color:", err)
+			os.Exit(1)
+		}
+		fmt.Println("pointer RGB:", value)
 	}
 }
 

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -544,7 +544,33 @@ func TypeStrDelay(text string, delay int) {
 	TypeStr(text)
 	MilliSleep(delay)
 }
-func PasteStr(string) error      { return ErrNotSupported }
+
+// PasteStr writes text to the clipboard and pastes it through the active
+// Pure-Go keyboard backend. Readiness is checked before changing the clipboard
+// so unsupported builds do not cause a misleading partial side effect.
+func PasteStr(text string) error {
+	return pasteStringWith(text, runtime.GOOS, KeyboardReady, clipboard.WriteAll, KeyTap)
+}
+
+func pasteStringWith(
+	text, goos string,
+	ready func() error,
+	write func(string) error,
+	tap func(string, ...interface{}) error,
+) error {
+	if err := ready(); err != nil {
+		return err
+	}
+	if err := write(text); err != nil {
+		return err
+	}
+	modifier := "control"
+	if goos == "darwin" {
+		modifier = "command"
+	}
+	return tap("v", modifier)
+}
+
 func ReadAll() (string, error)   { return clipboard.ReadAll() }
 func WriteAll(text string) error { return clipboard.WriteAll(text) }
 func CharCodeAt(s string, n int) rune {

--- a/robotgo_nocgo_convenience_test.go
+++ b/robotgo_nocgo_convenience_test.go
@@ -1,0 +1,151 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestPasteStringWithStopsBeforeClipboardWhenKeyboardIsUnavailable(t *testing.T) {
+	readinessErr := errors.New("keyboard unavailable")
+	var calls []string
+
+	err := pasteStringWith(
+		"text",
+		"windows",
+		func() error {
+			calls = append(calls, "ready")
+			return readinessErr
+		},
+		func(string) error {
+			calls = append(calls, "write")
+			return nil
+		},
+		func(string, ...interface{}) error {
+			calls = append(calls, "tap")
+			return nil
+		},
+	)
+
+	if !errors.Is(err, readinessErr) {
+		t.Fatalf("pasteStringWith error = %v, want %v", err, readinessErr)
+	}
+	if want := []string{"ready"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestPasteStringWithStopsAfterClipboardFailure(t *testing.T) {
+	writeErr := errors.New("clipboard unavailable")
+	var calls []string
+
+	err := pasteStringWith(
+		"text",
+		"windows",
+		func() error {
+			calls = append(calls, "ready")
+			return nil
+		},
+		func(text string) error {
+			calls = append(calls, "write:"+text)
+			return writeErr
+		},
+		func(string, ...interface{}) error {
+			calls = append(calls, "tap")
+			return nil
+		},
+	)
+
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("pasteStringWith error = %v, want %v", err, writeErr)
+	}
+	if want := []string{"ready", "write:text"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestPasteStringWithSelectsPlatformModifier(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		goos string
+		want string
+	}{
+		{name: "Windows", goos: "windows", want: "control"},
+		{name: "Linux", goos: "linux", want: "control"},
+		{name: "macOS", goos: "darwin", want: "command"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var gotKey string
+			var gotModifiers []interface{}
+			err := pasteStringWith(
+				"RobotGo",
+				test.goos,
+				func() error { return nil },
+				func(text string) error {
+					if text != "RobotGo" {
+						t.Fatalf("clipboard text = %q", text)
+					}
+					return nil
+				},
+				func(key string, modifiers ...interface{}) error {
+					gotKey = key
+					gotModifiers = append([]interface{}(nil), modifiers...)
+					return nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("pasteStringWith: %v", err)
+			}
+			if gotKey != "v" {
+				t.Fatalf("key = %q, want v", gotKey)
+			}
+			if want := []interface{}{test.want}; !reflect.DeepEqual(gotModifiers, want) {
+				t.Fatalf("modifiers = %v, want %v", gotModifiers, want)
+			}
+		})
+	}
+}
+
+func TestGetLocationColorWithForwardsCoordinatesAndDisplay(t *testing.T) {
+	color, err := getLocationColorWith(
+		[]int{2},
+		func() (int, int, error) { return -30, 47, nil },
+		func(x, y int, displayID ...int) (string, error) {
+			if x != -30 || y != 47 {
+				t.Fatalf("coordinates = (%d, %d)", x, y)
+			}
+			if want := []int{2}; !reflect.DeepEqual(displayID, want) {
+				t.Fatalf("display IDs = %v, want %v", displayID, want)
+			}
+			return "a1b2c3", nil
+		},
+	)
+	if err != nil || color != "a1b2c3" {
+		t.Fatalf("getLocationColorWith = %q, %v", color, err)
+	}
+}
+
+func TestGetLocationColorWithPropagatesLocationFailure(t *testing.T) {
+	locationErr := errors.New("location unavailable")
+	pixelCalled := false
+
+	color, err := getLocationColorWith(
+		nil,
+		func() (int, int, error) { return 0, 0, locationErr },
+		func(int, int, ...int) (string, error) {
+			pixelCalled = true
+			return "", nil
+		},
+	)
+	if !errors.Is(err, locationErr) {
+		t.Fatalf("error = %v, want %v", err, locationErr)
+	}
+	if color != "" {
+		t.Fatalf("color = %q, want empty", color)
+	}
+	if pixelCalled {
+		t.Fatal("pixel backend called after location failure")
+	}
+}

--- a/robotgo_nocgo_parity.go
+++ b/robotgo_nocgo_parity.go
@@ -80,13 +80,28 @@ func GetHWNDByPid(pid int) int {
 	}
 	return int(handle)
 }
-func GetLocationColor(...int) (string, error) { return "", ErrNotSupported }
-func GetMousePos() (int, int)                 { return Location() }
-func GetTitleE(args ...int) (string, error)   { return pureGoWindowTitle(args...) }
-func GetXDisplayName() string                 { return "" }
-func SetXDisplayName(string) error            { return ErrNotSupported }
-func Is64Bit() bool                           { return strconv.IntSize == 64 }
-func IsMain(displayID int) bool               { return displayID == GetMainId() }
+func GetLocationColor(displayID ...int) (string, error) {
+	return getLocationColorWith(displayID, LocationE, GetPixelColor)
+}
+
+func getLocationColorWith(
+	displayID []int,
+	location func() (int, int, error),
+	pixelColor func(int, int, ...int) (string, error),
+) (string, error) {
+	x, y, err := location()
+	if err != nil {
+		return "", err
+	}
+	return pixelColor(x, y, displayID...)
+}
+
+func GetMousePos() (int, int)               { return Location() }
+func GetTitleE(args ...int) (string, error) { return pureGoWindowTitle(args...) }
+func GetXDisplayName() string               { return "" }
+func SetXDisplayName(string) error          { return ErrNotSupported }
+func Is64Bit() bool                         { return strconv.IntSize == 64 }
+func IsMain(displayID int) bool             { return displayID == GetMainId() }
 func IsValid() bool {
 	_, err := pureGoWindowActive()
 	return err == nil

--- a/windows_input_integration_test.go
+++ b/windows_input_integration_test.go
@@ -4,6 +4,7 @@ package robotgo_test
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/marang/robotgo"
@@ -31,6 +32,7 @@ func TestPureGoWindowsInputRuntime(t *testing.T) {
 		}
 	})
 
+	moved := false
 	for _, delta := range []int{1, -1} {
 		if err := robotgo.MoveE(startX+delta, startY); err != nil {
 			t.Fatalf("MoveE(%d,%d): %v", startX+delta, startY, err)
@@ -40,8 +42,22 @@ func TestPureGoWindowsInputRuntime(t *testing.T) {
 			t.Fatalf("LocationE after move: %v", err)
 		}
 		if x == startX+delta && y == startY {
-			return
+			moved = true
+			break
 		}
 	}
-	t.Fatal("Windows input desktop accepted no observable one-pixel pointer move")
+	if !moved {
+		t.Fatal("Windows input desktop accepted no observable one-pixel pointer move")
+	}
+
+	locationColor, err := robotgo.GetLocationColor()
+	if err != nil {
+		t.Fatalf("GetLocationColor: %v", err)
+	}
+	if len(locationColor) != 6 {
+		t.Fatalf("GetLocationColor = %q, want six-digit RGB", locationColor)
+	}
+	if _, err := strconv.ParseUint(locationColor, 16, 24); err != nil {
+		t.Fatalf("GetLocationColor = %q, want hexadecimal RGB: %v", locationColor, err)
+	}
 }

--- a/windows_window_integration_test.go
+++ b/windows_window_integration_test.go
@@ -16,12 +16,14 @@ import (
 
 const envRequireWindowsWindowIntegration = "ROBOTGO_REQUIRE_WINDOWS_WINDOW_INTEGRATION"
 
+const windowsIntegrationFocusEditMessage = win.WM_USER + 1
+
 func TestPureGoWindowsWindowRuntime(t *testing.T) {
 	if os.Getenv(envRequireWindowsWindowIntegration) != "1" {
-		t.Skip("set " + envRequireWindowsWindowIntegration + "=1 to exercise a real Windows desktop window")
+		t.Skip("set " + envRequireWindowsWindowIntegration + "=1 to exercise a real Windows desktop window and the text clipboard")
 	}
 
-	handle, stopped := startWindowsIntegrationWindow(t)
+	handle, editHandle, stopped := startWindowsIntegrationWindow(t)
 	pid := os.Getpid()
 
 	capability := GetRuntimeCapabilities().Window
@@ -82,6 +84,27 @@ func TestPureGoWindowsWindowRuntime(t *testing.T) {
 	if got := GetPid(); got != pid {
 		t.Fatalf("GetPid() = %d, want %d", got, pid)
 	}
+
+	previousClipboard, clipboardErr := ReadAll()
+	if clipboardErr != nil {
+		previousClipboard = ""
+	}
+	t.Cleanup(func() {
+		if err := WriteAll(previousClipboard); err != nil {
+			t.Errorf("restore text clipboard: %v", err)
+		}
+	})
+	if focused := win.SendMessage(handle, windowsIntegrationFocusEditMessage, 0, 0); focused != uintptr(editHandle) {
+		t.Fatalf("focus integration edit returned %#x, want %#x", focused, editHandle)
+	}
+	const pasteText = "RobotGo Pure-Go paste ✓"
+	if err := PasteStr(pasteText); err != nil {
+		t.Fatalf("PasteStr: %v", err)
+	}
+	waitForWindowsCondition(t, "clipboard text to reach owned edit control", func() bool {
+		return windowsWindowText(editHandle) == pasteText
+	})
+
 	if minimized, err := IsMinimizedE(); err != nil || minimized {
 		t.Fatalf("IsMinimizedE() = %v, %v after restore", minimized, err)
 	}
@@ -109,9 +132,13 @@ func TestPureGoWindowsWindowRuntime(t *testing.T) {
 	}
 }
 
-func startWindowsIntegrationWindow(t *testing.T) (win.HWND, <-chan struct{}) {
+func startWindowsIntegrationWindow(t *testing.T) (win.HWND, win.HWND, <-chan struct{}) {
 	t.Helper()
-	created := make(chan win.HWND, 1)
+	type createdWindows struct {
+		window win.HWND
+		edit   win.HWND
+	}
+	created := make(chan createdWindows, 1)
 	failed := make(chan error, 1)
 	stopped := make(chan struct{})
 
@@ -131,8 +158,12 @@ func startWindowsIntegrationWindow(t *testing.T) (win.HWND, <-chan struct{}) {
 			failed <- err
 			return
 		}
+		var editHandle win.HWND
 		windowProc := syscall.NewCallback(func(handle uintptr, message uint32, wParam, lParam uintptr) uintptr {
 			switch message {
+			case windowsIntegrationFocusEditMessage:
+				win.SetFocus(editHandle)
+				return uintptr(win.GetFocus())
 			case win.WM_DESTROY:
 				win.PostQuitMessage(0)
 				return 0
@@ -160,8 +191,22 @@ func startWindowsIntegrationWindow(t *testing.T) (win.HWND, <-chan struct{}) {
 			failed <- errorsFromWindowsCall("CreateWindowEx")
 			return
 		}
+		editClass, err := syscall.UTF16PtrFromString("EDIT")
+		if err != nil {
+			failed <- err
+			return
+		}
+		editHandle = win.CreateWindowEx(
+			win.WS_EX_CLIENTEDGE, editClass, nil,
+			win.WS_CHILD|win.WS_VISIBLE|win.WS_TABSTOP|win.ES_AUTOHSCROLL,
+			20, 20, 360, 32, handle, 0, instance, nil,
+		)
+		if editHandle == 0 {
+			failed <- errorsFromWindowsCall("CreateWindowEx EDIT")
+			return
+		}
 		win.ShowWindow(handle, win.SW_SHOW)
-		created <- handle
+		created <- createdWindows{window: handle, edit: editHandle}
 
 		var message win.MSG
 		for {
@@ -180,19 +225,19 @@ func startWindowsIntegrationWindow(t *testing.T) (win.HWND, <-chan struct{}) {
 	}()
 
 	select {
-	case handle := <-created:
+	case windows := <-created:
 		t.Cleanup(func() {
-			if win.GetWindowThreadProcessId(handle, nil) != 0 {
-				win.PostMessage(handle, win.WM_CLOSE, 0, 0)
+			if win.GetWindowThreadProcessId(windows.window, nil) != 0 {
+				win.PostMessage(windows.window, win.WM_CLOSE, 0, 0)
 			}
 		})
-		return handle, stopped
+		return windows.window, windows.edit, stopped
 	case err := <-failed:
 		t.Fatalf("create integration window: %v", err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out creating integration window")
 	}
-	return 0, stopped
+	return 0, 0, stopped
 }
 
 func waitForWindowsCondition(t *testing.T, description string, condition func() bool) {
@@ -213,4 +258,17 @@ func errorsFromWindowsCall(operation string) error {
 		return fmt.Errorf("%s failed", operation)
 	}
 	return fmt.Errorf("%s failed: %w", operation, err)
+}
+
+func windowsWindowText(handle win.HWND) string {
+	length := win.GetWindowTextLength(handle)
+	buffer := make([]uint16, length+1)
+	if len(buffer) == 0 {
+		return ""
+	}
+	read := win.GetWindowText(handle, &buffer[0], int32(len(buffer)))
+	if read <= 0 {
+		return ""
+	}
+	return syscall.UTF16ToString(buffer[:read])
 }


### PR DESCRIPTION
## Goal

Close another Phase 3 Pure-Go parity slice without unsafe hosted-runner input.

## Changes

- implement non-CGO `PasteStr` through readiness, clipboard, and the selected keyboard backend
- implement non-CGO `GetLocationColor` through pointer location plus one-pixel capture
- fix successful Windows `GlobalUnlock` handling in clipboard reads
- add hermetic dependency-order/error tests
- extend blocking Windows evidence with pointer-color capture and Unicode paste into a self-owned edit control
- keep the example side-effect-free by default and document opt-in behavior

## Safety and compatibility

- unsupported keyboard builds fail before changing the clipboard
- the runtime paste target is owned by the test; no foreign application receives keys
- the integration cleanup restores the previous readable text clipboard value and cursor position
- public signatures remain unchanged

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- CGO and non-CGO `golangci-lint run --timeout=5m ./...`
- Windows amd64/386 non-CGO integration cross-compile
- macOS amd64 non-CGO cross-compile

Real Windows desktop checks remain required before merge.