### PR TITLE
fix: harden capture helper parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,14 @@ On Linux, `GetPixelColor` and `GetPxColor` use the selected capture backend for
 a 1x1 region. Out-of-bounds coordinates and capture failures therefore return
 an error instead of being indistinguishable from a valid black pixel.
 
+`CaptureBitmapStr` serializes the selected backend's captured pixels in the
+versioned `robotgo.bitmap.v1` format. `FindBitmapStr` accepts one optional
+serialized haystack and otherwise captures the screen; its result is relative
+to that haystack. `FindColorCS` searches an explicit capture region and returns
+absolute screen coordinates. Its optional tolerance defaults to `0.01` and
+must be a finite value from `0` (exact) through `1` (any RGB color). All three
+helpers preserve capture backend errors.
+
 `GetLinuxCapabilities` reports the detected session, compositor, selected
 feature backends, fallbacks, and unsupported reasons:
 
@@ -634,6 +642,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Pure-Go Windows window inspection and opt-in control](examples/purego_windows_window/main.go)
 - [Consent-aware RemoteDesktop portal input](examples/remote_desktop_input/main.go)
 - [Persistent ScreenCast/PipeWire capture](examples/screencast_capture/main.go)
+- [Bitmap-string and region color-search helpers](examples/capture_helpers/main.go)
 - [Hyprland active-window maximize state](examples/wayland_window_state/main.go)
 - [Window and process helpers](examples/window/main.go)
 - [Display scaling](examples/scale/main.go)

--- a/TEST.md
+++ b/TEST.md
@@ -516,6 +516,7 @@ CGO_ENABLED=0 go test ./...
 go test -tags "wayland" ./...
 go test -tags "portal" ./screen/portal -v
 go test -tags "pipewire" ./screen/portal -v
