### PR TITLE
feat: add reliable Hyprland maximize state

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Current technical differences include:
   explains backend choice, fallback, and unsupported behavior.
 - Sway, Hyprland, generic wlroots, and Wayland-core window backend resolution,
   with partial operations reported honestly instead of universal support being
-  implied.
+  implied. Hyprland additionally supports reliable active-window maximize
+  query, set, and restore through `hyprctl`.
 - A defined non-CGO contract: Pure-Go capture is available through CoreGraphics
   on macOS, native APIs on Windows, and X11. Windows and Linux/X11 additionally
   have keyboard/pointer backends; Wayland capture uses the consent-aware
@@ -633,6 +634,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Pure-Go Windows window inspection and opt-in control](examples/purego_windows_window/main.go)
 - [Consent-aware RemoteDesktop portal input](examples/remote_desktop_input/main.go)
 - [Persistent ScreenCast/PipeWire capture](examples/screencast_capture/main.go)
+- [Hyprland active-window maximize state](examples/wayland_window_state/main.go)
 - [Window and process helpers](examples/window/main.go)
 - [Display scaling](examples/scale/main.go)
 
@@ -730,8 +732,11 @@ Real Wayland input results are tracked in the
 - [Product roadmap](docs/plan/product-roadmap.md)
 - [Wayland implementation history](docs/wayland-history.md)
 
-The active product slice remains selective Phase 3 Pure-Go expansion. The
-Linux/X11 evaluation is complete: shared behavior is blocking CI,
+The active product slice is Phase 4 API and compositor parity. Hyprland now
+provides trustworthy active-window maximize query, set, and restore while
+Sway and generic wlroots retain explicit unsupported query results because
+their available IPC does not expose an equivalent maximize state. The
+preceding Linux/X11 evaluation is complete: shared behavior is blocking CI,
 current guardian-path decision evidence is versioned, and native CGO remains
 the default while Pure-Go supports CGO-disabled builds. The Pure-Go X11 core is
 race-testable and its separate guardian performs bounded, claim-checked cleanup

--- a/TEST.md
+++ b/TEST.md
@@ -497,6 +497,10 @@ intentionally preserving a foreign replacement is not itself an error.
   - Opt-in for sway active-window title E2E integration (`GetTitleE`).
 - `ROBOTGO_HYPRLAND_TITLE_E2E=1`
   - Opt-in for hyprland active-window title E2E integration (`GetTitleE`).
+- `ROBOTGO_HYPRLAND_MAXIMIZE_E2E=1`
+  - Opt-in for Hyprland active-window maximize query/set/restore integration.
+    The test refuses to alter an initially fullscreen window and restores an
+    initial normal or maximized state during cleanup.
 - `ROBOTGO_REQUIRE_X11_INTEGRATION=1`
   - Makes missing `DISPLAY` or XTEST support fail the X11 integration suites;
     CI always enables it.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -248,6 +248,10 @@ The compatibility surface now includes:
 
 - Error-returning window state/query APIs (`IsTopMostE`, `SetTopMostE`,
   `IsMinimizedE`, `IsMaximizedE`) with explicit unsupported behavior.
+- Hyprland active-window maximize query, set, and restore backed by its
+  compositor-reported state. Fullscreen remains distinct from maximized;
+  Sway/generic wlroots queries stay explicitly unsupported rather than
+  inferring state.
 - Bitmap string helpers (`CaptureBitmapStr`, `FindBitmapStr`, `BitmapFromStr`,
   `ToStrBitmap`).
 - Region/tolerance color search through `FindColorCS`/`FindcolorCS`.
@@ -256,8 +260,8 @@ The compatibility surface now includes:
 Remaining work must improve runtime support without inventing misleading
 cross-platform semantics:
 
-- Implement compositor-backed window state/query behavior where the compositor
-  exposes trustworthy state and retain explicit unsupported results elsewhere.
+- Extend compositor-backed state/query behavior beyond the delivered Hyprland
+  maximize slice only where equally trustworthy state is exposed.
 - Validate bitmap and color-search behavior across capture backends and
   supported platforms.
 - Stable multi-screen and bounds behavior for negative origins, transforms,

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -67,6 +67,11 @@ Current implementation baseline:
 - `wlroots-generic` currently implements active-window minimize/maximize
   (state=true) when `wlrctl` is available; unsupported operations remain
   explicit.
+- `hyprland` uses the compositor's reported fullscreen mode for
+  `IsMaximizedE` and supports both maximize and restore through `hyprctl`.
+  Fullscreen is not reported as maximized. Sway and generic wlroots keep
+  returning `ErrNotSupported` because their available IPC does not expose a
+  trustworthy equivalent state.
 - Bitmap string helpers are available via `CaptureBitmapStr`,
   `FindBitmapStr`, `BitmapFromStr`, and `ToStrBitmap`.
 - Region/tolerance color search is available via `FindColorCS`/`FindcolorCS`.
