### PR TITLE
fix: stabilize Wayland multi-display bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,17 @@ pure X11 session it reports Window and Hook capabilities as unavailable;
 error-returning window operations return `ErrNotSupported`. Use the default
 Linux build for an X11 session.
 
+Wayland display bounds use logical compositor coordinates. `GetScreenRect()`
+and any negative display index return the aggregate desktop rectangle,
+including a negative origin. `GetScreenSize()` returns that aggregate width and
+height. Non-negative indices select individual outputs in deterministic order:
+the output containing logical `(0,0)` is index `0`, followed by top-to-bottom,
+left-to-right geometry order. `DisplaysNum()` and `GetMainId()` query Wayland
+directly and do not require Xwayland. An out-of-range index returns a zero
+rectangle; it never silently falls back to the aggregate desktop. Native
+`xdg-output` logical geometry takes precedence, preserving fractional scale;
+the core-output fallback applies integer scale and all eight transforms.
+
 Capture selection is:
 
 1. Native `wlr-screencopy` using DMA-BUF when supported.
@@ -635,6 +646,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Keyboard and clipboard](examples/key/main.go)
 - [Screen capture and pixels](examples/screen/main.go)
 - [Full-screen capture with backend reporting](examples/screen_full/main.go)
+- [Cross-platform aggregate and per-output bounds](examples/display_bounds/main.go)
 - [Linux capabilities](examples/linux_capabilities/main.go)
 - [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
 - [Pure-Go X11 input probe and opt-in demo](examples/purego_x11_input/main.go)

--- a/TEST.md
+++ b/TEST.md
@@ -181,6 +181,8 @@ Purpose:
 - Linux Wayland screencopy/mock-server coverage
 - Hermetic native crop mapping for multi-output coordinates, fractional scale,
   overflow boundaries, and all eight output transforms
+- Hermetic aggregate/per-output bounds for negative origins, fractional
+  `xdg-output` geometry, stable display indices, scale, and all transforms
 - DRM helper tests
 
 Typical command:

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -260,6 +260,11 @@ The compatibility surface now includes:
   coordinates, and capture-error propagation. Hermetic tests exercise native
   Wayland screencopy, the Screenshot portal, and Pure-Go backend dispatch;
   generic string/search tests run in both CGO and non-CGO builds.
+- Native Wayland aggregate/per-output bounds preserve negative origins,
+  fractional `xdg-output` logical sizes, integer core-output scale, and all
+  transforms. Display indices are deterministic and shared with screencopy;
+  display count/main-index queries no longer depend on X11. The
+  `wayland-info` fallback also handles output records without numeric IDs.
 - Hook/event capability reporting on Wayland.
 
 Remaining work must improve runtime support without inventing misleading
@@ -269,8 +274,8 @@ cross-platform semantics:
   maximize slice only where equally trustworthy state is exposed.
 - Add protected real-desktop capture-helper evidence beyond the delivered
   hermetic native Wayland, portal, and cross-build backend contracts.
-- Stable multi-screen and bounds behavior for negative origins, transforms,
-  scale, and absent display identifiers.
+- Collect protected real-compositor multi-output bounds evidence beyond the
+  delivered hermetic geometry matrix and single-output Weston integration.
 
 Every addition needs unit tests, an applicable runtime integration test, and a
 runnable example unless the environment makes one technically impossible.

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -51,6 +51,11 @@ Current implementation baseline:
 - Fallback output bounds use short success/failure TTLs and can be refreshed
   explicitly with `InvalidateScreenBoundsCache`, so hotplug and scale changes
   do not remain cached for the lifetime of the process.
+- Native aggregate/per-output bounds preserve logical negative origins,
+  fractional `xdg-output` sizes, core-output scale, and all transforms.
+  Deterministic output indices are shared with screencopy, Wayland display
+  count/main-index queries avoid X11, and the `wayland-info` fallback accepts
+  output records without numeric identifiers.
 - An explicitly started ScreenCast session provides reusable PipeWire frames
   behind the `pipewire` build tag. It preserves stream geometry/serial metadata,
   supports logical region crop with fractional scaling, converts negotiated raw
@@ -179,7 +184,8 @@ backends.
 - Window APIs:
   - Extend compositor-backed move/resize/activate/topmost/minimize/title
     behavior while preserving explicit `ErrNotSupported` elsewhere.
-  - Make `GetBounds`/`GetClient` robust via `xdg-output` (multi-output + fractional scaling).
+  - Validate the delivered `GetBounds`/`GetClient` `xdg-output` multi-output
+    and fractional-scale contract on protected wlroots/GNOME/KDE runners.
   - Add resource‑leak checks for Wayland window helpers.
 - API Parity Follow-up:
   - Extend compositor-backed implementations for existing topmost/min/max

--- a/examples/display_bounds/main.go
+++ b/examples/display_bounds/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	desktop := robotgo.GetScreenRect()
+	width, height := robotgo.GetScreenSize()
+	fmt.Printf(
+		"desktop: origin=(%d,%d) size=%dx%d (GetScreenSize=%dx%d)\n",
+		desktop.X,
+		desktop.Y,
+		desktop.W,
+		desktop.H,
+		width,
+		height,
+	)
+
+	count := robotgo.DisplaysNum()
+	mainID := robotgo.GetMainId()
+	fmt.Printf("outputs: %d, primary index: %d\n", count, mainID)
+	for displayID := 0; displayID < count; displayID++ {
+		rect := robotgo.GetScreenRect(displayID)
+		fmt.Printf(
+			"output[%d]: origin=(%d,%d) size=%dx%d primary=%t\n",
+			displayID,
+			rect.X,
+			rect.Y,
+			rect.W,
+			rect.H,
+			displayID == mainID,
+		)
+	}
+}

--- a/get_bounds_wayland.c
+++ b/get_bounds_wayland.c
@@ -8,8 +8,6 @@
 #include <string.h>
 
 struct registry_data {
-  struct wl_compositor **compositor;
-  struct xdg_wm_base **wm_base;
   struct zxdg_output_manager_v1 **xdg_output_manager;
   struct wl_list *outputs;
 };
@@ -18,6 +16,7 @@ struct output_info {
   struct wl_list link;
   struct wl_output *output;
   struct zxdg_output_v1 *xdg_output;
+  uint32_t name;
   int32_t x;
   int32_t y;
   int32_t logical_x;
@@ -87,6 +86,220 @@ static void output_logical_origin(const struct output_info *oi, int *ox, int *oy
     *oy = oi->y;
   }
 }
