### PR TITLE
feat: add Pure-Go macOS Quartz pointer input

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -146,6 +146,15 @@ jobs:
           -run "^TestPureGoWindowsInputRuntime$"
           -count=1 -timeout=30s -v .
 
+      - name: Test Pure-Go macOS input preflight
+        if: runner.os == 'macOS'
+        env:
+          CGO_ENABLED: "0"
+        run: >-
+          go test
+          -run "^TestPureGoDarwinInputRuntime$"
+          -count=1 -timeout=30s -v .
+
       - name: Test Pure-Go Windows window and paste desktop
         if: runner.os == 'Windows'
         env:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | Platform/session | Build | Current behavior |
 |---|---|---|
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
-| macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture, display bounds, and real Retina scale with explicit Screen Recording permission diagnostics; other unavailable GUI operations return `ErrNotSupported` |
+| macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture, display bounds, real Retina scale, and Quartz pointer input (move/relative/smooth/drag/click/toggle/scroll/location) with explicit Screen Recording and Accessibility diagnostics; keyboard and other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
 | Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds, real Win32 DPI scale and pixel-at-pointer queries, foreground-layout-aware `SendInput` keyboard/text plus clipboard paste, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
@@ -92,12 +92,27 @@ compositor to expose the corresponding virtual-input protocols. See
 Persistent capture runtime evidence is tracked separately in the
 [Wayland capture compatibility matrix](docs/compatibility/wayland-capture.md).
 
+## Pure-Go macOS pointer input
+
+With `CGO_ENABLED=0`, macOS pointer automation uses Quartz events directly
+through runtime-loaded system frameworks. `MouseReady` and
+`GetRuntimeCapabilities` use the non-prompting Accessibility preflight: if
+access is missing, they return/report `ErrPermissionDenied` with the relevant
+System Settings location. RobotGo never opens the consent dialog implicitly.
+
+The backend supports absolute and relative movement, bounded smooth movement,
+drag, single/double click, owned button toggles, horizontal/vertical pixel
+scrolling, and global pointer location. Persistent holds are ownership-checked;
+`CloseMainDisplayE` releases RobotGo-owned buttons before unloading the native
+frameworks. Pure-Go macOS keyboard injection remains explicitly unsupported.
+See [`examples/purego_macos_pointer`](examples/purego_macos_pointer).
+
 ## Requirements
 
 - Go 1.25 or newer, matching [`go.mod`](go.mod).
 - A CGO-compatible C toolchain for the full native desktop-automation feature
-  set. Pure-Go Linux/X11 capture/input and the explicitly started Linux
-  RemoteDesktop portal subset work in a non-CGO build.
+  set. The supported Pure-Go subsets in the table above work without a C
+  compiler; unavailable operations fail explicitly.
 - Platform development libraries for the selected backend.
 
 ### macOS

--- a/TEST.md
+++ b/TEST.md
@@ -35,8 +35,10 @@ capture dispatch for CoreGraphics, X11, Windows, and the Wayland screenshot
 portal. macOS tests use fake CoreGraphics bindings for deterministic permission,
 pixel, bounds, Retina display-mode scale, and resource-lifecycle coverage. The
 macOS non-CGO leg also resolves the real CoreGraphics display-mode symbols and
-queries the active display scale as a blocking test; neither path requires a
-Screen Recording grant.
+queries the active display scale as a blocking test. It additionally resolves
+the real Quartz input and Accessibility symbols and performs a non-prompting
+permission preflight without posting input. None of these runtime checks
+requires a Screen Recording or Accessibility grant.
 
 The real scale probe can be reproduced on a macOS GUI runner without granting
 Screen Recording or Accessibility access:
@@ -45,6 +47,27 @@ Screen Recording or Accessibility access:
 CGO_ENABLED=0 go test \
   -run '^TestPureGoDarwinDisplayScaleRuntime$' -count=1 -v .
 ```
+
+The safe Pure-Go input preflight can be reproduced on a macOS GUI runner
+without moving the pointer or opening a consent dialog:
+
+```bash
+CGO_ENABLED=0 go test \
+  -run '^TestPureGoDarwinInputRuntime$' -count=1 -v .
+```
+
+After granting Accessibility access, the opt-in real pointer test moves to the
+center of the main display and restores the original location during cleanup:
+
+```bash
+CGO_ENABLED=0 ROBOTGO_REQUIRE_DARWIN_INPUT_INTEGRATION=1 \
+  go test -tags darwinintegration \
+  -run '^TestPureGoDarwinPointerIntegration$' -count=1 -v .
+```
+
+This integration test is not run on GitHub-hosted macOS because those runners
+do not grant Accessibility control to repository test binaries. The
+non-prompting symbol and permission contract remains blocking there.
 
 Linux CI additionally runs the non-CGO X11 input backend against a real Xvfb
 server with XTEST 2.2 or newer and `us,de` keyboard layouts. A separate X11

--- a/backend_info.go
+++ b/backend_info.go
@@ -14,6 +14,7 @@ const (
 	featureBackendNativeCGO          = "native-cgo"
 	featureBackendPureGoPrefix       = "pure-go-"
 	featureBackendPureGoCoreGraphics = "pure-go-coregraphics"
+	featureBackendPureGoQuartzInput  = "pure-go-quartz-input"
 	featureBackendPureGoWindows      = "pure-go-windows"
 	featureBackendPureGoX11          = "pure-go-x11"
 	featureBackendGoProcess          = "go-process"

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -35,7 +35,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics, Windows, X11, and Wayland-portal capture; Windows `SendInput` keyboard/pointer backend with a blocking input-desktop probe; Win32 window introspection/control with a self-owned runtime window; Linux/X11 XGB/XTEST input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; lower-allocation request transport and safe balanced-input sequencing; protected three-OS CI; non-skipping multi-layout Xvfb input tests | Assess further backends selectively |
+| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture and XGB/XTEST input; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Complete macOS keyboard evaluation and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -140,6 +140,13 @@ architectures. Non-CGO macOS also reports the real Retina display-mode factor,
 returns scaled pixel dimensions with `GetScaleSize`, releases copied display
 modes deterministically, and verifies the real symbols/display query in the
 blocking macOS CI leg without requesting Screen Recording access.
+The same non-CGO build now provides Quartz pointer movement, relative and
+smooth movement, drag, single/double click, ownership-checked button toggles,
+horizontal/vertical scrolling, and pointer location. It preflights
+Accessibility without prompting, releases owned buttons deterministically, and
+has a blocking real-framework preflight that never posts input. Pure-Go macOS
+keyboard injection remains explicitly unsupported and is the next macOS
+evaluation slice.
 
 Windows non-CGO builds now provide a foreground-layout-aware `SendInput` keyboard and text
 backend, clipboard-assisted Unicode paste, pixel-at-pointer queries, plus exact pointer movement/location, smooth movement and drag,

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -16,8 +16,13 @@ Current implementation baseline:
   detection without portal or compositor probes.
 - Platform-neutral feature introspection is available via
   `GetRuntimeCapabilities`; macOS non-CGO builds report CoreGraphics capture,
-  display bounds, real Retina scale, and Screen Recording permission state
-  without prompting.
+  display bounds, real Retina scale, Screen Recording permission, and Quartz
+  pointer/Accessibility state without prompting.
+- macOS non-CGO builds provide a Pure-Go Quartz pointer backend with absolute,
+  relative and smooth movement, drag, click/double-click, owned button toggles,
+  horizontal/vertical scroll, pointer location, deterministic cleanup, and
+  explicit Accessibility denial. Pure-Go macOS keyboard injection remains
+  explicitly unsupported.
 - Linux/X11 non-CGO builds provide a Pure-Go XGB/XTEST keyboard and pointer
   backend with live readiness probes, text/Unicode, smooth movement/drag,
   scrolling, pointer location, explicit state errors, and deterministic

--- a/examples/purego_macos_pointer/main.go
+++ b/examples/purego_macos_pointer/main.go
@@ -1,0 +1,42 @@
+// Command purego_macos_pointer demonstrates permission-aware Pure-Go pointer
+// automation on macOS.
+package main
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	if runtime.GOOS != "darwin" {
+		log.Fatal("this example requires macOS")
+	}
+	defer func() {
+		if err := robotgo.CloseMainDisplayE(); err != nil {
+			log.Printf("release Pure-Go input resources: %v", err)
+		}
+	}()
+
+	capabilities := robotgo.GetRuntimeCapabilities()
+	fmt.Printf("pointer backend: %s\n", capabilities.Mouse.Backend)
+	if err := robotgo.MouseReady(); err != nil {
+		log.Fatalf("pointer automation is unavailable: %v", err)
+	}
+
+	x, y, err := robotgo.LocationE()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := robotgo.MoveE(x, y); err != nil {
+			log.Printf("restore pointer location: %v", err)
+		}
+	}()
+	if err := robotgo.MoveE(x+20, y+20); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("moved the pointer by 20 logical points; restoring it on exit")
+}

--- a/input_backend_darwin_nocgo.go
+++ b/input_backend_darwin_nocgo.go
@@ -1,0 +1,96 @@
+//go:build darwin && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/marang/robotgo/internal/darwininput"
+)
+
+type darwinInputBackend struct {
+	core *darwininput.Backend
+}
+
+var pureGoDarwinInput = &darwinInputBackend{core: darwininput.New()}
+
+func platformPureGoInputBackend() pureGoInputBackend { return pureGoDarwinInput }
+
+func closePureGoPlatformInput() error { return pureGoDarwinInput.Close() }
+
+func (*darwinInputBackend) Name() string { return featureBackendPureGoQuartzInput }
+
+func translatePureGoDarwinInputError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, darwininput.ErrUnsupported):
+		return fmt.Errorf("%w: %w", ErrNotSupported, err)
+	case errors.Is(err, darwininput.ErrPermission):
+		return fmt.Errorf("%w: %w", ErrPermissionDenied, err)
+	case errors.Is(err, darwininput.ErrOwnership):
+		return fmt.Errorf("%w: %w", ErrInputOwnership, err)
+	default:
+		return err
+	}
+}
+
+func (*darwinInputBackend) KeyboardReady() error {
+	return fmt.Errorf("%w: Pure-Go macOS keyboard injection is not implemented", ErrNotSupported)
+}
+
+func (backend *darwinInputBackend) MouseReady() error {
+	return translatePureGoDarwinInputError(backend.core.MouseReady())
+}
+
+func (*darwinInputBackend) Key(pureGoKeyEvent) error {
+	return fmt.Errorf("%w: Pure-Go macOS keyboard injection is not implemented", ErrNotSupported)
+}
+
+func (*darwinInputBackend) Text(pureGoTextEvent) error {
+	return fmt.Errorf("%w: Pure-Go macOS text injection is not implemented", ErrNotSupported)
+}
+
+func (backend *darwinInputBackend) MoveAbsolute(x, y int, _ []int) error {
+	return translatePureGoDarwinInputError(backend.core.MoveAbsolute(x, y))
+}
+
+func (backend *darwinInputBackend) MoveRelative(x, y int) error {
+	return translatePureGoDarwinInputError(backend.core.MoveRelative(x, y))
+}
+
+func (backend *darwinInputBackend) MoveSmooth(
+	x, y int,
+	relative bool,
+	lowDelay, highDelay float64,
+) error {
+	return translatePureGoDarwinInputError(
+		backend.core.MoveSmooth(x, y, relative, lowDelay, highDelay),
+	)
+}
+
+func (backend *darwinInputBackend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
+	return translatePureGoDarwinInputError(backend.core.DragSmooth(x, y, lowDelay, highDelay))
+}
+
+func (backend *darwinInputBackend) Location() (int, int, error) {
+	x, y, err := backend.core.Location()
+	return x, y, translatePureGoDarwinInputError(err)
+}
+
+func (backend *darwinInputBackend) Click(button string, double bool) error {
+	return translatePureGoDarwinInputError(backend.core.Click(button, double))
+}
+
+func (backend *darwinInputBackend) Toggle(button string, down bool) error {
+	return translatePureGoDarwinInputError(backend.core.Toggle(button, down))
+}
+
+func (backend *darwinInputBackend) Scroll(x, y int) error {
+	return translatePureGoDarwinInputError(backend.core.Scroll(x, y))
+}
+
+func (backend *darwinInputBackend) Close() error {
+	return translatePureGoDarwinInputError(backend.core.Close())
+}

--- a/input_backend_darwin_nocgo_integration_test.go
+++ b/input_backend_darwin_nocgo_integration_test.go
@@ -1,0 +1,49 @@
+//go:build darwin && !cgo && darwinintegration
+
+package robotgo
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPureGoDarwinPointerIntegration(t *testing.T) {
+	if os.Getenv("ROBOTGO_REQUIRE_DARWIN_INPUT_INTEGRATION") != "1" {
+		t.Skip("set ROBOTGO_REQUIRE_DARWIN_INPUT_INTEGRATION=1 after granting Accessibility access")
+	}
+	if err := MouseReady(); err != nil {
+		t.Fatalf("MouseReady: %v", err)
+	}
+	originalX, originalY, err := LocationE()
+	if err != nil {
+		t.Fatalf("original LocationE: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := MoveE(originalX, originalY); err != nil {
+			t.Errorf("restore pointer: %v", err)
+		}
+		if err := CloseMainDisplayE(); err != nil {
+			t.Errorf("CloseMainDisplayE: %v", err)
+		}
+	})
+
+	bounds := GetScreenRect()
+	if bounds.W <= 0 || bounds.H <= 0 {
+		t.Fatalf("invalid main-display bounds: %+v", bounds)
+	}
+	targetX := bounds.X + bounds.W/2
+	targetY := bounds.Y + bounds.H/2
+	if err := MoveE(targetX, targetY); err != nil {
+		t.Fatalf("MoveE(%d,%d): %v", targetX, targetY, err)
+	}
+	actualX, actualY, err := LocationE()
+	if err != nil {
+		t.Fatalf("moved LocationE: %v", err)
+	}
+	if actualX != targetX || actualY != targetY {
+		t.Fatalf(
+			"pointer location = (%d,%d), want (%d,%d)",
+			actualX, actualY, targetX, targetY,
+		)
+	}
+}

--- a/input_backend_darwin_nocgo_test.go
+++ b/input_backend_darwin_nocgo_test.go
@@ -1,0 +1,70 @@
+//go:build darwin && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/marang/robotgo/internal/darwininput"
+)
+
+func TestPureGoDarwinInputErrorTranslation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   error
+		want error
+	}{
+		{name: "unsupported", in: darwininput.ErrUnsupported, want: ErrNotSupported},
+		{name: "permission", in: darwininput.ErrPermission, want: ErrPermissionDenied},
+		{name: "ownership", in: darwininput.ErrOwnership, want: ErrInputOwnership},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := translatePureGoDarwinInputError(test.in); !errors.Is(err, test.want) {
+				t.Fatalf("translated error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+// TestPureGoDarwinInputRuntime is deliberately preflight-only: it resolves the
+// real framework symbols and checks Accessibility status without posting input
+// or opening a macOS consent dialog.
+func TestPureGoDarwinInputRuntime(t *testing.T) {
+	if err := KeyboardReady(); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("KeyboardReady = %v, want ErrNotSupported", err)
+	}
+
+	capabilities := GetRuntimeCapabilities()
+	if capabilities.Mouse.Backend != featureBackendPureGoQuartzInput {
+		t.Fatalf("mouse capability = %+v, want Quartz backend", capabilities.Mouse)
+	}
+	if capabilities.Keyboard.Available ||
+		capabilities.Keyboard.Backend != featureBackendPureGoQuartzInput {
+		t.Fatalf("keyboard capability = %+v, want named unsupported Quartz keyboard", capabilities.Keyboard)
+	}
+
+	readyErr := MouseReady()
+	switch {
+	case readyErr == nil:
+		if !capabilities.Mouse.Available {
+			t.Fatalf("MouseReady succeeded but capability = %+v", capabilities.Mouse)
+		}
+	case errors.Is(readyErr, ErrPermissionDenied):
+		if capabilities.Mouse.Available {
+			t.Fatalf("MouseReady denied but capability = %+v", capabilities.Mouse)
+		}
+		if !strings.Contains(readyErr.Error(), "Accessibility") {
+			t.Fatalf("permission error lacks actionable Accessibility hint: %v", readyErr)
+		}
+	case errors.Is(readyErr, ErrNotSupported):
+		t.Fatalf("required hosted-runner Quartz symbols are unavailable: %v", readyErr)
+	default:
+		t.Fatalf("unexpected MouseReady error: %v", readyErr)
+	}
+
+	if err := CloseMainDisplayE(); err != nil {
+		t.Fatalf("CloseMainDisplayE: %v", err)
+	}
+}

--- a/input_backend_default_nocgo.go
+++ b/input_backend_default_nocgo.go
@@ -1,4 +1,4 @@
-//go:build !cgo && !linux && !windows
+//go:build !cgo && !darwin && !linux && !windows
 
 package robotgo
 

--- a/input_backend_nocgo.go
+++ b/input_backend_nocgo.go
@@ -92,5 +92,17 @@ func pureGoInputCapabilities() (keyboard, mouse FeatureCapability) {
 		keyboard.Notes += "; SendInput follows the foreground target's keyboard layout and Windows UIPI; CloseMainDisplayE releases RobotGo-owned persistent holds"
 		mouse.Notes += "; pointer coordinates use the Windows virtual screen; CloseMainDisplayE releases RobotGo-owned persistent holds"
 	}
+	if backendName == featureBackendPureGoQuartzInput {
+		keyboard.Available = false
+		keyboard.Reason = ErrNotSupported.Error()
+		keyboard.Notes = "Pure-Go macOS keyboard injection is not implemented yet"
+		mouse.Notes = "Accessibility is preflighted without opening a consent dialog; pointer coordinates use the CoreGraphics global display space; CloseMainDisplayE releases RobotGo-owned persistent holds"
+		if err := backend.MouseReady(); err != nil {
+			mouse.Available = false
+			mouse.Reason = err.Error()
+		} else {
+			mouse.Reason = "Pure-Go Quartz pointer backend is ready"
+		}
+	}
 	return keyboard, mouse
 }

--- a/input_backend_nocgo_test.go
+++ b/input_backend_nocgo_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 type fakePureGoInputBackend struct {
+	name         string
 	calls        []string
 	location     Point
 	keyboardErr  error
@@ -18,7 +19,12 @@ type fakePureGoInputBackend struct {
 	operationErr error
 }
 
-func (*fakePureGoInputBackend) Name() string { return "pure-go-test-input" }
+func (backend *fakePureGoInputBackend) Name() string {
+	if backend.name != "" {
+		return backend.name
+	}
+	return "pure-go-test-input"
+}
 
 func (backend *fakePureGoInputBackend) record(format string, args ...interface{}) error {
 	backend.calls = append(backend.calls, fmt.Sprintf(format, args...))
@@ -250,6 +256,27 @@ func TestPureGoInputCapabilitiesDoNotPerformLiveProbes(t *testing.T) {
 	}
 	if len(backend.calls) != 0 {
 		t.Fatalf("capability inspection performed live backend calls: %v", backend.calls)
+	}
+}
+
+func TestPureGoQuartzCapabilitiesPreflightPointerWithoutClaimingKeyboard(t *testing.T) {
+	mouseErr := errors.Join(ErrPermissionDenied, errors.New("Accessibility denied"))
+	backend := &fakePureGoInputBackend{
+		name:     featureBackendPureGoQuartzInput,
+		mouseErr: mouseErr,
+	}
+	installFakePureGoInputBackend(t, backend)
+
+	keyboard, mouse := pureGoInputCapabilities()
+	if keyboard.Available || keyboard.Backend != featureBackendPureGoQuartzInput ||
+		keyboard.Reason != ErrNotSupported.Error() {
+		t.Fatalf("keyboard capability = %+v, want explicit unsupported Quartz keyboard", keyboard)
+	}
+	if mouse.Available || mouse.Backend != featureBackendPureGoQuartzInput {
+		t.Fatalf("mouse capability = %+v, want unavailable Quartz pointer", mouse)
+	}
+	if !reflect.DeepEqual(backend.calls, []string{"mouse-ready"}) {
+		t.Fatalf("Quartz capability probe calls = %v, want only mouse-ready", backend.calls)
 	}
 }
 

--- a/internal/darwininput/backend.go
+++ b/internal/darwininput/backend.go
@@ -1,0 +1,538 @@
+// Package darwininput provides RobotGo's Pure-Go macOS pointer backend.
+package darwininput
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+)
+
+const (
+	doubleClickGap           = 200 * time.Millisecond
+	dragStartDelay           = 50 * time.Millisecond
+	maximumSmoothDelay       = 10_000
+	maximumCoordinate  int64 = 1 << 53
+)
+
+var (
+	// ErrUnsupported reports an operation unavailable through the Quartz backend.
+	ErrUnsupported = errors.New("Pure-Go macOS input operation is unsupported")
+	// ErrPermission reports missing macOS Accessibility permission.
+	ErrPermission = errors.New("Pure-Go macOS input requires Accessibility permission")
+	// ErrOwnership reports an attempt to release or overwrite foreign input state.
+	ErrOwnership = errors.New("Pure-Go macOS input state is not owned by RobotGo")
+)
+
+type point struct {
+	X float64
+	Y float64
+}
+
+type mouseButton struct {
+	code      uint32
+	downType  uint32
+	upType    uint32
+	dragType  uint32
+	canonical string
+}
+
+type inputSystem interface {
+	Ready() error
+	CursorPosition() (point, error)
+	ButtonDown(uint32) (bool, error)
+	PostMouse(eventType uint32, location point, button uint32, clickState int64) error
+	PostScroll(horizontal, vertical int32) error
+	Close() error
+}
+
+type openSystem func() (inputSystem, error)
+
+// Backend serializes Quartz pointer transactions and tracks persistent holds.
+type Backend struct {
+	mu sync.Mutex
+
+	open   openSystem
+	system inputSystem
+	sleep  func(time.Duration)
+
+	ownedButtons map[uint32]mouseButton
+	ownedOrder   []uint32
+	lastLocation point
+	hasLocation  bool
+}
+
+// New creates a lazily initialized backend backed by macOS frameworks.
+func New() *Backend {
+	return newBackend(openNativeSystem, time.Sleep)
+}
+
+func newBackend(open openSystem, sleep func(time.Duration)) *Backend {
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	return &Backend{
+		open:         open,
+		sleep:        sleep,
+		ownedButtons: make(map[uint32]mouseButton),
+	}
+}
+
+func (backend *Backend) systemLocked() (inputSystem, error) {
+	if backend.system != nil {
+		return backend.system, nil
+	}
+	system, err := backend.open()
+	if err != nil {
+		return nil, err
+	}
+	backend.system = system
+	return system, nil
+}
+
+func (backend *Backend) readyLocked() (inputSystem, error) {
+	system, err := backend.systemLocked()
+	if err != nil {
+		return nil, err
+	}
+	if err := system.Ready(); err != nil {
+		return nil, err
+	}
+	return system, nil
+}
+
+// MouseReady checks the non-prompting Accessibility preflight and Quartz access.
+func (backend *Backend) MouseReady() error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	_, err := backend.readyLocked()
+	return err
+}
+
+func validateCoordinate(value int) error {
+	if int64(value) < -maximumCoordinate || int64(value) > maximumCoordinate {
+		return fmt.Errorf("Pure-Go macOS coordinate %d cannot be represented exactly by CoreGraphics", value)
+	}
+	return nil
+}
+
+func integralCoordinate(value float64) (int64, error) {
+	if math.IsNaN(value) || math.IsInf(value, 0) ||
+		value < -float64(maximumCoordinate) || value > float64(maximumCoordinate) {
+		return 0, fmt.Errorf("CoreGraphics returned invalid pointer coordinate %v", value)
+	}
+	return int64(value), nil
+}
+
+func locationLocked(system inputSystem) (int64, int64, error) {
+	location, err := system.CursorPosition()
+	if err != nil {
+		return 0, 0, err
+	}
+	x, err := integralCoordinate(location.X)
+	if err != nil {
+		return 0, 0, err
+	}
+	y, err := integralCoordinate(location.Y)
+	if err != nil {
+		return 0, 0, err
+	}
+	return x, y, nil
+}
+
+// MoveAbsolute moves the pointer in the CoreGraphics global coordinate space.
+func (backend *Backend) MoveAbsolute(x, y int) error {
+	if err := validateCoordinate(x); err != nil {
+		return err
+	}
+	if err := validateCoordinate(y); err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.readyLocked()
+	if err != nil {
+		return err
+	}
+	target := point{X: float64(x), Y: float64(y)}
+	if err := system.PostMouse(eventMouseMoved, target, buttonLeft, 0); err != nil {
+		return err
+	}
+	backend.lastLocation, backend.hasLocation = target, true
+	return nil
+}
+
+// MoveRelative moves from the current pointer location.
+func (backend *Backend) MoveRelative(x, y int) error {
+	if err := validateCoordinate(x); err != nil {
+		return err
+	}
+	if err := validateCoordinate(y); err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.readyLocked()
+	if err != nil {
+		return err
+	}
+	currentX, currentY, err := locationLocked(system)
+	if err != nil {
+		return err
+	}
+	targetX, targetY := currentX+int64(x), currentY+int64(y)
+	if targetX < -maximumCoordinate || targetX > maximumCoordinate ||
+		targetY < -maximumCoordinate || targetY > maximumCoordinate {
+		return errors.New("Pure-Go macOS relative pointer target cannot be represented exactly by CoreGraphics")
+	}
+	target := point{X: float64(targetX), Y: float64(targetY)}
+	if err := system.PostMouse(eventMouseMoved, target, buttonLeft, 0); err != nil {
+		return err
+	}
+	backend.lastLocation, backend.hasLocation = target, true
+	return nil
+}
+
+func validSmoothDelayRange(lowDelay, highDelay float64) bool {
+	return !math.IsNaN(lowDelay) && !math.IsNaN(highDelay) &&
+		!math.IsInf(lowDelay, 0) && !math.IsInf(highDelay, 0) &&
+		lowDelay >= 0 && highDelay >= lowDelay && highDelay <= maximumSmoothDelay
+}
+
+type smoothMovePlan struct {
+	startX, startY   int64
+	targetX, targetY int64
+	steps            int
+	delay            time.Duration
+}
+
+func (backend *Backend) planSmoothMoveLocked(
+	system inputSystem,
+	x, y int,
+	relative bool,
+	lowDelay, highDelay float64,
+) (smoothMovePlan, error) {
+	if !validSmoothDelayRange(lowDelay, highDelay) {
+		return smoothMovePlan{}, fmt.Errorf(
+			"Pure-Go macOS invalid smooth-move delay range %g..%g ms",
+			lowDelay, highDelay,
+		)
+	}
+	if err := validateCoordinate(x); err != nil {
+		return smoothMovePlan{}, err
+	}
+	if err := validateCoordinate(y); err != nil {
+		return smoothMovePlan{}, err
+	}
+	startX, startY, err := locationLocked(system)
+	if err != nil {
+		return smoothMovePlan{}, err
+	}
+	targetX, targetY := int64(x), int64(y)
+	if relative {
+		targetX += startX
+		targetY += startY
+	}
+	if targetX < -maximumCoordinate || targetX > maximumCoordinate ||
+		targetY < -maximumCoordinate || targetY > maximumCoordinate {
+		return smoothMovePlan{}, errors.New("Pure-Go macOS smooth pointer target cannot be represented exactly by CoreGraphics")
+	}
+	distance := math.Hypot(float64(targetX-startX), float64(targetY-startY))
+	steps := int(math.Ceil(distance / 8))
+	if steps < 1 {
+		steps = 1
+	}
+	if steps > 240 {
+		steps = 240
+	}
+	return smoothMovePlan{
+		startX: startX, startY: startY,
+		targetX: targetX, targetY: targetY,
+		steps: steps,
+		delay: time.Duration((lowDelay + highDelay) / 2 * float64(time.Millisecond)),
+	}, nil
+}
+
+func (backend *Backend) executeSmoothMoveLocked(
+	system inputSystem,
+	plan smoothMovePlan,
+	eventType, button uint32,
+) error {
+	lastX, lastY := plan.startX, plan.startY
+	for step := 1; step <= plan.steps; step++ {
+		progress := float64(step) / float64(plan.steps)
+		if progress < 0.5 {
+			progress = 4 * progress * progress * progress
+		} else {
+			inverse := -2*progress + 2
+			progress = 1 - inverse*inverse*inverse/2
+		}
+		currentX := int64(math.Round(float64(plan.startX) + float64(plan.targetX-plan.startX)*progress))
+		currentY := int64(math.Round(float64(plan.startY) + float64(plan.targetY-plan.startY)*progress))
+		if currentX == lastX && currentY == lastY && step != plan.steps {
+			continue
+		}
+		if err := system.PostMouse(eventType, point{X: float64(currentX), Y: float64(currentY)}, button, 0); err != nil {
+			return err
+		}
+		backend.lastLocation = point{X: float64(currentX), Y: float64(currentY)}
+		backend.hasLocation = true
+		lastX, lastY = currentX, currentY
+		if plan.delay > 0 && step != plan.steps {
+			backend.sleep(plan.delay)
+		}
+	}
+	return nil
+}
+
+// MoveSmooth performs a bounded eased movement.
+func (backend *Backend) MoveSmooth(x, y int, relative bool, lowDelay, highDelay float64) error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.readyLocked()
+	if err != nil {
+		return err
+	}
+	plan, err := backend.planSmoothMoveLocked(system, x, y, relative, lowDelay, highDelay)
+	if err != nil {
+		return err
+	}
+	return backend.executeSmoothMoveLocked(system, plan, eventMouseMoved, buttonLeft)
+}
+
+func resolveMouseButton(name string) (mouseButton, error) {
+	switch name {
+	case "", "left":
+		return mouseButton{
+			code: buttonLeft, downType: eventLeftMouseDown,
+			upType: eventLeftMouseUp, dragType: eventLeftMouseDragged,
+			canonical: "left",
+		}, nil
+	case "right":
+		return mouseButton{
+			code: buttonRight, downType: eventRightMouseDown,
+			upType: eventRightMouseUp, dragType: eventRightMouseDragged,
+			canonical: "right",
+		}, nil
+	case "center", "middle":
+		return mouseButton{
+			code: buttonCenter, downType: eventOtherMouseDown,
+			upType: eventOtherMouseUp, dragType: eventOtherMouseDragged,
+			canonical: "center",
+		}, nil
+	case "wheelUp", "wheelDown", "wheelLeft", "wheelRight":
+		return mouseButton{}, fmt.Errorf("%w: use Scroll for wheel input instead of button %q", ErrUnsupported, name)
+	default:
+		return mouseButton{}, fmt.Errorf("invalid Pure-Go macOS pointer button %q", name)
+	}
+}
+
+func (backend *Backend) buttonAvailableLocked(system inputSystem, button mouseButton) error {
+	if _, owned := backend.ownedButtons[button.code]; owned {
+		return fmt.Errorf("%w: pointer button %q is already held by RobotGo", ErrOwnership, button.canonical)
+	}
+	down, err := system.ButtonDown(button.code)
+	if err != nil {
+		return err
+	}
+	if down {
+		return fmt.Errorf("%w: pointer button %q is already down", ErrOwnership, button.canonical)
+	}
+	return nil
+}
+
+func (backend *Backend) pressLocked(system inputSystem, button mouseButton, location point, clickState int64) error {
+	if err := system.PostMouse(button.downType, location, button.code, clickState); err != nil {
+		return err
+	}
+	backend.lastLocation, backend.hasLocation = location, true
+	backend.ownedButtons[button.code] = button
+	backend.ownedOrder = append(backend.ownedOrder, button.code)
+	return nil
+}
+
+func (backend *Backend) releaseLocked(system inputSystem, button mouseButton, location point, clickState int64) error {
+	if err := system.PostMouse(button.upType, location, button.code, clickState); err != nil {
+		return err
+	}
+	backend.lastLocation, backend.hasLocation = location, true
+	delete(backend.ownedButtons, button.code)
+	for index := len(backend.ownedOrder) - 1; index >= 0; index-- {
+		if backend.ownedOrder[index] != button.code {
+			continue
+		}
+		backend.ownedOrder = append(backend.ownedOrder[:index], backend.ownedOrder[index+1:]...)
+		break
+	}
+	return nil
+}
+
+// Click injects one or two complete button pulses.
+func (backend *Backend) Click(name string, double bool) error {
+	button, err := resolveMouseButton(name)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.readyLocked()
+	if err != nil {
+		return err
+	}
+	location, err := system.CursorPosition()
+	if err != nil {
+		return err
+	}
+	count := 1
+	if double {
+		count = 2
+	}
+	for click := 1; click <= count; click++ {
+		if err := backend.buttonAvailableLocked(system, button); err != nil {
+			return err
+		}
+		clickState := int64(click)
+		if err := backend.pressLocked(system, button, location, clickState); err != nil {
+			return err
+		}
+		if err := backend.releaseLocked(system, button, location, clickState); err != nil {
+			return err
+		}
+		if click != count {
+			backend.sleep(doubleClickGap)
+		}
+	}
+	return nil
+}
+
+// Toggle changes a persistent pointer-button state with ownership checks.
+func (backend *Backend) Toggle(name string, down bool) error {
+	button, err := resolveMouseButton(name)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.readyLocked()
+	if err != nil {
+		return err
+	}
+	location, err := system.CursorPosition()
+	if err != nil {
+		return err
+	}
+	if down {
+		if err := backend.buttonAvailableLocked(system, button); err != nil {
+			return err
+		}
+		return backend.pressLocked(system, button, location, 1)
+	}
+	owned, ok := backend.ownedButtons[button.code]
+	if !ok {
+		return fmt.Errorf("%w: pointer button %q was not pressed by this backend", ErrOwnership, button.canonical)
+	}
+	return backend.releaseLocked(system, owned, location, 1)
+}
+
+// DragSmooth owns the left button for the complete drag transaction.
+func (backend *Backend) DragSmooth(x, y int, lowDelay, highDelay float64) error {
+	button, _ := resolveMouseButton("left")
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.readyLocked()
+	if err != nil {
+		return err
+	}
+	plan, err := backend.planSmoothMoveLocked(system, x, y, false, lowDelay, highDelay)
+	if err != nil {
+		return err
+	}
+	if err := backend.buttonAvailableLocked(system, button); err != nil {
+		return err
+	}
+	start := point{X: float64(plan.startX), Y: float64(plan.startY)}
+	if err := backend.pressLocked(system, button, start, 1); err != nil {
+		return err
+	}
+	backend.sleep(dragStartDelay)
+	moveErr := backend.executeSmoothMoveLocked(system, plan, button.dragType, button.code)
+	releaseLocation := point{X: float64(plan.targetX), Y: float64(plan.targetY)}
+	if moveErr != nil {
+		if current, locationErr := system.CursorPosition(); locationErr == nil {
+			releaseLocation = current
+		} else if backend.hasLocation {
+			releaseLocation = backend.lastLocation
+		}
+	}
+	releaseErr := backend.releaseLocked(system, button, releaseLocation, 1)
+	return errors.Join(moveErr, releaseErr)
+}
+
+// Location returns the pointer location in global display coordinates.
+func (backend *Backend) Location() (int, int, error) {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.readyLocked()
+	if err != nil {
+		return 0, 0, err
+	}
+	x, y, err := locationLocked(system)
+	return int(x), int(y), err
+}
+
+// Scroll injects horizontal and vertical pixel-based wheel deltas.
+func (backend *Backend) Scroll(x, y int) error {
+	if int(int32(x)) != x || int(int32(y)) != y {
+		return errors.New("Pure-Go macOS scroll delta exceeds CoreGraphics int32 range")
+	}
+	if x == 0 && y == 0 {
+		return nil
+	}
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.readyLocked()
+	if err != nil {
+		return err
+	}
+	return system.PostScroll(int32(x), int32(y))
+}
+
+// Close releases RobotGo-owned buttons and unloads the native frameworks.
+func (backend *Backend) Close() error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if backend.system == nil {
+		return nil
+	}
+	system := backend.system
+	var closeErr error
+	if len(backend.ownedButtons) > 0 {
+		location, locationErr := system.CursorPosition()
+		if locationErr != nil && backend.hasLocation {
+			location = backend.lastLocation
+			locationErr = nil
+		}
+		if locationErr != nil {
+			return locationErr
+		}
+		ownedOrder := append([]uint32(nil), backend.ownedOrder...)
+		for index := len(ownedOrder) - 1; index >= 0; index-- {
+			code := ownedOrder[index]
+			button, owned := backend.ownedButtons[code]
+			if !owned {
+				continue
+			}
+			closeErr = errors.Join(closeErr, backend.releaseLocked(system, button, location, 1))
+		}
+	}
+	if len(backend.ownedButtons) > 0 {
+		return closeErr
+	}
+	closeErr = errors.Join(closeErr, system.Close())
+	backend.system = nil
+	backend.ownedButtons = make(map[uint32]mouseButton)
+	backend.ownedOrder = backend.ownedOrder[:0]
+	backend.hasLocation = false
+	return closeErr
+}

--- a/internal/darwininput/backend_test.go
+++ b/internal/darwininput/backend_test.go
@@ -1,0 +1,371 @@
+package darwininput
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+)
+
+type recordedMouseEvent struct {
+	eventType  uint32
+	location   point
+	button     uint32
+	clickState int64
+}
+
+type fakeInputSystem struct {
+	readyErr       error
+	location       point
+	locationErr    error
+	buttons        map[uint32]bool
+	buttonStateErr error
+	mouseEvents    []recordedMouseEvent
+	scrolls        [][2]int32
+	postMouseCalls int
+	postMouseErrAt int
+	closeCalls     int
+}
+
+func (system *fakeInputSystem) Ready() error { return system.readyErr }
+
+func (system *fakeInputSystem) CursorPosition() (point, error) {
+	return system.location, system.locationErr
+}
+
+func (system *fakeInputSystem) ButtonDown(button uint32) (bool, error) {
+	return system.buttons[button], system.buttonStateErr
+}
+
+func (system *fakeInputSystem) PostMouse(
+	eventType uint32,
+	location point,
+	button uint32,
+	clickState int64,
+) error {
+	system.postMouseCalls++
+	if system.postMouseErrAt == system.postMouseCalls {
+		return errors.New("post mouse failed")
+	}
+	system.mouseEvents = append(system.mouseEvents, recordedMouseEvent{
+		eventType: eventType, location: location,
+		button: button, clickState: clickState,
+	})
+	system.location = location
+	switch eventType {
+	case eventLeftMouseDown, eventRightMouseDown, eventOtherMouseDown:
+		system.buttons[button] = true
+	case eventLeftMouseUp, eventRightMouseUp, eventOtherMouseUp:
+		system.buttons[button] = false
+	}
+	return nil
+}
+
+func (system *fakeInputSystem) PostScroll(horizontal, vertical int32) error {
+	system.scrolls = append(system.scrolls, [2]int32{horizontal, vertical})
+	return nil
+}
+
+func (system *fakeInputSystem) Close() error {
+	system.closeCalls++
+	return nil
+}
+
+func testBackend(system *fakeInputSystem, sleeps *[]time.Duration) *Backend {
+	if system.buttons == nil {
+		system.buttons = make(map[uint32]bool)
+	}
+	return newBackend(
+		func() (inputSystem, error) { return system, nil },
+		func(delay time.Duration) { *sleeps = append(*sleeps, delay) },
+	)
+}
+
+func TestMouseReadyIsLazyAndPreservesPermissionError(t *testing.T) {
+	wantErr := errors.Join(ErrPermission, errors.New("denied"))
+	system := &fakeInputSystem{buttons: make(map[uint32]bool), readyErr: wantErr}
+	openCalls := 0
+	backend := newBackend(func() (inputSystem, error) {
+		openCalls++
+		return system, nil
+	}, nil)
+
+	if err := backend.MouseReady(); !errors.Is(err, ErrPermission) {
+		t.Fatalf("MouseReady error = %v, want ErrPermission", err)
+	}
+	if err := backend.MouseReady(); !errors.Is(err, ErrPermission) {
+		t.Fatalf("second MouseReady error = %v, want ErrPermission", err)
+	}
+	if openCalls != 1 {
+		t.Fatalf("native opens = %d, want one cached system", openCalls)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if system.closeCalls != 1 {
+		t.Fatalf("native closes = %d, want 1", system.closeCalls)
+	}
+}
+
+func TestMouseReadyRetriesFailedNativeOpen(t *testing.T) {
+	openCalls := 0
+	backend := newBackend(func() (inputSystem, error) {
+		openCalls++
+		return nil, ErrUnsupported
+	}, nil)
+	for attempt := 0; attempt < 2; attempt++ {
+		if err := backend.MouseReady(); !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("MouseReady attempt %d error = %v, want ErrUnsupported", attempt+1, err)
+		}
+	}
+	if openCalls != 2 {
+		t.Fatalf("failed native opens = %d, want retry on each call", openCalls)
+	}
+}
+
+func TestPointerMoveLocationAndRelativeCoordinates(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{location: point{X: -10.4, Y: 20.6}}
+	backend := testBackend(system, &sleeps)
+
+	x, y, err := backend.Location()
+	if err != nil || x != -10 || y != 20 {
+		t.Fatalf("Location = (%d,%d,%v), want (-10,20,nil)", x, y, err)
+	}
+	if err := backend.MoveRelative(3, -4); err != nil {
+		t.Fatalf("MoveRelative: %v", err)
+	}
+	if err := backend.MoveAbsolute(-50, 60); err != nil {
+		t.Fatalf("MoveAbsolute: %v", err)
+	}
+	want := []recordedMouseEvent{
+		{eventType: eventMouseMoved, location: point{X: -7, Y: 16}, button: buttonLeft},
+		{eventType: eventMouseMoved, location: point{X: -50, Y: 60}, button: buttonLeft},
+	}
+	if !reflect.DeepEqual(system.mouseEvents, want) {
+		t.Fatalf("mouse events = %#v, want %#v", system.mouseEvents, want)
+	}
+	if strconv.IntSize == 64 {
+		overflow := maximumCoordinate + 1
+		if err := backend.MoveAbsolute(int(overflow), 0); err == nil {
+			t.Fatal("inexact CoreGraphics coordinate unexpectedly succeeded")
+		}
+	}
+}
+
+func TestPointerRejectsInvalidNativeCoordinates(t *testing.T) {
+	for _, location := range []point{
+		{X: math.NaN()},
+		{Y: math.Inf(1)},
+		{X: float64(maximumCoordinate + 2)},
+	} {
+		var sleeps []time.Duration
+		backend := testBackend(&fakeInputSystem{location: location}, &sleeps)
+		if _, _, err := backend.Location(); err == nil {
+			t.Fatalf("Location unexpectedly accepted %+v", location)
+		}
+	}
+}
+
+func TestSmoothMoveIsBoundedAndEndsAtTarget(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{location: point{X: 0, Y: 0}}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.MoveSmooth(24, 0, false, 1, 3); err != nil {
+		t.Fatalf("MoveSmooth: %v", err)
+	}
+	if len(system.mouseEvents) != 3 {
+		t.Fatalf("smooth events = %d, want 3", len(system.mouseEvents))
+	}
+	last := system.mouseEvents[len(system.mouseEvents)-1]
+	if last.location != (point{X: 24, Y: 0}) || last.eventType != eventMouseMoved {
+		t.Fatalf("last smooth event = %+v, want target mouse-moved", last)
+	}
+	if !reflect.DeepEqual(sleeps, []time.Duration{2 * time.Millisecond, 2 * time.Millisecond}) {
+		t.Fatalf("smooth sleeps = %v, want two 2ms intervals", sleeps)
+	}
+	for _, delays := range [][2]float64{
+		{-1, 1},
+		{2, 1},
+		{0, math.NaN()},
+		{0, math.Inf(1)},
+		{0, maximumSmoothDelay + 1},
+	} {
+		if err := backend.MoveSmooth(1, 1, false, delays[0], delays[1]); err == nil {
+			t.Fatalf("invalid delays %v unexpectedly succeeded", delays)
+		}
+	}
+}
+
+func TestDoubleClickUsesMatchingClickStates(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Click("right", true); err != nil {
+		t.Fatalf("Click: %v", err)
+	}
+	want := []recordedMouseEvent{
+		{eventType: eventRightMouseDown, button: buttonRight, clickState: 1},
+		{eventType: eventRightMouseUp, button: buttonRight, clickState: 1},
+		{eventType: eventRightMouseDown, button: buttonRight, clickState: 2},
+		{eventType: eventRightMouseUp, button: buttonRight, clickState: 2},
+	}
+	if !reflect.DeepEqual(system.mouseEvents, want) {
+		t.Fatalf("double-click events = %#v, want %#v", system.mouseEvents, want)
+	}
+	if !reflect.DeepEqual(sleeps, []time.Duration{doubleClickGap}) {
+		t.Fatalf("double-click sleeps = %v, want %v", sleeps, doubleClickGap)
+	}
+}
+
+func TestPointerButtonMappingsAndWheelContract(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		down, up   uint32
+		buttonCode uint32
+	}{
+		{name: "left", down: eventLeftMouseDown, up: eventLeftMouseUp, buttonCode: buttonLeft},
+		{name: "right", down: eventRightMouseDown, up: eventRightMouseUp, buttonCode: buttonRight},
+		{name: "middle", down: eventOtherMouseDown, up: eventOtherMouseUp, buttonCode: buttonCenter},
+	} {
+		var sleeps []time.Duration
+		system := &fakeInputSystem{}
+		backend := testBackend(system, &sleeps)
+		if err := backend.Click(test.name, false); err != nil {
+			t.Fatalf("Click(%q): %v", test.name, err)
+		}
+		if len(system.mouseEvents) != 2 ||
+			system.mouseEvents[0].eventType != test.down ||
+			system.mouseEvents[1].eventType != test.up ||
+			system.mouseEvents[0].button != test.buttonCode {
+			t.Fatalf("Click(%q) events = %#v", test.name, system.mouseEvents)
+		}
+	}
+
+	var sleeps []time.Duration
+	backend := testBackend(&fakeInputSystem{}, &sleeps)
+	for _, name := range []string{"wheelUp", "wheelDown", "wheelLeft", "wheelRight"} {
+		if err := backend.Click(name, false); !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("Click(%q) error = %v, want ErrUnsupported", name, err)
+		}
+	}
+	if err := backend.Click("side", false); err == nil {
+		t.Fatal("unknown pointer button unexpectedly succeeded")
+	}
+}
+
+func TestToggleRejectsForeignStateAndCloseReleasesOwnedButtons(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{
+		location: point{X: 12, Y: 34},
+		buttons:  map[uint32]bool{buttonRight: true},
+	}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Toggle("right", true); !errors.Is(err, ErrOwnership) {
+		t.Fatalf("foreign right-button error = %v, want ErrOwnership", err)
+	}
+	if err := backend.Toggle("left", false); !errors.Is(err, ErrOwnership) {
+		t.Fatalf("unowned left release = %v, want ErrOwnership", err)
+	}
+	if err := backend.Toggle("left", true); err != nil {
+		t.Fatalf("left down: %v", err)
+	}
+	system.locationErr = errors.New("location unavailable during close")
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close with cached held location: %v", err)
+	}
+	wantTypes := []uint32{eventLeftMouseDown, eventLeftMouseUp}
+	var gotTypes []uint32
+	for _, event := range system.mouseEvents {
+		gotTypes = append(gotTypes, event.eventType)
+	}
+	if !reflect.DeepEqual(gotTypes, wantTypes) {
+		t.Fatalf("event types = %v, want %v", gotTypes, wantTypes)
+	}
+	if system.buttons[buttonLeft] {
+		t.Fatal("Close left a RobotGo-owned button down")
+	}
+	if system.closeCalls != 1 {
+		t.Fatalf("native closes = %d, want 1", system.closeCalls)
+	}
+}
+
+func TestCloseKeepsBackendOpenWhenOwnedReleaseFails(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{location: point{X: 1, Y: 2}}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Toggle("left", true); err != nil {
+		t.Fatalf("left down: %v", err)
+	}
+	system.postMouseErrAt = 2
+	if err := backend.Close(); err == nil {
+		t.Fatal("Close unexpectedly hid owned-button release failure")
+	}
+	if system.closeCalls != 0 {
+		t.Fatalf("native closes = %d, want backend retained for retry", system.closeCalls)
+	}
+	system.postMouseErrAt = 0
+	if err := backend.Close(); err != nil {
+		t.Fatalf("retry Close: %v", err)
+	}
+	if system.closeCalls != 1 {
+		t.Fatalf("native closes after retry = %d, want 1", system.closeCalls)
+	}
+}
+
+func TestDragAlwaysAttemptsReleaseAndScrollPreservesAxes(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{location: point{X: 0, Y: 0}}
+	backend := testBackend(system, &sleeps)
+
+	system.postMouseErrAt = 2
+	if err := backend.DragSmooth(16, 0, 0, 0); err == nil {
+		t.Fatal("DragSmooth unexpectedly hid move failure")
+	}
+	if system.buttons[buttonLeft] {
+		t.Fatal("DragSmooth failure left the owned button down")
+	}
+	if len(system.mouseEvents) != 2 ||
+		system.mouseEvents[0].eventType != eventLeftMouseDown ||
+		system.mouseEvents[1].eventType != eventLeftMouseUp {
+		t.Fatalf("drag events = %#v, want down then attempted move then up", system.mouseEvents)
+	}
+	if err := backend.Scroll(-3, 4); err != nil {
+		t.Fatalf("Scroll: %v", err)
+	}
+	if !reflect.DeepEqual(system.scrolls, [][2]int32{{-3, 4}}) {
+		t.Fatalf("scrolls = %v, want horizontal=-3 vertical=4", system.scrolls)
+	}
+}
+
+func TestZeroScrollDoesNotOpenNativeSystem(t *testing.T) {
+	openCalls := 0
+	backend := newBackend(func() (inputSystem, error) {
+		openCalls++
+		return &fakeInputSystem{}, nil
+	}, nil)
+	if err := backend.Scroll(0, 0); err != nil {
+		t.Fatalf("zero Scroll: %v", err)
+	}
+	if openCalls != 0 {
+		t.Fatalf("zero Scroll native opens = %d, want 0", openCalls)
+	}
+}
+
+func TestScrollRejectsInt32Overflow(t *testing.T) {
+	if strconv.IntSize < 64 {
+		t.Skip("Go int cannot represent an overflowing CoreGraphics scroll delta")
+	}
+	var sleeps []time.Duration
+	backend := testBackend(&fakeInputSystem{}, &sleeps)
+	overflow := int64(1) << 31
+	if err := backend.Scroll(int(overflow), 0); err == nil {
+		t.Fatal("overflowing horizontal scroll unexpectedly succeeded")
+	}
+}

--- a/internal/darwininput/constants.go
+++ b/internal/darwininput/constants.go
@@ -1,0 +1,18 @@
+package darwininput
+
+const (
+	buttonLeft   uint32 = 0
+	buttonRight  uint32 = 1
+	buttonCenter uint32 = 2
+
+	eventLeftMouseDown     uint32 = 1
+	eventLeftMouseUp       uint32 = 2
+	eventRightMouseDown    uint32 = 3
+	eventRightMouseUp      uint32 = 4
+	eventMouseMoved        uint32 = 5
+	eventLeftMouseDragged  uint32 = 6
+	eventRightMouseDragged uint32 = 7
+	eventOtherMouseDown    uint32 = 25
+	eventOtherMouseUp      uint32 = 26
+	eventOtherMouseDragged uint32 = 27
+)

--- a/internal/darwininput/system_darwin.go
+++ b/internal/darwininput/system_darwin.go
@@ -1,0 +1,196 @@
+//go:build darwin
+
+package darwininput
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ebitengine/purego"
+)
+
+const (
+	applicationServicesFramework = "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices"
+	coreFoundationFramework      = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+	coreGraphicsFramework        = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+
+	cgEventSourceStatePrivate         int32  = -1
+	cgEventSourceStateCombinedSession int32  = 0
+	cgHIDEventTap                     uint32 = 0
+	cgScrollEventUnitPixel            uint32 = 0
+	cgMouseEventClickState            uint32 = 1
+	cgMouseEventDeltaX                uint32 = 4
+	cgMouseEventDeltaY                uint32 = 5
+)
+
+type nativeSystem struct {
+	applicationServicesHandle uintptr
+	coreFoundationHandle      uintptr
+	coreGraphicsHandle        uintptr
+	eventSource               uintptr
+
+	isProcessTrusted       func() bool
+	eventCreate            func(uintptr) uintptr
+	eventGetLocation       func(uintptr) point
+	eventSourceCreate      func(int32) uintptr
+	eventSourceButtonState func(int32, uint32) bool
+	eventCreateMouse       func(uintptr, uint32, point, uint32) uintptr
+	eventCreateScroll      func(uintptr, uint32, uint32, int32, int32, int32) uintptr
+	eventSetIntegerField   func(uintptr, uint32, int64)
+	eventPost              func(uint32, uintptr)
+	cfRelease              func(uintptr)
+}
+
+func openNativeSystem() (inputSystem, error) {
+	system := &nativeSystem{}
+	var err error
+	system.applicationServicesHandle, err = purego.Dlopen(
+		applicationServicesFramework,
+		purego.RTLD_NOW|purego.RTLD_LOCAL,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: load ApplicationServices: %w", ErrUnsupported, err)
+	}
+	system.coreGraphicsHandle, err = purego.Dlopen(
+		coreGraphicsFramework,
+		purego.RTLD_NOW|purego.RTLD_LOCAL,
+	)
+	if err != nil {
+		openErr := fmt.Errorf("%w: load CoreGraphics: %w", ErrUnsupported, err)
+		return nil, errors.Join(openErr, system.Close())
+	}
+	system.coreFoundationHandle, err = purego.Dlopen(
+		coreFoundationFramework,
+		purego.RTLD_NOW|purego.RTLD_LOCAL,
+	)
+	if err != nil {
+		openErr := fmt.Errorf("%w: load CoreFoundation: %w", ErrUnsupported, err)
+		return nil, errors.Join(openErr, system.Close())
+	}
+	required := []struct {
+		handle uintptr
+		target any
+		name   string
+	}{
+		{system.applicationServicesHandle, &system.isProcessTrusted, "AXIsProcessTrusted"},
+		{system.coreGraphicsHandle, &system.eventCreate, "CGEventCreate"},
+		{system.coreGraphicsHandle, &system.eventGetLocation, "CGEventGetLocation"},
+		{system.coreGraphicsHandle, &system.eventSourceCreate, "CGEventSourceCreate"},
+		{system.coreGraphicsHandle, &system.eventSourceButtonState, "CGEventSourceButtonState"},
+		{system.coreGraphicsHandle, &system.eventCreateMouse, "CGEventCreateMouseEvent"},
+		{system.coreGraphicsHandle, &system.eventCreateScroll, "CGEventCreateScrollWheelEvent2"},
+		{system.coreGraphicsHandle, &system.eventSetIntegerField, "CGEventSetIntegerValueField"},
+		{system.coreGraphicsHandle, &system.eventPost, "CGEventPost"},
+		{system.coreFoundationHandle, &system.cfRelease, "CFRelease"},
+	}
+	for _, function := range required {
+		symbol, symbolErr := purego.Dlsym(function.handle, function.name)
+		if symbolErr != nil {
+			openErr := fmt.Errorf("%w: resolve macOS symbol %s: %w", ErrUnsupported, function.name, symbolErr)
+			return nil, errors.Join(openErr, system.Close())
+		}
+		purego.RegisterFunc(function.target, symbol)
+	}
+	// A private source keeps RobotGo's generated-event state independent from
+	// other login-session sources. Ownership checks still query the combined
+	// session table so physical and foreign synthetic holds are observable.
+	system.eventSource = system.eventSourceCreate(cgEventSourceStatePrivate)
+	if system.eventSource == 0 {
+		openErr := fmt.Errorf("%w: CoreGraphics could not create a private event source", ErrUnsupported)
+		return nil, errors.Join(openErr, system.Close())
+	}
+	return system, nil
+}
+
+func (system *nativeSystem) Ready() error {
+	if !system.isProcessTrusted() {
+		return fmt.Errorf(
+			"%w: grant this application access in System Settings > Privacy & Security > Accessibility",
+			ErrPermission,
+		)
+	}
+	event := system.eventCreate(0)
+	if event == 0 {
+		return errors.New("CoreGraphics could not create a pointer-location event; an active macOS GUI session is required")
+	}
+	system.cfRelease(event)
+	return nil
+}
+
+func (system *nativeSystem) CursorPosition() (point, error) {
+	event := system.eventCreate(0)
+	if event == 0 {
+		return point{}, errors.New("CoreGraphics could not create a pointer-location event")
+	}
+	defer system.cfRelease(event)
+	return system.eventGetLocation(event), nil
+}
+
+func (system *nativeSystem) ButtonDown(button uint32) (bool, error) {
+	return system.eventSourceButtonState(cgEventSourceStateCombinedSession, button), nil
+}
+
+func (system *nativeSystem) PostMouse(
+	eventType uint32,
+	location point,
+	button uint32,
+	clickState int64,
+) error {
+	event := system.eventCreateMouse(system.eventSource, eventType, location, button)
+	if event == 0 {
+		return fmt.Errorf("CoreGraphics could not create mouse event type %d", eventType)
+	}
+	defer system.cfRelease(event)
+	if clickState > 0 {
+		system.eventSetIntegerField(event, cgMouseEventClickState, clickState)
+	}
+	switch eventType {
+	case eventMouseMoved, eventLeftMouseDragged, eventRightMouseDragged, eventOtherMouseDragged:
+		current, err := system.CursorPosition()
+		if err != nil {
+			return err
+		}
+		system.eventSetIntegerField(event, cgMouseEventDeltaX, int64(location.X-current.X))
+		system.eventSetIntegerField(event, cgMouseEventDeltaY, int64(location.Y-current.Y))
+	}
+	system.eventPost(cgHIDEventTap, event)
+	return nil
+}
+
+func (system *nativeSystem) PostScroll(horizontal, vertical int32) error {
+	event := system.eventCreateScroll(
+		system.eventSource,
+		cgScrollEventUnitPixel,
+		2,
+		vertical,
+		horizontal,
+		0,
+	)
+	if event == 0 {
+		return errors.New("CoreGraphics could not create scroll-wheel event")
+	}
+	defer system.cfRelease(event)
+	system.eventPost(cgHIDEventTap, event)
+	return nil
+}
+
+func (system *nativeSystem) Close() error {
+	var closeErr error
+	if system.eventSource != 0 && system.cfRelease != nil {
+		system.cfRelease(system.eventSource)
+		system.eventSource = 0
+	}
+	if system.coreFoundationHandle != 0 {
+		closeErr = errors.Join(closeErr, purego.Dlclose(system.coreFoundationHandle))
+		system.coreFoundationHandle = 0
+	}
+	if system.coreGraphicsHandle != 0 {
+		closeErr = errors.Join(closeErr, purego.Dlclose(system.coreGraphicsHandle))
+		system.coreGraphicsHandle = 0
+	}
+	if system.applicationServicesHandle != 0 {
+		closeErr = errors.Join(closeErr, purego.Dlclose(system.applicationServicesHandle))
+		system.applicationServicesHandle = 0
+	}
+	return closeErr
+}

--- a/internal/darwininput/system_notdarwin.go
+++ b/internal/darwininput/system_notdarwin.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package darwininput
+
+import "fmt"
+
+func openNativeSystem() (inputSystem, error) {
+	return nil, fmt.Errorf("%w: Quartz input is available only on macOS", ErrUnsupported)
+}


### PR DESCRIPTION
## Goal

Advance Phase 3 with a useful non-CGO macOS input backend while preserving explicit permission, unsupported, and ownership contracts.

## What changed

- add a lazily loaded Pure-Go Quartz pointer backend for macOS
- support absolute/relative/smooth movement, drag, click/double-click, owned button toggles, horizontal/vertical scroll, and pointer location
- preflight Accessibility with `AXIsProcessTrusted` without opening a consent dialog
- keep Pure-Go macOS keyboard input explicitly unsupported
- use a private Quartz event source while checking foreign button state through the combined login session
- release RobotGo-owned buttons deterministically and retain state for cleanup retry after release failures
- add hermetic backend tests, a safe real-framework preflight on GitHub macOS, and an opt-in real pointer integration test
- add a runnable example and update README, TEST, Wayland status, product roadmap, and CI

## User impact

`CGO_ENABLED=0` macOS builds now expose useful pointer automation instead of `ErrNotSupported`. Missing Accessibility access is reported as `ErrPermissionDenied` with an actionable System Settings hint. Capability inspection never opens a permission prompt or posts input.

## Validation

- `go test ./... -count=1`
- `CGO_ENABLED=0 go test ./... -count=1`
- `go test -race ./... -count=1`
- `go test -race ./internal/darwininput -count=20`
- `CGO_ENABLED=0/1 golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0/1 go vet ./...`
- Darwin amd64 and arm64 cross-compiled with `darwinintegration`
- new backend core: 82.7% statement coverage

## Risk and limits

Quartz posting has no synchronous success result, so the backend can validate permission and event construction but cannot observe downstream application handling. The GitHub-hosted macOS test deliberately performs only symbol resolution and non-prompting Accessibility preflight; the opt-in integration test requires an explicitly authorized local runner and restores the original pointer position.