@@ -86,15 +91,20 @@ Current implementation baseline:
   preconditions are not present.
 - wlroots min/max E2E test exists behind opt-in env flag:
   `ROBOTGO_WLROOTS_MINMAX_E2E=1`.
+- Hyprland maximize query/set/restore E2E coverage exists behind
+  `ROBOTGO_HYPRLAND_MAXIMIZE_E2E=1` and restores the initial supported state.
 
 Window backend support matrix (current):
 
-| Backend | Resolver trigger | Active title | Active close | PID/handle close | Activate/min/max |
-|---|---|---|---|---|---|
-| `sway` | `SWAYSOCK` or sway desktop/session | Yes (`swaymsg`) | Yes (`swaymsg kill`) | No (`ErrNotSupported`) | Yes (`wlrctl window minimize/maximize state:active`, state=true only) |
-| `hyprland` | `HYPRLAND_INSTANCE_SIGNATURE` or hyprland desktop/session | Yes (`hyprctl activewindow -j`) | Yes (`hyprctl dispatch killactive`) | No (`ErrNotSupported`) | Yes (`wlrctl window minimize/maximize state:active`, state=true only) |
-| `wlroots-generic` | wlroots-family compositor (wayfire/river/labwc/dwl/gamescope) | No (`ErrNotSupported`) | No (`ErrNotSupported`) | No (`ErrNotSupported`) | Yes (`wlrctl window minimize/maximize state:active`, state=true only) |
-| `wayland-core/*` | wayland session without specific/family backend support | No (`ErrNotSupported`) | No (`ErrNotSupported`) | No (`ErrNotSupported`) | No (`ErrNotSupported`) |
+| Backend | Resolver trigger | Active title | Active close | Minimize | Maximize/restore | `IsMaximizedE` |
+|---|---|---|---|---|---|---|
+| `sway` | `SWAYSOCK` or sway desktop/session | Yes (`swaymsg`) | Yes (`swaymsg kill`) | `wlrctl`, set only | `wlrctl`, set only | No (`ErrNotSupported`) |
+| `hyprland` | `HYPRLAND_INSTANCE_SIGNATURE` or hyprland desktop/session | Yes (`hyprctl activewindow -j`) | Yes (`hyprctl dispatch killactive`) | `wlrctl`, set only | Yes (`hyprctl`, set and restore) | Yes (`hyprctl activewindow -j`) |
+| `wlroots-generic` | wlroots-family compositor (wayfire/river/labwc/dwl/gamescope) | No (`ErrNotSupported`) | No (`ErrNotSupported`) | `wlrctl`, set only | `wlrctl`, set only | No (`ErrNotSupported`) |
+| `wayland-core/*` | wayland session without specific/family backend support | No (`ErrNotSupported`) | No (`ErrNotSupported`) | No (`ErrNotSupported`) | No (`ErrNotSupported`) | No (`ErrNotSupported`) |
+
+PID/handle-specific control remains unsupported for all listed Wayland
+backends.
 
 - Priority Backlog (1-7):
   - 1. Register protected GNOME/KDE/wlroots runners and validate the complete
@@ -106,8 +116,8 @@ Window backend support matrix (current):
     GNOME/KDE/wlroots runners and promote its leak/timeout tests to release
     gates. The implementation and opt-in integration harness are present.
     `[new vs robotgo-pro]`
-  - 3. Extend window state/query operations from explicit error parity to real
-    compositor-backed behavior where state is observable.
+  - 3. Continue window state/query operations beyond the delivered Hyprland
+    maximize slice where a compositor exposes equally trustworthy state.
   - 4. Wayland reliability matrix across wlroots/GNOME/KDE: multi-output,
     fractional scale, transforms, portal consent, and fallback.
     `[new vs robotgo-pro]`

--- a/examples/wayland_window_state/main.go
+++ b/examples/wayland_window_state/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	maximize := flag.Bool("maximize", false, "maximize the active Hyprland window")
+	restore := flag.Bool("restore", false, "restore the active Hyprland window")
+	flag.Parse()
+
+	if *maximize && *restore {
+		fmt.Fprintln(os.Stderr, "-maximize and -restore are mutually exclusive")
+		os.Exit(2)
+	}
+
+	if *maximize || *restore {
+		if err := robotgo.MaxWindowE(0, *maximize); err != nil {
+			fmt.Fprintln(os.Stderr, "change active-window state:", err)
+			os.Exit(1)
+		}
+	}
+
+	maximized, err := robotgo.IsMaximizedE()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "query active-window state:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("active window maximized: %t\n", maximized)
+}

