### PR TITLE
feat: add Pure-Go macOS Quartz keyboard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ workflow. `GetLinuxCapabilities` provides additional compositor detail.
 | Platform/session | Build | Current behavior |
 |---|---|---|
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
-| macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture, display bounds, real Retina scale, and Quartz pointer input (move/relative/smooth/drag/click/toggle/scroll/location) with explicit Screen Recording and Accessibility diagnostics; keyboard and other unavailable GUI operations return `ErrNotSupported` |
+| macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture, display bounds, real Retina scale, and Quartz keyboard/pointer input with exact UTF-16 text, owned holds, process targeting, cleanup, and explicit Screen Recording/Accessibility diagnostics; media keys without a stable Quartz keycode and other unavailable GUI operations return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
 | Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds, real Win32 DPI scale and pixel-at-pointer queries, foreground-layout-aware `SendInput` keyboard/text plus clipboard paste, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
@@ -92,20 +92,43 @@ compositor to expose the corresponding virtual-input protocols. See
 Persistent capture runtime evidence is tracked separately in the
 [Wayland capture compatibility matrix](docs/compatibility/wayland-capture.md).
 
-## Pure-Go macOS pointer input
+## Pure-Go macOS input
 
-With `CGO_ENABLED=0`, macOS pointer automation uses Quartz events directly
-through runtime-loaded system frameworks. `MouseReady` and
-`GetRuntimeCapabilities` use the non-prompting Accessibility preflight: if
+With `CGO_ENABLED=0`, macOS keyboard and pointer automation use Quartz events directly
+through runtime-loaded system frameworks. `MouseReady`, `KeyboardReady`, and
+`GetRuntimeCapabilities` use the same non-prompting
+Accessibility preflight: if
 access is missing, they return/report `ErrPermissionDenied` with the relevant
 System Settings location. RobotGo never opens the consent dialog implicitly.
 
-The backend supports absolute and relative movement, bounded smooth movement,
+Keyboard support includes key taps, combinations, ownership-checked persistent
+key states, optional process targeting, exact UTF-16 text (including non-BMP
+characters), delays, and clipboard-assisted paste. Printable `KeyTap` values
+use physical macOS ANSI key positions for shortcut compatibility; use
+`TypeStrE` when exact layout-independent text is required. Media/brightness
+keys and F21-F24 have no safe stable Quartz keycode and return
+`ErrNotSupported`.
+
+Pointer support includes absolute and relative movement, bounded smooth movement,
 drag, single/double click, owned button toggles, horizontal/vertical pixel
 scrolling, and global pointer location. Persistent holds are ownership-checked;
-`CloseMainDisplayE` releases RobotGo-owned buttons before unloading the native
-frameworks. Pure-Go macOS keyboard injection remains explicitly unsupported.
-See [`examples/purego_macos_pointer`](examples/purego_macos_pointer).
+`CloseMainDisplayE` releases RobotGo-owned keys and buttons before unloading
+the native frameworks.
+
+```go
+if err := robotgo.KeyboardReady(); err != nil {
+	log.Fatal(err)
+}
+if err := robotgo.KeyTap("c", "cmd"); err != nil {
+	log.Fatal(err)
+}
+if err := robotgo.TypeStrE("Grüße 👋"); err != nil {
+	log.Fatal(err)
+}
+```
+
+See [`examples/purego_macos_input`](examples/purego_macos_input) and
+[`examples/purego_macos_pointer`](examples/purego_macos_pointer).
 
 ## Requirements
 

--- a/TEST.md
+++ b/TEST.md
@@ -36,9 +36,9 @@ portal. macOS tests use fake CoreGraphics bindings for deterministic permission,
 pixel, bounds, Retina display-mode scale, and resource-lifecycle coverage. The
 macOS non-CGO leg also resolves the real CoreGraphics display-mode symbols and
 queries the active display scale as a blocking test. It additionally resolves
-the real Quartz input and Accessibility symbols and performs a non-prompting
-permission preflight without posting input. None of these runtime checks
-requires a Screen Recording or Accessibility grant.
+the real Quartz keyboard/pointer and Accessibility symbols and performs a
+non-prompting permission preflight without posting input. None of these runtime
+checks requires a Screen Recording or Accessibility grant.
 
 The real scale probe can be reproduced on a macOS GUI runner without granting
 Screen Recording or Accessibility access:
@@ -56,16 +56,17 @@ CGO_ENABLED=0 go test \
   -run '^TestPureGoDarwinInputRuntime$' -count=1 -v .
 ```
 
-After granting Accessibility access, the opt-in real pointer test moves to the
-center of the main display and restores the original location during cleanup:
+After granting Accessibility access, the opt-in real input tests move to the
+center of the main display and restore the original location, and exercise one
+ownership-checked Shift hold/release without typing text:
 
 ```bash
 CGO_ENABLED=0 ROBOTGO_REQUIRE_DARWIN_INPUT_INTEGRATION=1 \
   go test -tags darwinintegration \
