### PR TITLE
feat: add Pure-Go macOS Retina scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | Platform/session | Build | Current behavior |
 |---|---|---|
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
-| macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture and display bounds with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
+| macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture, display bounds, and real Retina scale with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
 | Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds, real Win32 DPI scale and pixel-at-pointer queries, foreground-layout-aware `SendInput` keyboard/text plus clipboard paste, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |

--- a/TEST.md
+++ b/TEST.md
@@ -33,8 +33,18 @@ The non-CGO suite runs on Linux, macOS, and Windows in CI. It also verifies
 runtime build/feature introspection, pixel-color parity, and hermetic Pure-Go
 capture dispatch for CoreGraphics, X11, Windows, and the Wayland screenshot
 portal. macOS tests use fake CoreGraphics bindings for deterministic permission,
-pixel, bounds, and resource-lifecycle coverage; they do not require a Screen
-Recording grant.
+pixel, bounds, Retina display-mode scale, and resource-lifecycle coverage. The
+macOS non-CGO leg also resolves the real CoreGraphics display-mode symbols and
+queries the active display scale as a blocking test; neither path requires a
+Screen Recording grant.
+
+The real scale probe can be reproduced on a macOS GUI runner without granting
+Screen Recording or Accessibility access:
+
+```bash
+CGO_ENABLED=0 go test \
+  -run '^TestPureGoDarwinDisplayScaleRuntime$' -count=1 -v .
+```
 
 Linux CI additionally runs the non-CGO X11 input backend against a real Xvfb
 server with XTEST 2.2 or newer and `us,de` keyboard layouts. A separate X11

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -136,7 +136,10 @@ color APIs provide non-CGO capture through CoreGraphics on macOS, Windows and
 X11 screenshot paths, and the hardened screenshot portal on Wayland. macOS
 display enumeration, Screen Recording preflight, RGBA conversion, and
 CoreGraphics ownership are covered hermetically on both supported
-architectures.
+architectures. Non-CGO macOS also reports the real Retina display-mode factor,
+returns scaled pixel dimensions with `GetScaleSize`, releases copied display
+modes deterministically, and verifies the real symbols/display query in the
+blocking macOS CI leg without requesting Screen Recording access.
 
 Windows non-CGO builds now provide a foreground-layout-aware `SendInput` keyboard and text
 backend, clipboard-assisted Unicode paste, pixel-at-pointer queries, plus exact pointer movement/location, smooth movement and drag,

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -16,7 +16,8 @@ Current implementation baseline:
   detection without portal or compositor probes.
 - Platform-neutral feature introspection is available via
   `GetRuntimeCapabilities`; macOS non-CGO builds report CoreGraphics capture,
-  display bounds, and Screen Recording permission state without prompting.
+  display bounds, real Retina scale, and Screen Recording permission state
+  without prompting.
 - Linux/X11 non-CGO builds provide a Pure-Go XGB/XTEST keyboard and pointer
   backend with live readiness probes, text/Unicode, smooth movement/drag,
   scrolling, pointer location, explicit state errors, and deterministic

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -321,22 +321,25 @@ func alertArgs(args ...string) (string, string) {
 	return defaultButton, cancelButton
 }
 
