### PR TITLE
feat: add Pure-Go Windows DPI scale parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
 | macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture and display bounds with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
-| Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds and pixel-at-pointer queries, foreground-layout-aware `SendInput` keyboard/text plus clipboard paste, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
+| Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds, real Win32 DPI scale and pixel-at-pointer queries, foreground-layout-aware `SendInput` keyboard/text plus clipboard paste, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
 | Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds plus XTEST mouse, keyboard, text/Unicode, pointer-location, smooth-move/drag, vertical scroll, and live readiness probes; horizontal scroll is explicitly unsupported |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |

--- a/TEST.md
+++ b/TEST.md
@@ -67,8 +67,9 @@ Pure-Go Windows window control uses a self-owned Win32 top-level window, so the
 hosted runner can validate the full window contract and clipboard-assisted
 keyboard injection without typing into another application. The test covers
 capability reporting, PID/handle resolution, title, outer/client bounds,
-minimize/maximize, foreground activation, Unicode `PasteStr` into an owned edit
-control, topmost state, and `WM_CLOSE`:
+Win32 DPI scale without double-scaling capture bounds, minimize/maximize,
+foreground activation, Unicode `PasteStr` into an owned edit control, topmost
+state, and `WM_CLOSE`:
 
 ```powershell
 $env:CGO_ENABLED = "0"

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -149,7 +149,8 @@ semantics. The Windows non-CGO CI leg runs the explicitly gated real
 input-desktop pointer/pixel test and restores the original global cursor position.
 The same build provides Win32 window capability reporting, active handle/PID,
 PID-to-window resolution, titles, outer/client geometry, activation,
-minimize/maximize, topmost state, and graceful close. Its blocking runtime test
+minimize/maximize, topmost state, graceful close, and real Win32 DPI scale
+queries while retaining physical capture-space bounds. Its blocking runtime test
 creates and owns the target window, exercises each operation, and never mutates
 an unrelated application. The owned runtime window also contains an edit
 control that provides blocking evidence for clipboard-assisted Unicode paste

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -26,7 +26,8 @@ Current implementation baseline:
   through user32, including exact Unicode, smooth movement/drag, horizontal and
   vertical scroll, ownership checks, partial-injection rollback, live
   readiness, deterministic in-process cleanup, clipboard-assisted paste, and
-  pixel-at-pointer queries.
+  pixel-at-pointer queries. Win32 DPI scale is reported without re-scaling
+  capture bounds that are already in physical pixel coordinates.
 - Non-CGO `CaptureImg`/`CaptureScreen`, their Go-bitmap/string variants, and
   pixel-color queries use the hardened screenshot portal on Wayland and the
   Pure-Go screenshot backend on X11/Windows; unsupported targets fail explicitly.

--- a/examples/scale/main.go
+++ b/examples/scale/main.go
@@ -9,6 +9,7 @@ import (
 func main() {
 	// syscall.NewLazyDLL("user32.dll").NewProc("SetProcessDPIAware").Call()
 
+	fmt.Println("DPI scale factor:", robotgo.SysScale())
 	width, height := robotgo.GetScaleSize()
 	fmt.Println("get scale screen size: ", width, height)
 

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -321,7 +321,27 @@ func alertArgs(args ...string) (string, string) {
 	return defaultButton, cancelButton
 }
 
-func SysScale(...int) float64 { return 1 }
+// SysScale returns the native DPI scale on Pure-Go Windows. Other non-CGO
+// platforms retain the neutral factor until their display backend exposes a
+// trustworthy scale query.
+func SysScale(displayID ...int) float64 {
+	return pureGoSysScale(runtime.GOOS, displayID, ScaleF)
+}
+
+func pureGoSysScale(
+	goos string,
+	displayID []int,
+	windowsScale func(...int) float64,
+) float64 {
+	if goos != "windows" {
+		return 1
+	}
+	scale := windowsScale(displayID...)
+	if !(scale > 0) {
+		return 1
+	}
+	return scale
+}
 
 func GetBounds(target int, args ...int) (int, int, int, int) {
 	return pureGoWindowBounds(target, len(args) > 0 || currentTreatAsHandle(), false)
@@ -780,6 +800,10 @@ func GetScreenRect(displayID ...int) Rect {
 	}
 	return GetDisplayRect(id)
 }
+
+// GetScaleSize returns the capture-space screen size. Pure-Go display bounds
+// already use the coordinates expected by the capture backend, so applying the
+// DPI factor again would double-scale Windows regions.
 func GetScaleSize(...int) (int, int) { return GetScreenSize() }
 func DisplaysNum() int               { return platformDisplayCount() }
 

--- a/robotgo_nocgo_convenience_test.go
+++ b/robotgo_nocgo_convenience_test.go
@@ -4,6 +4,7 @@ package robotgo
 
 import (
 	"errors"
+	"math"
 	"reflect"
 	"testing"
 )
@@ -147,5 +148,43 @@ func TestGetLocationColorWithPropagatesLocationFailure(t *testing.T) {
 	}
 	if pixelCalled {
 		t.Fatal("pixel backend called after location failure")
+	}
+}
+
+func TestPureGoSysScaleForwardsWindowsTarget(t *testing.T) {
+	var got []int
+	scale := pureGoSysScale("windows", []int{42}, func(displayID ...int) float64 {
+		got = append([]int(nil), displayID...)
+		return 1.5
+	})
+	if scale != 1.5 {
+		t.Fatalf("scale = %v, want 1.5", scale)
+	}
+	if want := []int{42}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("display IDs = %v, want %v", got, want)
+	}
+}
+
+func TestPureGoSysScaleUsesNeutralFactorOutsideWindows(t *testing.T) {
+	called := false
+	scale := pureGoSysScale("linux", []int{42}, func(...int) float64 {
+		called = true
+		return 2
+	})
+	if scale != 1 {
+		t.Fatalf("scale = %v, want 1", scale)
+	}
+	if called {
+		t.Fatal("Windows scale callback called on Linux")
+	}
+}
+
+func TestPureGoSysScaleRejectsInvalidWindowsFactor(t *testing.T) {
+	for _, invalid := range []float64{0, -1, math.NaN()} {
+		if scale := pureGoSysScale("windows", nil, func(...int) float64 {
+			return invalid
+		}); scale != 1 {
+			t.Fatalf("scale for %v = %v, want neutral factor 1", invalid, scale)
+		}
 	}
 }

--- a/robotgo_nocgo_parity.go
+++ b/robotgo_nocgo_parity.go
@@ -3,6 +3,7 @@
 package robotgo
 
 import (
+	"math"
 	"runtime"
 	"strconv"
 	"strings"
@@ -177,16 +178,23 @@ func GetHandByPid(target int, args ...int) Handle {
 	}
 	return Handle(handle)
 }
-func GetHandPid(target int, args ...int) Handle       { return GetHandByPid(target, args...) }
-func MicroSleep(tm float64)                           { time.Sleep(time.Duration(tm * float64(time.Millisecond))) }
-func PadHexs(hex CHex) string                         { return PadHex(uint32(hex)) }
-func UintToHex(value uint32) CHex                     { return CHex(value) }
-func Scaled(x int, displayID ...int) int              { return Scaled0(x, ScaleF(displayID...)) }
-func Scaled0(x int, factor float64) int               { return int(float64(x) * factor) }
-func Scaled1(x int, factor float64) int               { return int(float64(x) / factor) }
-func ScaleX() int                                     { return 96 }
-func Scale0() int                                     { return int(float64(ScaleX()) / 0.96) }
-func Scale1() int                                     { return 100 }
+func GetHandPid(target int, args ...int) Handle { return GetHandByPid(target, args...) }
+func MicroSleep(tm float64)                     { time.Sleep(time.Duration(tm * float64(time.Millisecond))) }
+func PadHexs(hex CHex) string                   { return PadHex(uint32(hex)) }
+func UintToHex(value uint32) CHex               { return CHex(value) }
+func Scaled(x int, displayID ...int) int        { return Scaled0(x, ScaleF(displayID...)) }
+func Scaled0(x int, factor float64) int         { return int(float64(x) * factor) }
+func Scaled1(x int, factor float64) int         { return int(float64(x) / factor) }
+func ScaleX() int {
+	if runtime.GOOS != "windows" {
+		return 0
+	}
+	return int(math.Round(96 * SysScale(-2)))
+}
+func Scale0() int { return int(float64(ScaleX()) / 0.96) }
+func Scale1() int {
+	return int(math.Round(float64(ScaleX()) * 100 / 96))
+}
 func Mul(x int) int                                   { return x * Scale1() / 100 }
 func MoveScale(x, y int, _ ...int) (int, int)         { return x, y }
 func MoveArgs(x, y int) (int, int)                    { mx, my := Location(); return mx + x, my + y }

--- a/windows_window_integration_test.go
+++ b/windows_window_integration_test.go
@@ -4,6 +4,7 @@ package robotgo
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"runtime"
 	"syscall"
@@ -29,6 +30,29 @@ func TestPureGoWindowsWindowRuntime(t *testing.T) {
 	capability := GetRuntimeCapabilities().Window
 	if !capability.Available || capability.Backend != featureBackendPureGoWindows {
 		t.Fatalf("window capability = %+v", capability)
+	}
+
+	dpi := GetDPI(handle)
+	wantScale := float64(dpi) / 96
+	if wantScale == 0 {
+		wantScale = 1
+	}
+	if scale := SysScale(int(handle)); math.Abs(scale-wantScale) > 1e-9 {
+		t.Fatalf("SysScale(handle) = %v, want %v from %d DPI", scale, wantScale, dpi)
+	}
+	if scale := SysScale(-2); !(scale > 0) {
+		t.Fatalf("SysScale(desktop) = %v, want positive factor", scale)
+	}
+	if dpi := ScaleX(); dpi <= 0 {
+		t.Fatalf("ScaleX() = %d, want positive Windows DPI", dpi)
+	}
+	screenWidth, screenHeight := GetScreenSize()
+	scaleWidth, scaleHeight := GetScaleSize()
+	if scaleWidth != screenWidth || scaleHeight != screenHeight {
+		t.Fatalf(
+			"GetScaleSize() = %dx%d, GetScreenSize() = %dx%d; Pure-Go bounds are already physical pixels",
+			scaleWidth, scaleHeight, screenWidth, screenHeight,
+		)
 	}
 
 	title, err := GetTitleE(int(handle), 1)


### PR DESCRIPTION
## Goal

Replace the non-CGO Windows neutral scale placeholder with real Win32 DPI data while preserving correct capture coordinates.

## Changes

- route non-CGO Windows `SysScale` through the existing Win32 `GetDpiForWindow` path
- derive deprecated `ScaleX`/`Scale1` compatibility values from the real desktop DPI
- keep non-Windows non-CGO builds on the documented neutral factor
- explicitly retain `GetScaleSize` in capture space because Windows display bounds are already physical pixels
- extend the self-owned Windows runtime test with direct `GetDPI(hwnd)` comparison and a no-double-scaling assertion
- update the scale example, support overview, testing guide, and roadmap

## Validation

- default and non-CGO `go test ./...`
- `go test -race ./...`
- default and non-CGO `go vet ./...`
- default and non-CGO `golangci-lint run --timeout=5m ./...`
- Windows amd64/386 non-CGO integration cross-compile
- macOS amd64 non-CGO cross-compile

The real Windows desktop job remains required before merge.