+
+struct output_rect_ref {
+  const struct output_info *output;
+  int x;
+  int y;
+  int w;
+  int h;
+  int primary;
+};
+
+static int output_rect(const struct output_info *oi,
+                       struct output_rect_ref *rect) {
+  if (!oi || !rect) {
+    return -1;
+  }
+
+  int w = 0;
+  int h = 0;
+  int x = 0;
+  int y = 0;
+  output_logical_size(oi, &w, &h);
+  output_logical_origin(oi, &x, &y);
+  if (w <= 0 || h <= 0) {
+    return -1;
+  }
+
+  long long right = (long long)x + (long long)w;
+  long long bottom = (long long)y + (long long)h;
+  if (right > INT_MAX || right < INT_MIN ||
+      bottom > INT_MAX || bottom < INT_MIN) {
+    return -1;
+  }
+
+  rect->output = oi;
+  rect->x = x;
+  rect->y = y;
+  rect->w = w;
+  rect->h = h;
+  rect->primary = x <= 0 && right > 0 && y <= 0 && bottom > 0;
+  return 0;
+}
+
+static int compare_output_rect_refs(const void *left, const void *right) {
+  const struct output_rect_ref *a = left;
+  const struct output_rect_ref *b = right;
+  if (a->primary != b->primary) {
+    return b->primary - a->primary;
+  }
+  if (a->y != b->y) {
+    return a->y < b->y ? -1 : 1;
+  }
+  if (a->x != b->x) {
+    return a->x < b->x ? -1 : 1;
+  }
+  if (a->output->name != b->output->name) {
+    return a->output->name < b->output->name ? -1 : 1;
+  }
+  return 0;
+}
+
+static int collect_output_rects(struct wl_list *outputs,
+                                struct output_rect_ref **rects_out) {
+  if (!outputs || !rects_out) {
+    return -1;
+  }
+
+  int capacity = 0;
+  struct output_info *oi;
+  wl_list_for_each(oi, outputs, link) {
+    capacity++;
+  }
+  if (capacity <= 0) {
+    return 0;
+  }
+
+  struct output_rect_ref *rects =
+      calloc((size_t)capacity, sizeof(*rects));
+  if (!rects) {
+    return -1;
+  }
+
+  int count = 0;
+  wl_list_for_each(oi, outputs, link) {
+    if (output_rect(oi, &rects[count]) == 0) {
+      count++;
+    }
+  }
+  if (count == 0) {
+    free(rects);
+    return 0;
+  }
+
+  qsort(rects, (size_t)count, sizeof(*rects), compare_output_rect_refs);
+  *rects_out = rects;
+  return count;
+}
+
+static int resolve_output_rect(struct wl_list *outputs, int display_id,
+                               int *x, int *y, int *width, int *height) {
+  struct output_rect_ref *rects = NULL;
+  int count = collect_output_rects(outputs, &rects);
+  if (count <= 0) {
+    return -1;
+  }
+
+  long long min_x;
+  long long min_y;
+  long long max_x;
+  long long max_y;
+  if (display_id >= 0) {
+    if (display_id >= count) {
+      free(rects);
+      return -1;
+    }
+    const struct output_rect_ref *rect = &rects[display_id];
+    min_x = rect->x;
+    min_y = rect->y;
+    max_x = (long long)rect->x + rect->w;
+    max_y = (long long)rect->y + rect->h;
+  } else {
+    min_x = rects[0].x;
+    min_y = rects[0].y;
+    max_x = (long long)rects[0].x + rects[0].w;
+    max_y = (long long)rects[0].y + rects[0].h;
+    for (int i = 1; i < count; i++) {
+      long long right = (long long)rects[i].x + rects[i].w;
+      long long bottom = (long long)rects[i].y + rects[i].h;
+      if (rects[i].x < min_x) {
+        min_x = rects[i].x;
+      }
+      if (rects[i].y < min_y) {
+        min_y = rects[i].y;
+      }
+      if (right > max_x) {
+        max_x = right;
+      }
+      if (bottom > max_y) {
+        max_y = bottom;
+      }
+    }
+  }
+  free(rects);
+
+  long long w = max_x - min_x;
+  long long h = max_y - min_y;
+  if (min_x < INT_MIN || min_x > INT_MAX ||
+      min_y < INT_MIN || min_y > INT_MAX ||
+      w <= 0 || w > INT_MAX || h <= 0 || h > INT_MAX) {
+    return -1;
+  }
+  if (x) {
+    *x = (int)min_x;
+  }
+  if (y) {
+    *y = (int)min_y;
+  }
+  if (width) {
+    *width = (int)w;
+  }
+  if (height) {
+    *height = (int)h;
+  }
+  return 0;
+}
+
+#ifdef ROBOTGO_WAYLAND_TEST
+int robotgo_wayland_resolve_bounds_for_test(const int *values, int count,
+                                             int display_id,
+                                             int *x, int *y,
+                                             int *width, int *height) {
+  if (!values || count <= 0) {
+    return -1;
+  }
+
+  struct wl_list outputs;
+  wl_list_init(&outputs);
+  for (int i = 0; i < count; i++) {
+    const int *value = &values[i * 12];
+    struct output_info *oi = calloc(1, sizeof(*oi));
+    if (!oi) {
+      struct output_info *item, *tmp;
+      wl_list_for_each_safe(item, tmp, &outputs, link) {
+        wl_list_remove(&item->link);
+        free(item);
+      }
+      return -1;
+    }
+    oi->x = value[0];
+    oi->y = value[1];
+    oi->mode_w = value[2];
+    oi->mode_h = value[3];
+    oi->transform = value[4];
+    oi->scale = value[5];
+    oi->logical_x = value[6];
+    oi->logical_y = value[7];
+    oi->logical_w = value[8];
+    oi->logical_h = value[9];
+    oi->has_mode = value[2] > 0 && value[3] > 0;
+    oi->has_logical_pos = (value[10] & 1) != 0;
+    oi->has_logical_size = (value[10] & 2) != 0;
+    oi->name = (uint32_t)value[11];
+    wl_list_insert(outputs.prev, &oi->link);
+  }
+
+  int result =
+      resolve_output_rect(&outputs, display_id, x, y, width, height);
+  struct output_info *oi, *tmp;
+  wl_list_for_each_safe(oi, tmp, &outputs, link) {
+    wl_list_remove(&oi->link);
+    free(oi);
+  }
+  return result;
+}
+#endif
 
 static void output_geometry(void *data, struct wl_output *output,
                             int32_t x, int32_t y, int32_t physical_width,
@@ -198,13 +411,7 @@ static void registry_handle_global(void *data, struct wl_registry *registry,
                                    uint32_t name, const char *interface,
                                    uint32_t version) {
   struct registry_data *rdata = data;
-  if (strcmp(interface, "wl_compositor") == 0) {
-    *rdata->compositor =
-        wl_registry_bind(registry, name, &wl_compositor_interface, 1);
-  } else if (strcmp(interface, "xdg_wm_base") == 0) {
-    *rdata->wm_base =
-        wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
-  } else if (strcmp(interface, zxdg_output_manager_v1_interface.name) == 0) {
+  if (strcmp(interface, zxdg_output_manager_v1_interface.name) == 0) {
     uint32_t ver = version > 3 ? 3 : version;
     *rdata->xdg_output_manager =
         wl_registry_bind(registry, name, &zxdg_output_manager_v1_interface, ver);
@@ -220,6 +427,7 @@ static void registry_handle_global(void *data, struct wl_registry *registry,
       return;
     }
     oi->scale = 1;
+    oi->name = name;
     uint32_t ver = version > 2 ? 2 : version;
     oi->output = wl_registry_bind(registry, name, &wl_output_interface, ver);
     if (!oi->output) {
@@ -239,81 +447,12 @@ static const struct wl_registry_listener registry_listener = {
     .global_remove = NULL,
 };
 
-struct bounds_data {
-  int *width;
-  int *height;
-};
-
-static void xdg_toplevel_handle_configure(void *data,
-                                          struct xdg_toplevel *toplevel,
-                                          int32_t width, int32_t height,
-                                          struct wl_array *states) {
-  struct bounds_data *bdata = data;
-  if (bdata->width) {
-    *bdata->width = width;
+static void cleanup_outputs(struct wl_list *outputs) {
+  if (!outputs) {
+    return;
   }
-  if (bdata->height) {
-    *bdata->height = height;
-  }
-}
-
-static const struct xdg_toplevel_listener xdg_toplevel_listener = {
-    .configure = xdg_toplevel_handle_configure,
-    .close = NULL,
-};
-
-int get_bounds_wayland(struct wl_display *display, int *width, int *height) {
-  if (!display) {
-    return -1;
-  }
-
-  struct wl_compositor *compositor = NULL;
-  struct xdg_wm_base *wm_base = NULL;
-  struct zxdg_output_manager_v1 *xdg_output_manager = NULL;
-  struct wl_list outputs;
-  wl_list_init(&outputs);
-  struct registry_data rdata = {&compositor, &wm_base, &xdg_output_manager, &outputs};
-
-  struct wl_registry *registry = wl_display_get_registry(display);
-  wl_registry_add_listener(registry, &registry_listener, &rdata);
-  wl_display_roundtrip(display);
-  wl_registry_destroy(registry);
-  // Drain wl_output listeners.
-  wl_display_roundtrip(display);
-
-  int min_x = INT_MAX;
-  int min_y = INT_MAX;
-  int max_x = INT_MIN;
-  int max_y = INT_MIN;
   struct output_info *oi, *tmp;
-  wl_list_for_each(oi, &outputs, link) {
-    if (!oi->has_mode || oi->mode_w <= 0 || oi->mode_h <= 0) {
-      continue;
-    }
-    int lw = 0;
-    int lh = 0;
-    int ox = 0;
-    int oy = 0;
-    output_logical_size(oi, &lw, &lh);
-    output_logical_origin(oi, &ox, &oy);
-    if (lw <= 0 || lh <= 0) {
-      continue;
-    }
-    if (ox < min_x) {
-      min_x = ox;
-    }
-    if (oy < min_y) {
-      min_y = oy;
-    }
-    if (ox + lw > max_x) {
-      max_x = ox + lw;
-    }
-    if (oy + lh > max_y) {
-      max_y = oy + lh;
-    }
-  }
-
-  wl_list_for_each_safe(oi, tmp, &outputs, link) {
+  wl_list_for_each_safe(oi, tmp, outputs, link) {
     if (oi->xdg_output) {
       zxdg_output_v1_destroy(oi->xdg_output);
     }
@@ -323,72 +462,115 @@ int get_bounds_wayland(struct wl_display *display, int *width, int *height) {
     wl_list_remove(&oi->link);
     free(oi);
   }
+}
 
-  if (min_x != INT_MAX && max_x > min_x && max_y > min_y) {
-    if (width) {
-      *width = max_x - min_x;
-    }
-    if (height) {
-      *height = max_y - min_y;
-    }
-    if (wm_base) {
-      xdg_wm_base_destroy(wm_base);
-    }
-    if (xdg_output_manager) {
-      zxdg_output_manager_v1_destroy(xdg_output_manager);
-    }
-    if (compositor) {
-      wl_compositor_destroy(compositor);
-    }
-    return 0;
-  }
-
-  if (!compositor || !wm_base) {
-    if (wm_base) {
-      xdg_wm_base_destroy(wm_base);
-    }
-    if (xdg_output_manager) {
-      zxdg_output_manager_v1_destroy(xdg_output_manager);
-    }
-    if (compositor) {
-      wl_compositor_destroy(compositor);
-    }
-    return -1;
-  }
-
-  struct wl_surface *surface = wl_compositor_create_surface(compositor);
-  if (!surface) {
-    return -1;
-  }
-
-  struct xdg_surface *xdg_surface =
-      xdg_wm_base_get_xdg_surface(wm_base, surface);
-  if (!xdg_surface) {
-    wl_surface_destroy(surface);
-    return -1;
-  }
-
-  struct bounds_data bdata = {width, height};
-  struct xdg_toplevel *xdg_toplevel = xdg_surface_get_toplevel(xdg_surface);
-  xdg_toplevel_add_listener(xdg_toplevel, &xdg_toplevel_listener, &bdata);
-
-  wl_surface_commit(surface);
-  wl_display_roundtrip(display);
-
-  xdg_toplevel_destroy(xdg_toplevel);
-  xdg_surface_destroy(xdg_surface);
-  wl_surface_destroy(surface);
-  xdg_wm_base_destroy(wm_base);
+static void cleanup_xdg_output_manager(
+    struct zxdg_output_manager_v1 *xdg_output_manager) {
   if (xdg_output_manager) {
     zxdg_output_manager_v1_destroy(xdg_output_manager);
   }
-  wl_compositor_destroy(compositor);
+}
 
-  if (width && *width <= 0) {
+int get_screen_rect_wayland(struct wl_display *display, int display_id,
+                            int *x, int *y, int *width, int *height) {
+  if (!display) {
     return -1;
   }
-  if (height && *height <= 0) {
+
+  struct zxdg_output_manager_v1 *xdg_output_manager = NULL;
+  struct wl_list outputs;
+  wl_list_init(&outputs);
+  struct registry_data rdata = {&xdg_output_manager, &outputs};
+
+  struct wl_registry *registry = wl_display_get_registry(display);
+  if (!registry ||
+      wl_registry_add_listener(registry, &registry_listener, &rdata) != 0) {
+    if (registry) {
+      wl_registry_destroy(registry);
+    }
     return -1;
   }
-  return 0;
+  int ready = wl_display_roundtrip(display) >= 0;
+  wl_registry_destroy(registry);
+  // Drain wl_output listeners.
+  if (ready) {
+    ready = wl_display_roundtrip(display) >= 0;
+  }
+  if (!ready) {
+    cleanup_outputs(&outputs);
+    cleanup_xdg_output_manager(xdg_output_manager);
+    return -1;
+  }
+
+  int resolved_x = 0;
+  int resolved_y = 0;
+  int resolved_w = 0;
+  int resolved_h = 0;
+  int resolved = resolve_output_rect(&outputs, display_id,
+                                     &resolved_x, &resolved_y,
+                                     &resolved_w, &resolved_h);
+  cleanup_outputs(&outputs);
+
+  if (resolved == 0) {
+    if (x) {
+      *x = resolved_x;
+    }
+    if (y) {
+      *y = resolved_y;
+    }
+    if (width) {
+      *width = resolved_w;
+    }
+    if (height) {
+      *height = resolved_h;
+    }
+    cleanup_xdg_output_manager(xdg_output_manager);
+    return 0;
+  }
+
+  cleanup_xdg_output_manager(xdg_output_manager);
+  return -1;
+}
+
+int get_bounds_wayland(struct wl_display *display, int *width, int *height) {
+  return get_screen_rect_wayland(display, -1, NULL, NULL, width, height);
+}
+
+static int query_display_count(struct wl_display *display) {
+  if (!display) {
+    return 0;
+  }
+
+  struct zxdg_output_manager_v1 *xdg_output_manager = NULL;
+  struct wl_list outputs;
+  wl_list_init(&outputs);
+  struct registry_data rdata = {&xdg_output_manager, &outputs};
+
+  struct wl_registry *registry = wl_display_get_registry(display);
+  if (!registry) {
+    return 0;
+  }
+  int ready =
+      wl_registry_add_listener(registry, &registry_listener, &rdata) == 0 &&
+      wl_display_roundtrip(display) >= 0;
+  wl_registry_destroy(registry);
+  if (ready) {
+    ready = wl_display_roundtrip(display) >= 0;
+  }
+
+  struct output_rect_ref *rects = NULL;
+  int count = ready ? collect_output_rects(&outputs, &rects) : 0;
+  free(rects);
+
+  cleanup_outputs(&outputs);
+  cleanup_xdg_output_manager(xdg_output_manager);
+  return count > 0 ? count : 0;
+}
+
+int get_num_displays_wayland(struct wl_display *display) {
+  return query_display_count(display);
+}
+
+int get_main_display_wayland(struct wl_display *display) {
+  return query_display_count(display) > 0 ? 0 : -1;
 }

--- a/robotgo.go
+++ b/robotgo.go
@@ -545,18 +545,17 @@ func isWaylandSession() bool {
 }
 
 var (
-	reWaylandOutputID = regexp.MustCompile(`name:\s*([0-9]+)\s*$`)
-	rePosXY           = regexp.MustCompile(`x:\s*(-?[0-9]+),\s*y:\s*(-?[0-9]+)`)
-	reLogicalXY       = regexp.MustCompile(`logical_x:\s*(-?[0-9]+),\s*logical_y:\s*(-?[0-9]+)`)
-	reLogicalWH       = regexp.MustCompile(`logical_width:\s*([0-9]+),\s*logical_height:\s*([0-9]+)`)
-	reModeWH          = regexp.MustCompile(`width:\s*([0-9]+)\s*px,\s*height:\s*([0-9]+)\s*px`)
-	reXDGOutputID     = regexp.MustCompile(`output:\s*([0-9]+)\s*$`)
+	reWaylandOutputID  = regexp.MustCompile(`name:\s*([0-9]+)\s*$`)
+	rePosXY            = regexp.MustCompile(`x:\s*(-?[0-9]+),\s*y:\s*(-?[0-9]+)`)
+	reLogicalXY        = regexp.MustCompile(`logical_x:\s*(-?[0-9]+),\s*logical_y:\s*(-?[0-9]+)`)
+	reLogicalWH        = regexp.MustCompile(`logical_width:\s*([0-9]+),\s*logical_height:\s*([0-9]+)`)
+	reModeWH           = regexp.MustCompile(`width:\s*([0-9]+)\s*px,\s*height:\s*([0-9]+)\s*px`)
+	reXDGOutputID      = regexp.MustCompile(`output:\s*([0-9]+)\s*$`)
+	reWaylandScale     = regexp.MustCompile(`scale:\s*([0-9]+)`)
+	reWaylandTransform = regexp.MustCompile(
+		`transform:\s*([[:alnum:]_-]+)`,
+	)
 )
-
-type waylandOutputBounds struct {
-	x, y int
-	w, h int
-}
 
 type waylandWLModeState struct {
 	w, h int
@@ -671,9 +670,12 @@ func parseWaylandInfoBounds(raw string) (Rect, bool) {
 		pendingMode   waylandWLModeState
 		hasPending    bool
 		expectModeVal bool
+		scale         int
+		transform     int
 	}
 
 	xdgBounds := make(map[int]waylandOutputBounds)
+	var logicalBounds []waylandOutputBounds
 	var wlBounds []waylandOutputBounds
 
 	inXDG := false
@@ -682,7 +684,7 @@ func parseWaylandInfoBounds(raw string) (Rect, bool) {
 	var ws wlState
 
 	commitXDG := func() {
-		if !xs.hasID || !xs.hasLogicalWH {
+		if !xs.hasLogicalWH {
 			return
 		}
 		x := 0
@@ -691,16 +693,20 @@ func parseWaylandInfoBounds(raw string) (Rect, bool) {
 			x = xs.logicalX
 			y = xs.logicalY
 		}
-		xdgBounds[xs.outputID] = waylandOutputBounds{
+		bounds := waylandOutputBounds{
 			x: x,
 			y: y,
 			w: xs.logicalW,
 			h: xs.logicalH,
 		}
+		logicalBounds = append(logicalBounds, bounds)
+		if xs.hasID {
+			xdgBounds[xs.outputID] = bounds
+		}
 	}
 
 	commitWL := func() {
-		if !ws.hasID || !ws.hasPos {
+		if !ws.hasPos {
 			return
 		}
 		w := 0
@@ -713,8 +719,22 @@ func parseWaylandInfoBounds(raw string) (Rect, bool) {
 		if w <= 0 || h <= 0 {
 			return
 		}
-		if b, ok := xdgBounds[ws.outputID]; ok && b.w > 0 && b.h > 0 {
-			wlBounds = append(wlBounds, b)
+		if ws.hasID {
+			if b, ok := xdgBounds[ws.outputID]; ok && b.w > 0 && b.h > 0 {
+				wlBounds = append(wlBounds, b)
+				return
+			}
+		}
+		scale := ws.scale
+		if scale <= 0 {
+			scale = 1
+		}
+		w /= scale
+		h /= scale
+		if waylandTransformRotatesDimensions(ws.transform) {
+			w, h = h, w
+		}
+		if w <= 0 || h <= 0 {
 			return
 		}
 		wlBounds = append(wlBounds, waylandOutputBounds{
@@ -723,6 +743,10 @@ func parseWaylandInfoBounds(raw string) (Rect, bool) {
 			w: w,
 			h: h,
 		})
+	}
+
+	newWLState := func() wlState {
+		return wlState{scale: 1, transform: waylandTransformNormal}
 	}
 
 	sc := bufio.NewScanner(strings.NewReader(raw))
@@ -741,11 +765,11 @@ func parseWaylandInfoBounds(raw string) (Rect, bool) {
 			if inWL {
 				commitWL()
 				inWL = false
-				ws = wlState{}
+				ws = newWLState()
 			}
 			if strings.HasPrefix(line, "interface: 'wl_output'") {
 				inWL = true
-				ws = wlState{}
+				ws = newWLState()
 				if m := reWaylandOutputID.FindStringSubmatch(line); len(m) == 2 {
 					if id, err := strconv.Atoi(m[1]); err == nil {
 						ws.outputID = id
@@ -796,6 +820,16 @@ func parseWaylandInfoBounds(raw string) (Rect, bool) {
 		}
 
 		if inWL {
+			if m := reWaylandScale.FindStringSubmatch(line); len(m) == 2 {
+				if scale, err := strconv.Atoi(m[1]); err == nil && scale > 0 {
+					ws.scale = scale
+				}
+			}
+			if m := reWaylandTransform.FindStringSubmatch(line); len(m) == 2 {
+				if transform, ok := parseWaylandTransform(m[1]); ok {
+					ws.transform = transform
+				}
+			}
 			if m := rePosXY.FindStringSubmatch(line); len(m) == 3 {
 				x, errX := strconv.Atoi(m[1])
 				y, errY := strconv.Atoi(m[2])
@@ -837,6 +871,9 @@ func parseWaylandInfoBounds(raw string) (Rect, bool) {
 			}
 		}
 	}
+	if sc.Err() != nil {
+		return Rect{}, false
+	}
 
 	if inXDG {
 		commitXDG()
@@ -845,40 +882,11 @@ func parseWaylandInfoBounds(raw string) (Rect, bool) {
 		commitWL()
 	}
 
-	if len(wlBounds) == 0 {
-		return Rect{}, false
+	if len(logicalBounds) > 0 &&
+		(len(wlBounds) == 0 || len(logicalBounds) == len(wlBounds)) {
+		return aggregateWaylandOutputBounds(logicalBounds)
 	}
-	minX := wlBounds[0].x
-	minY := wlBounds[0].y
-	maxX := wlBounds[0].x + wlBounds[0].w
-	maxY := wlBounds[0].y + wlBounds[0].h
-
-	for i := 1; i < len(wlBounds); i++ {
-		b := wlBounds[i]
-		if b.x < minX {
-			minX = b.x
-		}
-		if b.y < minY {
-			minY = b.y
-		}
-		if b.x+b.w > maxX {
-			maxX = b.x + b.w
-		}
-		if b.y+b.h > maxY {
-			maxY = b.y + b.h
-		}
-	}
-
-	w := maxX - minX
-	h := maxY - minY
-	if w <= 0 || h <= 0 {
-		return Rect{}, false
-	}
-
-	return Rect{
-		Point{X: minX, Y: minY},
-		Size{W: w, H: h},
-	}, true
+	return aggregateWaylandOutputBounds(wlBounds)
 }
 
 func captureDebugf(format string, args ...interface{}) {
@@ -1223,7 +1231,7 @@ func GetScreenRect(displayId ...int) Rect {
 	unlock := lockNativeX11Display()
 	rect := getScreenRectLocked(display, false)
 	unlock()
-	if (rect.W <= 0 || rect.H <= 0) && isWaylandSession() {
+	if display < 0 && (rect.W <= 0 || rect.H <= 0) && isWaylandSession() {
 		if wlRect, ok := waylandScreenBoundsFallback(); ok {
 			return wlRect
 		}

--- a/robotgo_linux.go
+++ b/robotgo_linux.go
@@ -39,21 +39,8 @@ import (
 // Wayland or X11 implementation based on DetectDisplayServer.
 func GetBounds(pid int, args ...int) (int, int, int, int) {
 	if base.DetectDisplayServer() == base.Wayland {
-		display := C.wl_display_connect(nil)
-		if display == nil {
-			log.Println("wl_display_connect failed")
-			rect := GetScreenRect(-1)
-			return rect.X, rect.Y, rect.W, rect.H
-		}
-		defer C.wl_display_disconnect(display)
-
-		var w, h C.int
-		if C.get_bounds_wayland(display, &w, &h) != 0 {
-			log.Println("get_bounds_wayland failed")
-			rect := GetScreenRect(-1)
-			return rect.X, rect.Y, rect.W, rect.H
-		}
-		return 0, 0, int(w), int(h)
+		rect := GetScreenRect(-1)
+		return rect.X, rect.Y, rect.W, rect.H
 	}
 	if !nativeX11BackendCompiled() {
 		return 0, 0, 0, 0
@@ -78,21 +65,8 @@ func GetBounds(pid int, args ...int) (int, int, int, int) {
 // Wayland or X11 implementation based on DetectDisplayServer.
 func GetClient(pid int, args ...int) (int, int, int, int) {
 	if base.DetectDisplayServer() == base.Wayland {
-		display := C.wl_display_connect(nil)
-		if display == nil {
-			log.Println("wl_display_connect failed")
-			rect := GetScreenRect(-1)
-			return rect.X, rect.Y, rect.W, rect.H
-		}
-		defer C.wl_display_disconnect(display)
-
-		var w, h C.int
-		if C.get_bounds_wayland(display, &w, &h) != 0 {
-			log.Println("get_bounds_wayland failed")
-			rect := GetScreenRect(-1)
-			return rect.X, rect.Y, rect.W, rect.H
-		}
-		return 0, 0, int(w), int(h)
+		rect := GetScreenRect(-1)
+		return rect.X, rect.Y, rect.W, rect.H
 	}
 	if !nativeX11BackendCompiled() {
 		return 0, 0, 0, 0
@@ -255,8 +229,18 @@ func GetXidByPid(xu *xgbutil.XUtil, pid int) (xproto.Window, error) {
 	return 0, errors.New("failed to find a window with a matching pid")
 }
 
-// DisplaysNum get the count of displays
+// DisplaysNum returns the number of outputs exposed by the active display
+// server without routing Wayland sessions through X11.
 func DisplaysNum() int {
+	if base.DetectDisplayServer() == base.Wayland {
+		display := C.wl_display_connect(nil)
+		if display == nil {
+			return 0
+		}
+		defer C.wl_display_disconnect(display)
+		return int(C.get_num_displays_wayland(display))
+	}
+
 	c, err := xgb.NewConn()
 	if err != nil {
 		return 0
@@ -276,8 +260,19 @@ func DisplaysNum() int {
 	return int(reply.Number)
 }
 
-// GetMainId get the main display id
+// GetMainId returns the primary display index for the active display server.
+// Wayland output indices are deterministic: the output containing logical
+// coordinate (0,0) is first, followed by geometry order.
 func GetMainId() int {
+	if base.DetectDisplayServer() == base.Wayland {
+		display := C.wl_display_connect(nil)
+		if display == nil {
+			return -1
+		}
+		defer C.wl_display_disconnect(display)
+		return int(C.get_main_display_wayland(display))
+	}
+
 	conn, err := xgb.NewConn()
 	if err != nil {
 		return -1

--- a/robotgo_wayland_cap_test.go
+++ b/robotgo_wayland_cap_test.go
@@ -4,6 +4,7 @@ package robotgo
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -151,6 +152,70 @@ interface: 'wl_output',                                  version:  4, name: 58
 	}
 	if rect.X != 10 || rect.Y != 20 || rect.W != 800 || rect.H != 600 {
 		t.Fatalf("unexpected bounds: %+v", rect)
+	}
+}
+
+func TestParseWaylandInfoBoundsWithoutOutputIdentifiers(t *testing.T) {
+	raw := `interface: 'zxdg_output_manager_v1', version: 3
+	xdg_output_v1
+		logical_x: -1280, logical_y: 0
+		logical_width: 1280, logical_height: 720
+	xdg_output_v1
+		logical_x: 0, logical_y: -900
+		logical_width: 1600, logical_height: 900
+interface: 'wl_output', version: 4
+	x: -1920, y: 0, scale: 1,
+	mode:
+		width: 1920 px, height: 1080 px, refresh: 60.000 Hz,
+		flags: current
+interface: 'wl_output', version: 4
+	x: 0, y: -900, scale: 1,
+	mode:
+		width: 2400 px, height: 1350 px, refresh: 60.000 Hz,
+		flags: current
+`
+	rect, ok := parseWaylandInfoBounds(raw)
+	if !ok {
+		t.Fatal("expected identifier-free xdg-output parse success")
+	}
+	if want := (Rect{
+		Point: Point{X: -1280, Y: -900},
+		Size:  Size{W: 2880, H: 1620},
+	}); rect != want {
+		t.Fatalf("identifier-free logical bounds = %+v, want %+v", rect, want)
+	}
+}
+
+func TestParseWaylandInfoBoundsCoreFallbackScaleAndTransform(t *testing.T) {
+	raw := `interface: 'wl_output', version: 4
+	x: -800, y: 20, physical_width: 600 mm, physical_height: 340 mm,
+	transform: 90,
+	scale: 2
+	mode:
+		width: 2400 px, height: 1600 px, refresh: 60.000 Hz,
+		flags: current
+`
+	rect, ok := parseWaylandInfoBounds(raw)
+	if !ok {
+		t.Fatal("expected core-output fallback parse success")
+	}
+	if want := (Rect{
+		Point: Point{X: -800, Y: 20},
+		Size:  Size{W: 800, H: 1200},
+	}); rect != want {
+		t.Fatalf("scaled transformed bounds = %+v, want %+v", rect, want)
+	}
+}
+
+func TestParseWaylandInfoBoundsRejectsOverflow(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	raw := fmt.Sprintf(`interface: 'zxdg_output_manager_v1', version: 3
+	xdg_output_v1
+		logical_x: %d, logical_y: 0
+		logical_width: 2, logical_height: 1
+`, maxInt)
+	if rect, ok := parseWaylandInfoBounds(raw); ok {
+		t.Fatalf("overflowing bounds unexpectedly parsed as %+v", rect)
 	}
 }
 

--- a/screen/screen_c.h
+++ b/screen/screen_c.h
@@ -16,20 +16,30 @@
 #endif
 
 #if defined(IS_LINUX) && defined(ROBOTGO_USE_WAYLAND)
-static inline int wayland_main_bounds(int32_t *w, int32_t *h) {
+static inline int wayland_screen_rect(int32_t display_id, int32_t *x,
+                                      int32_t *y, int32_t *w, int32_t *h) {
     struct wl_display *display = wl_display_connect(NULL);
     if (!display) {
         return -1;
     }
 
+    int xx = 0;
+    int yy = 0;
     int ww = 0;
     int hh = 0;
-    int rc = get_bounds_wayland(display, &ww, &hh);
+    int rc = get_screen_rect_wayland(display, display_id,
+                                     &xx, &yy, &ww, &hh);
     wl_display_disconnect(display);
     if (rc != 0 || ww <= 0 || hh <= 0) {
         return -1;
     }
 
+    if (x) {
+        *x = (int32_t)xx;
+    }
+    if (y) {
+        *y = (int32_t)yy;
+    }
     if (w) {
         *w = (int32_t)ww;
     }
@@ -37,6 +47,10 @@ static inline int wayland_main_bounds(int32_t *w, int32_t *h) {
         *h = (int32_t)hh;
     }
     return 0;
+}
+
+static inline int wayland_main_bounds(int32_t *w, int32_t *h) {
+    return wayland_screen_rect(-1, NULL, NULL, w, h);
 }
 #endif
 
@@ -184,11 +198,13 @@ static inline MMRectInt32 getScreenRect(int32_t display_id) {
                     (int32_t)DisplayWidth(display, screen),
                     (int32_t)DisplayHeight(display, screen));
 #else
+    int32_t x = 0;
+    int32_t y = 0;
     int32_t w = 0;
     int32_t h = 0;
 #if defined(ROBOTGO_USE_WAYLAND)
-    if (wayland_main_bounds(&w, &h) == 0) {
-        return MMRectInt32Make(0, 0, w, h);
+    if (wayland_screen_rect(display_id, &x, &y, &w, &h) == 0) {
+        return MMRectInt32Make(x, y, w, h);
     }
 #endif
     return MMRectInt32Make(0, 0, 0, 0);

--- a/screen/screengrab_wayland_impl.c
+++ b/screen/screengrab_wayland_impl.c
@@ -151,6 +151,87 @@ static void output_logical_origin(const struct output *out, int *ox, int *oy) {
   }
 }
 
+struct output_ref {
+  struct output *output;
+  int x;
+  int y;
+  int w;
+  int h;
+  int primary;
+};
+
+static int compare_output_refs(const void *left, const void *right) {
+  const struct output_ref *a = left;
+  const struct output_ref *b = right;
+  if (a->primary != b->primary) {
+    return b->primary - a->primary;
+  }
+  if (a->y != b->y) {
+    return a->y < b->y ? -1 : 1;
+  }
+  if (a->x != b->x) {
+    return a->x < b->x ? -1 : 1;
+  }
+  if (a->output->name != b->output->name) {
+    return a->output->name < b->output->name ? -1 : 1;
+  }
+  return 0;
+}
+
+static struct output *output_by_stable_index(struct wl_list *outputs,
+                                             int display_id) {
+  if (!outputs || display_id < 0) {
+    return NULL;
+  }
+
+  int capacity = 0;
+  struct output *it;
+  wl_list_for_each(it, outputs, link) {
+    capacity++;
+  }
+  if (capacity <= 0) {
+    return NULL;
+  }
+
+  struct output_ref *refs = calloc((size_t)capacity, sizeof(*refs));
+  if (!refs) {
+    return NULL;
+  }
+  int count = 0;
+  wl_list_for_each(it, outputs, link) {
+    int x = 0;
+    int y = 0;
+    int w = 0;
+    int h = 0;
+    output_logical_origin(it, &x, &y);
+    output_logical_size(it, &w, &h);
+    long long right = (long long)x + w;
+    long long bottom = (long long)y + h;
+    if (w <= 0 || h <= 0 ||
+        right > INT_MAX || right < INT_MIN ||
+        bottom > INT_MAX || bottom < INT_MIN) {
+      continue;
+    }
+    refs[count].output = it;
+    refs[count].x = x;
+    refs[count].y = y;
+    refs[count].w = w;
+    refs[count].h = h;
+    refs[count].primary =
+        x <= 0 && right > 0 && y <= 0 && bottom > 0;
+    count++;
+  }
+  if (display_id >= count) {
+    free(refs);
+    return NULL;
+  }
+
+  qsort(refs, (size_t)count, sizeof(*refs), compare_output_refs);
+  struct output *selected = refs[display_id].output;
+  free(refs);
+  return selected;
+}
+
 static long long rect_intersection_area(struct int_rect a, struct int_rect b) {
   int x1 = a.x > b.x ? a.x : b.x;
   int y1 = a.y > b.y ? a.y : b.y;
@@ -371,6 +452,45 @@ int robotgo_wayland_select_output_rect_for_test(int req_x, int req_y,
     }
   }
   return best_index;
+}
+
+int robotgo_wayland_stable_output_name_for_test(const int *values,
+                                                 int output_count,
+                                                 int display_id) {
+  if (!values || output_count <= 0) {
+    return -1;
+  }
+  struct wl_list outputs;
+  wl_list_init(&outputs);
+  for (int i = 0; i < output_count; i++) {
+    const int *value = &values[i * 5];
+    struct output *out = calloc(1, sizeof(*out));
+    if (!out) {
+      struct output *item, *tmp;
+      wl_list_for_each_safe(item, tmp, &outputs, link) {
+        wl_list_remove(&item->link);
+        free(item);
+      }
+      return -1;
+    }
+    out->logical_x = value[0];
+    out->logical_y = value[1];
+    out->logical_w = value[2];
+    out->logical_h = value[3];
+    out->has_logical_pos = 1;
+    out->has_logical_size = 1;
+    out->name = (uint32_t)value[4];
+    wl_list_insert(outputs.prev, &out->link);
+  }
+
+  struct output *selected = output_by_stable_index(&outputs, display_id);
+  int result = selected ? (int)selected->name : -1;
+  struct output *out, *tmp;
+  wl_list_for_each_safe(out, tmp, &outputs, link) {
+    wl_list_remove(&out->link);
+    free(out);
+  }
+  return result;
 }
 #endif
 
@@ -1120,14 +1240,13 @@ MMBitmapRef capture_screen_wayland_impl(int32_t x, int32_t y, int32_t w,
   }
   struct output *out = NULL;
   if (display_id >= 0) {
-    int idx = 0;
-    struct output *it;
-    wl_list_for_each(it, &cap.outputs, link) {
-      if (idx == display_id) {
-        out = it;
-        break;
+    out = output_by_stable_index(&cap.outputs, display_id);
+    if (!out) {
+      if (err) {
+        *err = ScreengrabErrNoOutputs;
       }
-      idx++;
+      cleanup_capture(&cap);
+      return NULL;
     }
   }
   if (!out) {
@@ -1135,9 +1254,6 @@ MMBitmapRef capture_screen_wayland_impl(int32_t x, int32_t y, int32_t w,
     long long best_area = -1;
     struct output *it;
     wl_list_for_each(it, &cap.outputs, link) {
-      if (!it->has_mode || it->mode_w <= 0 || it->mode_h <= 0) {
-        continue;
-      }
       int lw = 0;
       int lh = 0;
       int ox = 0;

--- a/wayland_bounds_common.go
+++ b/wayland_bounds_common.go
@@ -1,0 +1,118 @@
+//go:build cgo
+
+package robotgo
+
+import "strings"
+
+const (
+	waylandTransformNormal = iota
+	waylandTransform90
+	waylandTransform180
+	waylandTransform270
+	waylandTransformFlipped
+	waylandTransformFlipped90
+	waylandTransformFlipped180
+	waylandTransformFlipped270
+)
+
+type waylandOutputBounds struct {
+	x, y int
+	w, h int
+}
+
+func aggregateWaylandOutputBounds(bounds []waylandOutputBounds) (Rect, bool) {
+	if len(bounds) == 0 {
+		return Rect{}, false
+	}
+	maxInt64 := int64(^uint64(0) >> 1)
+	edge := func(origin, size int) (int64, bool) {
+		if size <= 0 {
+			return 0, false
+		}
+		o := int64(origin)
+		s := int64(size)
+		if o > maxInt64-s {
+			return 0, false
+		}
+		return o + s, true
+	}
+	minX := int64(bounds[0].x)
+	minY := int64(bounds[0].y)
+	maxX, okX := edge(bounds[0].x, bounds[0].w)
+	maxY, okY := edge(bounds[0].y, bounds[0].h)
+	if !okX || !okY {
+		return Rect{}, false
+	}
+	for i := 1; i < len(bounds); i++ {
+		b := bounds[i]
+		x := int64(b.x)
+		y := int64(b.y)
+		right, okRight := edge(b.x, b.w)
+		bottom, okBottom := edge(b.y, b.h)
+		if !okRight || !okBottom {
+			return Rect{}, false
+		}
+		if x < minX {
+			minX = x
+		}
+		if y < minY {
+			minY = y
+		}
+		if right > maxX {
+			maxX = right
+		}
+		if bottom > maxY {
+			maxY = bottom
+		}
+	}
+	if (minX < 0 && maxX > maxInt64+minX) ||
+		(minY < 0 && maxY > maxInt64+minY) {
+		return Rect{}, false
+	}
+	width := maxX - minX
+	height := maxY - minY
+	maxInt := int64(^uint(0) >> 1)
+	minInt := -maxInt - 1
+	if minX < minInt || minY < minInt ||
+		maxX > maxInt || maxY > maxInt ||
+		width <= 0 || width > maxInt || height <= 0 || height > maxInt {
+		return Rect{}, false
+	}
+	return Rect{
+		Point{X: int(minX), Y: int(minY)},
+		Size{W: int(width), H: int(height)},
+	}, true
+}
+
+func parseWaylandTransform(value string) (int, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "normal":
+		return waylandTransformNormal, true
+	case "90":
+		return waylandTransform90, true
+	case "180":
+		return waylandTransform180, true
+	case "270":
+		return waylandTransform270, true
+	case "flipped":
+		return waylandTransformFlipped, true
+	case "flipped-90":
+		return waylandTransformFlipped90, true
+	case "flipped-180":
+		return waylandTransformFlipped180, true
+	case "flipped-270":
+		return waylandTransformFlipped270, true
+	default:
+		return waylandTransformNormal, false
+	}
+}
+
+func waylandTransformRotatesDimensions(transform int) bool {
+	switch transform {
+	case waylandTransform90, waylandTransform270,
+		waylandTransformFlipped90, waylandTransformFlipped270:
+		return true
+	default:
+		return false
+	}
+}

--- a/wayland_geometry_test.go
+++ b/wayland_geometry_test.go
@@ -111,3 +111,156 @@ func TestWaylandMultiOutputSelectionMatrix(t *testing.T) {
 		})
 	}
 }
+
+func TestWaylandBoundsPreserveLogicalDesktopGeometry(t *testing.T) {
+	outputs := []waylandBoundsOutputForTest{
+		{
+			position:    [2]int{20, 30},
+			mode:        [2]int{1920, 1080},
+			scale:       1,
+			logicalPos:  [2]int{0, 0},
+			logicalSize: [2]int{1280, 720},
+			hasLogical:  true,
+			name:        30,
+		},
+		{
+			position:    [2]int{-1024, 0},
+			mode:        [2]int{1024, 768},
+			scale:       1,
+			logicalPos:  [2]int{-1024, 0},
+			logicalSize: [2]int{1024, 768},
+			hasLogical:  true,
+			name:        10,
+		},
+		{
+			position:  [2]int{1280, 0},
+			mode:      [2]int{2160, 3840},
+			transform: 1,
+			scale:     2,
+			name:      20,
+		},
+	}
+
+	aggregate, ok := resolveWaylandBoundsForTest(outputs, -1)
+	if !ok {
+		t.Fatal("aggregate bounds resolution failed")
+	}
+	if want := [4]int{-1024, 0, 4224, 1080}; aggregate != want {
+		t.Fatalf("aggregate bounds = %v, want %v", aggregate, want)
+	}
+
+	tests := []struct {
+		displayID int
+		want      [4]int
+	}{
+		{displayID: 0, want: [4]int{0, 0, 1280, 720}},
+		{displayID: 1, want: [4]int{-1024, 0, 1024, 768}},
+		{displayID: 2, want: [4]int{1280, 0, 1920, 1080}},
+	}
+	for _, test := range tests {
+		got, ok := resolveWaylandBoundsForTest(outputs, test.displayID)
+		if !ok {
+			t.Fatalf("display %d bounds resolution failed", test.displayID)
+		}
+		if got != test.want {
+			t.Fatalf("display %d bounds = %v, want %v", test.displayID, got, test.want)
+		}
+	}
+	if _, ok := resolveWaylandBoundsForTest(outputs, len(outputs)); ok {
+		t.Fatal("out-of-range display index unexpectedly resolved")
+	}
+}
+
+func TestWaylandBoundsAcceptLogicalGeometryWithoutCoreMode(t *testing.T) {
+	outputs := []waylandBoundsOutputForTest{{
+		logicalPos:  [2]int{-640, -360},
+		logicalSize: [2]int{1280, 720},
+		hasLogical:  true,
+		name:        1,
+	}}
+	got, ok := resolveWaylandBoundsForTest(outputs, -1)
+	if !ok {
+		t.Fatal("logical-only output bounds resolution failed")
+	}
+	if want := [4]int{-640, -360, 1280, 720}; got != want {
+		t.Fatalf("logical-only bounds = %v, want %v", got, want)
+	}
+}
+
+func TestWaylandBoundsRejectUnrepresentableAggregate(t *testing.T) {
+	const (
+		minInt32 = -1 << 31
+		maxInt32 = 1<<31 - 1
+	)
+	outputs := []waylandBoundsOutputForTest{
+		{
+			logicalPos:  [2]int{minInt32, 0},
+			logicalSize: [2]int{1, 1},
+			hasLogical:  true,
+			name:        1,
+		},
+		{
+			logicalPos:  [2]int{maxInt32 - 1, 0},
+			logicalSize: [2]int{1, 1},
+			hasLogical:  true,
+			name:        2,
+		},
+	}
+	if bounds, ok := resolveWaylandBoundsForTest(outputs, -1); ok {
+		t.Fatalf("unrepresentable aggregate unexpectedly resolved as %v", bounds)
+	}
+}
+
+func TestWaylandBoundsFallbackAppliesScaleAndTransforms(t *testing.T) {
+	for transform := 0; transform < 8; transform++ {
+		t.Run(string(rune('0'+transform)), func(t *testing.T) {
+			got, ok := resolveWaylandBoundsForTest(
+				[]waylandBoundsOutputForTest{{
+					position:  [2]int{-10, 20},
+					mode:      [2]int{2400, 1600},
+					transform: transform,
+					scale:     2,
+					name:      1,
+				}},
+				-1,
+			)
+			if !ok {
+				t.Fatal("fallback output bounds resolution failed")
+			}
+			want := [4]int{-10, 20, 1200, 800}
+			if transform == 1 || transform == 3 || transform == 5 || transform == 7 {
+				want = [4]int{-10, 20, 800, 1200}
+			}
+			if got != want {
+				t.Fatalf("transform %d bounds = %v, want %v", transform, got, want)
+			}
+		})
+	}
+}
+
+func TestWaylandExplicitDisplayIndexMatchesBoundsOrder(t *testing.T) {
+	outputs := [][5]int{
+		{-1920, 0, 1920, 1080, 58},
+		{0, 0, 1280, 720, 99},
+		{0, 720, 1280, 1024, 12},
+	}
+	tests := []struct {
+		displayID int
+		wantName  int
+	}{
+		{displayID: 0, wantName: 99},
+		{displayID: 1, wantName: 58},
+		{displayID: 2, wantName: 12},
+		{displayID: 3, wantName: -1},
+	}
+	for _, test := range tests {
+		if got := stableWaylandOutputNameForTest(outputs, test.displayID); got != test.wantName {
+			t.Fatalf(
+				"display %d selected registry output %d, want %d",
+				test.displayID,
+				got,
+				test.wantName,
+			)
+		}
+	}
+}

--- a/wayland_geometry_testhelper.go
+++ b/wayland_geometry_testhelper.go
@@ -12,6 +12,13 @@ int robotgo_wayland_select_output_rect_for_test(int req_x, int req_y,
                                                  int req_w, int req_h,
                                                  const int *rects,
                                                  int rect_count);
+int robotgo_wayland_resolve_bounds_for_test(const int *values, int count,
+                                             int display_id,
+                                             int *x, int *y,
+                                             int *width, int *height);
+int robotgo_wayland_stable_output_name_for_test(const int *values,
+                                                 int output_count,
+                                                 int display_id);
 */
 import "C"
 
@@ -37,5 +44,75 @@ func selectWaylandOutputRectForTest(request [4]int, outputs [][4]int) int {
 	return int(C.robotgo_wayland_select_output_rect_for_test(
 		C.int(request[0]), C.int(request[1]), C.int(request[2]), C.int(request[3]),
 		(*C.int)(unsafe.Pointer(&values[0])), C.int(len(outputs)),
+	))
+}
+
+type waylandBoundsOutputForTest struct {
+	position    [2]int
+	mode        [2]int
+	transform   int
+	scale       int
+	logicalPos  [2]int
+	logicalSize [2]int
+	hasLogical  bool
+	name        int
+}
+
+func resolveWaylandBoundsForTest(outputs []waylandBoundsOutputForTest, displayID int) ([4]int, bool) {
+	if len(outputs) == 0 {
+		return [4]int{}, false
+	}
+	const valuesPerOutput = 12
+	values := make([]C.int, 0, len(outputs)*valuesPerOutput)
+	for _, output := range outputs {
+		flags := 0
+		if output.hasLogical {
+			flags = 3
+		}
+		values = append(
+			values,
+			C.int(output.position[0]),
+			C.int(output.position[1]),
+			C.int(output.mode[0]),
+			C.int(output.mode[1]),
+			C.int(output.transform),
+			C.int(output.scale),
+			C.int(output.logicalPos[0]),
+			C.int(output.logicalPos[1]),
+			C.int(output.logicalSize[0]),
+			C.int(output.logicalSize[1]),
+			C.int(flags),
+			C.int(output.name),
+		)
+	}
+	var x, y, width, height C.int
+	if C.robotgo_wayland_resolve_bounds_for_test(
+		(*C.int)(unsafe.Pointer(&values[0])),
+		C.int(len(outputs)),
+		C.int(displayID),
+		&x,
+		&y,
+		&width,
+		&height,
+	) != 0 {
+		return [4]int{}, false
+	}
+	return [4]int{int(x), int(y), int(width), int(height)}, true
+}
+
+func stableWaylandOutputNameForTest(outputs [][5]int, displayID int) int {
+	if len(outputs) == 0 {
+		return -1
+	}
+	values := make([]C.int, 0, len(outputs)*len(outputs[0]))
+	for _, output := range outputs {
+		for _, value := range output {
+			values = append(values, C.int(value))
+		}
+	}
+	return int(C.robotgo_wayland_stable_output_name_for_test(
+		(*C.int)(unsafe.Pointer(&values[0])),
+		C.int(len(outputs)),
+		C.int(displayID),
 	))
 }

--- a/window/get_bounds_wayland.h
+++ b/window/get_bounds_wayland.h
@@ -1,5 +1,8 @@
 #pragma once
-#include "xdg-shell-client-protocol.h"
 #include <wayland-client.h>
 
 int get_bounds_wayland(struct wl_display *display, int *width, int *height);
+int get_screen_rect_wayland(struct wl_display *display, int display_id,
+                            int *x, int *y, int *width, int *height);
+int get_num_displays_wayland(struct wl_display *display);
+int get_main_display_wayland(struct wl_display *display);

--- a/window/wayland_bounds.c
+++ b/window/wayland_bounds.c
@@ -10,11 +10,13 @@ Bounds wayland_get_bounds(void) {
     return bounds;
   }
 
+  int x = 0;
+  int y = 0;
   int width = 0;
   int height = 0;
-  if (get_bounds_wayland(display, &width, &height) == 0) {
-    bounds.X = 0;
-    bounds.Y = 0;
+  if (get_screen_rect_wayland(display, -1, &x, &y, &width, &height) == 0) {
+    bounds.X = x;
+    bounds.Y = y;
     bounds.W = width;
     bounds.H = height;
   }

--- a/window/wayland_test.go
+++ b/window/wayland_test.go
@@ -63,9 +63,37 @@ func TestGetBoundsWayland(t *testing.T) {
 		t.Fatalf("expected Wayland, got %v", ds)
 	}
 
-	_, _, w, h := robotgo.GetBounds(0)
-	if w == 0 || h == 0 {
+	rect := robotgo.GetScreenRect()
+	if rect.W == 0 || rect.H == 0 {
 		t.Skip("wayland compositor did not provide bounds")
+	}
+	x, y, w, h := robotgo.GetBounds(0)
+	if x != rect.X || y != rect.Y || w != rect.W || h != rect.H {
+		t.Fatalf("GetBounds = (%d,%d %dx%d), screen rect = %+v", x, y, w, h, rect)
+	}
+	clientX, clientY, clientW, clientH := robotgo.GetClient(0)
+	if clientX != rect.X || clientY != rect.Y ||
+		clientW != rect.W || clientH != rect.H {
+		t.Fatalf(
+			"GetClient = (%d,%d %dx%d), screen rect = %+v",
+			clientX,
+			clientY,
+			clientW,
+			clientH,
+			rect,
+		)
+	}
+	if count := robotgo.DisplaysNum(); count != 1 {
+		t.Fatalf("DisplaysNum = %d, want 1", count)
+	}
+	if mainID := robotgo.GetMainId(); mainID != 0 {
+		t.Fatalf("GetMainId = %d, want 0", mainID)
+	}
+	if displayRect := robotgo.GetScreenRect(0); displayRect != rect {
+		t.Fatalf("GetScreenRect(0) = %+v, aggregate = %+v", displayRect, rect)
+	}
+	if invalid := robotgo.GetScreenRect(1); invalid != (robotgo.Rect{}) {
+		t.Fatalf("GetScreenRect(1) = %+v, want zero rect", invalid)
 	}
 }
 
@@ -96,6 +124,9 @@ func TestWaylandBoundsResourceRelease(t *testing.T) {
 		_, _, w, h = robotgo.GetClient(0)
 		if w == 0 || h == 0 {
 			t.Skip("wayland compositor did not provide client bounds")
+		}
+		if count := robotgo.DisplaysNum(); count != 1 {
+			t.Fatalf("DisplaysNum = %d, want 1", count)
 		}
 	}
 	after := countFDs(t)


### PR DESCRIPTION
## Ziel

Wayland-Bounds sollen auf Multi-Output-Desktops dieselben logischen Koordinaten wie Capture verwenden, ohne X11-Abhängigkeit oder plausible falsche Null-/Fallbackwerte.

## Änderungen

- erhält den nativen aggregierten Desktop-Ursprung einschließlich negativer `x/y` statt ihn an der C-Grenze auf `(0,0)` zu verlieren
- unterstützt `GetScreenRect(displayID)` pro Output; negative/fehlende IDs liefern das Aggregat, ungültige positive IDs explizit einen Null-Rect statt still das Aggregat
- definiert eine deterministische Output-Reihenfolge: Output mit logischem `(0,0)` zuerst, danach Geometrie-Reihenfolge
- verwendet dieselbe Reihenfolge für explizite native Screencopy-Display-IDs
- fragt `DisplaysNum` und `GetMainId` in Wayland-Sessions nativ ab statt über X11/Xwayland
- bevorzugt fractional-scaling-fähige `xdg-output`-Geometrie; Core-Output-Fallback berücksichtigt integer scale und alle acht Transforms
- akzeptiert beim `wayland-info`-Fallback vollständige logische Output-Datensätze auch ohne numerische Output-IDs
- lehnt überlaufende/unrepräsentierbare Desktop-Rechtecke fail-closed ab
- entfernt den falschen Alt-Fallback, der eine `xdg_toplevel`-Fensterempfehlung als Desktop-Bounds interpretierte
- ergänzt ein plattformübergreifendes Bounds-Beispiel und aktualisiert README, TEST und Roadmap

## Evidenz

- hermetische C/CGO-Matrix für negative Ursprünge, fractional logical size, Core-Scale, alle Transforms, stabile Indizes, logical-only Outputs und Overflow
- Parser-Regressionen für identifier-freie `wayland-info`-Ausgabe, Scale/Transform und Overflow
- Weston-Integration vergleicht `GetScreenRect`, `GetBounds`, `GetClient`, Displayanzahl/Main-ID, ungültige IDs und FD-Lifecycle
- neuer C-Code separat mit `-Wall -Wextra -Werror` geprüft

## Lokale Validierung

- `go test ./...`
- `go test -race ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -tags wayland ./...`
- `go test -tags "wayland test" . -run 'Test(DrmFindRenderNode|Wayland)' -count=1 -v`
- `go test -tags "wayland integration" ./mouse ./window -count=1 -v`
- `go test -race -tags "wayland waylandint" . -run '^TestWaylandPublic' -count=1 -v`
- `go test -tags portal ./screen/portal -count=1`
- `go vet ./...`
- `golangci-lint run`

Die Weston-E2E ist lokal mangels installiertem Weston erwartungsgemäß übersprungen und wird durch den geschützten CI-Job ausgeführt.

## Kompatibilität/Risiko

Bewusste Korrektur sichtbarer Wayland-Semantik: Aggregat-Rechtecke können nun negative Ursprünge zurückgeben, und explizite Display-Indizes folgen einer dokumentierten stabilen Reihenfolge. Ungültige Indizes fallen nicht mehr unbemerkt auf einen anderen Output zurück.