--- a/robotgo.go
+++ b/robotgo.go
@@ -2541,12 +2541,12 @@ func IsMaximized() bool {
 	return ok
 }
 
-// IsMaximizedE reports whether the current active window is maximized and
-// returns an explicit unsupported error on Linux backends without reliable
-// state query support.
+// IsMaximizedE reports whether the current active window is maximized.
+// Hyprland uses its compositor state; Linux backends without a trustworthy
+// query return an explicit unsupported error.
 func IsMaximizedE() (bool, error) {
 	if runtime.GOOS == "linux" {
-		return false, linuxWindowStateNotSupported("query maximized state")
+		return resolveWindowBackend().Maximized()
 	}
 	return bool(C.IsMaximized()), nil
 }
@@ -2679,8 +2679,8 @@ func MaxWindow(pid int, args ...interface{}) {
 	_ = MaxWindowE(pid, args...)
 }
 
-// MaxWindowE sets the window max state and returns an explicit unsupported
-// error on Wayland sessions.
+// MaxWindowE sets or restores the window max state. Wayland backends without
+// trustworthy compositor support return an explicit unsupported error.
 func MaxWindowE(pid int, args ...interface{}) error {
 	state, err := parseWindowStateArguments(args)
 	if err != nil {

--- a/robotgo_wayland_window_policy_test.go
+++ b/robotgo_wayland_window_policy_test.go
@@ -108,3 +108,76 @@ func TestWaylandWlrootsCloseWindowStillUnsupported(t *testing.T) {
 		t.Fatalf("CloseWindowKill expected ErrNotSupported, got: %v", err)
 	}
 }
+
+func TestWaylandHyprlandMaximizedPublicAPI(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	t.Setenv(envWaylandDisplay, testWaylandDisplay)
+	t.Setenv(envDisplay, "")
+	t.Setenv(envDesktop, "")
+	t.Setenv(envSessionDesktop, "")
+	t.Setenv(envSwaySock, "")
+	t.Setenv(envHyprlandSignature, "hyprland-test")
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	internal := hyprlandFullscreenNone
+	client := hyprlandFullscreenNone
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdHyprCtl {
+			t.Fatalf("expected command %q, got %q", cmdHyprCtl, name)
+		}
+		if len(args) == 2 && args[0] == argActiveWindow && args[1] == argJSON {
+			if internal == hyprlandFullscreenMaximized &&
+				client == hyprlandFullscreenMaximized {
+				return []byte(`{"fullscreen":1,"fullscreenClient":1}`), nil
+			}
+			if internal == hyprlandFullscreenNone && client == hyprlandFullscreenNone {
+				return []byte(`{"fullscreen":0,"fullscreenClient":0}`), nil
+			}
+			t.Fatalf("unexpected test state internal=%d client=%d", internal, client)
+		}
+		if len(args) == 4 &&
+			args[0] == argDispatch &&
+			args[1] == argFullscreenState &&
+			args[2] == args[3] {
+			switch args[2] {
+			case argHyprlandMaximized:
+				internal, client = hyprlandFullscreenMaximized, hyprlandFullscreenMaximized
+			case argHyprlandNone:
+				internal, client = hyprlandFullscreenNone, hyprlandFullscreenNone
+			default:
+				t.Fatalf("unexpected maximize state: %q", args[2])
+			}
+			return []byte("ok"), nil
+		}
+		t.Fatalf("unexpected hyprctl args: %#v", args)
+		return nil, nil
+	}
+
+	maximized, err := IsMaximizedE()
+	if err != nil || maximized {
+		t.Fatalf("IsMaximizedE() = %v, %v; want false, nil", maximized, err)
+	}
+	if err := MaxWindowE(0, true); err != nil {
+		t.Fatalf("MaxWindowE(0, true) failed: %v", err)
+	}
+	maximized, err = IsMaximizedE()
+	if err != nil || !maximized {
+		t.Fatalf("IsMaximizedE() = %v, %v; want true, nil", maximized, err)
+	}
+	if err := MaxWindowE(0, false); err != nil {
+		t.Fatalf("MaxWindowE(0, false) failed: %v", err)
+	}
+	maximized, err = IsMaximizedE()
+	if err != nil || maximized {
+		t.Fatalf("IsMaximizedE() = %v, %v after restore; want false, nil", maximized, err)
+	}
+}

--- a/robotgo_wayland_wlroots_integration_test.go
+++ b/robotgo_wayland_wlroots_integration_test.go
@@ -4,14 +4,17 @@
 package robotgo
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"testing"
+	"time"
 )
 
 const envWlrootsMinMaxE2E = "ROBOTGO_WLROOTS_MINMAX_E2E"
 const envSwayTitleE2E = "ROBOTGO_SWAY_TITLE_E2E"
 const envHyprTitleE2E = "ROBOTGO_HYPRLAND_TITLE_E2E"
