### PR TITLE
fix: implement non-CGO legacy drag contract

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -51,9 +51,9 @@ self-hosted runners are registered.
 Pure-Go Windows input has hermetic tests for Win32 `INPUT` layout,
 foreground-layout key mapping, Unicode surrogate pairs, partial-injection
 rollback, ownership, buttons, scrolling, movement, clipboard-paste sequencing,
-and pixel-at-pointer dispatch. They run in the Windows non-CGO CI leg. The same
-leg runs a real input-desktop pointer and pixel-color probe and restores the
-original global cursor position:
+legacy drag release-on-failure, and pixel-at-pointer dispatch. They run in the
+Windows non-CGO CI leg. The same leg runs a real input-desktop pointer and
+pixel-color probe and restores the original global cursor position:
 
 ```powershell
 $env:CGO_ENABLED = "0"

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -142,6 +142,9 @@ Windows non-CGO builds now provide a foreground-layout-aware `SendInput` keyboar
 backend, clipboard-assisted Unicode paste, pixel-at-pointer queries, plus exact pointer movement/location, smooth movement and drag,
 buttons, horizontal and vertical scrolling, live readiness checks, partial
 injection rollback, ownership conflicts, and deterministic in-process cleanup.
+The deprecated `Drag` compatibility API is no longer a silent no-op: it
+composes the supported backend primitives and always attempts button release
+after a movement failure.
 Exact Unicode text is encoded as UTF-16, while `KeyTap` resolves characters
 through the foreground target's Windows keyboard layout instead of assuming US key
 positions. Hermetic tests validate 32/64-bit `INPUT` layout and transaction

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -27,7 +27,9 @@ Current implementation baseline:
   vertical scroll, ownership checks, partial-injection rollback, live
   readiness, deterministic in-process cleanup, clipboard-assisted paste, and
   pixel-at-pointer queries. Win32 DPI scale is reported without re-scaling
-  capture bounds that are already in physical pixel coordinates.
+  capture bounds that are already in physical pixel coordinates. The legacy
+  `Drag` wrapper composes real Pure-Go input and releases its button after move
+  failures instead of silently doing nothing.
 - Non-CGO `CaptureImg`/`CaptureScreen`, their Go-bitmap/string variants, and
   pixel-color queries use the hardened screenshot portal on Wayland and the
   Pure-Go screenshot backend on X11/Windows; unsupported targets fail explicitly.

--- a/robotgo_nocgo_convenience_test.go
+++ b/robotgo_nocgo_convenience_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -187,4 +188,109 @@ func TestPureGoSysScaleRejectsInvalidWindowsFactor(t *testing.T) {
 			t.Fatalf("scale for %v = %v, want neutral factor 1", invalid, scale)
 		}
 	}
+}
+
+func TestDragWithUsesSelectedButtonAndReleasesIt(t *testing.T) {
+	var calls []string
+	err := dragWith(
+		80,
+		90,
+		[]string{"right"},
+		func(args ...interface{}) error {
+			calls = append(calls, "toggle:"+interfacesLabel(args))
+			return nil
+		},
+		func(x, y int, displayID ...int) error {
+			calls = append(calls, "move:80,90")
+			if x != 80 || y != 90 || len(displayID) != 0 {
+				t.Fatalf("move = (%d, %d, %v)", x, y, displayID)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("dragWith: %v", err)
+	}
+	if want := []string{"toggle:right", "move:80,90", "toggle:right,up"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestDragWithDefaultsToLeftButton(t *testing.T) {
+	var toggles [][]interface{}
+	err := dragWith(
+		1,
+		2,
+		nil,
+		func(args ...interface{}) error {
+			toggles = append(toggles, append([]interface{}(nil), args...))
+			return nil
+		},
+		func(int, int, ...int) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("dragWith: %v", err)
+	}
+	want := [][]interface{}{{"left"}, {"left", "up"}}
+	if !reflect.DeepEqual(toggles, want) {
+		t.Fatalf("toggles = %v, want %v", toggles, want)
+	}
+}
+
+func TestDragWithStopsWhenButtonDownFails(t *testing.T) {
+	downErr := errors.New("button down failed")
+	moveCalled := false
+	toggleCalls := 0
+	err := dragWith(
+		1,
+		2,
+		nil,
+		func(...interface{}) error {
+			toggleCalls++
+			return downErr
+		},
+		func(int, int, ...int) error {
+			moveCalled = true
+			return nil
+		},
+	)
+	if !errors.Is(err, downErr) {
+		t.Fatalf("error = %v, want %v", err, downErr)
+	}
+	if toggleCalls != 1 || moveCalled {
+		t.Fatalf("toggle calls = %d, move called = %v", toggleCalls, moveCalled)
+	}
+}
+
+func TestDragWithReleasesButtonAfterMoveFailure(t *testing.T) {
+	moveErr := errors.New("move failed")
+	releaseErr := errors.New("release failed")
+	toggleCalls := 0
+	err := dragWith(
+		1,
+		2,
+		nil,
+		func(...interface{}) error {
+			toggleCalls++
+			if toggleCalls == 2 {
+				return releaseErr
+			}
+			return nil
+		},
+		func(int, int, ...int) error { return moveErr },
+	)
+	if !errors.Is(err, moveErr) || !errors.Is(err, releaseErr) {
+		t.Fatalf("error = %v, want joined move and release errors", err)
+	}
+	if toggleCalls != 2 {
+		t.Fatalf("toggle calls = %d, want down and release", toggleCalls)
+	}
+}
+
+func interfacesLabel(values []interface{}) string {
+	parts := make([]string, len(values))
+	for i, value := range values {
+		parts[i] = value.(string)
+	}
+	return strings.Join(parts, ",")
 }

--- a/robotgo_nocgo_parity.go
+++ b/robotgo_nocgo_parity.go
@@ -3,6 +3,7 @@
 package robotgo
 
 import (
+	"errors"
 	"math"
 	"runtime"
 	"strconv"
@@ -58,7 +59,28 @@ func CloseMainDisplay() { _ = CloseMainDisplayE() }
 func CloseMainDisplayE() error { return closePureGoPlatformInput() }
 
 func InvalidateScreenBoundsCache() {}
-func Drag(int, int, ...string)     {}
+func Drag(x, y int, args ...string) {
+	_ = dragWith(x, y, args, Toggle, MoveE)
+}
+
+func dragWith(
+	x, y int,
+	args []string,
+	toggle func(...interface{}) error,
+	move func(int, int, ...int) error,
+) error {
+	button := "left"
+	if len(args) > 0 {
+		button = args[0]
+	}
+	if err := toggle(button); err != nil {
+		return err
+	}
+	moveErr := move(x, y)
+	releaseErr := toggle(button, "up")
+	return errors.Join(moveErr, releaseErr)
+}
+
 func FreeBitmapArr(bits ...CBitmap) {
 	for _, bit := range bits {
 		FreeBitmap(bit)


### PR DESCRIPTION
## Goal

Remove a silent-success non-CGO compatibility stub.

## Changes

- implement deprecated `Drag` by composing the selected Pure-Go button and movement primitives
- honor the requested button, default to left, and always attempt release after movement errors
- join movement and release failures internally for complete testability
- add hermetic sequencing, default-button, down-failure, and release-after-failure tests
- document the corrected compatibility behavior

## Scope

`Alert` remains explicitly unavailable without a suitable non-modal/custom-button backend. `CloseWindowKill` remains explicitly unsupported because it is destructive and needs a separately designed/tested process-ownership contract.

## Validation

- default and non-CGO tests
- race and vet
- default and non-CGO lint
- Windows integration cross-compile
- macOS non-CGO cross-compile