+go test -tags "wayland test" ./screen -run 'TestScreencopy(BitmapStringHelper|WlShm|PortalFallback)' -v
 go test -tags "wayland integration" . ./mouse ./window -v
 ```
 

--- a/bitmap_common.go
+++ b/bitmap_common.go
@@ -5,12 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"unsafe"
 )
 
 const (
-	bitmapStringFormat  = "robotgo.bitmap.v1"
-	maxBitmapBufferSize = 512 * 1024 * 1024
+	bitmapStringFormat      = "robotgo.bitmap.v1"
+	maxBitmapBufferSize     = 512 * 1024 * 1024
+	defaultColorTolerance   = 0.01
+	minimumRGBBytesPerPixel = 3
+	maximumRGBBytesPerPixel = 4
 )
 
 type bitmapStringPayload struct {
@@ -158,6 +162,9 @@ func CaptureBitmapStr(args ...int) (string, error) {
 
 // FindBitmapStr searches for needleStr inside haystackStr.
 func FindBitmapStr(needleStr string, haystackStr ...string) (int, int, error) {
+	if len(haystackStr) > 1 {
+		return -1, -1, fmt.Errorf("find bitmap string accepts at most one haystack, got %d", len(haystackStr))
+	}
 	needle, err := BitmapFromStr(needleStr)
 	if err != nil {
 		return -1, -1, err
@@ -174,29 +181,29 @@ func FindBitmapStr(needleStr string, haystackStr ...string) (int, int, error) {
 	return findBitmap(haystack, needle)
 }
 
-// FindColorCS searches a captured region for a color with optional tolerance.
+// FindColorCS searches a captured region for a color and returns absolute
+// screen coordinates. Tolerance is optional, defaults to 0.01, and must be a
+// finite value in the inclusive range 0 through 1.
 func FindColorCS(x, y, width, height int, color CHex, tolerance ...float64) (int, int, error) {
 	if width <= 0 || height <= 0 {
 		return -1, -1, fmt.Errorf("invalid search region %dx%d", width, height)
 	}
-	tol := 0.0
-	if len(tolerance) > 0 {
-		tol = tolerance[0]
-	}
-	if tol < 0 {
-		return -1, -1, fmt.Errorf("invalid color tolerance %f", tol)
+	tol, err := parseColorTolerance(tolerance)
+	if err != nil {
+		return -1, -1, err
 	}
 	bmp, err := CaptureGo(x, y, width, height)
+	if err != nil {
+		return -1, -1, err
+	}
+	buf, err := bitmapRGBBuffer(bmp)
 	if err != nil {
 		return -1, -1, err
 	}
 	r, g, b := splitHex(uint32(color))
 	for yy := 0; yy < bmp.Height; yy++ {
 		for xx := 0; xx < bmp.Width; xx++ {
-			pr, pg, pb, ok := bitmapRGBAt(bmp, xx, yy)
-			if !ok {
-				return -1, -1, errors.New("invalid bitmap pixel layout")
-			}
+			pr, pg, pb := bitmapRGBAtBuffer(bmp, buf, xx, yy)
 			if rgbSimilar(pr, pg, pb, r, g, b, tol) {
 				return x + xx, y + yy, nil
 			}
@@ -208,6 +215,20 @@ func FindColorCS(x, y, width, height int, color CHex, tolerance ...float64) (int
 // FindcolorCS preserves the historical RobotGo-Pro spelling.
 func FindcolorCS(x, y, width, height int, color CHex, tolerance ...float64) (int, int, error) {
 	return FindColorCS(x, y, width, height, color, tolerance...)
+}
+
+func parseColorTolerance(tolerance []float64) (float64, error) {
+	if len(tolerance) > 1 {
+		return 0, fmt.Errorf("color search accepts at most one tolerance, got %d", len(tolerance))
+	}
+	value := defaultColorTolerance
+	if len(tolerance) == 1 {
+		value = tolerance[0]
+	}
+	if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 || value > 1 {
+		return 0, fmt.Errorf("invalid color tolerance %v: expected a finite value from 0 through 1", value)
+	}
+	return value, nil
 }
 
 func splitHex(hex uint32) (uint8, uint8, uint8) {
@@ -226,22 +247,37 @@ func bitmapRGBAt(bit Bitmap, x, y int) (uint8, uint8, uint8, bool) {
 	if x < 0 || y < 0 || x >= bit.Width || y >= bit.Height {
 		return 0, 0, 0, false
 	}
-	buf, err := bitmapReadableBuffer(bit)
+	buf, err := bitmapRGBBuffer(bit)
 	if err != nil {
 		return 0, 0, 0, false
 	}
-	offset := y*bit.Bytewidth + x*int(bit.BytesPerPixel)
-	if offset < 0 || offset > len(buf)-3 {
-		return 0, 0, 0, false
+	r, g, b := bitmapRGBAtBuffer(bit, buf, x, y)
+	return r, g, b, true
+}
+
+func bitmapRGBBuffer(bit Bitmap) ([]byte, error) {
+	if bit.BytesPerPixel < minimumRGBBytesPerPixel ||
+		bit.BytesPerPixel > maximumRGBBytesPerPixel {
+		return nil, fmt.Errorf(
+			"unsupported bitmap bytesPerPixel=%d; RGB operations require 3 or 4",
+			bit.BytesPerPixel,
+		)
 	}
-	return buf[offset+2], buf[offset+1], buf[offset], true
+	return bitmapReadableBuffer(bit)
+}
+
+func bitmapRGBAtBuffer(bit Bitmap, buf []byte, x, y int) (uint8, uint8, uint8) {
+	offset := y*bit.Bytewidth + x*int(bit.BytesPerPixel)
+	return buf[offset+2], buf[offset+1], buf[offset]
 }
 
 func findBitmap(haystack, needle Bitmap) (int, int, error) {
-	if _, err := bitmapReadableBuffer(haystack); err != nil {
+	haystackBuf, err := bitmapRGBBuffer(haystack)
+	if err != nil {
 		return -1, -1, err
 	}
-	if _, err := bitmapReadableBuffer(needle); err != nil {
+	needleBuf, err := bitmapRGBBuffer(needle)
+	if err != nil {
 		return -1, -1, err
 	}
 	if needle.Width > haystack.Width || needle.Height > haystack.Height {
@@ -249,7 +285,7 @@ func findBitmap(haystack, needle Bitmap) (int, int, error) {
 	}
 	for y := 0; y <= haystack.Height-needle.Height; y++ {
 		for x := 0; x <= haystack.Width-needle.Width; x++ {
-			if bitmapMatchesAt(haystack, needle, x, y) {
+			if bitmapMatchesAt(haystack, haystackBuf, needle, needleBuf, x, y) {
 				return x, y, nil
 			}
 		}
@@ -257,15 +293,18 @@ func findBitmap(haystack, needle Bitmap) (int, int, error) {
 	return -1, -1, nil
 }
 
-func bitmapMatchesAt(haystack, needle Bitmap, startX, startY int) bool {
+func bitmapMatchesAt(
+	haystack Bitmap,
+	haystackBuf []byte,
+	needle Bitmap,
+	needleBuf []byte,
+	startX, startY int,
+) bool {
 	for y := 0; y < needle.Height; y++ {
 		for x := 0; x < needle.Width; x++ {
-			hr, hg, hb, ok := bitmapRGBAt(haystack, startX+x, startY+y)
-			if !ok {
-				return false
-			}
-			nr, ng, nb, ok := bitmapRGBAt(needle, x, y)
-			if !ok || hr != nr || hg != ng || hb != nb {
+			hr, hg, hb := bitmapRGBAtBuffer(haystack, haystackBuf, startX+x, startY+y)
+			nr, ng, nb := bitmapRGBAtBuffer(needle, needleBuf, x, y)
+			if hr != nr || hg != ng || hb != nb {
 				return false
 			}
 		}

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -255,6 +255,11 @@ The compatibility surface now includes:
 - Bitmap string helpers (`CaptureBitmapStr`, `FindBitmapStr`, `BitmapFromStr`,
   `ToStrBitmap`).
 - Region/tolerance color search through `FindColorCS`/`FindcolorCS`.
+- Cross-build helper contracts covering versioned bitmap round-trips, strict
+  RGB layout validation, default/explicit color tolerance, absolute region
+  coordinates, and capture-error propagation. Hermetic tests exercise native
+  Wayland screencopy, the Screenshot portal, and Pure-Go backend dispatch;
+  generic string/search tests run in both CGO and non-CGO builds.
 - Hook/event capability reporting on Wayland.
 
 Remaining work must improve runtime support without inventing misleading
@@ -262,8 +267,8 @@ cross-platform semantics:
 
 - Extend compositor-backed state/query behavior beyond the delivered Hyprland
   maximize slice only where equally trustworthy state is exposed.
-- Validate bitmap and color-search behavior across capture backends and
-  supported platforms.
+- Add protected real-desktop capture-helper evidence beyond the delivered
+  hermetic native Wayland, portal, and cross-build backend contracts.
 - Stable multi-screen and bounds behavior for negative origins, transforms,
   scale, and absent display identifiers.
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -75,6 +75,10 @@ Current implementation baseline:
 - Bitmap string helpers are available via `CaptureBitmapStr`,
   `FindBitmapStr`, `BitmapFromStr`, and `ToStrBitmap`.
 - Region/tolerance color search is available via `FindColorCS`/`FindcolorCS`.
+- Bitmap-string and color-search contracts run in CGO and non-CGO builds.
+  Hermetic backend tests cover native screencopy, Screenshot portal, and
+  Pure-Go dispatch. `FindColorCS` returns absolute coordinates, defaults to
+  `0.01` tolerance, validates the `0..1` range, and preserves backend errors.
 - Explicit RemoteDesktop portal sessions are available through `input/portal`:
   live capability probing, consent/session lifecycle, pointer/keyboard notify
   methods, cancellation, denial, timeout, and teardown are covered hermetically.
@@ -181,9 +185,10 @@ backends.
   - Extend compositor-backed implementations for existing topmost/min/max
     status APIs where Wayland protocols or helpers make the state observable.
   - Extend bitmap string helper coverage beyond current in-memory string
-    helpers where needed; file open/save helpers remain separate.
-  - Keep `FindColorCS` compatibility behavior covered across platform capture
-    backends.
+    and hermetic capture-backend contracts where real protected desktop
+    evidence is needed; file open/save helpers remain separate.
+  - Keep the delivered `FindColorCS` compatibility contract covered on real
+    protected platform capture runners.
   - Keep any new APIs consistent with Wayland semantics:
     - Return explicit `NotSupported` where protocol/compositor limitations apply.
 - Build/Tooling:

--- a/examples/capture_helpers/main.go
+++ b/examples/capture_helpers/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	x := flag.Int("x", 0, "capture/search region x coordinate")
+	y := flag.Int("y", 0, "capture/search region y coordinate")
+	width := flag.Int("width", 100, "capture/search region width")
+	height := flag.Int("height", 100, "capture/search region height")
+	colorHex := flag.String("color", "", "optional RGB color to find, for example 33ccff")
+	tolerance := flag.Float64("tolerance", 0.01, "color tolerance from 0 through 1")
+	flag.Parse()
+
+	serialized, err := robotgo.CaptureBitmapStr(*x, *y, *width, *height)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "capture bitmap string:", err)
+		os.Exit(1)
+	}
+	bitmap, err := robotgo.BitmapFromStr(serialized)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "decode bitmap string:", err)
+		os.Exit(1)
+	}
+	fmt.Printf(
+		"backend=%s bitmap=%dx%d serialized-bytes=%d\n",
+		robotgo.LastBackend(),
+		bitmap.Width,
+		bitmap.Height,
+		len(serialized),
+	)
+
+	matchX, matchY, err := robotgo.FindBitmapStr(serialized, serialized)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "find bitmap string:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("serialized bitmap round-trip match=(%d,%d)\n", matchX, matchY)
+
+	if strings.TrimSpace(*colorHex) == "" {
+		return
+	}
+	rawColor := strings.TrimPrefix(strings.TrimSpace(*colorHex), "#")
+	if len(rawColor) >= 2 && strings.EqualFold(rawColor[:2], "0x") {
+		rawColor = rawColor[2:]
+	}
+	value, err := strconv.ParseUint(rawColor, 16, 24)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parse -color:", err)
+		os.Exit(2)
+	}
+	matchX, matchY, err = robotgo.FindColorCS(
+		*x,
+		*y,
+		*width,
+		*height,
+		robotgo.CHex(value),
+		*tolerance,
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "find color:", err)
+		os.Exit(1)
+	}
+	if matchX < 0 {
+		fmt.Println("color not found")
+		return
+	}
+	fmt.Printf("color found at absolute screen coordinate (%d,%d)\n", matchX, matchY)
+}

--- a/img_cgo_test.go
+++ b/img_cgo_test.go
@@ -1,0 +1,32 @@
+//go:build cgo
+
+package robotgo
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"testing"
+)
+
+func TestOwnedBitmapFromCStaysValidAfterFree(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	src.SetRGBA(0, 0, color.RGBA{R: 21, G: 22, B: 23, A: 255})
+
+	cbit := ToCBitmap(RGBAToBitmap(src))
+	owned, err := ownedBitmapFromC(cbit)
+	FreeBitmap(cbit)
+	if err != nil {
+		t.Fatalf("ownedBitmapFromC error: %v", err)
+	}
+
+	got := ToRGBAGo(owned)
+	if !bytes.Equal(src.Pix, got.Pix) {
+		t.Fatalf("owned bitmap mismatch after FreeBitmap: %v vs %v", src.Pix, got.Pix)
+	}
+	if _, err := ToStrBitmap(owned); err != nil {
+		t.Fatalf("ToStrBitmap on owned bitmap after FreeBitmap error: %v", err)
+	}
+}

--- a/img_test.go
+++ b/img_test.go
@@ -1,11 +1,10 @@
-//go:build cgo
-
 package robotgo
 
 import (
 	"bytes"
 	"image"
 	"image/color"
+	"math"
 	"testing"
 )
 
@@ -69,28 +68,6 @@ func TestBitmapStringRoundTripAndFind(t *testing.T) {
 	}
 }
 
-func TestOwnedBitmapFromCStaysValidAfterFree(t *testing.T) {
-	t.Parallel()
-
-	src := image.NewRGBA(image.Rect(0, 0, 1, 1))
-	src.SetRGBA(0, 0, color.RGBA{R: 21, G: 22, B: 23, A: 255})
-
-	cbit := ToCBitmap(RGBAToBitmap(src))
-	owned, err := ownedBitmapFromC(cbit)
-	FreeBitmap(cbit)
-	if err != nil {
-		t.Fatalf("ownedBitmapFromC error: %v", err)
-	}
-
-	got := ToRGBAGo(owned)
-	if !bytes.Equal(src.Pix, got.Pix) {
-		t.Fatalf("owned bitmap mismatch after FreeBitmap: %v vs %v", src.Pix, got.Pix)
-	}
-	if _, err := ToStrBitmap(owned); err != nil {
-		t.Fatalf("ToStrBitmap on owned bitmap after FreeBitmap error: %v", err)
-	}
-}
-
 func TestFindColorCSSignatureOrder(t *testing.T) {
 	t.Parallel()
 
@@ -109,6 +86,93 @@ func TestBitmapStringInvalid(t *testing.T) {
 	}
 	if _, err := ToStrBitmap(Bitmap{}); err == nil {
 		t.Fatalf("expected invalid bitmap error")
+	}
+}
+
+func TestBitmapStringRejectsUnsupportedRGBSearchLayout(t *testing.T) {
+	t.Parallel()
+
+	twoByteBitmap, err := NewBitmap([]byte{1, 2, 3, 4}, 2, 1, 4, 16, 2)
+	if err != nil {
+		t.Fatalf("NewBitmap error: %v", err)
+	}
+	serialized, err := ToStrBitmap(twoByteBitmap)
+	if err != nil {
+		t.Fatalf("ToStrBitmap error: %v", err)
+	}
+	if _, _, err := FindBitmapStr(serialized, serialized); err == nil {
+		t.Fatal("FindBitmapStr unexpectedly accepted a two-byte pixel layout")
+	}
+}
+
+func TestFindBitmapStrRejectsMultipleHaystacks(t *testing.T) {
+	t.Parallel()
+
+	bitmap, err := NewBitmap([]byte{1, 2, 3}, 1, 1, 3, 24, 3)
+	if err != nil {
+		t.Fatalf("NewBitmap error: %v", err)
+	}
+	serialized, err := ToStrBitmap(bitmap)
+	if err != nil {
+		t.Fatalf("ToStrBitmap error: %v", err)
+	}
+	if _, _, err := FindBitmapStr(serialized, serialized, serialized); err == nil {
+		t.Fatal("FindBitmapStr unexpectedly accepted multiple haystacks")
+	}
+}
+
+func TestFindBitmapStrSupportsThreeBytePixelsAndPaddedStride(t *testing.T) {
+	t.Parallel()
+
+	haystack, err := NewBitmap(
+		[]byte{
+			3, 2, 1, 6, 5, 4, 99, 99,
+			9, 8, 7, 12, 11, 10, 88, 88,
+		},
+		2,
+		2,
+		8,
+		24,
+		3,
+	)
+	if err != nil {
+		t.Fatalf("NewBitmap haystack error: %v", err)
+	}
+	needle, err := NewBitmap([]byte{12, 11, 10}, 1, 1, 3, 24, 3)
+	if err != nil {
+		t.Fatalf("NewBitmap needle error: %v", err)
+	}
+	haystackStr, err := ToStrBitmap(haystack)
+	if err != nil {
+		t.Fatalf("ToStrBitmap haystack error: %v", err)
+	}
+	needleStr, err := ToStrBitmap(needle)
+	if err != nil {
+		t.Fatalf("ToStrBitmap needle error: %v", err)
+	}
+	x, y, err := FindBitmapStr(needleStr, haystackStr)
+	if err != nil {
+		t.Fatalf("FindBitmapStr error: %v", err)
+	}
+	if x != 1 || y != 1 {
+		t.Fatalf("FindBitmapStr = (%d,%d), want (1,1)", x, y)
+	}
+}
+
+func TestParseColorTolerance(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseColorTolerance(nil)
+	if err != nil || got != defaultColorTolerance {
+		t.Fatalf("parseColorTolerance(nil) = %v, %v; want %v, nil", got, err, defaultColorTolerance)
+	}
+	for _, value := range []float64{-0.01, 1.01, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		if _, err := parseColorTolerance([]float64{value}); err == nil {
+			t.Fatalf("parseColorTolerance(%v) unexpectedly succeeded", value)
+		}
+	}
+	if _, err := parseColorTolerance([]float64{0, 0}); err == nil {
+		t.Fatal("parseColorTolerance unexpectedly accepted multiple values")
 	}
 }
 

--- a/robotgo_nocgo_capture_helpers_test.go
+++ b/robotgo_nocgo_capture_helpers_test.go
@@ -1,0 +1,151 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"image"
+	"image/color"
+	"math"
+	"runtime"
+	"testing"
+)
+
+func preservePureGoCaptureHelperState(t *testing.T) {
+	t.Helper()
+	capture := pureGoCaptureImage
+	backend := LastBackend()
+	t.Cleanup(func() {
+		pureGoCaptureImage = capture
+		setPureGoCaptureBackend(backend)
+	})
+}
+
+func TestPureGoCaptureHelperParity(t *testing.T) {
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		t.Skipf("Pure-Go capture is unsupported on %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	preservePureGoCaptureHelperState(t)
+	if runtime.GOOS == "linux" {
+		t.Setenv(envWaylandDisplay, "")
+		t.Setenv(envDisplay, ":99")
+		t.Setenv(envXDGSessionType, "x11")
+	}
+
+	const (
+		regionX = -10
+		regionY = 20
+		width   = 2
+		height  = 2
+	)
+	captureCalls := 0
+	pureGoCaptureImage = func(args ...int) (image.Image, error) {
+		if len(args) != 0 {
+			want := []int{regionX, regionY, width, height}
+			if len(args) != len(want) {
+				t.Fatalf("capture args = %v, want %v", args, want)
+			}
+			for i := range want {
+				if args[i] != want[i] {
+					t.Fatalf("capture args = %v, want %v", args, want)
+				}
+			}
+		}
+		captureCalls++
+		img := image.NewRGBA(image.Rect(0, 0, width, height))
+		img.SetRGBA(1, 1, color.RGBA{R: 50, G: 60, B: 70, A: 255})
+		return img, nil
+	}
+
+	serialized, err := CaptureBitmapStr(regionX, regionY, width, height)
+	if err != nil {
+		t.Fatalf("CaptureBitmapStr error: %v", err)
+	}
+	decoded, err := BitmapFromStr(serialized)
+	if err != nil {
+		t.Fatalf("BitmapFromStr error: %v", err)
+	}
+	r, g, b, ok := bitmapRGBAt(decoded, 1, 1)
+	if !ok || r != 50 || g != 60 || b != 70 {
+		t.Fatalf("decoded target pixel = %d,%d,%d,%v; want 50,60,70,true", r, g, b, ok)
+	}
+
+	needleImage := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	needleImage.SetRGBA(0, 0, color.RGBA{R: 50, G: 60, B: 70, A: 255})
+	needle, err := ToStrBitmap(RGBAToBitmap(needleImage))
+	if err != nil {
+		t.Fatalf("serialize needle: %v", err)
+	}
+	x, y, err := FindBitmapStr(needle)
+	if err != nil {
+		t.Fatalf("FindBitmapStr capture error: %v", err)
+	}
+	if x != 1 || y != 1 {
+		t.Fatalf("FindBitmapStr capture result = (%d,%d), want (1,1)", x, y)
+	}
+
+	x, y, err = FindColorCS(regionX, regionY, width, height, CHex(0x333c46))
+	if err != nil {
+		t.Fatalf("FindColorCS default tolerance error: %v", err)
+	}
+	if x != regionX+1 || y != regionY+1 {
+		t.Fatalf("FindColorCS = (%d,%d), want (%d,%d)", x, y, regionX+1, regionY+1)
+	}
+
+	x, y, err = FindcolorCS(regionX, regionY, width, height, CHex(0x333c46), 0)
+	if err != nil {
+		t.Fatalf("FindcolorCS exact tolerance error: %v", err)
+	}
+	if x != -1 || y != -1 {
+		t.Fatalf("FindcolorCS exact result = (%d,%d), want (-1,-1)", x, y)
+	}
+
+	if captureCalls != 4 {
+		t.Fatalf("capture calls = %d, want 4", captureCalls)
+	}
+	if got, want := LastBackend(), pureGoScreenshotBackend(runtime.GOOS); got != want {
+		t.Fatalf("LastBackend = %q, want %q", got, want)
+	}
+}
+
+func TestPureGoCaptureHelpersPreserveBackendErrors(t *testing.T) {
+	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
+		t.Skipf("Pure-Go capture is unsupported on %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	preservePureGoCaptureHelperState(t)
+	if runtime.GOOS == "linux" {
+		t.Setenv(envWaylandDisplay, "")
+		t.Setenv(envDisplay, ":99")
+		t.Setenv(envXDGSessionType, "x11")
+	}
+
+	wantErr := errors.New("capture failed")
+	calls := 0
+	pureGoCaptureImage = func(...int) (image.Image, error) {
+		calls++
+		return nil, wantErr
+	}
+	needle, err := ToStrBitmap(RGBAToBitmap(image.NewRGBA(image.Rect(0, 0, 1, 1))))
+	if err != nil {
+		t.Fatalf("serialize needle: %v", err)
+	}
+
+	if _, _, err := FindColorCS(0, 0, 1, 1, CHex(0), math.NaN()); err == nil {
+		t.Fatal("FindColorCS unexpectedly accepted a NaN tolerance")
+	}
+	if calls != 0 {
+		t.Fatalf("invalid tolerance reached capture backend %d times", calls)
+	}
+	if _, err := CaptureBitmapStr(0, 0, 1, 1); !errors.Is(err, wantErr) {
+		t.Fatalf("CaptureBitmapStr error = %v, want wrapped capture error", err)
+	}
+	if _, _, err := FindBitmapStr(needle); !errors.Is(err, wantErr) {
+		t.Fatalf("FindBitmapStr error = %v, want wrapped capture error", err)
+	}
+	if _, _, err := FindColorCS(0, 0, 1, 1, CHex(0)); !errors.Is(err, wantErr) {
+		t.Fatalf("FindColorCS error = %v, want wrapped capture error", err)
+	}
+	if calls != 3 {
+		t.Fatalf("capture backend calls = %d, want 3", calls)
+	}
+}

--- a/robotgo_nocgo_capture_test.go
+++ b/robotgo_nocgo_capture_test.go
@@ -403,6 +403,50 @@ func TestPureGoCaptureImgReportsExplicitUnsupported(t *testing.T) {
 	}
 }
 
+func TestPureGoPortalCaptureHelperParity(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv(envWaylandDisplay, "wayland-test")
+	t.Setenv(envDisplay, "")
+	t.Setenv(envDisablePortal, "")
+
+	calls := 0
+	pureGoPortalCaptureImage = func(_ context.Context, x, y, width, height int) (image.Image, error) {
+		if x != -4 || y != 7 || width != 2 || height != 2 {
+			t.Fatalf("portal region = (%d,%d %dx%d), want (-4,7 2x2)", x, y, width, height)
+		}
+		calls++
+		img := image.NewRGBA(image.Rect(0, 0, width, height))
+		img.SetRGBA(1, 0, color.RGBA{R: 10, G: 20, B: 30, A: 255})
+		return img, nil
+	}
+
+	serialized, err := CaptureBitmapStr(-4, 7, 2, 2)
+	if err != nil {
+		t.Fatalf("CaptureBitmapStr error: %v", err)
+	}
+	decoded, err := BitmapFromStr(serialized)
+	if err != nil {
+		t.Fatalf("BitmapFromStr error: %v", err)
+	}
+	if decoded.Width != 2 || decoded.Height != 2 {
+		t.Fatalf("decoded bitmap = %dx%d, want 2x2", decoded.Width, decoded.Height)
+	}
+
+	x, y, err := FindColorCS(-4, 7, 2, 2, CHex(0x0a141e), 0)
+	if err != nil {
+		t.Fatalf("FindColorCS error: %v", err)
+	}
+	if x != -3 || y != 7 {
+		t.Fatalf("FindColorCS = (%d,%d), want (-3,7)", x, y)
+	}
+	if calls != 2 {
+		t.Fatalf("portal capture calls = %d, want 2", calls)
+	}
+	if LastBackend() != BackendPortal {
+		t.Fatalf("LastBackend = %q, want %q", LastBackend(), BackendPortal)
+	}
+}
+
 func TestPureGoCaptureImgWrapsPortalFailure(t *testing.T) {
 	preservePureGoCaptureFakes(t)
 	t.Setenv("WAYLAND_DISPLAY", "wayland-test")

--- a/screen/capture_test.go
+++ b/screen/capture_test.go
@@ -51,6 +51,7 @@ func TestCaptureScreen(t *testing.T) {
 		t.Setenv("DISPLAY", "")
 		t.Setenv("WAYLAND_DISPLAY", "")
 		t.Setenv("ROBOTGO_FORCE_PORTAL", "1")
+		t.Setenv("ROBOTGO_DISABLE_PORTAL", "1")
 		t.Setenv("ROBOTGO_PORTAL_STUB_GREEN", "1")
 		img, err := robotgo.CaptureImg()
 		if err != nil {
@@ -61,6 +62,33 @@ func TestCaptureScreen(t *testing.T) {
 		}
 		if lb := robotgo.LastBackend(); lb != robotgo.BackendPortal {
 			t.Fatalf("expected portal backend, got %v", lb)
+		}
+
+		serialized, err := robotgo.CaptureBitmapStr(10, 20, 2, 2)
+		if err != nil {
+			t.Fatalf("portal CaptureBitmapStr failed: %v", err)
+		}
+		decoded, err := robotgo.BitmapFromStr(serialized)
+		if err != nil {
+			t.Fatalf("portal BitmapFromStr failed: %v", err)
+		}
+		if decoded.Width != 2 || decoded.Height != 2 {
+			t.Fatalf("portal decoded bitmap = %dx%d, want 2x2", decoded.Width, decoded.Height)
+		}
+		x, y, err := robotgo.FindBitmapStr(serialized)
+		if err != nil {
+			t.Fatalf("portal FindBitmapStr capture failed: %v", err)
+		}
+		if x != 0 || y != 0 {
+			t.Fatalf("portal FindBitmapStr = (%d,%d), want (0,0)", x, y)
+		}
+
+		x, y, err = robotgo.FindColorCS(10, 20, 2, 2, robotgo.CHex(0x00ff00), 0)
+		if err != nil {
+			t.Fatalf("portal FindColorCS failed: %v", err)
+		}
+		if x != 10 || y != 20 {
+			t.Fatalf("portal FindColorCS = (%d,%d), want (10,20)", x, y)
 		}
 	})
 }

--- a/screen/screengrab_wayland_test.go
+++ b/screen/screengrab_wayland_test.go
@@ -124,6 +124,36 @@ func TestScreencopyWlShm(t *testing.T) {
 
 }
 
+func TestScreencopyBitmapStringHelper(t *testing.T) {
+	dir := t.TempDir()
+	sock := "robotgo-wl-bitmap-string"
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+	t.Setenv("WAYLAND_DISPLAY", sock)
+	t.Setenv("ROBOTGO_DISABLE_PORTAL", "1")
+	robotgo.SetWaylandBackend(robotgo.WaylandBackendWlShm)
+	t.Cleanup(func() { robotgo.SetWaylandBackend(robotgo.WaylandBackendAuto) })
+
+	done := make(chan struct{})
+	startMockServer(sock, 0, 0, 0, done)
+	t.Cleanup(func() { cleanupMockServer(t, done) })
+	waitForMockServer(t, dir, sock)
+
+	serialized, err := robotgo.CaptureBitmapStr()
+	if err != nil {
+		t.Fatalf("CaptureBitmapStr failed: %v", err)
+	}
+	decoded, err := robotgo.BitmapFromStr(serialized)
+	if err != nil {
+		t.Fatalf("BitmapFromStr failed: %v", err)
+	}
+	if decoded.Width <= 0 || decoded.Height <= 0 {
+		t.Fatalf("decoded bitmap has invalid dimensions %dx%d", decoded.Width, decoded.Height)
+	}
+	if got := robotgo.LastBackend(); got != robotgo.BackendScreencopy {
+		t.Fatalf("backend = %q, want %q", got, robotgo.BackendScreencopy)
+	}
+}
+
 func TestScreencopyPortalFallback(t *testing.T) {
 	dir := t.TempDir()
 	sock := "robotgo-wl"


### PR DESCRIPTION
## Ziel

Die Bitmap-String- und Farbsuch-Helfer sollen auf nativen, Portal- und Pure-Go-Capture-Backends denselben überprüfbaren Vertrag erfüllen.

## Änderungen

- stellt den historischen `FindColorCS`-Standardwert `0.01` wieder her und validiert genau einen endlichen Toleranzwert in `0..1`
- dokumentiert absolute Koordinaten für `FindColorCS` und relative Koordinaten für `FindBitmapStr`
- lehnt mehrdeutige Mehrfach-Haystacks und nicht unterstützte 1-/2-Byte-Pixellayouts explizit ab
- unterstützt validierte 3-/4-Byte-BGR(A)-Bitmaps einschließlich gepaddeter Strides
- validiert Bitmap-Puffer einmal pro Suche statt pro Pixel
- deckt implizite Capture-Pfade, Backend-Fehler und `LastBackend` für Pure-Go, Portal und native Wayland-screencopy ab
- verschiebt generische Bitmap-Tests aus dem CGO-only Scope und ergänzt ein ausführbares Beispiel
- aktualisiert README, TEST und Roadmap

## Validierung

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -tags wayland ./...`
- `go test -tags portal ./screen/portal -count=1 -v`
- `go test -tags "wayland test" ./screen -run 'TestScreencopy(BitmapStringHelper|WlShm|PortalFallback)' -count=1 -v`
- `go test -race ./...`
- `go test -race -tags "wayland waylandint" . -run '^TestWaylandPublic' -count=1 -v`
- `go vet ./...`
- `golangci-lint run`
- Non-CGO Cross-Compile-Tests für Windows/amd64 und Darwin/arm64

Die Weston-Bounds-Integration wurde lokal mangels installiertem Weston erwartungsgemäß übersprungen; sie ist von diesem Helper-Block nicht betroffen.

## Risiko

Bewusst sichtbare Vertragsverschärfung: zusätzliche optionale Argumente und ungültige/nicht-endliche Toleranzen liefern nun Fehler statt stillschweigend ignoriert zu werden. Der historische Standardwert `0.01` wird wieder konsistent verwendet.