+const envHyprMaximizeE2E = "ROBOTGO_HYPRLAND_MAXIMIZE_E2E"
 
 func TestWlrootsGenericRuntimeCapabilityIntegration(t *testing.T) {
 	if runtime.GOOS != "linux" {
@@ -171,5 +174,92 @@ func TestHyprlandTitleE2EOptIn(t *testing.T) {
 	}
 	if title == "" {
 		t.Fatalf("GetTitleE returned empty title in hyprland e2e mode")
+	}
+}
+
+func TestHyprlandMaximizeE2EOptIn(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+	if os.Getenv(envHyprMaximizeE2E) == "" {
+		t.Skipf("set %s=1 to run hyprland maximize e2e integration", envHyprMaximizeE2E)
+	}
+	if DetectDisplayServer() != DisplayServerWayland {
+		t.Skip("requires Wayland session")
+	}
+
+	b := resolveWindowBackend()
+	if b.Name() != windowBackendHypr {
+		t.Skipf("requires hyprland backend runtime, got %q", b.Name())
+	}
+	if !hasCommand(cmdHyprCtl) {
+		t.Skip("requires hyprctl command in PATH")
+	}
+
+	info, err := getHyprlandActiveWindow()
+	if err != nil {
+		t.Fatalf("query initial active-window state: %v", err)
+	}
+	if info.Fullscreen == nil || info.FullscreenClient == nil {
+		t.Fatal("hyprctl activewindow response omitted internal/client fullscreen state")
+	}
+	if *info.Fullscreen != hyprlandFullscreenNone &&
+		*info.Fullscreen != hyprlandFullscreenMaximized {
+		t.Skipf(
+			"active window is in fullscreen mode %d; refusing to alter a non-normal/non-maximized state",
+			*info.Fullscreen,
+		)
+	}
+	if *info.FullscreenClient != *info.Fullscreen {
+		t.Skipf(
+			"active window has decoupled internal/client state %d/%d; refusing to alter it",
+			*info.Fullscreen,
+			*info.FullscreenClient,
+		)
+	}
+
+	initial := *info.Fullscreen == hyprlandFullscreenMaximized
+	waitForState := func(want bool) error {
+		deadline := time.Now().Add(windowCommandTimeout)
+		for {
+			got, err := IsMaximizedE()
+			if err == nil && got == want {
+				return nil
+			}
+			if time.Now().After(deadline) {
+				if err == nil {
+					return fmt.Errorf(
+						"IsMaximizedE() did not become %v before timeout; got %v",
+						want,
+						got,
+					)
+				}
+				return fmt.Errorf(
+					"IsMaximizedE() did not become %v before timeout; got %v, %w",
+					want,
+					got,
+					err,
+				)
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+	}
+	t.Cleanup(func() {
+		if err := MaxWindowE(0, initial); err != nil {
+			t.Errorf("restore initial maximized state: %v", err)
+			return
+		}
+		if err := waitForState(initial); err != nil {
+			t.Errorf("verify restored maximized state: %v", err)
+		}
+	})
+
+	target := !initial
+	if err := MaxWindowE(0, target); err != nil {
+		t.Fatalf("MaxWindowE(0, %v): %v", target, err)
+	}
+
+	if err := waitForState(target); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/window_backend.go
+++ b/window_backend.go
@@ -48,7 +48,7 @@ const (
 	notesWlrootsBackend            = "wlroots generic backend selected; operation support to be implemented via wlroots-compatible paths"
 	reasonCompositorSpecific       = "compositor-specific backend selected with partial operation support"
 	notesSwayPartialSupport        = "supports active-window title retrieval and close; active minimize/maximize available when wlrctl is present"
-	notesHyprPartialSupport        = "supports active-window title retrieval and close; active minimize/maximize available when wlrctl is present"
+	notesHyprPartialSupport        = "supports active-window title, close, and reliable maximize query/set/restore; active minimize requires wlrctl"
 	cmdSwayMsg                     = "swaymsg"
 	cmdHyprCtl                     = "hyprctl"
 	cmdWlrCtl                      = "wlrctl"
@@ -64,11 +64,19 @@ const (
 	argKill                        = "kill"
 	argDispatch                    = "dispatch"
 	argKillActive                  = "killactive"
+	argFullscreenState             = "fullscreenstate"
+	argHyprlandNone                = "0"
+	argHyprlandMaximized           = "1"
 	windowCommandTimeout           = 2 * time.Second
+	hyprlandFullscreenNone         = 0
+	hyprlandFullscreenMaximized    = 1
+	hyprlandFullscreenFull         = 2
+	hyprlandFullscreenMaxAndFull   = 3
 )
 
 var (
 	errWindowTitleUnavailable = errors.New("window title unavailable from compositor backend")
+	errWindowStateUnavailable = errors.New("window state unavailable from compositor backend")
 	errWindowOperationFailed  = errors.New("window operation failed for compositor backend")
 	runWindowCommand          = func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		return exec.CommandContext(ctx, name, args...).Output()
@@ -90,6 +98,7 @@ type windowBackend interface {
 	SetActive(win Handle) error
 	Minimize(pid int, state bool, isPid bool) error
 	Maximize(pid int, state bool, isPid bool) error
+	Maximized() (bool, error)
 	Close(args ...int) error
 	Title(args ...int) (string, error)
 }
@@ -191,6 +200,10 @@ func (nativeWindowBackend) Maximize(pid int, state bool, isPid bool) error {
 	return nil
 }
 
+func (nativeWindowBackend) Maximized() (bool, error) {
+	return false, linuxWindowStateNotSupported("query maximized state")
+}
+
 func (nativeWindowBackend) Close(args ...int) error {
 	if err := nativeX11WindowReady(); err != nil {
 		return err
@@ -280,6 +293,10 @@ func (b waylandCoreWindowBackend) Maximize(pid int, state bool, isPid bool) erro
 	return b.unsupported("maximize window")
 }
 
+func (b waylandCoreWindowBackend) Maximized() (bool, error) {
+	return false, b.unsupported("query maximized state")
+}
+
 func (b waylandCoreWindowBackend) Close(args ...int) error {
 	_ = args
 	return b.unsupported("close window")
@@ -343,6 +360,9 @@ func (swayWindowBackend) Maximize(pid int, state bool, isPid bool) error {
 	}
 	return runWlrctlActiveWindowAction("maximize window", argMaximize)
 }
+func (swayWindowBackend) Maximized() (bool, error) {
+	return false, waylandWindowNotSupported("query maximized state")
+}
 func (swayWindowBackend) Close(args ...int) error {
 	if len(args) > 0 {
 		return waylandWindowNotSupported("close window by pid/handle")
@@ -397,10 +417,78 @@ func (hyprlandWindowBackend) Maximize(pid int, state bool, isPid bool) error {
 	if pid > 0 || isPid {
 		return waylandWindowNotSupported("maximize window by pid/handle")
 	}
-	if !state {
-		return waylandWindowNotSupported("restore maximized window")
+	if !hasCommand(cmdHyprCtl) {
+		return waylandWindowNotSupported("maximize window (hyprctl unavailable)")
 	}
-	return runWlrctlActiveWindowAction("maximize window", argMaximize)
+	info, err := getHyprlandActiveWindow()
+	if err != nil {
+		return fmt.Errorf("%w: %w", errWindowStateUnavailable, err)
+	}
+	if info.Fullscreen == nil || info.FullscreenClient == nil {
+		return fmt.Errorf(
+			"%w: hyprland response omitted fullscreen state",
+			errWindowStateUnavailable,
+		)
+	}
+	if !validHyprlandFullscreenMode(*info.Fullscreen) ||
+		!validHyprlandFullscreenMode(*info.FullscreenClient) {
+		return fmt.Errorf(
+			"%w: invalid hyprland fullscreen state internal=%d client=%d",
+			errWindowStateUnavailable,
+			*info.Fullscreen,
+			*info.FullscreenClient,
+		)
+	}
+
+	if state {
+		if *info.Fullscreen == hyprlandFullscreenMaximized &&
+			*info.FullscreenClient == hyprlandFullscreenMaximized {
+			return nil
+		}
+	} else {
+		if !hyprlandFullscreenModeIsMaximized(*info.Fullscreen) &&
+			!hyprlandFullscreenModeIsMaximized(*info.FullscreenClient) {
+			return nil
+		}
+	}
+
+	mode := argHyprlandNone
+	if state {
+		mode = argHyprlandMaximized
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
+	defer cancel()
+	if _, err := runWindowCommand(
+		ctx,
+		cmdHyprCtl,
+		argDispatch,
+		argFullscreenState,
+		mode,
+		mode,
+	); err != nil {
+		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
+	}
+	return nil
+}
+func (hyprlandWindowBackend) Maximized() (bool, error) {
+	if !hasCommand(cmdHyprCtl) {
+		return false, waylandWindowNotSupported("query maximized state (hyprctl unavailable)")
+	}
+	info, err := getHyprlandActiveWindow()
+	if err != nil {
+		return false, fmt.Errorf("%w: %w", errWindowStateUnavailable, err)
+	}
+	if info.Fullscreen == nil {
+		return false, fmt.Errorf("%w: hyprland response omitted fullscreen state", errWindowStateUnavailable)
+	}
+	if !validHyprlandFullscreenMode(*info.Fullscreen) {
+		return false, fmt.Errorf(
+			"%w: invalid hyprland fullscreen state %d",
+			errWindowStateUnavailable,
+			*info.Fullscreen,
+		)
+	}
+	return hyprlandFullscreenModeIsMaximized(*info.Fullscreen), nil
 }
 func (hyprlandWindowBackend) Close(args ...int) error {
 	if len(args) > 0 {
@@ -468,6 +556,10 @@ func (wlrootsGenericWindowBackend) Maximize(pid int, state bool, isPid bool) err
 	return runWlrctlActiveWindowAction("maximize window", argMaximize)
 }
 
+func (wlrootsGenericWindowBackend) Maximized() (bool, error) {
+	return false, waylandWindowNotSupported("query maximized state")
+}
+
 func runWlrctlActiveWindowAction(op, action string) error {
 	if !hasCommand(cmdWlrCtl) {
 		return waylandWindowNotSupported(op + " (wlrctl unavailable)")
@@ -533,19 +625,37 @@ func getSwayActiveWindowTitle() (string, error) {
 }
 
 type hyprlandActiveWindow struct {
-	Title string `json:"title"`
+	Title            string `json:"title"`
+	Fullscreen       *int   `json:"fullscreen"`
+	FullscreenClient *int   `json:"fullscreenClient"`
 }
 
-func getHyprlandActiveWindowTitle() (string, error) {
+func validHyprlandFullscreenMode(mode int) bool {
+	return mode >= hyprlandFullscreenNone && mode <= hyprlandFullscreenMaxAndFull
+}
+
+func hyprlandFullscreenModeIsMaximized(mode int) bool {
+	return mode == hyprlandFullscreenMaximized || mode == hyprlandFullscreenMaxAndFull
+}
+
+func getHyprlandActiveWindow() (hyprlandActiveWindow, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
 	defer cancel()
 	out, err := runWindowCommand(ctx, cmdHyprCtl, argActiveWindow, argJSON)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", errWindowTitleUnavailable, err)
+		return hyprlandActiveWindow{}, err
 	}
 	var info hyprlandActiveWindow
 	if err := json.Unmarshal(out, &info); err != nil {
-		return "", fmt.Errorf("%w: invalid hyprland json: %v", errWindowTitleUnavailable, err)
+		return hyprlandActiveWindow{}, fmt.Errorf("invalid hyprland json: %w", err)
+	}
+	return info, nil
+}
+
+func getHyprlandActiveWindowTitle() (string, error) {
+	info, err := getHyprlandActiveWindow()
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", errWindowTitleUnavailable, err)
 	}
 	if strings.TrimSpace(info.Title) == "" {
 		return "", errWindowTitleUnavailable

--- a/window_backend_test.go
+++ b/window_backend_test.go
@@ -299,6 +299,89 @@ func TestHyprlandWindowBackendTitle(t *testing.T) {
 	}
 }
 
+func TestHyprlandWindowBackendMaximized(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	tests := []struct {
+		name string
+		json string
+		want bool
+	}{
+		{name: "normal", json: `{"fullscreen":0}`, want: false},
+		{name: "maximized", json: `{"fullscreen":1}`, want: true},
+		{name: "fullscreen", json: `{"fullscreen":2}`, want: false},
+		{name: "legacy combined state", json: `{"fullscreen":3}`, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				_ = ctx
+				if name != cmdHyprCtl {
+					t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
+				}
+				if len(args) != 2 || args[0] != argActiveWindow || args[1] != argJSON {
+					t.Fatalf("unexpected args: %#v", args)
+				}
+				return []byte(tt.json), nil
+			}
+
+			got, err := newHyprlandWindowBackend().Maximized()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("Maximized() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHyprlandWindowBackendMaximizedRejectsUnreliableState(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	tests := []struct {
+		name string
+		json string
+	}{
+		{name: "missing state", json: `{"title":"Editor"}`},
+		{name: "invalid state", json: `{"fullscreen":4}`},
+		{name: "malformed response", json: `{"fullscreen":`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runWindowCommand = func(context.Context, string, ...string) ([]byte, error) {
+				return []byte(tt.json), nil
+			}
+
+			_, err := newHyprlandWindowBackend().Maximized()
+			if !errors.Is(err, errWindowStateUnavailable) {
+				t.Fatalf("Maximized() error = %v, want errWindowStateUnavailable", err)
+			}
+		})
+	}
+}
+
+func TestHyprlandWindowBackendMaximizedRequiresHyprctl(t *testing.T) {
+	t.Setenv(envPath, t.TempDir())
+
+	_, err := newHyprlandWindowBackend().Maximized()
+	if !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("Maximized() error = %v, want ErrNotSupported", err)
+	}
+}
+
 func TestCompositorSpecificBackendTitleByPIDUnsupported(t *testing.T) {
 	for _, b := range []windowBackend{newSwayWindowBackend(), newHyprlandWindowBackend()} {
 		_, err := b.Title(1234)
@@ -385,7 +468,7 @@ func TestHyprlandWindowBackendCloseActive(t *testing.T) {
 	}
 }
 
-func TestHyprlandWindowBackendMinMaxActiveViaWlrctl(t *testing.T) {
+func TestHyprlandWindowBackendMinimizeActiveViaWlrctl(t *testing.T) {
 	tmp := t.TempDir()
 	writeStubCommand(t, tmp, cmdWlrCtl)
 	t.Setenv(envPath, tmp)
@@ -407,18 +490,211 @@ func TestHyprlandWindowBackendMinMaxActiveViaWlrctl(t *testing.T) {
 	if err := b.Minimize(0, true, false); err != nil {
 		t.Fatalf("unexpected minimize error: %v", err)
 	}
-	if err := b.Maximize(0, true, false); err != nil {
-		t.Fatalf("unexpected maximize error: %v", err)
-	}
 
-	if len(calls) != 2 {
-		t.Fatalf("expected 2 calls, got %d", len(calls))
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
 	}
 	if len(calls[0]) != 3 || calls[0][0] != argWindow || calls[0][1] != argMinimize || calls[0][2] != argStateActive {
 		t.Fatalf("unexpected minimize args: %#v", calls[0])
 	}
-	if len(calls[1]) != 3 || calls[1][0] != argWindow || calls[1][1] != argMaximize || calls[1][2] != argStateActive {
-		t.Fatalf("unexpected maximize args: %#v", calls[1])
+}
+
+func TestHyprlandWindowBackendMaximizeSetAndRestore(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	var calls [][]string
+	internal := hyprlandFullscreenNone
+	client := hyprlandFullscreenNone
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdHyprCtl {
+			t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
+		}
+		if len(args) == 2 && args[0] == argActiveWindow && args[1] == argJSON {
+			switch {
+			case internal == hyprlandFullscreenNone && client == hyprlandFullscreenNone:
+				return []byte(`{"fullscreen":0,"fullscreenClient":0}`), nil
+			case internal == hyprlandFullscreenMaximized && client == hyprlandFullscreenMaximized:
+				return []byte(`{"fullscreen":1,"fullscreenClient":1}`), nil
+			default:
+				t.Fatalf("unexpected test state internal=%d client=%d", internal, client)
+			}
+		}
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) == 4 && args[0] == argDispatch && args[1] == argFullscreenState {
+			switch args[2] {
+			case argHyprlandNone:
+				internal, client = hyprlandFullscreenNone, hyprlandFullscreenNone
+			case argHyprlandMaximized:
+				internal, client = hyprlandFullscreenMaximized, hyprlandFullscreenMaximized
+			}
+		}
+		return []byte("ok"), nil
+	}
+
+	b := newHyprlandWindowBackend()
+	if err := b.Maximize(0, true, false); err != nil {
+		t.Fatalf("maximize failed: %v", err)
+	}
+	if err := b.Maximize(0, false, false); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+
+	want := [][]string{
+		{argDispatch, argFullscreenState, argHyprlandMaximized, argHyprlandMaximized},
+		{argDispatch, argFullscreenState, argHyprlandNone, argHyprlandNone},
+	}
+	if len(calls) != len(want) {
+		t.Fatalf("calls = %#v, want %#v", calls, want)
+	}
+	for i := range want {
+		if len(calls[i]) != len(want[i]) {
+			t.Fatalf("call %d = %#v, want %#v", i, calls[i], want[i])
+		}
+		for j := range want[i] {
+			if calls[i][j] != want[i][j] {
+				t.Fatalf("call %d = %#v, want %#v", i, calls[i], want[i])
+			}
+		}
+	}
+}
+
+func TestHyprlandWindowBackendMaximizeAvoidsLegacyToggle(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	dispatches := 0
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdHyprCtl {
+			t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
+		}
+		if len(args) == 2 && args[0] == argActiveWindow && args[1] == argJSON {
+			return []byte(`{"fullscreen":1,"fullscreenClient":1}`), nil
+		}
+		dispatches++
+		return []byte("ok"), nil
+	}
+
+	b := newHyprlandWindowBackend()
+	if err := b.Maximize(0, true, false); err != nil {
+		t.Fatalf("maximize already-maximized window: %v", err)
+	}
+	if dispatches != 0 {
+		t.Fatalf("already-maximized state dispatched %d commands; older Hyprland would toggle it off", dispatches)
+	}
+}
+
+func TestHyprlandWindowBackendMaximizeRejectsUnreliableState(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	tests := []struct {
+		name string
+		json string
+	}{
+		{name: "missing client state", json: `{"fullscreen":0}`},
+		{name: "invalid internal state", json: `{"fullscreen":4,"fullscreenClient":0}`},
+		{name: "invalid client state", json: `{"fullscreen":0,"fullscreenClient":-2}`},
+		{name: "malformed response", json: `{"fullscreen":`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runWindowCommand = func(context.Context, string, ...string) ([]byte, error) {
+				return []byte(tt.json), nil
+			}
+
+			err := newHyprlandWindowBackend().Maximize(0, true, false)
+			if !errors.Is(err, errWindowStateUnavailable) {
+				t.Fatalf("Maximize() error = %v, want errWindowStateUnavailable", err)
+			}
+		})
+	}
+}
+
+func TestHyprlandWindowBackendMaximizePreservesCommandError(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	wantErr := errors.New("dispatch failed")
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdHyprCtl {
+			t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
+		}
+		if len(args) == 2 && args[0] == argActiveWindow && args[1] == argJSON {
+			return []byte(`{"fullscreen":0,"fullscreenClient":0}`), nil
+		}
+		return nil, wantErr
+	}
+
+	err := newHyprlandWindowBackend().Maximize(0, true, false)
+	if !errors.Is(err, errWindowOperationFailed) {
+		t.Fatalf("Maximize() error = %v, want errWindowOperationFailed", err)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Maximize() error = %v, want wrapped command error", err)
+	}
+}
+
+func TestHyprlandWindowBackendRestorePreservesFullscreen(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	dispatches := 0
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdHyprCtl {
+			t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
+		}
+		if len(args) == 2 && args[0] == argActiveWindow && args[1] == argJSON {
+			return []byte(`{"fullscreen":2,"fullscreenClient":2}`), nil
+		}
+		dispatches++
+		return []byte("ok"), nil
+	}
+
+	if err := newHyprlandWindowBackend().Maximize(0, false, false); err != nil {
+		t.Fatalf("restore fullscreen window: %v", err)
+	}
+	if dispatches != 0 {
+		t.Fatalf("restore on fullscreen state dispatched %d commands; want no-op", dispatches)
+	}
+}
+
+func TestNonHyprlandWindowBackendsRejectMaximizedQuery(t *testing.T) {
+	backends := []windowBackend{
+		newSwayWindowBackend(),
+		newWlrootsGenericWindowBackend(),
+		waylandCoreWindowBackend{compositor: compositorMutter},
+	}
+	for _, backend := range backends {
+		_, err := backend.Maximized()
+		if !errors.Is(err, ErrNotSupported) {
+			t.Fatalf("%s Maximized() error = %v, want ErrNotSupported", backend.Name(), err)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

- route `IsMaximizedE` through the Linux window backend and implement trustworthy Hyprland active-window state queries
- implement Hyprland maximize and restore with exact internal/client `fullscreenstate` values
- preserve pure fullscreen on restore and avoid legacy Hyprland toggle behavior by reading state before dispatch
- keep Sway, generic wlroots, and Wayland core queries explicitly unsupported
- add public API regression tests, version-compatibility cases, an opt-in real Hyprland integration test, and a runnable example
- update README, test documentation, Wayland status, and the product roadmap

## Why

Phase 4 calls for compositor-backed window state only where the compositor exposes trustworthy state. Hyprland provides numeric internal/client fullscreen modes, while Sway and generic wlroots do not expose an equivalent maximized-state query. This adds real support without treating fullscreen as maximized or fabricating state on unsupported backends.

The implementation deliberately uses the long-standing `fullscreenstate` dispatcher after querying current state. Older Hyprland releases interpreted newer `set`/`unset` arguments as a toggle, which could invert the requested state.

## User impact

On Hyprland, `IsMaximizedE()` now reports the active window's compositor state and `MaxWindowE(0, true|false)` can maximize or restore it. Pure fullscreen remains distinct. Unsupported compositors continue returning `ErrNotSupported`.

## Validation

- `go test ./...`
- `go test -tags wayland ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test -tags "wayland integration" . ./mouse ./window`

The real Hyprland mutation test is opt-in via `ROBOTGO_HYPRLAND_MAXIMIZE_E2E=1`; it refuses decoupled/fullscreen initial states and restores and verifies the original normal/maximized state.