-// SysScale returns the native DPI scale on Pure-Go Windows. Other non-CGO
-// platforms retain the neutral factor until their display backend exposes a
-// trustworthy scale query.
+// SysScale returns the native DPI/Retina scale on Pure-Go Windows and macOS.
+// Other non-CGO platforms, and a failed scale query, retain the neutral factor.
 func SysScale(displayID ...int) float64 {
-	return pureGoSysScale(runtime.GOOS, displayID, ScaleF)
+	scale := ScaleF
+	if runtime.GOOS == "darwin" {
+		scale = platformDarwinScale
+	}
+	return pureGoSysScale(runtime.GOOS, displayID, scale)
 }
 
 func pureGoSysScale(
 	goos string,
 	displayID []int,
-	windowsScale func(...int) float64,
+	platformScale func(...int) float64,
 ) float64 {
-	if goos != "windows" {
+	if goos != "windows" && goos != "darwin" {
 		return 1
 	}
-	scale := windowsScale(displayID...)
+	scale := platformScale(displayID...)
 	if !(scale > 0) {
 		return 1
 	}
@@ -801,11 +804,18 @@ func GetScreenRect(displayID ...int) Rect {
 	return GetDisplayRect(id)
 }
 
-// GetScaleSize returns the capture-space screen size. Pure-Go display bounds
-// already use the coordinates expected by the capture backend, so applying the
-// DPI factor again would double-scale Windows regions.
-func GetScaleSize(...int) (int, int) { return GetScreenSize() }
-func DisplaysNum() int               { return platformDisplayCount() }
+// GetScaleSize returns the display's scaled pixel size. CoreGraphics bounds are
+// logical points and therefore use the Retina factor; Pure-Go Windows bounds
+// are already physical pixels and must not be scaled again.
+func GetScaleSize(displayID ...int) (int, int) {
+	width, height := GetScreenSize()
+	if runtime.GOOS == "darwin" {
+		scale := SysScale(displayID...)
+		return int(float64(width) * scale), int(float64(height) * scale)
+	}
+	return width, height
+}
+func DisplaysNum() int { return platformDisplayCount() }
 
 // GetPixelColor returns the pixel color at (x, y) as a six-digit RGB string.
 func GetPixelColor(x, y int, displayID ...int) (string, error) {

--- a/robotgo_nocgo_convenience_test.go
+++ b/robotgo_nocgo_convenience_test.go
@@ -166,7 +166,21 @@ func TestPureGoSysScaleForwardsWindowsTarget(t *testing.T) {
 	}
 }
 
-func TestPureGoSysScaleUsesNeutralFactorOutsideWindows(t *testing.T) {
+func TestPureGoSysScaleForwardsDarwinTarget(t *testing.T) {
+	var got []int
+	scale := pureGoSysScale("darwin", []int{42}, func(displayID ...int) float64 {
+		got = append([]int(nil), displayID...)
+		return 2
+	})
+	if scale != 2 {
+		t.Fatalf("scale = %v, want 2", scale)
+	}
+	if want := []int{42}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("display IDs = %v, want %v", got, want)
+	}
+}
+
+func TestPureGoSysScaleUsesNeutralFactorOutsideSupportedPlatforms(t *testing.T) {
 	called := false
 	scale := pureGoSysScale("linux", []int{42}, func(...int) float64 {
 		called = true

--- a/scale_backend_notdarwin_nocgo.go
+++ b/scale_backend_notdarwin_nocgo.go
@@ -1,0 +1,5 @@
+//go:build !cgo && !darwin
+
+package robotgo
+
+func platformDarwinScale(...int) float64 { return 1 }

--- a/screen_backend_darwin_nocgo.go
+++ b/screen_backend_darwin_nocgo.go
@@ -40,6 +40,11 @@ type darwinGraphicsAPI struct {
 	preflightCaptureAccess    func() bool
 	getActiveDisplayList      func(uint32, *uint32, *uint32) int32
 	displayBounds             func(uint32) cgRect
+	mainDisplayID             func() uint32
+	displayCopyDisplayMode    func(uint32) uintptr
+	displayModeGetPixelWidth  func(uintptr) uintptr
+	displayModeGetWidth       func(uintptr) uintptr
+	displayModeRelease        func(uintptr)
 	windowListCreateImage     func(cgRect, uint32, uint32, uint32) uintptr
 	imageRelease              func(uintptr)
 	colorSpaceCreateDeviceRGB func() uintptr
@@ -89,6 +94,26 @@ func openDarwinCoreGraphics() (*darwinGraphicsAPI, error) {
 		if err := bind(function.target, function.name); err != nil {
 			_ = api.close()
 			return nil, errors.Join(ErrNotSupported, err)
+		}
+	}
+	scaleFunctions := []struct {
+		target any
+		name   string
+	}{
+		{&api.mainDisplayID, "CGMainDisplayID"},
+		{&api.displayCopyDisplayMode, "CGDisplayCopyDisplayMode"},
+		{&api.displayModeGetPixelWidth, "CGDisplayModeGetPixelWidth"},
+		{&api.displayModeGetWidth, "CGDisplayModeGetWidth"},
+		{&api.displayModeRelease, "CGDisplayModeRelease"},
+	}
+	for _, function := range scaleFunctions {
+		if err := bind(function.target, function.name); err != nil {
+			api.mainDisplayID = nil
+			api.displayCopyDisplayMode = nil
+			api.displayModeGetPixelWidth = nil
+			api.displayModeGetWidth = nil
+			api.displayModeRelease = nil
+			break
 		}
 	}
 	if symbol, err := purego.Dlsym(handle, "CGPreflightScreenCaptureAccess"); err == nil {
@@ -171,6 +196,19 @@ func platformCapture(x, y, width, height int) (*image.RGBA, error) {
 	return captureDarwinWithAPI(api, image.Rect(x, y, x+width, y+height))
 }
 
+func platformDarwinScale(displayID ...int) float64 {
+	api, err := openDarwinGraphics()
+	if err != nil {
+		return 1
+	}
+	defer func() { _ = api.close() }()
+	scale, err := darwinDisplayScale(api, displayID...)
+	if err != nil {
+		return 1
+	}
+	return scale
+}
+
 func darwinDisplayCount(api *darwinGraphicsAPI) (int, error) {
 	var count uint32
 	if result := api.getActiveDisplayList(0, nil, &count); result != cgErrorSuccess {
@@ -208,6 +246,45 @@ func darwinDisplayBounds(api *darwinGraphicsAPI, displayIndex int) (image.Rectan
 		return image.Rectangle{}, fmt.Errorf("display %d returned empty bounds", displayIndex)
 	}
 	return result, nil
+}
+
+func darwinDisplayScale(api *darwinGraphicsAPI, displayID ...int) (float64, error) {
+	if api.mainDisplayID == nil ||
+		api.displayCopyDisplayMode == nil ||
+		api.displayModeGetPixelWidth == nil ||
+		api.displayModeGetWidth == nil ||
+		api.displayModeRelease == nil {
+		return 0, fmt.Errorf("%w: CoreGraphics display-mode scale symbols are unavailable", ErrNotSupported)
+	}
+
+	id := api.mainDisplayID()
+	if len(displayID) > 0 && displayID[0] != -1 {
+		if displayID[0] < 0 || uint64(displayID[0]) > uint64(^uint32(0)) {
+			return 0, fmt.Errorf("invalid CoreGraphics display ID %d", displayID[0])
+		}
+		id = uint32(displayID[0])
+	}
+	mode := api.displayCopyDisplayMode(id)
+	if mode == 0 {
+		return 0, fmt.Errorf("CoreGraphics returned no display mode for display %d", id)
+	}
+	defer api.displayModeRelease(mode)
+
+	pixelWidth := api.displayModeGetPixelWidth(mode)
+	logicalWidth := api.displayModeGetWidth(mode)
+	if pixelWidth == 0 || logicalWidth == 0 {
+		return 0, fmt.Errorf(
+			"CoreGraphics returned invalid display-mode widths for display %d: pixels=%d logical=%d",
+			id,
+			pixelWidth,
+			logicalWidth,
+		)
+	}
+	scale := float64(pixelWidth) / float64(logicalWidth)
+	if !(scale > 0) || math.IsInf(scale, 0) || math.IsNaN(scale) {
+		return 0, fmt.Errorf("CoreGraphics returned invalid display scale %v for display %d", scale, id)
+	}
+	return scale, nil
 }
 
 func captureDarwinWithAPI(api *darwinGraphicsAPI, region image.Rectangle) (*image.RGBA, error) {

--- a/screen_backend_darwin_nocgo_test.go
+++ b/screen_backend_darwin_nocgo_test.go
@@ -5,12 +5,14 @@ package robotgo
 import (
 	"errors"
 	"image"
+	"math"
 	"testing"
 	"unsafe"
 )
 
 type darwinGraphicsCounters struct {
 	closeCalls        int
+	modeReleaseCalls  int
 	imageReleaseCalls int
 	colorReleaseCalls int
 	contextCalls      int
@@ -29,7 +31,16 @@ func fakeDarwinGraphics(bounds cgRect, counters *darwinGraphicsCounters) *darwin
 			}
 			return cgErrorSuccess
 		},
-		displayBounds:         func(uint32) cgRect { return bounds },
+		displayBounds:          func(uint32) cgRect { return bounds },
+		mainDisplayID:          func() uint32 { return 42 },
+		displayCopyDisplayMode: func(uint32) uintptr { return 21 },
+		displayModeGetPixelWidth: func(uintptr) uintptr {
+			return 200
+		},
+		displayModeGetWidth: func(uintptr) uintptr {
+			return 100
+		},
+		displayModeRelease:    func(uintptr) { counters.modeReleaseCalls++ },
 		windowListCreateImage: func(cgRect, uint32, uint32, uint32) uintptr { return 11 },
 		imageRelease:          func(uintptr) { counters.imageReleaseCalls++ },
 		colorSpaceCreateDeviceRGB: func() uintptr {
@@ -113,6 +124,167 @@ func TestDarwinDisplayBoundsUseEnclosingEdges(t *testing.T) {
 	}
 	if _, err := darwinDisplayBounds(api, 1); err == nil {
 		t.Fatal("out-of-range display index unexpectedly succeeded")
+	}
+}
+
+func TestDarwinDisplayScaleUsesRetinaWidthsAndReleasesMode(t *testing.T) {
+	counters := &darwinGraphicsCounters{}
+	api := fakeDarwinGraphics(cgRect{}, counters)
+	var requestedDisplay uint32
+	api.displayCopyDisplayMode = func(displayID uint32) uintptr {
+		requestedDisplay = displayID
+		return 55
+	}
+	api.displayModeGetPixelWidth = func(mode uintptr) uintptr {
+		if mode != 55 {
+			t.Fatalf("pixel-width mode = %d, want 55", mode)
+		}
+		return 3024
+	}
+	api.displayModeGetWidth = func(mode uintptr) uintptr {
+		if mode != 55 {
+			t.Fatalf("logical-width mode = %d, want 55", mode)
+		}
+		return 1512
+	}
+
+	scale, err := darwinDisplayScale(api, 77)
+	if err != nil {
+		t.Fatalf("darwinDisplayScale: %v", err)
+	}
+	if scale != 2 {
+		t.Fatalf("scale = %v, want 2", scale)
+	}
+	if requestedDisplay != 77 {
+		t.Fatalf("display ID = %d, want 77", requestedDisplay)
+	}
+	if counters.modeReleaseCalls != 1 {
+		t.Fatalf("display-mode releases = %d, want 1", counters.modeReleaseCalls)
+	}
+}
+
+func TestDarwinDisplayScaleUsesMainDisplay(t *testing.T) {
+	for _, displayID := range [][]int{nil, {-1}} {
+		counters := &darwinGraphicsCounters{}
+		api := fakeDarwinGraphics(cgRect{}, counters)
+		requestedDisplay := uint32(0)
+		api.mainDisplayID = func() uint32 { return 91 }
+		api.displayCopyDisplayMode = func(displayID uint32) uintptr {
+			requestedDisplay = displayID
+			return 55
+		}
+		if _, err := darwinDisplayScale(api, displayID...); err != nil {
+			t.Fatalf("darwinDisplayScale(%v): %v", displayID, err)
+		}
+		if requestedDisplay != 91 {
+			t.Fatalf("darwinDisplayScale(%v) display = %d, want main display 91", displayID, requestedDisplay)
+		}
+	}
+}
+
+func TestDarwinDisplayScaleReportsUnavailableAndInvalidModes(t *testing.T) {
+	counters := &darwinGraphicsCounters{}
+	api := fakeDarwinGraphics(cgRect{}, counters)
+	api.displayModeGetWidth = nil
+	if _, err := darwinDisplayScale(api); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("missing-symbol error = %v, want ErrNotSupported", err)
+	}
+
+	api = fakeDarwinGraphics(cgRect{}, counters)
+	api.displayCopyDisplayMode = func(uint32) uintptr { return 0 }
+	if _, err := darwinDisplayScale(api); err == nil {
+		t.Fatal("nil display mode unexpectedly succeeded")
+	}
+
+	api = fakeDarwinGraphics(cgRect{}, counters)
+	api.displayModeGetPixelWidth = func(uintptr) uintptr { return 0 }
+	if _, err := darwinDisplayScale(api); err == nil {
+		t.Fatal("zero pixel width unexpectedly succeeded")
+	}
+	if counters.modeReleaseCalls != 1 {
+		t.Fatalf("display-mode releases = %d, want release after invalid width", counters.modeReleaseCalls)
+	}
+
+	if _, err := darwinDisplayScale(api, -2); err == nil {
+		t.Fatal("invalid negative display ID unexpectedly succeeded")
+	}
+}
+
+func TestPureGoDarwinSysScaleEntryPoint(t *testing.T) {
+	previous := openDarwinGraphics
+	counters := &darwinGraphicsCounters{}
+	openDarwinGraphics = func() (*darwinGraphicsAPI, error) {
+		return fakeDarwinGraphics(cgRect{}, counters), nil
+	}
+	t.Cleanup(func() { openDarwinGraphics = previous })
+
+	if scale := SysScale(); scale != 2 {
+		t.Fatalf("SysScale() = %v, want 2", scale)
+	}
+	if counters.modeReleaseCalls != 1 || counters.closeCalls != 1 {
+		t.Fatalf("resource counters = %+v, want one mode release and framework close", counters)
+	}
+}
+
+func TestPureGoDarwinGetScaleSizeUsesRetinaFactor(t *testing.T) {
+	previous := openDarwinGraphics
+	counters := &darwinGraphicsCounters{}
+	openDarwinGraphics = func() (*darwinGraphicsAPI, error) {
+		return fakeDarwinGraphics(cgRect{Size: cgSize{Width: 3, Height: 2}}, counters), nil
+	}
+	t.Cleanup(func() { openDarwinGraphics = previous })
+
+	width, height := GetScaleSize()
+	if width != 6 || height != 4 {
+		t.Fatalf("GetScaleSize() = %dx%d, want 6x4 Retina pixels", width, height)
+	}
+	if counters.modeReleaseCalls != 1 || counters.closeCalls != 2 {
+		t.Fatalf("resource counters = %+v, want one mode release and two framework closes", counters)
+	}
+}
+
+func TestPureGoDarwinDisplayScaleRuntime(t *testing.T) {
+	api, err := openDarwinCoreGraphics()
+	if err != nil {
+		t.Fatalf("open CoreGraphics: %v", err)
+	}
+	defer func() {
+		if err := api.close(); err != nil {
+			t.Errorf("close CoreGraphics: %v", err)
+		}
+	}()
+
+	scale, err := darwinDisplayScale(api)
+	if err != nil {
+		t.Fatalf("query main-display scale: %v", err)
+	}
+	if !(scale > 0) {
+		t.Fatalf("main-display scale = %v, want positive factor", scale)
+	}
+	if publicScale := SysScale(); math.Abs(publicScale-scale) > 1e-9 {
+		t.Fatalf("SysScale() = %v, direct CoreGraphics scale = %v", publicScale, scale)
+	}
+	logicalWidth, logicalHeight := GetScreenSize()
+	scaledWidth, scaledHeight := GetScaleSize()
+	if logicalWidth <= 0 || logicalHeight <= 0 || scaledWidth <= 0 || scaledHeight <= 0 {
+		t.Fatalf(
+			"display sizes must be positive: logical=%dx%d scaled=%dx%d",
+			logicalWidth,
+			logicalHeight,
+			scaledWidth,
+			scaledHeight,
+		)
+	}
+	if scaledWidth != int(float64(logicalWidth)*scale) ||
+		scaledHeight != int(float64(logicalHeight)*scale) {
+		t.Fatalf(
+			"GetScaleSize() = %dx%d, logical=%dx%d scale=%v",
+			scaledWidth,
+			scaledHeight,
+			logicalWidth,
+			logicalHeight,
+			scale,
+		)
 	}
 }
 


### PR DESCRIPTION
## Goal

Replace the neutral non-CGO macOS scale placeholder with a real, permissionless CoreGraphics display-mode query.

## Changes

- resolve CoreGraphics display-mode scale symbols dynamically through the existing Pure-Go loader
- compute Retina scale from pixel width / logical width for the main or explicit `CGDirectDisplayID`
- release every copied `CGDisplayMode` deterministically
- keep scale symbols optional so capture/bounds support is not weakened on an older runtime
- make `SysScale` and `GetScaleSize` report real macOS Retina values
- preserve Windows physical-pixel behavior without double scaling
- add hermetic symbol, ID, invalid-mode, fallback, sizing, and ownership tests
- add a blocking real CoreGraphics scale probe that needs neither Screen Recording nor Accessibility permission
- update support, testing, and roadmap documentation

## Validation

- default and non-CGO tests
- race, vet, and both lint variants
- macOS amd64 and arm64 non-CGO cross-compile
- Windows non-CGO cross-compile

The draft remains open until the real macOS hosted runner resolves the symbols and returns a valid active-display scale.