-  -run '^TestPureGoDarwinPointerIntegration$' -count=1 -v .
+  -run '^TestPureGoDarwin(Pointer|Keyboard)Integration$' -count=1 -v .
 ```
 
-This integration test is not run on GitHub-hosted macOS because those runners
+These integration tests are not run on GitHub-hosted macOS because those runners
 do not grant Accessibility control to repository test binaries. The
 non-prompting symbol and permission contract remains blocking there.
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -35,7 +35,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
-| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture and XGB/XTEST input; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Complete macOS keyboard evaluation and assess further backends selectively |
+| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and keyboard/pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz keyboard/pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture and XGB/XTEST input; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS keyboard-injection evidence and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
 
@@ -140,13 +140,18 @@ architectures. Non-CGO macOS also reports the real Retina display-mode factor,
 returns scaled pixel dimensions with `GetScaleSize`, releases copied display
 modes deterministically, and verifies the real symbols/display query in the
 blocking macOS CI leg without requesting Screen Recording access.
-The same non-CGO build now provides Quartz pointer movement, relative and
-smooth movement, drag, single/double click, ownership-checked button toggles,
+The same non-CGO build now provides Quartz keyboard taps/combinations,
+ownership-checked persistent holds, PID-targeted events, exact UTF-16 text with
+surrogate-pair support, clipboard-assisted paste, and pointer movement,
+relative and smooth movement, drag, single/double click, ownership-checked button toggles,
 horizontal/vertical scrolling, and pointer location. It preflights
-Accessibility without prompting, releases owned buttons deterministically, and
-has a blocking real-framework preflight that never posts input. Pure-Go macOS
-keyboard injection remains explicitly unsupported and is the next macOS
-evaluation slice.
+Accessibility without prompting, releases owned keys/buttons deterministically,
+and has a blocking real-framework preflight that resolves keyboard and pointer
+symbols without posting input. Hermetic tests cover modifier ordering, foreign
+state, PID ownership, partial-event rollback, Unicode and cleanup. An opt-in
+Accessibility-gated test posts and releases a real modifier without typing into
+another application. Media/brightness keys and F21-F24 remain explicitly
+unsupported because Quartz exposes no safe stable keycode for them.
 
 Windows non-CGO builds now provide a foreground-layout-aware `SendInput` keyboard and text
 backend, clipboard-assisted Unicode paste, pixel-at-pointer queries, plus exact pointer movement/location, smooth movement and drag,

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -17,12 +17,13 @@ Current implementation baseline:
 - Platform-neutral feature introspection is available via
   `GetRuntimeCapabilities`; macOS non-CGO builds report CoreGraphics capture,
   display bounds, real Retina scale, Screen Recording permission, and Quartz
-  pointer/Accessibility state without prompting.
-- macOS non-CGO builds provide a Pure-Go Quartz pointer backend with absolute,
-  relative and smooth movement, drag, click/double-click, owned button toggles,
-  horizontal/vertical scroll, pointer location, deterministic cleanup, and
-  explicit Accessibility denial. Pure-Go macOS keyboard injection remains
-  explicitly unsupported.
+  keyboard/pointer Accessibility state without prompting.
+- macOS non-CGO builds provide a Pure-Go Quartz input backend with key
+  taps/combinations, owned holds, process targeting, exact UTF-16 text,
+  plus absolute, relative and smooth movement, drag, click/double-click, owned
+  button toggles, horizontal/vertical scroll, pointer location, deterministic
+  cleanup, and explicit Accessibility denial. Media/brightness keys without
+  stable Quartz keycodes remain explicitly unsupported.
 - Linux/X11 non-CGO builds provide a Pure-Go XGB/XTEST keyboard and pointer
   backend with live readiness probes, text/Unicode, smooth movement/drag,
   scrolling, pointer location, explicit state errors, and deterministic

--- a/examples/purego_macos_input/main.go
+++ b/examples/purego_macos_input/main.go
@@ -1,0 +1,44 @@
+// Command purego_macos_input demonstrates permission-aware Pure-Go keyboard
+// automation on macOS without injecting input unless -act is supplied.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"runtime"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	act := flag.Bool("act", false, "type into the currently focused application")
+	text := flag.String("text", "RobotGo Pure-Go Quartz input", "text used with -act")
+	flag.Parse()
+
+	if runtime.GOOS != "darwin" {
+		log.Fatal("this example requires macOS")
+	}
+	defer func() {
+		if err := robotgo.CloseMainDisplayE(); err != nil {
+			log.Printf("release Pure-Go input resources: %v", err)
+		}
+	}()
+
+	capability := robotgo.GetRuntimeCapabilities().Keyboard
+	fmt.Printf(
+		"keyboard backend: %s; available: %t; reason: %s\n",
+		capability.Backend, capability.Available, capability.Reason,
+	)
+	if !*act {
+		fmt.Println("inspection only; pass -act to type into the focused application")
+		return
+	}
+	if err := robotgo.KeyboardReady(); err != nil {
+		log.Fatalf("keyboard automation is unavailable: %v", err)
+	}
+	if err := robotgo.TypeStrE(*text); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("text sent through exact UTF-16 Quartz events")
+}

--- a/input_backend_darwin_nocgo.go
+++ b/input_backend_darwin_nocgo.go
@@ -5,9 +5,12 @@ package robotgo
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/marang/robotgo/internal/darwininput"
 )
+
+const maxDarwinTextDelayMilliseconds = int64(^uint64(0)>>1) / int64(time.Millisecond)
 
 type darwinInputBackend struct {
 	core *darwininput.Backend
@@ -36,20 +39,39 @@ func translatePureGoDarwinInputError(err error) error {
 	}
 }
 
-func (*darwinInputBackend) KeyboardReady() error {
-	return fmt.Errorf("%w: Pure-Go macOS keyboard injection is not implemented", ErrNotSupported)
+func (backend *darwinInputBackend) KeyboardReady() error {
+	return translatePureGoDarwinInputError(backend.core.KeyboardReady())
 }
 
 func (backend *darwinInputBackend) MouseReady() error {
 	return translatePureGoDarwinInputError(backend.core.MouseReady())
 }
 
-func (*darwinInputBackend) Key(pureGoKeyEvent) error {
-	return fmt.Errorf("%w: Pure-Go macOS keyboard injection is not implemented", ErrNotSupported)
+func (backend *darwinInputBackend) Key(event pureGoKeyEvent) error {
+	return translatePureGoDarwinInputError(backend.core.Key(darwininput.KeyEvent{
+		Key:       event.Key,
+		Modifiers: event.Modifiers,
+		PID:       event.PID,
+		Down:      event.Down,
+		Tap:       event.Tap,
+	}))
 }
 
-func (*darwinInputBackend) Text(pureGoTextEvent) error {
-	return fmt.Errorf("%w: Pure-Go macOS text injection is not implemented", ErrNotSupported)
+func (backend *darwinInputBackend) Text(event pureGoTextEvent) error {
+	if event.Delay < 0 {
+		return errors.New("robotgo: macOS text delay must be non-negative")
+	}
+	if int64(event.Delay) > maxDarwinTextDelayMilliseconds {
+		return fmt.Errorf(
+			"robotgo: macOS text delay %dms exceeds time.Duration",
+			event.Delay,
+		)
+	}
+	return translatePureGoDarwinInputError(backend.core.Text(darwininput.TextEvent{
+		Text:  event.Text,
+		PID:   event.PID,
+		Delay: time.Duration(event.Delay) * time.Millisecond,
+	}))
 }
 
 func (backend *darwinInputBackend) MoveAbsolute(x, y int, _ []int) error {

--- a/input_backend_darwin_nocgo_integration_test.go
+++ b/input_backend_darwin_nocgo_integration_test.go
@@ -3,6 +3,7 @@
 package robotgo
 
 import (
+	"errors"
 	"os"
 	"testing"
 )
@@ -45,5 +46,34 @@ func TestPureGoDarwinPointerIntegration(t *testing.T) {
 			"pointer location = (%d,%d), want (%d,%d)",
 			actualX, actualY, targetX, targetY,
 		)
+	}
+}
+
+func TestPureGoDarwinKeyboardIntegration(t *testing.T) {
+	if os.Getenv("ROBOTGO_REQUIRE_DARWIN_INPUT_INTEGRATION") != "1" {
+		t.Skip("set ROBOTGO_REQUIRE_DARWIN_INPUT_INTEGRATION=1 after granting Accessibility access")
+	}
+	if err := KeyboardReady(); err != nil {
+		t.Fatalf("KeyboardReady: %v", err)
+	}
+	t.Cleanup(func() {
+		// A failed assertion must never leave our synthetic modifier held.
+		_ = KeyUp("shift")
+		if err := CloseMainDisplayE(); err != nil {
+			t.Errorf("CloseMainDisplayE: %v", err)
+		}
+	})
+
+	if err := KeyDown("shift"); err != nil {
+		t.Fatalf("KeyDown(shift): %v", err)
+	}
+	if err := KeyDown("shift"); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("duplicate KeyDown(shift) = %v, want ErrInputOwnership", err)
+	}
+	if err := KeyUp("shift"); err != nil {
+		t.Fatalf("KeyUp(shift): %v", err)
+	}
+	if err := KeyUp("shift"); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("orphan KeyUp(shift) = %v, want ErrInputOwnership", err)
 	}
 }

--- a/input_backend_darwin_nocgo_test.go
+++ b/input_backend_darwin_nocgo_test.go
@@ -32,36 +32,40 @@ func TestPureGoDarwinInputErrorTranslation(t *testing.T) {
 // real framework symbols and checks Accessibility status without posting input
 // or opening a macOS consent dialog.
 func TestPureGoDarwinInputRuntime(t *testing.T) {
-	if err := KeyboardReady(); !errors.Is(err, ErrNotSupported) {
-		t.Fatalf("KeyboardReady = %v, want ErrNotSupported", err)
-	}
-
 	capabilities := GetRuntimeCapabilities()
 	if capabilities.Mouse.Backend != featureBackendPureGoQuartzInput {
 		t.Fatalf("mouse capability = %+v, want Quartz backend", capabilities.Mouse)
 	}
-	if capabilities.Keyboard.Available ||
-		capabilities.Keyboard.Backend != featureBackendPureGoQuartzInput {
-		t.Fatalf("keyboard capability = %+v, want named unsupported Quartz keyboard", capabilities.Keyboard)
+	if capabilities.Keyboard.Backend != featureBackendPureGoQuartzInput {
+		t.Fatalf("keyboard capability = %+v, want Quartz backend", capabilities.Keyboard)
 	}
 
-	readyErr := MouseReady()
+	keyboardErr := KeyboardReady()
+	mouseErr := MouseReady()
 	switch {
-	case readyErr == nil:
-		if !capabilities.Mouse.Available {
-			t.Fatalf("MouseReady succeeded but capability = %+v", capabilities.Mouse)
+	case keyboardErr == nil && mouseErr == nil:
+		if !capabilities.Keyboard.Available || !capabilities.Mouse.Available {
+			t.Fatalf("input readiness succeeded but capabilities = %+v", capabilities)
 		}
-	case errors.Is(readyErr, ErrPermissionDenied):
-		if capabilities.Mouse.Available {
-			t.Fatalf("MouseReady denied but capability = %+v", capabilities.Mouse)
+	case errors.Is(keyboardErr, ErrPermissionDenied) &&
+		errors.Is(mouseErr, ErrPermissionDenied):
+		if capabilities.Keyboard.Available || capabilities.Mouse.Available {
+			t.Fatalf("input readiness denied but capabilities = %+v", capabilities)
 		}
-		if !strings.Contains(readyErr.Error(), "Accessibility") {
-			t.Fatalf("permission error lacks actionable Accessibility hint: %v", readyErr)
+		if !strings.Contains(keyboardErr.Error(), "Accessibility") ||
+			!strings.Contains(mouseErr.Error(), "Accessibility") {
+			t.Fatalf(
+				"permission errors lack actionable Accessibility hint: keyboard=%v mouse=%v",
+				keyboardErr, mouseErr,
+			)
 		}
-	case errors.Is(readyErr, ErrNotSupported):
-		t.Fatalf("required hosted-runner Quartz symbols are unavailable: %v", readyErr)
+	case errors.Is(keyboardErr, ErrNotSupported) || errors.Is(mouseErr, ErrNotSupported):
+		t.Fatalf(
+			"required hosted-runner Quartz symbols are unavailable: keyboard=%v mouse=%v",
+			keyboardErr, mouseErr,
+		)
 	default:
-		t.Fatalf("unexpected MouseReady error: %v", readyErr)
+		t.Fatalf("inconsistent input readiness: keyboard=%v mouse=%v", keyboardErr, mouseErr)
 	}
 
 	if err := CloseMainDisplayE(); err != nil {

--- a/input_backend_nocgo.go
+++ b/input_backend_nocgo.go
@@ -93,10 +93,14 @@ func pureGoInputCapabilities() (keyboard, mouse FeatureCapability) {
 		mouse.Notes += "; pointer coordinates use the Windows virtual screen; CloseMainDisplayE releases RobotGo-owned persistent holds"
 	}
 	if backendName == featureBackendPureGoQuartzInput {
-		keyboard.Available = false
-		keyboard.Reason = ErrNotSupported.Error()
-		keyboard.Notes = "Pure-Go macOS keyboard injection is not implemented yet"
+		keyboard.Notes = "Accessibility is preflighted without opening a consent dialog; Quartz key events support modifiers, process targeting, and exact UTF-16 text; media keys without a stable Quartz keycode return ErrNotSupported; CloseMainDisplayE releases RobotGo-owned persistent holds"
 		mouse.Notes = "Accessibility is preflighted without opening a consent dialog; pointer coordinates use the CoreGraphics global display space; CloseMainDisplayE releases RobotGo-owned persistent holds"
+		if err := backend.KeyboardReady(); err != nil {
+			keyboard.Available = false
+			keyboard.Reason = err.Error()
+		} else {
+			keyboard.Reason = "Pure-Go Quartz keyboard backend is ready"
+		}
 		if err := backend.MouseReady(); err != nil {
 			mouse.Available = false
 			mouse.Reason = err.Error()

--- a/input_backend_nocgo_test.go
+++ b/input_backend_nocgo_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -259,7 +260,7 @@ func TestPureGoInputCapabilitiesDoNotPerformLiveProbes(t *testing.T) {
 	}
 }
 
-func TestPureGoQuartzCapabilitiesPreflightPointerWithoutClaimingKeyboard(t *testing.T) {
+func TestPureGoQuartzCapabilitiesPreflightKeyboardAndPointer(t *testing.T) {
 	mouseErr := errors.Join(ErrPermissionDenied, errors.New("Accessibility denied"))
 	backend := &fakePureGoInputBackend{
 		name:     featureBackendPureGoQuartzInput,
@@ -268,15 +269,34 @@ func TestPureGoQuartzCapabilitiesPreflightPointerWithoutClaimingKeyboard(t *test
 	installFakePureGoInputBackend(t, backend)
 
 	keyboard, mouse := pureGoInputCapabilities()
-	if keyboard.Available || keyboard.Backend != featureBackendPureGoQuartzInput ||
-		keyboard.Reason != ErrNotSupported.Error() {
-		t.Fatalf("keyboard capability = %+v, want explicit unsupported Quartz keyboard", keyboard)
+	if !keyboard.Available || keyboard.Backend != featureBackendPureGoQuartzInput {
+		t.Fatalf("keyboard capability = %+v, want available Quartz keyboard", keyboard)
 	}
 	if mouse.Available || mouse.Backend != featureBackendPureGoQuartzInput {
 		t.Fatalf("mouse capability = %+v, want unavailable Quartz pointer", mouse)
 	}
-	if !reflect.DeepEqual(backend.calls, []string{"mouse-ready"}) {
-		t.Fatalf("Quartz capability probe calls = %v, want only mouse-ready", backend.calls)
+	if !reflect.DeepEqual(backend.calls, []string{"keyboard-ready", "mouse-ready"}) {
+		t.Fatalf("Quartz capability probe calls = %v, want keyboard and mouse readiness", backend.calls)
+	}
+}
+
+func TestPureGoQuartzCapabilitiesReportKeyboardDenialSeparately(t *testing.T) {
+	keyboardErr := errors.Join(ErrPermissionDenied, errors.New("Accessibility denied"))
+	backend := &fakePureGoInputBackend{
+		name:        featureBackendPureGoQuartzInput,
+		keyboardErr: keyboardErr,
+	}
+	installFakePureGoInputBackend(t, backend)
+
+	keyboard, mouse := pureGoInputCapabilities()
+	if keyboard.Available || !strings.Contains(keyboard.Reason, "Accessibility denied") {
+		t.Fatalf("keyboard capability = %+v, want explicit denial", keyboard)
+	}
+	if !mouse.Available || mouse.Backend != featureBackendPureGoQuartzInput {
+		t.Fatalf("mouse capability = %+v, want available Quartz pointer", mouse)
+	}
+	if !reflect.DeepEqual(backend.calls, []string{"keyboard-ready", "mouse-ready"}) {
+		t.Fatalf("Quartz capability probe calls = %v", backend.calls)
 	}
 }
 

--- a/internal/darwininput/backend.go
+++ b/internal/darwininput/backend.go
@@ -1,4 +1,4 @@
-// Package darwininput provides RobotGo's Pure-Go macOS pointer backend.
+// Package darwininput provides RobotGo's Pure-Go macOS input backend.
 package darwininput
 
 import (
@@ -40,16 +40,21 @@ type mouseButton struct {
 
 type inputSystem interface {
 	Ready() error
+	KeyboardReady() error
 	CursorPosition() (point, error)
 	ButtonDown(uint32) (bool, error)
+	KeyDown(uint16) (bool, error)
+	ModifierFlags() (uint64, error)
 	PostMouse(eventType uint32, location point, button uint32, clickState int64) error
 	PostScroll(horizontal, vertical int32) error
+	PostKey(key uint16, down bool, flags uint64, pid int32) error
+	PostUnicode(units []uint16, down bool, flags uint64, pid int32) error
 	Close() error
 }
 
 type openSystem func() (inputSystem, error)
 
-// Backend serializes Quartz pointer transactions and tracks persistent holds.
+// Backend serializes Quartz input transactions and tracks persistent holds.
 type Backend struct {
 	mu sync.Mutex
 
@@ -57,10 +62,12 @@ type Backend struct {
 	system inputSystem
 	sleep  func(time.Duration)
 
-	ownedButtons map[uint32]mouseButton
-	ownedOrder   []uint32
-	lastLocation point
-	hasLocation  bool
+	ownedButtons  map[uint32]mouseButton
+	ownedOrder    []uint32
+	ownedKeys     map[uint16]ownedKey
+	ownedKeyOrder []uint16
+	lastLocation  point
+	hasLocation   bool
 }
 
 // New creates a lazily initialized backend backed by macOS frameworks.
@@ -76,6 +83,7 @@ func newBackend(open openSystem, sleep func(time.Duration)) *Backend {
 		open:         open,
 		sleep:        sleep,
 		ownedButtons: make(map[uint32]mouseButton),
+		ownedKeys:    make(map[uint16]ownedKey),
 	}
 }
 
@@ -498,7 +506,7 @@ func (backend *Backend) Scroll(x, y int) error {
 	return system.PostScroll(int32(x), int32(y))
 }
 
-// Close releases RobotGo-owned buttons and unloads the native frameworks.
+// Close releases RobotGo-owned input and unloads the native frameworks.
 func (backend *Backend) Close() error {
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
@@ -507,6 +515,34 @@ func (backend *Backend) Close() error {
 	}
 	system := backend.system
 	var closeErr error
+	if len(backend.ownedKeys) > 0 {
+		flags, flagsErr := system.ModifierFlags()
+		if flagsErr != nil {
+			return flagsErr
+		}
+		flags |= backend.ownedModifierFlagsLocked()
+		ownedOrder := append([]uint16(nil), backend.ownedKeyOrder...)
+		released := make(map[uint16]struct{}, len(ownedOrder))
+		for index := len(ownedOrder) - 1; index >= 0; index-- {
+			key, owned := backend.ownedKeys[ownedOrder[index]]
+			if !owned {
+				continue
+			}
+			nextFlags, flagsErr := backend.flagsAfterReleaseLocked(
+				system, key, flags, released,
+			)
+			if flagsErr != nil {
+				closeErr = errors.Join(closeErr, flagsErr)
+				continue
+			}
+			releaseErr := backend.releaseKeyLocked(system, key, nextFlags)
+			closeErr = errors.Join(closeErr, releaseErr)
+			if releaseErr == nil {
+				flags = nextFlags
+				released[key.code] = struct{}{}
+			}
+		}
+	}
 	if len(backend.ownedButtons) > 0 {
 		location, locationErr := system.CursorPosition()
 		if locationErr != nil && backend.hasLocation {
@@ -526,13 +562,15 @@ func (backend *Backend) Close() error {
 			closeErr = errors.Join(closeErr, backend.releaseLocked(system, button, location, 1))
 		}
 	}
-	if len(backend.ownedButtons) > 0 {
+	if len(backend.ownedKeys) > 0 || len(backend.ownedButtons) > 0 {
 		return closeErr
 	}
 	closeErr = errors.Join(closeErr, system.Close())
 	backend.system = nil
 	backend.ownedButtons = make(map[uint32]mouseButton)
 	backend.ownedOrder = backend.ownedOrder[:0]
+	backend.ownedKeys = make(map[uint16]ownedKey)
+	backend.ownedKeyOrder = backend.ownedKeyOrder[:0]
 	backend.hasLocation = false
 	return closeErr
 }

--- a/internal/darwininput/backend_test.go
+++ b/internal/darwininput/backend_test.go
@@ -16,20 +16,46 @@ type recordedMouseEvent struct {
 	clickState int64
 }
 
+type recordedKeyEvent struct {
+	key   uint16
+	down  bool
+	flags uint64
+	pid   int32
+}
+
+type recordedUnicodeEvent struct {
+	units []uint16
+	down  bool
+	flags uint64
+	pid   int32
+}
+
 type fakeInputSystem struct {
-	readyErr       error
-	location       point
-	locationErr    error
-	buttons        map[uint32]bool
-	buttonStateErr error
-	mouseEvents    []recordedMouseEvent
-	scrolls        [][2]int32
-	postMouseCalls int
-	postMouseErrAt int
-	closeCalls     int
+	readyErr         error
+	location         point
+	locationErr      error
+	buttons          map[uint32]bool
+	buttonStateErr   error
+	keys             map[uint16]bool
+	keyStateErr      error
+	modifierFlags    uint64
+	modifierFlagsErr error
+	mouseEvents      []recordedMouseEvent
+	scrolls          [][2]int32
+	keyEvents        []recordedKeyEvent
+	unicodeEvents    []recordedUnicodeEvent
+	postMouseCalls   int
+	postMouseErrAt   int
+	postKeyCalls     int
+	postKeyErrAt     int
+	postUnicodeCalls int
+	postUnicodeErrAt int
+	closeCalls       int
 }
 
 func (system *fakeInputSystem) Ready() error { return system.readyErr }
+
+func (system *fakeInputSystem) KeyboardReady() error { return system.readyErr }
 
 func (system *fakeInputSystem) CursorPosition() (point, error) {
 	return system.location, system.locationErr
@@ -37,6 +63,14 @@ func (system *fakeInputSystem) CursorPosition() (point, error) {
 
 func (system *fakeInputSystem) ButtonDown(button uint32) (bool, error) {
 	return system.buttons[button], system.buttonStateErr
+}
+
+func (system *fakeInputSystem) KeyDown(key uint16) (bool, error) {
+	return system.keys[key], system.keyStateErr
+}
+
+func (system *fakeInputSystem) ModifierFlags() (uint64, error) {
+	return system.modifierFlags, system.modifierFlagsErr
 }
 
 func (system *fakeInputSystem) PostMouse(
@@ -68,6 +102,61 @@ func (system *fakeInputSystem) PostScroll(horizontal, vertical int32) error {
 	return nil
 }
 
+func (system *fakeInputSystem) PostKey(key uint16, down bool, flags uint64, pid int32) error {
+	system.postKeyCalls++
+	if system.postKeyErrAt == system.postKeyCalls {
+		return errors.New("post key failed")
+	}
+	system.keyEvents = append(system.keyEvents, recordedKeyEvent{
+		key: key, down: down, flags: flags, pid: pid,
+	})
+	system.keys[key] = down
+	switch key {
+	case keyShift, keyRightShift:
+		if system.keys[keyShift] || system.keys[keyRightShift] {
+			system.modifierFlags |= eventFlagMaskShift
+		} else {
+			system.modifierFlags &^= eventFlagMaskShift
+		}
+	case keyControl, keyRightControl:
+		if system.keys[keyControl] || system.keys[keyRightControl] {
+			system.modifierFlags |= eventFlagMaskControl
+		} else {
+			system.modifierFlags &^= eventFlagMaskControl
+		}
+	case keyOption, keyRightOption:
+		if system.keys[keyOption] || system.keys[keyRightOption] {
+			system.modifierFlags |= eventFlagMaskAlternate
+		} else {
+			system.modifierFlags &^= eventFlagMaskAlternate
+		}
+	case keyCommand, keyRightCommand:
+		if system.keys[keyCommand] || system.keys[keyRightCommand] {
+			system.modifierFlags |= eventFlagMaskCommand
+		} else {
+			system.modifierFlags &^= eventFlagMaskCommand
+		}
+	}
+	return nil
+}
+
+func (system *fakeInputSystem) PostUnicode(
+	units []uint16,
+	down bool,
+	flags uint64,
+	pid int32,
+) error {
+	system.postUnicodeCalls++
+	if system.postUnicodeErrAt == system.postUnicodeCalls {
+		return errors.New("post unicode failed")
+	}
+	system.unicodeEvents = append(system.unicodeEvents, recordedUnicodeEvent{
+		units: append([]uint16(nil), units...),
+		down:  down, flags: flags, pid: pid,
+	})
+	return nil
+}
+
 func (system *fakeInputSystem) Close() error {
 	system.closeCalls++
 	return nil
@@ -76,6 +165,9 @@ func (system *fakeInputSystem) Close() error {
 func testBackend(system *fakeInputSystem, sleeps *[]time.Duration) *Backend {
 	if system.buttons == nil {
 		system.buttons = make(map[uint32]bool)
+	}
+	if system.keys == nil {
+		system.keys = make(map[uint16]bool)
 	}
 	return newBackend(
 		func() (inputSystem, error) { return system, nil },

--- a/internal/darwininput/keyboard.go
+++ b/internal/darwininput/keyboard.go
@@ -1,0 +1,616 @@
+package darwininput
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// KeyEvent is one normalized Quartz keyboard operation.
+type KeyEvent struct {
+	Key       string
+	Modifiers []string
+	PID       int
+	Down      bool
+	Tap       bool
+}
+
+// TextEvent is one exact Unicode text operation.
+type TextEvent struct {
+	Text  string
+	PID   int
+	Delay time.Duration
+}
+
+type ownedKey struct {
+	code uint16
+	flag uint64
+	pid  int32
+	name string
+}
+
+var namedKeyCodes = map[string]uint16{
+	"backspace": keyDelete,
+	"delete":    keyForwardDelete,
+	"enter":     keyReturn,
+	"tab":       keyTab,
+	"esc":       keyEscape,
+	"escape":    keyEscape,
+	"up":        keyUp,
+	"down":      keyDown,
+	"right":     keyRight,
+	"left":      keyLeft,
+	"home":      keyHome,
+	"end":       keyEnd,
+	"pageup":    keyPageUp,
+	"pagedown":  keyPageDown,
+
+	"cmd":         keyCommand,
+	"command":     keyCommand,
+	"lcmd":        keyCommand,
+	"rcmd":        keyRightCommand,
+	"alt":         keyOption,
+	"lalt":        keyOption,
+	"ralt":        keyRightOption,
+	"ctrl":        keyControl,
+	"control":     keyControl,
+	"lctrl":       keyControl,
+	"rctrl":       keyRightControl,
+	"shift":       keyShift,
+	"lshift":      keyShift,
+	"rshift":      keyRightShift,
+	"right_shift": keyRightShift,
+	"capslock":    keyCapsLock,
+	"space":       keySpace,
+	"print":       keyF13,
+	"printscreen": keyF13,
+	"insert":      keyHelp,
+
+	"num0": keyKeypad0, "numpad_0": keyKeypad0,
+	"num1": keyKeypad1, "numpad_1": keyKeypad1,
+	"num2": keyKeypad2, "numpad_2": keyKeypad2,
+	"num3": keyKeypad3, "numpad_3": keyKeypad3,
+	"num4": keyKeypad4, "numpad_4": keyKeypad4,
+	"num5": keyKeypad5, "numpad_5": keyKeypad5,
+	"num6": keyKeypad6, "numpad_6": keyKeypad6,
+	"num7": keyKeypad7, "numpad_7": keyKeypad7,
+	"num8": keyKeypad8, "numpad_8": keyKeypad8,
+	"num9": keyKeypad9, "numpad_9": keyKeypad9,
+	"num_lock": keyKeypadClear, "numpad_lock": keyKeypadClear,
+	"num.": keyKeypadDecimal, "num+": keyKeypadPlus,
+	"num-": keyKeypadMinus, "num*": keyKeypadMultiply,
+	"num/": keyKeypadDivide, "num_clear": keyKeypadClear,
+	"num_enter": keyKeypadEnter, "num_equal": keyKeypadEquals,
+}
+
+var functionKeyCodes = [...]uint16{
+	keyF1, keyF2, keyF3, keyF4, keyF5,
+	keyF6, keyF7, keyF8, keyF9, keyF10,
+	keyF11, keyF12, keyF13, keyF14, keyF15,
+	keyF16, keyF17, keyF18, keyF19, keyF20,
+}
+
+var asciiKeyCodes = map[byte]uint16{
+	'a': keyA, 'b': keyB, 'c': keyC, 'd': keyD, 'e': keyE,
+	'f': keyF, 'g': keyG, 'h': keyH, 'i': keyI, 'j': keyJ,
+	'k': keyK, 'l': keyL, 'm': keyM, 'n': keyN, 'o': keyO,
+	'p': keyP, 'q': keyQ, 'r': keyR, 's': keyS, 't': keyT,
+	'u': keyU, 'v': keyV, 'w': keyW, 'x': keyX, 'y': keyY,
+	'z': keyZ,
+	'0': key0, '1': key1, '2': key2, '3': key3, '4': key4,
+	'5': key5, '6': key6, '7': key7, '8': key8, '9': key9,
+	'!': key1, '@': key2, '#': key3, '$': key4, '%': key5,
+	'^': key6, '&': key7, '*': key8, '(': key9, ')': key0,
+	'`': keyGrave, '~': keyGrave,
+	'-': keyMinus, '_': keyMinus,
+	'=': keyEqual, '+': keyEqual,
+	'[': keyLeftBracket, '{': keyLeftBracket,
+	']': keyRightBracket, '}': keyRightBracket,
+	'\\': keyBackslash, '|': keyBackslash,
+	';': keySemicolon, ':': keySemicolon,
+	'\'': keyQuote, '"': keyQuote,
+	',': keyComma, '<': keyComma,
+	'.': keyPeriod, '>': keyPeriod,
+	'/': keySlash, '?': keySlash,
+	' ': keySpace,
+}
+
+var explicitlyUnsupportedKeys = map[string]struct{}{
+	"f21": {}, "f22": {}, "f23": {}, "f24": {},
+	"menu": {}, "scroll_lock": {}, "pause_break": {},
+	"audio_mute": {}, "audio_vol_down": {}, "audio_vol_up": {},
+	"audio_play": {}, "audio_stop": {}, "audio_pause": {},
+	"audio_prev": {}, "audio_next": {}, "audio_rewind": {},
+	"audio_forward": {}, "audio_repeat": {}, "audio_random": {},
+	"lights_mon_up": {}, "lights_mon_down": {},
+	"lights_kbd_toggle": {}, "lights_kbd_up": {}, "lights_kbd_down": {},
+}
+
+// KeyboardReady checks the non-prompting Accessibility preflight and Quartz access.
+func (backend *Backend) KeyboardReady() error {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	_, err := backend.keyboardReadyLocked()
+	return err
+}
+
+func (backend *Backend) keyboardReadyLocked() (inputSystem, error) {
+	system, err := backend.systemLocked()
+	if err != nil {
+		return nil, err
+	}
+	if err := system.KeyboardReady(); err != nil {
+		return nil, err
+	}
+	return system, nil
+}
+
+func validatePID(pid int) (int32, error) {
+	if pid < 0 || int64(pid) > math.MaxInt32 {
+		return 0, fmt.Errorf("Pure-Go macOS process ID %d is outside [0,%d]", pid, math.MaxInt32)
+	}
+	return int32(pid), nil
+}
+
+func resolveKey(name string) (ownedKey, error) {
+	switch name {
+	case "\n", "\r":
+		return ownedKey{code: keyReturn, name: name}, nil
+	case "\t":
+		return ownedKey{code: keyTab, name: name}, nil
+	case "\b":
+		return ownedKey{code: keyDelete, name: name}, nil
+	}
+	lower := strings.ToLower(name)
+	if code, ok := namedKeyCodes[lower]; ok {
+		return ownedKey{code: code, flag: modifierFlag(code), name: lower}, nil
+	}
+	if strings.HasPrefix(lower, "f") {
+		number, err := strconv.Atoi(strings.TrimPrefix(lower, "f"))
+		if err == nil && number >= 1 && number <= len(functionKeyCodes) {
+			return ownedKey{code: functionKeyCodes[number-1], name: lower}, nil
+		}
+	}
+	if _, unsupported := explicitlyUnsupportedKeys[lower]; unsupported {
+		return ownedKey{}, fmt.Errorf("%w: macOS Quartz has no safe key event for %q", ErrUnsupported, name)
+	}
+	if len(name) == 1 {
+		character := name[0]
+		if character >= 'A' && character <= 'Z' {
+			character += 'a' - 'A'
+		}
+		if code, ok := asciiKeyCodes[character]; ok {
+			return ownedKey{code: code, name: name}, nil
+		}
+	}
+	if utf8.ValidString(name) && utf8.RuneCountInString(name) == 1 {
+		value, _ := utf8.DecodeRuneInString(name)
+		return ownedKey{}, fmt.Errorf(
+			"%w: %U has no stable physical Quartz keycode; use TypeStrE for text",
+			ErrUnsupported, value,
+		)
+	}
+	return ownedKey{}, fmt.Errorf("%w: invalid macOS key %q", ErrUnsupported, name)
+}
+
+func modifierFlag(code uint16) uint64 {
+	switch code {
+	case keyShift, keyRightShift:
+		return eventFlagMaskShift
+	case keyControl, keyRightControl:
+		return eventFlagMaskControl
+	case keyOption, keyRightOption:
+		return eventFlagMaskAlternate
+	case keyCommand, keyRightCommand:
+		return eventFlagMaskCommand
+	default:
+		return 0
+	}
+}
+
+func intrinsicKeyFlags(code uint16) uint64 {
+	switch code {
+	case keyKeypadDecimal, keyKeypadMultiply, keyKeypadPlus,
+		keyKeypadClear, keyKeypadDivide, keyKeypadEnter, keyKeypadMinus,
+		keyKeypadEquals, keyKeypad0, keyKeypad1, keyKeypad2, keyKeypad3,
+		keyKeypad4, keyKeypad5, keyKeypad6, keyKeypad7, keyKeypad8,
+		keyKeypad9:
+		return eventFlagMaskNumericPad
+	case keyHelp:
+		return eventFlagMaskHelp
+	default:
+		return 0
+	}
+}
+
+func hasMomentaryKeyState(code uint16) bool {
+	// Quartz reports Caps Lock's toggle state through CGEventSourceKeyState,
+	// which is not evidence that another source currently holds the key down.
+	return code != keyCapsLock
+}
+
+func modifierCodes(flag uint64) []uint16 {
+	switch flag {
+	case eventFlagMaskShift:
+		return []uint16{keyShift, keyRightShift}
+	case eventFlagMaskControl:
+		return []uint16{keyControl, keyRightControl}
+	case eventFlagMaskAlternate:
+		return []uint16{keyOption, keyRightOption}
+	case eventFlagMaskCommand:
+		return []uint16{keyCommand, keyRightCommand}
+	default:
+		return nil
+	}
+}
+
+func (backend *Backend) flagsAfterReleaseLocked(
+	system inputSystem,
+	key ownedKey,
+	flags uint64,
+	released map[uint16]struct{},
+) (uint64, error) {
+	if key.flag == 0 {
+		return flags, nil
+	}
+	for _, code := range modifierCodes(key.flag) {
+		if code == key.code {
+			continue
+		}
+		if _, owned := backend.ownedKeys[code]; owned {
+			return flags, nil
+		}
+		if _, releasedHere := released[code]; releasedHere {
+			continue
+		}
+		down, err := system.KeyDown(code)
+		if err != nil {
+			return flags, err
+		}
+		if down {
+			return flags, nil
+		}
+	}
+	return flags &^ key.flag, nil
+}
+
+func (backend *Backend) ownedModifierFlagsLocked() uint64 {
+	var flags uint64
+	for _, key := range backend.ownedKeys {
+		flags |= key.flag
+	}
+	return flags
+}
+
+func resolveModifiers(names []string) ([]ownedKey, error) {
+	result := make([]ownedKey, 0, len(names))
+	seen := make(map[uint16]struct{}, len(names))
+	for _, name := range names {
+		if strings.EqualFold(name, "none") {
+			continue
+		}
+		key, err := resolveKey(name)
+		if err != nil {
+			return nil, err
+		}
+		if key.flag == 0 {
+			return nil, fmt.Errorf("%w: %q is not a macOS modifier", ErrUnsupported, name)
+		}
+		if _, duplicate := seen[key.code]; duplicate {
+			continue
+		}
+		seen[key.code] = struct{}{}
+		result = append(result, key)
+	}
+	return result, nil
+}
+
+func removeOwnedKey(order []uint16, code uint16) []uint16 {
+	for index := len(order) - 1; index >= 0; index-- {
+		if order[index] == code {
+			return append(order[:index], order[index+1:]...)
+		}
+	}
+	return order
+}
+
+func (backend *Backend) pressKeyLocked(
+	system inputSystem,
+	key ownedKey,
+	flags uint64,
+) error {
+	if err := system.PostKey(
+		key.code, true, flags|intrinsicKeyFlags(key.code), key.pid,
+	); err != nil {
+		return err
+	}
+	backend.ownedKeys[key.code] = key
+	backend.ownedKeyOrder = append(backend.ownedKeyOrder, key.code)
+	return nil
+}
+
+func (backend *Backend) releaseKeyLocked(
+	system inputSystem,
+	key ownedKey,
+	flags uint64,
+) error {
+	if err := system.PostKey(
+		key.code, false, flags|intrinsicKeyFlags(key.code), key.pid,
+	); err != nil {
+		return err
+	}
+	delete(backend.ownedKeys, key.code)
+	backend.ownedKeyOrder = removeOwnedKey(backend.ownedKeyOrder, key.code)
+	return nil
+}
+
+type keyStep struct {
+	key  ownedKey
+	down bool
+}
+
+func (backend *Backend) executeKeyStepsLocked(
+	system inputSystem,
+	steps []keyStep,
+	flags uint64,
+) error {
+	initiallyOwned := make(map[uint16]struct{}, len(backend.ownedKeys))
+	for code := range backend.ownedKeys {
+		initiallyOwned[code] = struct{}{}
+	}
+	var transactionOrder []uint16
+	released := make(map[uint16]struct{})
+	for _, step := range steps {
+		nextFlags := flags
+		if step.down && step.key.flag != 0 {
+			nextFlags |= step.key.flag
+		}
+		if !step.down && step.key.flag != 0 {
+			var flagsErr error
+			nextFlags, flagsErr = backend.flagsAfterReleaseLocked(
+				system, step.key, flags, released,
+			)
+			if flagsErr != nil {
+				rollbackErr := backend.rollbackKeysLocked(
+					system, transactionOrder, initiallyOwned, flags, released,
+				)
+				return errors.Join(flagsErr, rollbackErr)
+			}
+		}
+		var err error
+		if step.down {
+			err = backend.pressKeyLocked(system, step.key, nextFlags)
+			if err == nil {
+				transactionOrder = append(transactionOrder, step.key.code)
+			}
+		} else {
+			err = backend.releaseKeyLocked(system, step.key, nextFlags)
+			if err == nil {
+				released[step.key.code] = struct{}{}
+			}
+		}
+		if err == nil {
+			flags = nextFlags
+			continue
+		}
+		rollbackErr := backend.rollbackKeysLocked(
+			system, transactionOrder, initiallyOwned, flags, released,
+		)
+		return errors.Join(err, rollbackErr)
+	}
+	return nil
+}
+
+func (backend *Backend) rollbackKeysLocked(
+	system inputSystem,
+	order []uint16,
+	initiallyOwned map[uint16]struct{},
+	flags uint64,
+	released map[uint16]struct{},
+) error {
+	var rollbackErr error
+	for index := len(order) - 1; index >= 0; index-- {
+		code := order[index]
+		if _, existed := initiallyOwned[code]; existed {
+			continue
+		}
+		key, owned := backend.ownedKeys[code]
+		if !owned {
+			continue
+		}
+		nextFlags, flagsErr := backend.flagsAfterReleaseLocked(
+			system, key, flags, released,
+		)
+		if flagsErr != nil {
+			rollbackErr = errors.Join(rollbackErr, flagsErr)
+			continue
+		}
+		releaseErr := backend.releaseKeyLocked(system, key, nextFlags)
+		rollbackErr = errors.Join(rollbackErr, releaseErr)
+		if releaseErr == nil {
+			flags = nextFlags
+			released[key.code] = struct{}{}
+		}
+	}
+	return rollbackErr
+}
+
+func (backend *Backend) temporaryModifiersLocked(
+	system inputSystem,
+	modifiers []ownedKey,
+	main ownedKey,
+	pid int32,
+) ([]ownedKey, error) {
+	result := make([]ownedKey, 0, len(modifiers))
+	for _, modifier := range modifiers {
+		if modifier.code == main.code {
+			continue
+		}
+		modifier.pid = pid
+		if owned, ok := backend.ownedKeys[modifier.code]; ok {
+			if owned.pid != pid {
+				return nil, fmt.Errorf(
+					"%w: modifier %q is held for process %d, not %d",
+					ErrOwnership, modifier.name, owned.pid, pid,
+				)
+			}
+			continue
+		}
+		down, err := system.KeyDown(modifier.code)
+		if err != nil {
+			return nil, err
+		}
+		if down {
+			continue
+		}
+		result = append(result, modifier)
+	}
+	return result, nil
+}
+
+func modifierSteps(modifiers []ownedKey, down bool) []keyStep {
+	steps := make([]keyStep, 0, len(modifiers))
+	if down {
+		for _, modifier := range modifiers {
+			steps = append(steps, keyStep{key: modifier, down: true})
+		}
+		return steps
+	}
+	for index := len(modifiers) - 1; index >= 0; index-- {
+		steps = append(steps, keyStep{key: modifiers[index], down: false})
+	}
+	return steps
+}
+
+// Key injects one physical Quartz key transaction.
+func (backend *Backend) Key(event KeyEvent) error {
+	pid, err := validatePID(event.PID)
+	if err != nil {
+		return err
+	}
+	main, err := resolveKey(event.Key)
+	if err != nil {
+		return err
+	}
+	modifiers, err := resolveModifiers(event.Modifiers)
+	if err != nil {
+		return err
+	}
+	main.pid = pid
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.keyboardReadyLocked()
+	if err != nil {
+		return err
+	}
+	flags, err := system.ModifierFlags()
+	if err != nil {
+		return err
+	}
+	flags |= backend.ownedModifierFlagsLocked()
+	temporary, err := backend.temporaryModifiersLocked(system, modifiers, main, pid)
+	if err != nil {
+		return err
+	}
+
+	if event.Tap || event.Down {
+		if _, owned := backend.ownedKeys[main.code]; owned {
+			return fmt.Errorf("%w: key %q is already held by RobotGo", ErrOwnership, event.Key)
+		}
+		if hasMomentaryKeyState(main.code) {
+			down, stateErr := system.KeyDown(main.code)
+			if stateErr != nil {
+				return stateErr
+			}
+			if down {
+				return fmt.Errorf("%w: key %q is already down", ErrOwnership, event.Key)
+			}
+		}
+	}
+
+	steps := modifierSteps(temporary, true)
+	switch {
+	case event.Tap:
+		steps = append(steps, keyStep{key: main, down: true}, keyStep{key: main})
+	case event.Down:
+		steps = append(steps, keyStep{key: main, down: true})
+	default:
+		owned, ok := backend.ownedKeys[main.code]
+		if !ok {
+			return fmt.Errorf("%w: key %q was not pressed by this backend", ErrOwnership, event.Key)
+		}
+		if owned.pid != pid {
+			return fmt.Errorf(
+				"%w: key %q is held for process %d, not %d",
+				ErrOwnership, event.Key, owned.pid, pid,
+			)
+		}
+		steps = append(steps, keyStep{key: owned})
+	}
+	steps = append(steps, modifierSteps(temporary, false)...)
+	return backend.executeKeyStepsLocked(system, steps, flags)
+}
+
+// Text injects exact UTF-16 strings through Quartz Unicode keyboard events.
+func (backend *Backend) Text(event TextEvent) error {
+	pid, err := validatePID(event.PID)
+	if err != nil {
+		return err
+	}
+	if event.Delay < 0 {
+		return errors.New("Pure-Go macOS text delay must be non-negative")
+	}
+	if !utf8.ValidString(event.Text) {
+		return errors.New("Pure-Go macOS text is not valid UTF-8")
+	}
+	if strings.IndexByte(event.Text, 0) >= 0 {
+		return errors.New("Pure-Go macOS text cannot contain NUL")
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	system, err := backend.keyboardReadyLocked()
+	if err != nil {
+		return err
+	}
+	flags, err := system.ModifierFlags()
+	if err != nil {
+		return err
+	}
+	if flags&keyboardShortcutFlags != 0 {
+		return fmt.Errorf(
+			"%w: release active Shift, Control, Option, and Command keys before exact text input",
+			ErrOwnership,
+		)
+	}
+	for _, key := range backend.ownedKeys {
+		if key.flag != 0 {
+			return fmt.Errorf(
+				"%w: release RobotGo-owned modifier %q before exact text input",
+				ErrOwnership, key.name,
+			)
+		}
+	}
+
+	runes := []rune(event.Text)
+	for index, value := range runes {
+		units := utf16.Encode([]rune{value})
+		if err := system.PostUnicode(units, true, 0, pid); err != nil {
+			return fmt.Errorf("type %U key down: %w", value, err)
+		}
+		if err := system.PostUnicode(units, false, 0, pid); err != nil {
+			cleanupErr := system.PostUnicode(units, false, 0, pid)
+			return fmt.Errorf("type %U key up: %w", value, errors.Join(err, cleanupErr))
+		}
+		if event.Delay > 0 && index+1 < len(runes) {
+			backend.sleep(event.Delay)
+		}
+	}
+	return nil
+}

--- a/internal/darwininput/keyboard_constants.go
+++ b/internal/darwininput/keyboard_constants.go
@@ -1,0 +1,127 @@
+package darwininput
+
+const (
+	keyA              uint16 = 0x00
+	keyS              uint16 = 0x01
+	keyD              uint16 = 0x02
+	keyF              uint16 = 0x03
+	keyH              uint16 = 0x04
+	keyG              uint16 = 0x05
+	keyZ              uint16 = 0x06
+	keyX              uint16 = 0x07
+	keyC              uint16 = 0x08
+	keyV              uint16 = 0x09
+	keyB              uint16 = 0x0b
+	keyQ              uint16 = 0x0c
+	keyW              uint16 = 0x0d
+	keyE              uint16 = 0x0e
+	keyR              uint16 = 0x0f
+	keyY              uint16 = 0x10
+	keyT              uint16 = 0x11
+	key1              uint16 = 0x12
+	key2              uint16 = 0x13
+	key3              uint16 = 0x14
+	key4              uint16 = 0x15
+	key6              uint16 = 0x16
+	key5              uint16 = 0x17
+	keyEqual          uint16 = 0x18
+	key9              uint16 = 0x19
+	key7              uint16 = 0x1a
+	keyMinus          uint16 = 0x1b
+	key8              uint16 = 0x1c
+	key0              uint16 = 0x1d
+	keyRightBracket   uint16 = 0x1e
+	keyO              uint16 = 0x1f
+	keyU              uint16 = 0x20
+	keyLeftBracket    uint16 = 0x21
+	keyI              uint16 = 0x22
+	keyP              uint16 = 0x23
+	keyL              uint16 = 0x25
+	keyJ              uint16 = 0x26
+	keyQuote          uint16 = 0x27
+	keyK              uint16 = 0x28
+	keySemicolon      uint16 = 0x29
+	keyBackslash      uint16 = 0x2a
+	keyComma          uint16 = 0x2b
+	keySlash          uint16 = 0x2c
+	keyN              uint16 = 0x2d
+	keyM              uint16 = 0x2e
+	keyPeriod         uint16 = 0x2f
+	keyTab            uint16 = 0x30
+	keySpace          uint16 = 0x31
+	keyGrave          uint16 = 0x32
+	keyDelete         uint16 = 0x33
+	keyRightCommand   uint16 = 0x36
+	keyCommand        uint16 = 0x37
+	keyShift          uint16 = 0x38
+	keyCapsLock       uint16 = 0x39
+	keyOption         uint16 = 0x3a
+	keyControl        uint16 = 0x3b
+	keyRightShift     uint16 = 0x3c
+	keyRightOption    uint16 = 0x3d
+	keyRightControl   uint16 = 0x3e
+	keyF17            uint16 = 0x40
+	keyKeypadDecimal  uint16 = 0x41
+	keyKeypadMultiply uint16 = 0x43
+	keyKeypadPlus     uint16 = 0x45
+	keyKeypadClear    uint16 = 0x47
+	keyKeypadDivide   uint16 = 0x4b
+	keyKeypadEnter    uint16 = 0x4c
+	keyKeypadMinus    uint16 = 0x4e
+	keyF18            uint16 = 0x4f
+	keyF19            uint16 = 0x50
+	keyKeypadEquals   uint16 = 0x51
+	keyKeypad0        uint16 = 0x52
+	keyKeypad1        uint16 = 0x53
+	keyKeypad2        uint16 = 0x54
+	keyKeypad3        uint16 = 0x55
+	keyKeypad4        uint16 = 0x56
+	keyKeypad5        uint16 = 0x57
+	keyKeypad6        uint16 = 0x58
+	keyKeypad7        uint16 = 0x59
+	keyF20            uint16 = 0x5a
+	keyKeypad8        uint16 = 0x5b
+	keyKeypad9        uint16 = 0x5c
+	keyF5             uint16 = 0x60
+	keyF6             uint16 = 0x61
+	keyF7             uint16 = 0x62
+	keyF3             uint16 = 0x63
+	keyF8             uint16 = 0x64
+	keyF9             uint16 = 0x65
+	keyF11            uint16 = 0x67
+	keyF13            uint16 = 0x69
+	keyF16            uint16 = 0x6a
+	keyF14            uint16 = 0x6b
+	keyF10            uint16 = 0x6d
+	keyF12            uint16 = 0x6f
+	keyF15            uint16 = 0x71
+	keyHelp           uint16 = 0x72
+	keyHome           uint16 = 0x73
+	keyPageUp         uint16 = 0x74
+	keyForwardDelete  uint16 = 0x75
+	keyF4             uint16 = 0x76
+	keyEnd            uint16 = 0x77
+	keyF2             uint16 = 0x78
+	keyPageDown       uint16 = 0x79
+	keyF1             uint16 = 0x7a
+	keyLeft           uint16 = 0x7b
+	keyRight          uint16 = 0x7c
+	keyDown           uint16 = 0x7d
+	keyUp             uint16 = 0x7e
+	keyReturn         uint16 = 0x24
+	keyEscape         uint16 = 0x35
+)
+
+const (
+	eventFlagMaskShift      uint64 = 1 << 17
+	eventFlagMaskControl    uint64 = 1 << 18
+	eventFlagMaskAlternate  uint64 = 1 << 19
+	eventFlagMaskCommand    uint64 = 1 << 20
+	eventFlagMaskNumericPad uint64 = 1 << 21
+	eventFlagMaskHelp       uint64 = 1 << 22
+
+	keyboardShortcutFlags = eventFlagMaskShift |
+		eventFlagMaskControl |
+		eventFlagMaskAlternate |
+		eventFlagMaskCommand
+)

--- a/internal/darwininput/keyboard_test.go
+++ b/internal/darwininput/keyboard_test.go
@@ -1,0 +1,358 @@
+package darwininput
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestKeyboardReadyUsesLazyNonPromptingPreflight(t *testing.T) {
+	wantErr := errors.Join(ErrPermission, errors.New("denied"))
+	system := &fakeInputSystem{readyErr: wantErr}
+	openCalls := 0
+	backend := newBackend(func() (inputSystem, error) {
+		openCalls++
+		if system.buttons == nil {
+			system.buttons = make(map[uint32]bool)
+		}
+		if system.keys == nil {
+			system.keys = make(map[uint16]bool)
+		}
+		return system, nil
+	}, nil)
+
+	for attempt := 0; attempt < 2; attempt++ {
+		if err := backend.KeyboardReady(); !errors.Is(err, ErrPermission) {
+			t.Fatalf("KeyboardReady attempt %d error = %v, want ErrPermission", attempt+1, err)
+		}
+	}
+	if openCalls != 1 {
+		t.Fatalf("native opens = %d, want one cached system", openCalls)
+	}
+}
+
+func TestKeyTapPostsModifiersAndProcessTarget(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{}
+	backend := testBackend(system, &sleeps)
+
+	err := backend.Key(KeyEvent{
+		Key: "A", Modifiers: []string{"shift"},
+		PID: 42, Tap: true,
+	})
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	want := []recordedKeyEvent{
+		{key: keyShift, down: true, flags: eventFlagMaskShift, pid: 42},
+		{key: keyA, down: true, flags: eventFlagMaskShift, pid: 42},
+		{key: keyA, flags: eventFlagMaskShift, pid: 42},
+		{key: keyShift, pid: 42},
+	}
+	if !reflect.DeepEqual(system.keyEvents, want) {
+		t.Fatalf("key events = %#v, want %#v", system.keyEvents, want)
+	}
+	if len(backend.ownedKeys) != 0 {
+		t.Fatalf("tap left owned keys = %#v", backend.ownedKeys)
+	}
+}
+
+func TestShiftedDigitUsesMatchingPhysicalKey(t *testing.T) {
+	for character, code := range map[string]uint16{
+		"!": key1, "@": key2, "#": key3, "$": key4, "%": key5,
+		"^": key6, "&": key7, "*": key8, "(": key9, ")": key0,
+	} {
+		t.Run(character, func(t *testing.T) {
+			key, err := resolveKey(character)
+			if err != nil {
+				t.Fatalf("resolveKey(%q): %v", character, err)
+			}
+			if key.code != code {
+				t.Fatalf("resolveKey(%q) = %#x, want %#x", character, key.code, code)
+			}
+		})
+	}
+}
+
+func TestKeypadEventsKeepNumericPadFlag(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Key(KeyEvent{Key: "num1", Tap: true}); err != nil {
+		t.Fatalf("keypad tap: %v", err)
+	}
+	want := []recordedKeyEvent{
+		{key: keyKeypad1, down: true, flags: eventFlagMaskNumericPad},
+		{key: keyKeypad1, flags: eventFlagMaskNumericPad},
+	}
+	if !reflect.DeepEqual(system.keyEvents, want) {
+		t.Fatalf("keypad events = %#v, want %#v", system.keyEvents, want)
+	}
+}
+
+func TestKeyTapPreservesForeignModifier(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{
+		keys:          map[uint16]bool{keyShift: true},
+		modifierFlags: eventFlagMaskShift,
+	}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Key(KeyEvent{
+		Key: "a", Modifiers: []string{"shift"}, Tap: true,
+	}); err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	want := []recordedKeyEvent{
+		{key: keyA, down: true, flags: eventFlagMaskShift},
+		{key: keyA, flags: eventFlagMaskShift},
+	}
+	if !reflect.DeepEqual(system.keyEvents, want) {
+		t.Fatalf("key events = %#v, want %#v", system.keyEvents, want)
+	}
+	if !system.keys[keyShift] {
+		t.Fatal("tap released a foreign Shift hold")
+	}
+}
+
+func TestReleasingOneSidedModifierPreservesOtherSideFlag(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{
+		keys:          map[uint16]bool{keyShift: true},
+		modifierFlags: eventFlagMaskShift,
+	}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Key(KeyEvent{Key: "rshift", Tap: true}); err != nil {
+		t.Fatalf("right Shift tap: %v", err)
+	}
+	want := []recordedKeyEvent{
+		{key: keyRightShift, down: true, flags: eventFlagMaskShift},
+		{key: keyRightShift, flags: eventFlagMaskShift},
+	}
+	if !reflect.DeepEqual(system.keyEvents, want) {
+		t.Fatalf("key events = %#v, want %#v", system.keyEvents, want)
+	}
+	if system.modifierFlags != eventFlagMaskShift || !system.keys[keyShift] {
+		t.Fatalf(
+			"left Shift state was lost: flags=%#x keys=%#v",
+			system.modifierFlags, system.keys,
+		)
+	}
+}
+
+func TestReleasedOwnedSiblingDoesNotLookForeignWhenQuartzStateLags(t *testing.T) {
+	system := &fakeInputSystem{
+		keys: map[uint16]bool{keyRightShift: true},
+	}
+	backend := &Backend{
+		ownedKeys: map[uint16]ownedKey{
+			keyShift: {code: keyShift, flag: eventFlagMaskShift},
+		},
+	}
+	flags, err := backend.flagsAfterReleaseLocked(
+		system,
+		ownedKey{code: keyShift, flag: eventFlagMaskShift},
+		eventFlagMaskShift,
+		map[uint16]struct{}{keyRightShift: {}},
+	)
+	if err != nil {
+		t.Fatalf("flagsAfterReleaseLocked: %v", err)
+	}
+	if flags != 0 {
+		t.Fatalf("flags after final owned Shift release = %#x, want 0", flags)
+	}
+}
+
+func TestOwnedPIDModifierSuppliesFlagsWhenGlobalStateOmitsIt(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Key(KeyEvent{Key: "cmd", PID: 17, Down: true}); err != nil {
+		t.Fatalf("command down: %v", err)
+	}
+	// CGEventPostToPid does not have to expose target-local state through the
+	// combined global source table. The backend's ownership remains authoritative.
+	system.modifierFlags = 0
+	system.keys[keyCommand] = false
+	if err := backend.Key(KeyEvent{
+		Key: "a", Modifiers: []string{"cmd"}, PID: 17, Tap: true,
+	}); err != nil {
+		t.Fatalf("command-a: %v", err)
+	}
+	got := system.keyEvents[len(system.keyEvents)-2:]
+	want := []recordedKeyEvent{
+		{key: keyA, down: true, flags: eventFlagMaskCommand, pid: 17},
+		{key: keyA, flags: eventFlagMaskCommand, pid: 17},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("command-a events = %#v, want %#v", got, want)
+	}
+}
+
+func TestKeyToggleEnforcesOwnershipAndPID(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{keys: map[uint16]bool{keyB: true}}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Key(KeyEvent{Key: "b", Down: true}); !errors.Is(err, ErrOwnership) {
+		t.Fatalf("foreign key down error = %v, want ErrOwnership", err)
+	}
+	system.keys[keyB] = false
+	if err := backend.Key(KeyEvent{Key: "b", PID: 17, Down: true}); err != nil {
+		t.Fatalf("owned key down: %v", err)
+	}
+	if err := backend.Key(KeyEvent{Key: "b", PID: 17, Down: true}); !errors.Is(err, ErrOwnership) {
+		t.Fatalf("duplicate key down error = %v, want ErrOwnership", err)
+	}
+	if err := backend.Key(KeyEvent{Key: "b", PID: 18}); !errors.Is(err, ErrOwnership) {
+		t.Fatalf("wrong-PID key up error = %v, want ErrOwnership", err)
+	}
+	if err := backend.Key(KeyEvent{Key: "b", PID: 17}); err != nil {
+		t.Fatalf("owned key up: %v", err)
+	}
+	if system.keys[keyB] {
+		t.Fatal("owned key remained down")
+	}
+}
+
+func TestCapsLockToggleStateIsNotTreatedAsForeignHold(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{
+		keys: map[uint16]bool{keyCapsLock: true},
+	}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Key(KeyEvent{Key: "capslock", Tap: true}); err != nil {
+		t.Fatalf("Caps Lock tap with active toggle state: %v", err)
+	}
+	if len(system.keyEvents) != 2 ||
+		!system.keyEvents[0].down ||
+		system.keyEvents[1].down {
+		t.Fatalf("Caps Lock events = %#v, want one pulse", system.keyEvents)
+	}
+}
+
+func TestKeyFailureRollsBackNewHolds(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{postKeyErrAt: 3}
+	backend := testBackend(system, &sleeps)
+
+	err := backend.Key(KeyEvent{
+		Key: "c", Modifiers: []string{"cmd"}, Tap: true,
+	})
+	if err == nil {
+		t.Fatal("Key unexpectedly hid main-key release failure")
+	}
+	want := []recordedKeyEvent{
+		{key: keyCommand, down: true, flags: eventFlagMaskCommand},
+		{key: keyC, down: true, flags: eventFlagMaskCommand},
+		{key: keyC, flags: eventFlagMaskCommand},
+		{key: keyCommand},
+	}
+	if !reflect.DeepEqual(system.keyEvents, want) {
+		t.Fatalf("rollback events = %#v, want %#v", system.keyEvents, want)
+	}
+	if len(backend.ownedKeys) != 0 || system.keys[keyCommand] || system.keys[keyC] {
+		t.Fatalf("rollback left keys held: owned=%#v native=%#v", backend.ownedKeys, system.keys)
+	}
+}
+
+func TestCloseReleasesKeysBeforeModifiersInReverseOrder(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Key(KeyEvent{Key: "cmd", Down: true}); err != nil {
+		t.Fatalf("command down: %v", err)
+	}
+	if err := backend.Key(KeyEvent{
+		Key: "a", Modifiers: []string{"cmd"}, Down: true,
+	}); err != nil {
+		t.Fatalf("a down: %v", err)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	wantTail := []recordedKeyEvent{
+		{key: keyA, flags: eventFlagMaskCommand},
+		{key: keyCommand},
+	}
+	gotTail := system.keyEvents[len(system.keyEvents)-2:]
+	if !reflect.DeepEqual(gotTail, wantTail) {
+		t.Fatalf("close tail = %#v, want %#v", gotTail, wantTail)
+	}
+	if system.closeCalls != 1 || len(backend.ownedKeys) != 0 {
+		t.Fatalf("Close state: closes=%d owned=%#v", system.closeCalls, backend.ownedKeys)
+	}
+}
+
+func TestTextPostsWholeUnicodeScalarsAndDelay(t *testing.T) {
+	var sleeps []time.Duration
+	system := &fakeInputSystem{}
+	backend := testBackend(system, &sleeps)
+
+	if err := backend.Text(TextEvent{
+		Text: "A😀", PID: 9, Delay: 5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("Text: %v", err)
+	}
+	want := []recordedUnicodeEvent{
+		{units: []uint16{'A'}, down: true, pid: 9},
+		{units: []uint16{'A'}, pid: 9},
+		{units: []uint16{0xd83d, 0xde00}, down: true, pid: 9},
+		{units: []uint16{0xd83d, 0xde00}, pid: 9},
+	}
+	if !reflect.DeepEqual(system.unicodeEvents, want) {
+		t.Fatalf("Unicode events = %#v, want %#v", system.unicodeEvents, want)
+	}
+	if !reflect.DeepEqual(sleeps, []time.Duration{5 * time.Millisecond}) {
+		t.Fatalf("text sleeps = %v, want one 5ms delay", sleeps)
+	}
+}
+
+func TestTextRejectsUnsafeStateAndInvalidInput(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		event TextEvent
+		setup func(*fakeInputSystem)
+	}{
+		{name: "negative PID", event: TextEvent{Text: "x", PID: -1}},
+		{name: "negative delay", event: TextEvent{Text: "x", Delay: -time.Millisecond}},
+		{name: "NUL", event: TextEvent{Text: "x\x00y"}},
+		{
+			name: "foreign command", event: TextEvent{Text: "x"},
+			setup: func(system *fakeInputSystem) {
+				system.modifierFlags = eventFlagMaskCommand
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var sleeps []time.Duration
+			system := &fakeInputSystem{}
+			if test.setup != nil {
+				test.setup(system)
+			}
+			backend := testBackend(system, &sleeps)
+			if err := backend.Text(test.event); err == nil {
+				t.Fatal("Text unexpectedly succeeded")
+			}
+			if len(system.unicodeEvents) != 0 {
+				t.Fatalf("invalid text posted events: %#v", system.unicodeEvents)
+			}
+		})
+	}
+}
+
+func TestUnsupportedQuartzKeysFailExplicitly(t *testing.T) {
+	for _, name := range []string{"f21", "menu", "audio_play", "é"} {
+		var sleeps []time.Duration
+		backend := testBackend(&fakeInputSystem{}, &sleeps)
+		if err := backend.Key(KeyEvent{Key: name, Tap: true}); !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("Key(%q) error = %v, want ErrUnsupported", name, err)
+		}
+	}
+}

--- a/internal/darwininput/system_darwin.go
+++ b/internal/darwininput/system_darwin.go
@@ -5,6 +5,7 @@ package darwininput
 import (
 	"errors"
 	"fmt"
+	"runtime"
 
 	"github.com/ebitengine/purego"
 )
@@ -34,10 +35,16 @@ type nativeSystem struct {
 	eventGetLocation       func(uintptr) point
 	eventSourceCreate      func(int32) uintptr
 	eventSourceButtonState func(int32, uint32) bool
+	eventSourceKeyState    func(int32, uint16) bool
+	eventSourceFlagsState  func(int32) uint64
 	eventCreateMouse       func(uintptr, uint32, point, uint32) uintptr
 	eventCreateScroll      func(uintptr, uint32, uint32, int32, int32, int32) uintptr
+	eventCreateKeyboard    func(uintptr, uint16, bool) uintptr
+	eventSetUnicodeString  func(uintptr, uintptr, *uint16)
+	eventSetFlags          func(uintptr, uint64)
 	eventSetIntegerField   func(uintptr, uint32, int64)
 	eventPost              func(uint32, uintptr)
+	eventPostToPID         func(int32, uintptr)
 	cfRelease              func(uintptr)
 }
 
@@ -77,10 +84,16 @@ func openNativeSystem() (inputSystem, error) {
 		{system.coreGraphicsHandle, &system.eventGetLocation, "CGEventGetLocation"},
 		{system.coreGraphicsHandle, &system.eventSourceCreate, "CGEventSourceCreate"},
 		{system.coreGraphicsHandle, &system.eventSourceButtonState, "CGEventSourceButtonState"},
+		{system.coreGraphicsHandle, &system.eventSourceKeyState, "CGEventSourceKeyState"},
+		{system.coreGraphicsHandle, &system.eventSourceFlagsState, "CGEventSourceFlagsState"},
 		{system.coreGraphicsHandle, &system.eventCreateMouse, "CGEventCreateMouseEvent"},
 		{system.coreGraphicsHandle, &system.eventCreateScroll, "CGEventCreateScrollWheelEvent2"},
+		{system.coreGraphicsHandle, &system.eventCreateKeyboard, "CGEventCreateKeyboardEvent"},
+		{system.coreGraphicsHandle, &system.eventSetUnicodeString, "CGEventKeyboardSetUnicodeString"},
+		{system.coreGraphicsHandle, &system.eventSetFlags, "CGEventSetFlags"},
 		{system.coreGraphicsHandle, &system.eventSetIntegerField, "CGEventSetIntegerValueField"},
 		{system.coreGraphicsHandle, &system.eventPost, "CGEventPost"},
+		{system.coreGraphicsHandle, &system.eventPostToPID, "CGEventPostToPid"},
 		{system.coreFoundationHandle, &system.cfRelease, "CFRelease"},
 	}
 	for _, function := range required {
@@ -111,10 +124,22 @@ func (system *nativeSystem) Ready() error {
 	}
 	event := system.eventCreate(0)
 	if event == 0 {
-		return errors.New("CoreGraphics could not create a pointer-location event; an active macOS GUI session is required")
+		return errors.New("CoreGraphics could not create an input preflight event; an active macOS GUI session is required")
 	}
 	system.cfRelease(event)
 	return nil
+}
+
+func (system *nativeSystem) KeyboardReady() error {
+	// Creating and releasing an event does not inject input or prompt for
+	// consent. Do it before the Accessibility check so denied CI runners still
+	// exercise the real PureGo function signature.
+	event := system.eventCreateKeyboard(system.eventSource, keyA, true)
+	if event == 0 {
+		return errors.New("CoreGraphics could not create a keyboard preflight event")
+	}
+	system.cfRelease(event)
+	return system.Ready()
 }
 
 func (system *nativeSystem) CursorPosition() (point, error) {
@@ -128,6 +153,14 @@ func (system *nativeSystem) CursorPosition() (point, error) {
 
 func (system *nativeSystem) ButtonDown(button uint32) (bool, error) {
 	return system.eventSourceButtonState(cgEventSourceStateCombinedSession, button), nil
+}
+
+func (system *nativeSystem) KeyDown(key uint16) (bool, error) {
+	return system.eventSourceKeyState(cgEventSourceStateCombinedSession, key), nil
+}
+
+func (system *nativeSystem) ModifierFlags() (uint64, error) {
+	return system.eventSourceFlagsState(cgEventSourceStateCombinedSession), nil
 }
 
 func (system *nativeSystem) PostMouse(
@@ -171,6 +204,50 @@ func (system *nativeSystem) PostScroll(horizontal, vertical int32) error {
 	}
 	defer system.cfRelease(event)
 	system.eventPost(cgHIDEventTap, event)
+	return nil
+}
+
+func (system *nativeSystem) postKeyboardEvent(event uintptr, flags uint64, pid int32) {
+	system.eventSetFlags(event, flags)
+	if pid == 0 {
+		system.eventPost(cgHIDEventTap, event)
+		return
+	}
+	system.eventPostToPID(pid, event)
+}
+
+func (system *nativeSystem) PostKey(
+	key uint16,
+	down bool,
+	flags uint64,
+	pid int32,
+) error {
+	event := system.eventCreateKeyboard(system.eventSource, key, down)
+	if event == 0 {
+		return fmt.Errorf("CoreGraphics could not create keyboard event for keycode %#x", key)
+	}
+	defer system.cfRelease(event)
+	system.postKeyboardEvent(event, flags, pid)
+	return nil
+}
+
+func (system *nativeSystem) PostUnicode(
+	units []uint16,
+	down bool,
+	flags uint64,
+	pid int32,
+) error {
+	if len(units) == 0 {
+		return errors.New("CoreGraphics Unicode keyboard event requires at least one UTF-16 code unit")
+	}
+	event := system.eventCreateKeyboard(system.eventSource, 0, down)
+	if event == 0 {
+		return errors.New("CoreGraphics could not create Unicode keyboard event")
+	}
+	defer system.cfRelease(event)
+	system.eventSetUnicodeString(event, uintptr(len(units)), &units[0])
+	runtime.KeepAlive(units)
+	system.postKeyboardEvent(event, flags, pid)
 	return nil
 }
 


### PR DESCRIPTION
## Goal

Complete the next Phase 3 macOS Pure-Go slice by adding usable, explicit Quartz keyboard and text input without weakening CGO builds or silently claiming unsupported keys.

## What changed

- runtime-loads the CoreGraphics keyboard, Unicode, modifier-state, key-state, and PID-targeted event APIs through PureGo
- adds key taps, modified combinations, persistent key down/up, process targeting, and exact UTF-16 text including non-BMP surrogate pairs
- preserves foreign modifier state and tracks only RobotGo-owned holds
- rolls back partial multi-event transactions and releases owned keys through `CloseMainDisplayE`
- handles left/right modifier families, PID-local modifier state, Caps Lock toggle semantics, keypad flags, shifted symbols, delay bounds, and explicit unsupported media/brightness/F21-F24 keys
- reports live Quartz keyboard readiness and Accessibility denial through runtime capabilities
- adds a safe default example plus an Accessibility-gated real modifier integration test
- updates README, TEST guide, Wayland status, and the product roadmap

## User impact

`CGO_ENABLED=0` macOS builds can now use `KeyboardReady`, `KeyTap`, `KeyDown`/`KeyUp`, `TypeStrE`, `UnicodeTypeE`, and clipboard-assisted `PasteStr` through Quartz. Exact text is layout-independent; printable shortcut keys use physical macOS ANSI positions. Unsupported special keys fail with `ErrNotSupported`.

## Safety and review focus

- the normal macOS CI preflight creates/releases a real keyboard event but never posts it or opens a consent dialog
- injection remains behind macOS Accessibility permission
- opt-in integration posts only a Shift hold/release and requires `ROBOTGO_REQUIRE_DARWIN_INPUT_INTEGRATION=1`
- review focused on PureGo ABI signatures, event ownership, partial failure rollback, modifier flags, process targeting, and deterministic cleanup

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./internal/darwininput`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0 golangci-lint run --timeout=5m ./...`
- Darwin amd64 non-CGO cross-test compile with `darwinintegration`
- Darwin arm64 non-CGO cross-test compile
- `internal/darwininput` statement coverage: 82.3%