### PR TITLE
feat: add versioned runtime diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ for this fork.
 | Windows | Active window, title, close, minimize/maximize, topmost queries/setters, bounds/client geometry, and compositor-specific Wayland variants where supported |
 | Processes | Enumerate, inspect, find, activate, and terminate processes |
 | Images | Go image/bitmap conversion, template helpers, encoding, saving, and optional OCR |
-| Diagnostics | Build/backend detection plus feature-level capability, permission, fallback, and unsupported reporting |
+| Diagnostics | Versioned, sanitized build/backend, protocol-version, permission, fallback, remediation, and unsupported reporting |
 
 Availability is platform- and backend-dependent. Prefer error-returning APIs
 and inspect `GetRuntimeCapabilities` when an operation is required for a
-workflow. `GetLinuxCapabilities` provides additional compositor detail.
+workflow. `GetRuntimeDiagnostics` provides the stable machine-readable report;
+`GetLinuxCapabilities` remains the compact Linux-specific view.
 
 ## Support overview
 
@@ -583,6 +584,24 @@ fmt.Println("mouse:", caps.Mouse.Available, caps.Mouse.Backend, caps.Mouse.Reaso
 fmt.Println("process:", caps.Process.Available, caps.Process.Backend)
 ```
 
+`GetRuntimeDiagnostics` returns the versioned schema used by support tooling.
+It adds negotiated Wayland/portal/XTEST versions, non-prompting permission
+state, and remediation while excluding display addresses, restore tokens,
+stream identifiers, and unrelated environment values:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+defer cancel()
+report := robotgo.GetRuntimeDiagnostics(ctx)
+fmt.Println("schema:", report.SchemaVersion)
+fmt.Println("protocols:", report.Protocols)
+fmt.Println("permissions:", report.Permissions)
+fmt.Println("remediation:", report.Remediation)
+```
+
+The published support contract is
+[Runtime Compatibility Matrix v1](docs/compatibility/runtime-v1.md).
+
 On Linux/X11 with `CGO_ENABLED=0`, capability inspection reports the selected
 `pure-go-x11` keyboard and mouse backends without opening an X connection. Call
 `KeyboardReady` or `MouseReady` for a live XTEST 2.2+ check before acting. A
@@ -635,6 +654,7 @@ fmt.Println("window:", caps.Window.Backend, caps.Window.Available, caps.Window.R
 Run the complete diagnostic example with:
 
 ```bash
+go run ./examples/runtime_diagnostics
 go run -tags wayland ./examples/linux_capabilities
 ```
 
@@ -649,6 +669,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Cross-platform aggregate and per-output bounds](examples/display_bounds/main.go)
 - [Linux capabilities](examples/linux_capabilities/main.go)
 - [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
+- [Versioned runtime diagnostics](examples/runtime_diagnostics/main.go)
 - [Pure-Go X11 input probe and opt-in demo](examples/purego_x11_input/main.go)
 - [Pure-Go Windows input readiness and opt-in demo](examples/purego_windows_input/main.go)
 - [Pure-Go Windows window inspection and opt-in control](examples/purego_windows_window/main.go)

--- a/TEST.md
+++ b/TEST.md
@@ -22,6 +22,15 @@ CGO_ENABLED=0 go test -tags "ocr" ./...
 go test -tags "ocr" ./...
 ```
 
+The default and non-CGO suites also lock the versioned runtime-diagnostic
+schema, stable feature ordering, deadline-bounded portal probes, sanitized
+output, negotiated protocol versions, permission states, and remediation.
+Inspect a live host without opening a consent dialog with:
+
+```bash
+go run ./examples/runtime_diagnostics
+```
+
 Both build variants are blocking linter targets as well:
 
 ```bash

--- a/backend_info.go
+++ b/backend_info.go
@@ -37,7 +37,10 @@ type RuntimeBackendInfo struct {
 // current platform and build. Availability may include bounded runtime probes;
 // inspecting RuntimeBackendInfo never performs those probes.
 type RuntimeCapabilities struct {
-	Runtime       RuntimeBackendInfo
+	Runtime RuntimeBackendInfo
+	// Compositor is the detected Linux Wayland compositor family. It is empty
+	// on other platforms and display servers.
+	Compositor    string
 	Capture       FeatureCapability
 	Bounds        FeatureCapability
 	Keyboard      FeatureCapability

--- a/docs/compatibility/runtime-v1.md
+++ b/docs/compatibility/runtime-v1.md
@@ -1,0 +1,67 @@
+# Runtime Compatibility Matrix v1
+
+Matrix version: **1**
+Published: **2026-07-17**
+
+This matrix separates implemented behavior from blocking runtime evidence.
+`supported` means the applicable build and behavioral contract is blocking in
+CI. `implemented / evidence pending` means the backend exists and has hermetic
+coverage, but a required real desktop or permission-granted runner is not yet
+available. A pending row is not a passing row.
+
+## Platform and build matrix
+
+| Platform/session | Build mode | Status | Blocking evidence and limits |
+|---|---|---|---|
+| Linux/X11 | Native CGO | supported | Default Linux tests, race/vet/lint, Xvfb/XTEST public contract, XTEST-disabled negative contract |
+| Linux/X11 | Pure Go | supported | Non-CGO Linux tests plus non-skipping Xvfb/XTEST input, capture, bounds, cleanup, and crash-guardian contracts |
+| Linux/Wayland/wlroots | Native CGO, `wayland` | supported for advertised protocols | Weston integration plus hermetic screencopy, virtual input, bounds, scale, transform, fallback, and ownership tests; compositor-specific protocols remain capability-gated |
+| Linux/Wayland | Pure Go | supported for portal APIs | Non-CGO portal capture/input contracts; user consent and portal backend availability remain runtime requirements |
+| GNOME/Wayland | CGO and Pure Go portal paths | implemented / evidence pending | Protected GNOME runner required for RemoteDesktop and persistent ScreenCast evidence |
+| KDE Plasma/Wayland | CGO and Pure Go portal paths | implemented / evidence pending | Protected KDE runner required for RemoteDesktop and persistent ScreenCast evidence |
+| macOS | Native CGO | supported | Hosted macOS build/test; Screen Recording and Accessibility are runtime permissions |
+| macOS | Pure Go | supported, granted-input evidence pending | CoreGraphics capture/bounds/scale and Quartz input contracts; real symbol and non-prompting permission preflight are blocking; permission-granted injection is opt-in |
+| Windows | Native CGO | supported | Hosted Windows build/test |
+| Windows | Pure Go | supported | Hosted non-CGO tests plus real input-desktop pointer/pixel and self-owned window/control evidence |
+
+## Architecture evidence
+
+| Architecture | Status | Scope |
+|---|---|---|
+| `amd64` | supported | Primary Linux/X11/Wayland, Windows, and available hosted-platform evidence |
+| `arm64` | Pure-Go cross-build evidenced; native runtime support not broadly claimed | Go and non-CGO implementations are architecture-neutral; no dedicated protected Linux Wayland ARM runner is claimed |
+| Other Go architectures | compile/support not claimed by v1 | Add explicit cross-build and runtime evidence before promotion |
+
+GitHub-hosted runner architecture is not pinned by this repository. A release
+must record the concrete runner architecture from its workflow evidence rather
+than inferring it from an operating-system label.
+
+## Optional dependencies
+
+| Dependency or service | Enables | Behavior when absent |
+|---|---|---|
+| Wayland client, XKB, GBM/DRM development libraries | Native Wayland build | Build tag is unavailable; Pure-Go portal paths remain possible |
+| `xdg-desktop-portal` plus desktop backend | Screenshot, RemoteDesktop, ScreenCast | Capability is unavailable with remediation; RobotGo does not pretend success |
+| PipeWire development/runtime libraries and `pipewire` tag | Persistent ScreenCast frames | One-shot Screenshot/native screencopy remain eligible; persistent capture reports unsupported |
+| X11/XTEST | Native or Pure-Go X11 input | Readiness and diagnostics report missing/old XTEST explicitly |
+| Tesseract/Leptonica and `ocr` tag | OCR helpers | Core automation remains available without OCR |
+| Sway/Hyprland/wlroots command tools | Compositor-specific foreign-window operations | Wayland-core capability reports unsupported operations explicitly |
+
+## Diagnostic contract
+
+`GetRuntimeDiagnostics` returns schema version `1` with:
+
+- stable feature ordering and selected backend/fallback state;
+- negotiated Wayland, portal, and XTEST protocol versions when observable;
+- non-prompting permission/consent state;
+- actionable remediation for unavailable features;
+- platform, architecture, build implementation, display-server type, and
+  compositor family without display addresses, restore tokens, stream IDs, or
+  unrelated environment values.
+
+Run `go run ./examples/runtime_diagnostics` to print the JSON report. Schema
+changes that rename/remove fields or alter their meaning require a new matrix
+and diagnostic schema version.
+
+Detailed real-compositor evidence remains in
+[Wayland input](wayland-input.md) and [Wayland capture](wayland-capture.md).

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -37,12 +37,12 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and keyboard/pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz keyboard/pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture and XGB/XTEST input; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS keyboard-injection evidence and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
-| 5. Reliability product | Partial | Capability API/example and expanded CI variants | Versioned compatibility matrix, richer diagnostics, dedicated compositor jobs, sanitizer/leak gates |
+| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants | Dedicated compositor jobs, sanitizer/leak gates, release evidence snapshots |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
-an infrastructure blocker. The active implementation slice is Phase 3 Pure-Go
-backend parity and measurement.
+an infrastructure blocker. The active implementation slice is Phase 5
+reliability hardening; protected real-desktop evidence remains runner-dependent.
 
 ## Delivery Order
 
@@ -288,11 +288,15 @@ diagnostic API/example that reports selected backends, protocol versions,
 fallback decisions, permissions, and actionable remediation without exposing
 sensitive environment data.
 
-Current status: `GetLinuxCapabilities` and its runnable example expose selected
-feature backends, availability, fallbacks, reasons, and notes. CI covers three
-operating systems, non-CGO, tagged Wayland/portal, and Weston integration.
-Protocol versions, permission state, remediation guidance, versioned support
-data, dedicated GNOME/KDE/wlroots jobs, and native sanitizer gates remain open.
+Current status: `GetRuntimeDiagnostics` schema v1 and its runnable JSON example
+report selected feature backends, fallbacks, negotiated Wayland/portal/XTEST
+versions, non-prompting permission state, and remediation without exposing
+display addresses, restore tokens, stream identifiers, or unrelated environment
+values. The published `docs/compatibility/runtime-v1.md` matrix distinguishes
+blocking support from pending runtime evidence. CI covers three operating
+systems, non-CGO, tagged Wayland/portal, and Weston integration. Dedicated
+GNOME/KDE/wlroots jobs, release evidence snapshots, and native sanitizer gates
+remain open.
 
 Releases require:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -150,8 +150,9 @@ backends.
     releases owned input and restores only an exact unchanged, unpressed,
     non-modifier scratch claim. Foreign final images are preserved; exact-image
     ABA replacement is not observable in X11.
-  - 6. Publish versioned compatibility data and expand diagnostics with
-    protocol versions, permissions, and actionable remediation.
+  - 6. Keep the published runtime compatibility matrix and diagnostic schema
+    versioned. Schema v1 now reports negotiated protocol versions, permission
+    state, and actionable remediation without sensitive session data.
   - 7. Promote race/vet and native leak/sanitizer checks to blocking release
     gates, with dedicated GNOME/KDE/wlroots jobs.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ Run an example from the repository root, for example:
 
 ```bash
 go run ./examples/runtime_capabilities
+go run ./examples/runtime_diagnostics
 go run ./examples/screen_full
 ```
 
@@ -17,6 +18,8 @@ Available examples:
 
 - [`runtime_capabilities`](runtime_capabilities/main.go): cross-platform build,
   backend, feature, permission, and unsupported diagnostics.
+- [`runtime_diagnostics`](runtime_diagnostics/main.go): versioned JSON with
+  selected backends, protocol versions, permission state, and remediation.
 - [`linux_capabilities`](linux_capabilities/main.go): detailed Linux display
   server, compositor, portal, and fallback diagnostics.
 - [`screen`](screen/main.go): capture, pixel, bitmap, and display operations.

--- a/examples/runtime_diagnostics/main.go
+++ b/examples/runtime_diagnostics/main.go
@@ -1,0 +1,25 @@
+// Command runtime_diagnostics prints RobotGo's versioned, sanitized runtime
+// support report without requesting desktop consent.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	report := robotgo.GetRuntimeDiagnostics(ctx)
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(data))
+}

--- a/key.go
+++ b/key.go
@@ -489,6 +489,12 @@ func nativeWaylandKeyboardReady() error {
 	return err
 }
 
+func nativeWaylandKeyboardProtocolVersion() uint32 {
+	unlockKeyboard := lockLinuxKeyboard()
+	defer unlockKeyboard()
+	return uint32(C.robotgo_wayland_keyboard_protocol_version())
+}
+
 func closeWaylandKeyboard() { C.robotgo_wayland_keyboard_close() }
 
 func syncWaylandKeyboardForTest() int {

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -1459,6 +1459,12 @@ enum RobotGoKeyStatus {
                 return refresh_wayland_keyboard();
         }
 
+        uint32_t robotgo_wayland_keyboard_protocol_version(void) {
+                return wk_vk_manager == NULL
+                        ? 0
+                        : zwp_virtual_keyboard_manager_v1_get_version(wk_vk_manager);
+        }
+
         int robotgo_wayland_keyboard_last_error(void) {
                 return wk_last_error;
         }
@@ -1669,6 +1675,7 @@ enum RobotGoKeyStatus {
 
 #ifndef ROBOTGO_WAYLAND_KEYBOARD_DIAG_DEFINED
 static inline int robotgo_wayland_keyboard_ready(void) { return 0; }
+static inline uint32_t robotgo_wayland_keyboard_protocol_version(void) { return 0; }
 static inline int robotgo_wayland_keyboard_last_error(void) { return 0; }
 static inline int robotgo_wayland_keyboard_backend_enabled(void) { return 0; }
 static inline void robotgo_wayland_keyboard_close(void) { }

--- a/mouse/mouse_c.h
+++ b/mouse/mouse_c.h
@@ -296,12 +296,18 @@ enum RobotGoMouseStatus {
 	                }
 	                return rg_init_wayland();
 	        }
+	        static uint32_t robotgo_wayland_mouse_protocol_version(void) {
+	                return rg_wl_vptr_mgr == NULL
+	                        ? 0
+	                        : zwlr_virtual_pointer_manager_v1_get_version(rg_wl_vptr_mgr);
+	        }
 	        static void robotgo_wayland_mouse_close(void) { rg_cleanup_wayland(); }
 #endif /* ROBOTGO_USE_WAYLAND */
 	#ifndef ROBOTGO_USE_WAYLAND
 	        static bool robotgo_wayland_mouse_backend_selected(void) { return false; }
 	        static int robotgo_wayland_mouse_backend_enabled(void) { return 0; }
 	        static int robotgo_wayland_mouse_ready(void) { return 0; }
+	        static uint32_t robotgo_wayland_mouse_protocol_version(void) { return 0; }
 	        static void robotgo_wayland_mouse_close(void) { }
 	        static int robotgo_wayland_mouse_button_code(
 	                MMMouseButton button, uint32_t *code, unsigned int *index) {
@@ -322,6 +328,7 @@ enum RobotGoMouseStatus {
 static bool robotgo_wayland_mouse_backend_selected(void) { return false; }
 static int robotgo_wayland_mouse_backend_enabled(void) { return 0; }
 static int robotgo_wayland_mouse_ready(void) { return 0; }
+static uint32_t robotgo_wayland_mouse_protocol_version(void) { return 0; }
 static void robotgo_wayland_mouse_close(void) { }
 static int robotgo_wayland_mouse_button_code(
 	MMMouseButton button, uint32_t *code, unsigned int *index) {

--- a/robotgo.go
+++ b/robotgo.go
@@ -254,6 +254,20 @@ func probeRemoteDesktopCapability() FeatureCapability {
 	}
 }
 
+func nativeWaylandProtocolVersions() nativeWaylandProtocolInfo {
+	if selectedDisplayServer() != DisplayServerWayland {
+		return nativeWaylandProtocolInfo{}
+	}
+	info := nativeWaylandProtocolInfo{
+		Screencopy: uint32(C.robotgo_wayland_screencopy_version()),
+	}
+	info.VirtualKeyboard = nativeWaylandKeyboardProtocolVersion()
+	unlockMouse := lockLinuxMouse()
+	info.VirtualPointer = uint32(C.robotgo_wayland_mouse_protocol_version())
+	unlockMouse()
+	return info
+}
+
 // GetLinuxCapabilities reports runtime feature availability for Linux sessions.
 // On non-Linux platforms it returns a zero-value capability set.
 func GetLinuxCapabilities() LinuxCapabilities {

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -142,6 +142,14 @@ func DetectDisplayServer() DisplayServer {
 
 func configuredX11DisplaySelected() bool { return false }
 
+func nativeWaylandProtocolVersions() nativeWaylandProtocolInfo {
+	return nativeWaylandProtocolInfo{}
+}
+
+func nativeX11ProtocolVersion() (major, minor int, negotiated bool) {
+	return 0, 0, false
+}
+
 func GetLinuxCapabilities() LinuxCapabilities {
 	ds := selectedDisplayServer()
 	unsupported := FeatureCapability{
@@ -160,6 +168,9 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		Window:         unsupported,
 		Hook:           unsupported,
 		Events:         unsupported,
+	}
+	if runtime.GOOS == "linux" && ds == DisplayServerWayland {
+		capabilities.Compositor = detectWaylandCompositor()
 	}
 	overrideCapture, captureOverridden := pureGoCaptureOverrideCapability()
 	if captureOverridden {

--- a/runtime_capabilities_cgo.go
+++ b/runtime_capabilities_cgo.go
@@ -22,6 +22,7 @@ func runtimeCapabilities() RuntimeCapabilities {
 	}
 	if runtime.GOOS == "linux" {
 		linux := GetLinuxCapabilities()
+		result.Compositor = linux.Compositor
 		result.Capture = linux.Capture
 		result.Bounds = linux.Bounds
 		result.Keyboard = linux.Keyboard

--- a/runtime_capabilities_nocgo.go
+++ b/runtime_capabilities_nocgo.go
@@ -32,6 +32,7 @@ func runtimeCapabilities() RuntimeCapabilities {
 	}
 	if runtime.GOOS == "linux" {
 		linux := GetLinuxCapabilities()
+		result.Compositor = linux.Compositor
 		result.Capture = linux.Capture
 		result.Bounds = linux.Bounds
 		result.Keyboard = linux.Keyboard

--- a/runtime_diagnostics.go
+++ b/runtime_diagnostics.go
@@ -1,0 +1,223 @@
+package robotgo
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// RuntimeDiagnosticsSchemaVersion identifies the stable JSON/data contract
+// returned by GetRuntimeDiagnostics.
+const RuntimeDiagnosticsSchemaVersion = "1"
+
+const (
+	runtimeFeatureCapture       = "capture"
+	runtimeFeatureBounds        = "bounds"
+	runtimeFeatureKeyboard      = "keyboard"
+	runtimeFeatureMouse         = "mouse"
+	runtimeFeatureRemoteDesktop = "remote-desktop"
+	runtimeFeatureWindow        = "window"
+	runtimeFeatureProcess       = "process"
+	runtimeFeatureClipboard     = "clipboard"
+	runtimeFeatureHook          = "hook"
+	runtimeFeatureEvents        = "events"
+	runtimeFeatureDesktop       = "desktop"
+)
+
+// RuntimePermissionState describes a permission or consent state without
+// opening a system dialog.
+type RuntimePermissionState string
+
+const (
+	RuntimePermissionUnknown      RuntimePermissionState = "unknown"
+	RuntimePermissionNotRequired  RuntimePermissionState = "not-required"
+	RuntimePermissionNotRequested RuntimePermissionState = "not-requested"
+	RuntimePermissionGranted      RuntimePermissionState = "granted"
+	RuntimePermissionDenied       RuntimePermissionState = "denied"
+	RuntimePermissionCancelled    RuntimePermissionState = "cancelled"
+	RuntimePermissionTimedOut     RuntimePermissionState = "timed-out"
+	RuntimePermissionClosed       RuntimePermissionState = "closed"
+	RuntimePermissionFailed       RuntimePermissionState = "failed"
+	RuntimePermissionUnavailable  RuntimePermissionState = "unavailable"
+)
+
+// RuntimeFeatureDiagnostic is a stable, named view of one feature capability.
+type RuntimeFeatureDiagnostic struct {
+	Name      string `json:"name"`
+	Available bool   `json:"available"`
+	Fallback  bool   `json:"fallback"`
+	Backend   string `json:"backend,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+	Notes     string `json:"notes,omitempty"`
+}
+
+// RuntimeProtocolDiagnostic reports a protocol version negotiated with the
+// active compositor, display server, or desktop portal.
+type RuntimeProtocolDiagnostic struct {
+	Feature    string `json:"feature"`
+	Name       string `json:"name"`
+	Version    string `json:"version,omitempty"`
+	Negotiated bool   `json:"negotiated"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+// RuntimePermissionDiagnostic reports permission state without requesting
+// consent or exposing tokens and other sensitive session data.
+type RuntimePermissionDiagnostic struct {
+	Feature string                 `json:"feature"`
+	Name    string                 `json:"name"`
+	State   RuntimePermissionState `json:"state"`
+	Reason  string                 `json:"reason,omitempty"`
+}
+
+// RuntimeIdentityDiagnostic is the sanitized build identity included in a
+// versioned diagnostic report.
+type RuntimeIdentityDiagnostic struct {
+	RobotGoVersion      string                `json:"robotgo_version"`
+	GOOS                string                `json:"goos"`
+	GOARCH              string                `json:"goarch"`
+	CGOEnabled          bool                  `json:"cgo_enabled"`
+	BuildImplementation RuntimeImplementation `json:"build_implementation"`
+}
+
+// RuntimeRemediation describes one actionable step for an unavailable feature.
+type RuntimeRemediation struct {
+	Feature string `json:"feature"`
+	Action  string `json:"action"`
+}
+
+// RuntimeDiagnostics is the versioned, machine-readable runtime support
+// report. Feature and protocol ordering is stable within a schema version.
+type RuntimeDiagnostics struct {
+	SchemaVersion string                        `json:"schema_version"`
+	Runtime       RuntimeIdentityDiagnostic     `json:"runtime"`
+	DisplayServer DisplayServer                 `json:"display_server,omitempty"`
+	Compositor    string                        `json:"compositor,omitempty"`
+	Features      []RuntimeFeatureDiagnostic    `json:"features"`
+	Protocols     []RuntimeProtocolDiagnostic   `json:"protocols,omitempty"`
+	Permissions   []RuntimePermissionDiagnostic `json:"permissions,omitempty"`
+	Remediation   []RuntimeRemediation          `json:"remediation,omitempty"`
+}
+
+type nativeWaylandProtocolInfo struct {
+	Screencopy      uint32
+	VirtualKeyboard uint32
+	VirtualPointer  uint32
+}
+
+// GetRuntimeDiagnostics reports backend, protocol, permission, and remediation
+// information without opening a consent dialog. Feature discovery retains its
+// existing bounded probes; the additional structured portal probes use the
+// supplied deadline or a bounded default.
+func GetRuntimeDiagnostics(ctx context.Context) RuntimeDiagnostics {
+	capabilities := GetRuntimeCapabilities()
+	report := RuntimeDiagnostics{
+		SchemaVersion: RuntimeDiagnosticsSchemaVersion,
+		Runtime:       newRuntimeIdentityDiagnostic(capabilities.Runtime),
+		DisplayServer: capabilities.Runtime.DisplayServer,
+		Features:      runtimeFeatureDiagnostics(capabilities),
+	}
+	if capabilities.Runtime.GOOS == "linux" {
+		report.Compositor = capabilities.Compositor
+	}
+
+	probeCtx, cancel := boundedDiagnosticContext(ctx)
+	defer cancel()
+	report.Protocols, report.Permissions = platformRuntimeDiagnosticDetails(
+		probeCtx,
+		capabilities,
+	)
+	report.Remediation = runtimeRemediation(report.Features)
+	return report
+}
+
+func newRuntimeIdentityDiagnostic(info RuntimeBackendInfo) RuntimeIdentityDiagnostic {
+	return RuntimeIdentityDiagnostic{
+		RobotGoVersion:      GetVersion(),
+		GOOS:                info.GOOS,
+		GOARCH:              info.GOARCH,
+		CGOEnabled:          info.CGOEnabled,
+		BuildImplementation: info.BuildImplementation,
+	}
+}
+
+func boundedDiagnosticContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, 750*time.Millisecond)
+}
+
+func runtimeFeatureDiagnostics(c RuntimeCapabilities) []RuntimeFeatureDiagnostic {
+	return []RuntimeFeatureDiagnostic{
+		newRuntimeFeatureDiagnostic(runtimeFeatureCapture, c.Capture),
+		newRuntimeFeatureDiagnostic(runtimeFeatureBounds, c.Bounds),
+		newRuntimeFeatureDiagnostic(runtimeFeatureKeyboard, c.Keyboard),
+		newRuntimeFeatureDiagnostic(runtimeFeatureMouse, c.Mouse),
+		newRuntimeFeatureDiagnostic(runtimeFeatureRemoteDesktop, c.RemoteDesktop),
+		newRuntimeFeatureDiagnostic(runtimeFeatureWindow, c.Window),
+		newRuntimeFeatureDiagnostic(runtimeFeatureProcess, c.Process),
+		newRuntimeFeatureDiagnostic(runtimeFeatureClipboard, c.Clipboard),
+		newRuntimeFeatureDiagnostic(runtimeFeatureHook, c.Hook),
+		newRuntimeFeatureDiagnostic(runtimeFeatureEvents, c.Events),
+	}
+}
+
+func newRuntimeFeatureDiagnostic(name string, capability FeatureCapability) RuntimeFeatureDiagnostic {
+	return RuntimeFeatureDiagnostic{
+		Name:      name,
+		Available: capability.Available,
+		Fallback:  capability.Fallback,
+		Backend:   capability.Backend,
+		Reason:    capability.Reason,
+		Notes:     capability.Notes,
+	}
+}
+
+func runtimeRemediation(features []RuntimeFeatureDiagnostic) []RuntimeRemediation {
+	seen := make(map[string]struct{})
+	result := make([]RuntimeRemediation, 0)
+	for _, feature := range features {
+		if feature.Available {
+			continue
+		}
+		action := feature.Notes
+		if action == "" {
+			action = feature.Reason
+		}
+		if action == "" {
+			continue
+		}
+		if !actionableRuntimeAdvice(action) {
+			continue
+		}
+		key := feature.Name + "\x00" + action
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, RuntimeRemediation{
+			Feature: feature.Name,
+			Action:  action,
+		})
+	}
+	return result
+}
+
+func actionableRuntimeAdvice(action string) bool {
+	lower := strings.ToLower(action)
+	for _, verb := range []string{
+		"build", "call", "check", "configure", "enable", "grant", "install",
+		"provide", "remove", "run", "select", "set", "start", "use", "verify",
+	} {
+		if strings.HasPrefix(lower, verb+" ") ||
+			strings.Contains(lower, "; "+verb+" ") ||
+			strings.Contains(lower, ". "+verb+" ") {
+			return true
+		}
+	}
+	return false
+}

--- a/runtime_diagnostics_linux.go
+++ b/runtime_diagnostics_linux.go
@@ -1,0 +1,281 @@
+//go:build linux
+
+package robotgo
+
+import (
+	"context"
+	"fmt"
+
+	portalpkg "github.com/marang/robotgo/screen/portal"
+)
+
+const (
+	protocolWaylandScreencopy      = "zwlr_screencopy_manager_v1"
+	protocolWaylandVirtualKeyboard = "zwp_virtual_keyboard_manager_v1"
+	protocolWaylandVirtualPointer  = "zwlr_virtual_pointer_manager_v1"
+	protocolPortalRemoteDesktop    = "org.freedesktop.portal.RemoteDesktop"
+	protocolPortalScreenCast       = "org.freedesktop.portal.ScreenCast"
+	protocolXTest                  = "XTEST"
+	backendWaylandScreencopy       = "wayland+screencopy"
+	backendWaylandVirtualKeyboard  = "wayland-virtual-keyboard"
+	backendWaylandVirtualPointer   = "wayland-virtual-pointer"
+	backendPortalRemoteDesktop     = "portal-remote-desktop"
+	backendPortalScreenCast        = "portal-screencast+pipewire"
+)
+
+var (
+	runtimeNativeWaylandProtocolProbe = nativeWaylandProtocolVersions
+	runtimeX11ProtocolProbe           = nativeX11ProtocolVersion
+	runtimeRemoteDesktopProbe         = GetRemoteDesktopInputStatus
+	runtimeScreenCastProbe            = portalpkg.ProbeScreenCast
+)
+
+func platformRuntimeDiagnosticDetails(
+	ctx context.Context,
+	capabilities RuntimeCapabilities,
+) ([]RuntimeProtocolDiagnostic, []RuntimePermissionDiagnostic) {
+	if capabilities.Runtime.DisplayServer == DisplayServerX11 {
+		return x11RuntimeDiagnosticDetails(capabilities)
+	}
+	if capabilities.Runtime.DisplayServer != DisplayServerWayland {
+		return nil, unavailableDisplayPermissions(capabilities)
+	}
+	return waylandRuntimeDiagnosticDetails(ctx, capabilities)
+}
+
+func x11RuntimeDiagnosticDetails(
+	capabilities RuntimeCapabilities,
+) ([]RuntimeProtocolDiagnostic, []RuntimePermissionDiagnostic) {
+	major, minor, negotiated := runtimeX11ProtocolProbe()
+	version := ""
+	if negotiated {
+		version = fmt.Sprintf("%d.%d", major, minor)
+	}
+	protocols := []RuntimeProtocolDiagnostic{
+		{
+			Feature:    runtimeFeatureKeyboard,
+			Name:       protocolXTest,
+			Version:    version,
+			Negotiated: negotiated,
+			Reason:     capabilities.Keyboard.Reason,
+		},
+		{
+			Feature:    runtimeFeatureMouse,
+			Name:       protocolXTest,
+			Version:    version,
+			Negotiated: negotiated,
+			Reason:     capabilities.Mouse.Reason,
+		},
+	}
+	permissions := []RuntimePermissionDiagnostic{
+		notRequiredPermission(runtimeFeatureCapture, "X11 server access", capabilities.Capture.Reason),
+		notRequiredPermission(runtimeFeatureKeyboard, "X11 XTEST access", capabilities.Keyboard.Reason),
+		notRequiredPermission(runtimeFeatureMouse, "X11 XTEST access", capabilities.Mouse.Reason),
+		notRequiredPermission(runtimeFeatureWindow, "X11 window access", capabilities.Window.Reason),
+	}
+	return protocols, permissions
+}
+
+func waylandRuntimeDiagnosticDetails(
+	ctx context.Context,
+	capabilities RuntimeCapabilities,
+) ([]RuntimeProtocolDiagnostic, []RuntimePermissionDiagnostic) {
+	native := runtimeNativeWaylandProtocolProbe()
+	protocols := make([]RuntimeProtocolDiagnostic, 0, 5)
+	protocols = appendNativeWaylandProtocol(
+		protocols, runtimeFeatureCapture, protocolWaylandScreencopy, native.Screencopy,
+		capabilities.Capture.Backend == backendWaylandScreencopy,
+		capabilities.Capture.Reason,
+	)
+	protocols = appendNativeWaylandProtocol(
+		protocols, runtimeFeatureKeyboard, protocolWaylandVirtualKeyboard,
+		native.VirtualKeyboard,
+		capabilities.Keyboard.Backend == backendWaylandVirtualKeyboard,
+		capabilities.Keyboard.Reason,
+	)
+	protocols = appendNativeWaylandProtocol(
+		protocols, runtimeFeatureMouse, protocolWaylandVirtualPointer,
+		native.VirtualPointer,
+		capabilities.Mouse.Backend == backendWaylandVirtualPointer,
+		capabilities.Mouse.Reason,
+	)
+
+	remoteStatus, remoteErr := runtimeRemoteDesktopProbe(ctx)
+	remoteReason := remoteStatus.Reason
+	if remoteReason == "" && remoteErr != nil {
+		remoteReason = remoteErr.Error()
+	}
+	protocols = append(protocols, RuntimeProtocolDiagnostic{
+		Feature:    runtimeFeatureRemoteDesktop,
+		Name:       protocolPortalRemoteDesktop,
+		Version:    uintVersion(remoteStatus.PortalVersion),
+		Negotiated: remoteStatus.PortalAvailable && remoteStatus.PortalVersion != 0,
+		Reason:     remoteReason,
+	})
+
+	screenCast, screenCastErr := runtimeScreenCastProbe(ctx)
+	screenCastReason := ""
+	if screenCastErr != nil {
+		screenCastReason = screenCastErr.Error()
+	} else if !screenCast.PipeWireReady {
+		screenCastReason = "portal detected, but PipeWire file-descriptor transfer is unavailable"
+	}
+	protocols = append(protocols, RuntimeProtocolDiagnostic{
+		Feature:    runtimeFeatureCapture,
+		Name:       protocolPortalScreenCast,
+		Version:    uintVersion(screenCast.Version),
+		Negotiated: screenCastErr == nil && screenCast.Version != 0,
+		Reason:     screenCastReason,
+	})
+
+	remotePermission := RuntimePermissionDiagnostic{
+		Feature: runtimeFeatureRemoteDesktop,
+		Name:    "desktop portal consent",
+		State:   runtimeRemoteDesktopPermission(remoteStatus.Permission),
+		Reason:  remoteReason,
+	}
+	if remoteErr != nil && !remoteStatus.PortalAvailable &&
+		remotePermission.State == RuntimePermissionNotRequested {
+		remotePermission.State = RuntimePermissionUnavailable
+	}
+	permissions := []RuntimePermissionDiagnostic{
+		capturePermission(capabilities.Capture, screenCastErr),
+		inputPermission(runtimeFeatureKeyboard, capabilities.Keyboard, remotePermission),
+		inputPermission(runtimeFeatureMouse, capabilities.Mouse, remotePermission),
+		remotePermission,
+	}
+	return protocols, permissions
+}
+
+func appendNativeWaylandProtocol(
+	protocols []RuntimeProtocolDiagnostic,
+	feature, name string,
+	version uint32,
+	selected bool,
+	reason string,
+) []RuntimeProtocolDiagnostic {
+	if version == 0 && !selected {
+		return protocols
+	}
+	return append(protocols, RuntimeProtocolDiagnostic{
+		Feature:    feature,
+		Name:       name,
+		Version:    uintVersion(version),
+		Negotiated: version != 0,
+		Reason:     reason,
+	})
+}
+
+func capturePermission(
+	capability FeatureCapability,
+	screenCastErr error,
+) RuntimePermissionDiagnostic {
+	permission := RuntimePermissionDiagnostic{
+		Feature: runtimeFeatureCapture,
+		Name:    "desktop capture consent",
+		State:   RuntimePermissionUnavailable,
+		Reason:  capability.Reason,
+	}
+	switch capability.Backend {
+	case backendWaylandScreencopy:
+		permission.State = RuntimePermissionNotRequired
+	case backendPortalScreenCast:
+		permission.State = RuntimePermissionGranted
+	case string(BackendPortal):
+		permission.State = RuntimePermissionNotRequested
+	default:
+		if screenCastErr == nil {
+			permission.State = RuntimePermissionNotRequested
+		}
+	}
+	return permission
+}
+
+func inputPermission(
+	feature string,
+	capability FeatureCapability,
+	remote RuntimePermissionDiagnostic,
+) RuntimePermissionDiagnostic {
+	if capability.Backend == backendPortalRemoteDesktop || capability.Fallback {
+		remote.Feature = feature
+		return remote
+	}
+	state := RuntimePermissionUnavailable
+	if capability.Available {
+		state = RuntimePermissionNotRequired
+	}
+	return RuntimePermissionDiagnostic{
+		Feature: feature,
+		Name:    "Wayland compositor input policy",
+		State:   state,
+		Reason:  capability.Reason,
+	}
+}
+
+func unavailableDisplayPermissions(
+	capabilities RuntimeCapabilities,
+) []RuntimePermissionDiagnostic {
+	return []RuntimePermissionDiagnostic{
+		{
+			Feature: runtimeFeatureCapture,
+			Name:    "desktop session",
+			State:   RuntimePermissionUnavailable,
+			Reason:  capabilities.Capture.Reason,
+		},
+		{
+			Feature: runtimeFeatureKeyboard,
+			Name:    "desktop session",
+			State:   RuntimePermissionUnavailable,
+			Reason:  capabilities.Keyboard.Reason,
+		},
+		{
+			Feature: runtimeFeatureMouse,
+			Name:    "desktop session",
+			State:   RuntimePermissionUnavailable,
+			Reason:  capabilities.Mouse.Reason,
+		},
+	}
+}
+
+func notRequiredPermission(
+	feature, name, reason string,
+) RuntimePermissionDiagnostic {
+	return RuntimePermissionDiagnostic{
+		Feature: feature,
+		Name:    name,
+		State:   RuntimePermissionNotRequired,
+		Reason:  reason,
+	}
+}
+
+func runtimeRemoteDesktopPermission(
+	status RemoteDesktopPermissionStatus,
+) RuntimePermissionState {
+	switch status {
+	case RemoteDesktopPermissionNotRequested:
+		return RuntimePermissionNotRequested
+	case RemoteDesktopPermissionGranted:
+		return RuntimePermissionGranted
+	case RemoteDesktopPermissionClosed:
+		return RuntimePermissionClosed
+	case RemoteDesktopPermissionCancelled:
+		return RuntimePermissionCancelled
+	case RemoteDesktopPermissionTimedOut:
+		return RuntimePermissionTimedOut
+	case RemoteDesktopPermissionDenied:
+		return RuntimePermissionDenied
+	case RemoteDesktopPermissionFailed:
+		return RuntimePermissionFailed
+	case RemoteDesktopPermissionUnavailable:
+		return RuntimePermissionUnavailable
+	default:
+		return RuntimePermissionUnknown
+	}
+}
+
+func uintVersion(version uint32) string {
+	if version == 0 {
+		return ""
+	}
+	return fmt.Sprint(version)
+}

--- a/runtime_diagnostics_linux_test.go
+++ b/runtime_diagnostics_linux_test.go
@@ -1,0 +1,224 @@
+//go:build linux
+
+package robotgo
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	portalpkg "github.com/marang/robotgo/screen/portal"
+)
+
+func stubRuntimeDiagnosticProbes(t *testing.T) {
+	t.Helper()
+	oldNative := runtimeNativeWaylandProtocolProbe
+	oldX11 := runtimeX11ProtocolProbe
+	oldRemote := runtimeRemoteDesktopProbe
+	oldScreenCast := runtimeScreenCastProbe
+	t.Cleanup(func() {
+		runtimeNativeWaylandProtocolProbe = oldNative
+		runtimeX11ProtocolProbe = oldX11
+		runtimeRemoteDesktopProbe = oldRemote
+		runtimeScreenCastProbe = oldScreenCast
+	})
+}
+
+func TestWaylandRuntimeDiagnosticsReportProtocolsAndPermissions(t *testing.T) {
+	stubRuntimeDiagnosticProbes(t)
+	runtimeNativeWaylandProtocolProbe = func() nativeWaylandProtocolInfo {
+		return nativeWaylandProtocolInfo{
+			Screencopy:      3,
+			VirtualKeyboard: 1,
+			VirtualPointer:  2,
+		}
+	}
+	runtimeRemoteDesktopProbe = func(ctx context.Context) (RemoteDesktopInputStatus, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("RemoteDesktop diagnostic probe received no deadline")
+		}
+		return RemoteDesktopInputStatus{
+			PortalAvailable:   true,
+			PortalVersion:     2,
+			ScreenCastVersion: 4,
+			Permission:        RemoteDesktopPermissionGranted,
+			SessionActive:     true,
+			Reason:            "portal consent session is active",
+		}, nil
+	}
+	runtimeScreenCastProbe = func(ctx context.Context) (portalpkg.ScreenCastCapability, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("ScreenCast diagnostic probe received no deadline")
+		}
+		return portalpkg.ScreenCastCapability{
+			Version:       4,
+			PipeWireReady: true,
+		}, nil
+	}
+	capabilities := RuntimeCapabilities{
+		Runtime: RuntimeBackendInfo{
+			GOOS:          "linux",
+			DisplayServer: DisplayServerWayland,
+		},
+		Capture: FeatureCapability{
+			Available: true,
+			Backend:   backendWaylandScreencopy,
+			Reason:    "native capture ready",
+		},
+		Keyboard: FeatureCapability{
+			Available: true,
+			Fallback:  true,
+			Backend:   backendPortalRemoteDesktop,
+			Reason:    "portal keyboard session ready",
+		},
+		Mouse: FeatureCapability{
+			Available: true,
+			Backend:   backendWaylandVirtualPointer,
+			Reason:    "native pointer ready",
+		},
+	}
+
+	ctx, cancel := boundedDiagnosticContext(context.Background())
+	defer cancel()
+	protocols, permissions := waylandRuntimeDiagnosticDetails(ctx, capabilities)
+	wantProtocols := []RuntimeProtocolDiagnostic{
+		{
+			Feature:    "capture",
+			Name:       protocolWaylandScreencopy,
+			Version:    "3",
+			Negotiated: true,
+			Reason:     "native capture ready",
+		},
+		{
+			Feature:    "keyboard",
+			Name:       protocolWaylandVirtualKeyboard,
+			Version:    "1",
+			Negotiated: true,
+			Reason:     "portal keyboard session ready",
+		},
+		{
+			Feature:    "mouse",
+			Name:       protocolWaylandVirtualPointer,
+			Version:    "2",
+			Negotiated: true,
+			Reason:     "native pointer ready",
+		},
+		{
+			Feature:    "remote-desktop",
+			Name:       protocolPortalRemoteDesktop,
+			Version:    "2",
+			Negotiated: true,
+			Reason:     "portal consent session is active",
+		},
+		{
+			Feature:    "capture",
+			Name:       protocolPortalScreenCast,
+			Version:    "4",
+			Negotiated: true,
+		},
+	}
+	if !reflect.DeepEqual(protocols, wantProtocols) {
+		t.Fatalf("protocol diagnostics = %#v, want %#v", protocols, wantProtocols)
+	}
+	wantPermissions := []RuntimePermissionDiagnostic{
+		{
+			Feature: "capture",
+			Name:    "desktop capture consent",
+			State:   RuntimePermissionNotRequired,
+			Reason:  "native capture ready",
+		},
+		{
+			Feature: "keyboard",
+			Name:    "desktop portal consent",
+			State:   RuntimePermissionGranted,
+			Reason:  "portal consent session is active",
+		},
+		{
+			Feature: "mouse",
+			Name:    "Wayland compositor input policy",
+			State:   RuntimePermissionNotRequired,
+			Reason:  "native pointer ready",
+		},
+		{
+			Feature: "remote-desktop",
+			Name:    "desktop portal consent",
+			State:   RuntimePermissionGranted,
+			Reason:  "portal consent session is active",
+		},
+	}
+	if !reflect.DeepEqual(permissions, wantPermissions) {
+		t.Fatalf("permission diagnostics = %#v, want %#v", permissions, wantPermissions)
+	}
+}
+
+func TestWaylandRuntimeDiagnosticsPreserveProbeFailures(t *testing.T) {
+	stubRuntimeDiagnosticProbes(t)
+	runtimeNativeWaylandProtocolProbe = func() nativeWaylandProtocolInfo {
+		return nativeWaylandProtocolInfo{}
+	}
+	remoteErr := errors.New("RemoteDesktop interface missing")
+	screenCastErr := errors.New("ScreenCast interface missing")
+	runtimeRemoteDesktopProbe = func(context.Context) (RemoteDesktopInputStatus, error) {
+		return RemoteDesktopInputStatus{
+			Permission: RemoteDesktopPermissionUnavailable,
+			Reason:     "install a RemoteDesktop portal backend",
+		}, remoteErr
+	}
+	runtimeScreenCastProbe = func(context.Context) (portalpkg.ScreenCastCapability, error) {
+		return portalpkg.ScreenCastCapability{}, screenCastErr
+	}
+	capabilities := RuntimeCapabilities{
+		Runtime: RuntimeBackendInfo{DisplayServer: DisplayServerWayland},
+		Capture: FeatureCapability{
+			Backend: "portal",
+			Reason:  "portal capture unavailable",
+		},
+		Keyboard: FeatureCapability{Reason: "keyboard unavailable"},
+		Mouse:    FeatureCapability{Reason: "mouse unavailable"},
+	}
+	protocols, permissions := waylandRuntimeDiagnosticDetails(context.Background(), capabilities)
+	if protocols[0].Name != protocolPortalRemoteDesktop ||
+		protocols[0].Negotiated ||
+		protocols[0].Reason != "install a RemoteDesktop portal backend" {
+		t.Fatalf("RemoteDesktop failure diagnostics = %+v", protocols[0])
+	}
+	if protocols[1].Name != protocolPortalScreenCast ||
+		protocols[1].Negotiated ||
+		protocols[1].Reason != screenCastErr.Error() {
+		t.Fatalf("ScreenCast failure diagnostics = %+v", protocols[1])
+	}
+	if permissions[0].State != RuntimePermissionNotRequested {
+		t.Fatalf("portal capture permission = %q, want not-requested", permissions[0].State)
+	}
+	if permissions[3].State != RuntimePermissionUnavailable {
+		t.Fatalf("RemoteDesktop permission = %q, want unavailable", permissions[3].State)
+	}
+}
+
+func TestX11RuntimeDiagnosticsReportNegotiatedXTestVersion(t *testing.T) {
+	stubRuntimeDiagnosticProbes(t)
+	runtimeX11ProtocolProbe = func() (major, minor int, negotiated bool) {
+		return 2, 2, true
+	}
+	capabilities := RuntimeCapabilities{
+		Keyboard: FeatureCapability{Available: true, Reason: "XTEST ready"},
+		Capture:  FeatureCapability{Available: true, Reason: "X11 ready"},
+		Window:   FeatureCapability{Available: true, Reason: "X11 ready"},
+	}
+	protocols, permissions := x11RuntimeDiagnosticDetails(capabilities)
+	if len(protocols) != 2 ||
+		protocols[0].Feature != "keyboard" ||
+		protocols[1].Feature != "mouse" ||
+		protocols[0].Version != "2.2" ||
+		protocols[1].Version != "2.2" ||
+		!protocols[0].Negotiated ||
+		!protocols[1].Negotiated {
+		t.Fatalf("XTEST protocol diagnostics = %+v", protocols)
+	}
+	for _, permission := range permissions {
+		if permission.State != RuntimePermissionNotRequired {
+			t.Fatalf("X11 permission state = %q, want not-required", permission.State)
+		}
+	}
+}

--- a/runtime_diagnostics_other.go
+++ b/runtime_diagnostics_other.go
@@ -1,0 +1,110 @@
+//go:build !linux
+
+package robotgo
+
+import (
+	"context"
+	"runtime"
+	"strings"
+)
+
+func platformRuntimeDiagnosticDetails(
+	_ context.Context,
+	capabilities RuntimeCapabilities,
+) ([]RuntimeProtocolDiagnostic, []RuntimePermissionDiagnostic) {
+	switch runtime.GOOS {
+	case "darwin":
+		return nil, darwinRuntimePermissions(capabilities)
+	case "windows":
+		return nil, []RuntimePermissionDiagnostic{
+			nativeAPIPermission(runtimeFeatureCapture, "Windows desktop access", capabilities.Capture),
+			nativeAPIPermission(runtimeFeatureKeyboard, "Windows input policy", capabilities.Keyboard),
+			nativeAPIPermission(runtimeFeatureMouse, "Windows input policy", capabilities.Mouse),
+			nativeAPIPermission(runtimeFeatureWindow, "Windows process integrity policy", capabilities.Window),
+		}
+	default:
+		return nil, []RuntimePermissionDiagnostic{
+			{
+				Feature: runtimeFeatureDesktop,
+				Name:    "platform support",
+				State:   RuntimePermissionUnavailable,
+				Reason:  ErrNotSupported.Error(),
+			},
+		}
+	}
+}
+
+func darwinRuntimePermissions(
+	capabilities RuntimeCapabilities,
+) []RuntimePermissionDiagnostic {
+	return []RuntimePermissionDiagnostic{
+		{
+			Feature: runtimeFeatureCapture,
+			Name:    "Screen Recording",
+			State: permissionFromCapability(
+				capabilities.Capture,
+				"permission is granted",
+			),
+			Reason: capabilities.Capture.Reason,
+		},
+		{
+			Feature: runtimeFeatureKeyboard,
+			Name:    "Accessibility",
+			State: permissionFromCapability(
+				capabilities.Keyboard,
+				"backend is ready",
+			),
+			Reason: capabilities.Keyboard.Reason,
+		},
+		{
+			Feature: runtimeFeatureMouse,
+			Name:    "Accessibility",
+			State: permissionFromCapability(
+				capabilities.Mouse,
+				"backend is ready",
+			),
+			Reason: capabilities.Mouse.Reason,
+		},
+	}
+}
+
+func permissionFromCapability(
+	capability FeatureCapability,
+	grantedMarker string,
+) RuntimePermissionState {
+	reason := strings.ToLower(capability.Reason)
+	notes := strings.ToLower(capability.Notes)
+	if strings.Contains(reason, strings.ToLower(ErrPermissionDenied.Error())) {
+		return RuntimePermissionDenied
+	}
+	if strings.Contains(notes, "cannot be preflighted") ||
+		strings.Contains(notes, "could not be inspected") ||
+		strings.Contains(notes, "validates access") {
+		return RuntimePermissionUnknown
+	}
+	if capability.Available &&
+		(strings.Contains(notes, strings.ToLower(grantedMarker)) ||
+			strings.Contains(reason, strings.ToLower(grantedMarker))) {
+		return RuntimePermissionGranted
+	}
+	if capability.Available {
+		return RuntimePermissionUnknown
+	}
+	return RuntimePermissionUnavailable
+}
+
+func nativeAPIPermission(
+	feature, name string,
+	capability FeatureCapability,
+) RuntimePermissionDiagnostic {
+	state := RuntimePermissionUnavailable
+	if capability.Available {
+		state = RuntimePermissionNotRequired
+	}
+	return RuntimePermissionDiagnostic{
+		Feature: feature,
+		Name:    name,
+		State:   state,
+		Reason:  capability.Reason,
+	}
+}

--- a/runtime_diagnostics_other_test.go
+++ b/runtime_diagnostics_other_test.go
@@ -1,0 +1,51 @@
+//go:build !linux
+
+package robotgo
+
+import "testing"
+
+func TestPermissionFromCapabilityDoesNotOverclaimAmbiguousPreflight(t *testing.T) {
+	tests := []struct {
+		name       string
+		capability FeatureCapability
+		want       RuntimePermissionState
+	}{
+		{
+			name: "denied",
+			capability: FeatureCapability{
+				Reason: ErrPermissionDenied.Error(),
+			},
+			want: RuntimePermissionDenied,
+		},
+		{
+			name: "granted",
+			capability: FeatureCapability{
+				Available: true,
+				Notes:     "Screen Recording permission is granted",
+			},
+			want: RuntimePermissionGranted,
+		},
+		{
+			name: "preflight unavailable",
+			capability: FeatureCapability{
+				Available: true,
+				Notes:     "Screen Recording permission is granted or cannot be preflighted",
+			},
+			want: RuntimePermissionUnknown,
+		},
+		{
+			name: "unsupported",
+			capability: FeatureCapability{
+				Reason: ErrNotSupported.Error(),
+			},
+			want: RuntimePermissionUnavailable,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := permissionFromCapability(test.capability, "permission is granted"); got != test.want {
+				t.Fatalf("permission = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/runtime_diagnostics_test.go
+++ b/runtime_diagnostics_test.go
@@ -1,0 +1,117 @@
+package robotgo
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeFeatureDiagnosticsHaveStableOrder(t *testing.T) {
+	capability := FeatureCapability{
+		Available: true,
+		Fallback:  true,
+		Backend:   "test",
+		Reason:    "ready",
+		Notes:     "details",
+	}
+	features := runtimeFeatureDiagnostics(RuntimeCapabilities{
+		Capture:       capability,
+		Bounds:        capability,
+		Keyboard:      capability,
+		Mouse:         capability,
+		RemoteDesktop: capability,
+		Window:        capability,
+		Process:       capability,
+		Clipboard:     capability,
+		Hook:          capability,
+		Events:        capability,
+	})
+	got := make([]string, len(features))
+	for index := range features {
+		got[index] = features[index].Name
+		if features[index].Backend != capability.Backend ||
+			features[index].Reason != capability.Reason ||
+			features[index].Notes != capability.Notes {
+			t.Fatalf("feature %q lost capability detail: %+v", features[index].Name, features[index])
+		}
+	}
+	want := []string{
+		"capture", "bounds", "keyboard", "mouse", "remote-desktop",
+		"window", "process", "clipboard", "hook", "events",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("feature order = %v, want %v", got, want)
+	}
+}
+
+func TestRuntimeRemediationOnlyReportsUnavailableFeatures(t *testing.T) {
+	features := []RuntimeFeatureDiagnostic{
+		{Name: "capture", Available: true, Notes: "not an action"},
+		{Name: "keyboard", Notes: "enable the input backend"},
+		{Name: "keyboard", Notes: "enable the input backend"},
+		{Name: "window", Reason: "install a compositor helper"},
+		{Name: "events", Notes: "global events are unsupported"},
+		{Name: "events"},
+	}
+	got := runtimeRemediation(features)
+	want := []RuntimeRemediation{
+		{Feature: "keyboard", Action: "enable the input backend"},
+		{Feature: "window", Action: "install a compositor helper"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("remediation = %#v, want %#v", got, want)
+	}
+}
+
+func TestGetRuntimeDiagnosticsUsesVersionedSanitizedContract(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Cleanup(CloseWaylandInput)
+	}
+	t.Setenv("ROBOTGO_DIAGNOSTIC_SECRET_TEST", "do-not-expose")
+	if runtime.GOOS == "linux" {
+		t.Setenv(envWaylandDisplay, "secret-wayland-display")
+	}
+	report := GetRuntimeDiagnostics(context.Background())
+	if report.SchemaVersion != RuntimeDiagnosticsSchemaVersion {
+		t.Fatalf("schema version = %q, want %q", report.SchemaVersion, RuntimeDiagnosticsSchemaVersion)
+	}
+	if report.Runtime.GOOS == "" || report.Runtime.GOARCH == "" {
+		t.Fatalf("runtime identity missing: %+v", report.Runtime)
+	}
+	if len(report.Features) != 10 {
+		t.Fatalf("feature count = %d, want 10", len(report.Features))
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal diagnostics: %v", err)
+	}
+	if strings.Contains(string(data), "do-not-expose") {
+		t.Fatalf("diagnostics exposed unrelated environment data: %s", data)
+	}
+	if strings.Contains(string(data), "secret-wayland-display") {
+		t.Fatalf("diagnostics exposed the Wayland display address: %s", data)
+	}
+	if !strings.Contains(string(data), `"robotgo_version"`) ||
+		!strings.Contains(string(data), `"build_implementation"`) {
+		t.Fatalf("diagnostic identity does not use the v1 JSON contract: %s", data)
+	}
+}
+
+func TestBoundedDiagnosticContext(t *testing.T) {
+	ctx, cancel := boundedDiagnosticContext(context.Background())
+	defer cancel()
+	if _, ok := ctx.Deadline(); !ok {
+		t.Fatal("diagnostic context has no bounded deadline")
+	}
+
+	parent, parentCancel := context.WithCancel(context.Background())
+	parentCancel()
+	ctx, cancel = boundedDiagnosticContext(parent)
+	defer cancel()
+	if ctx.Err() == nil {
+		t.Fatal("cancelled parent context was not preserved")
+	}
+}

--- a/screen/screengrab_c.h
+++ b/screen/screengrab_c.h
@@ -40,6 +40,7 @@ static inline MMBitmapRef capture_screen_wayland(int32_t x, int32_t y, int32_t w
   return NULL;
 }
 static inline int robotgo_wayland_screencopy_ready(void) { return 0; }
+static inline uint32_t robotgo_wayland_screencopy_version(void) { return 0; }
 #elif defined(IS_LINUX)
 #if !defined(DISPLAY_SERVER_WAYLAND)
 #include "../base/xdisplay_c.h"
@@ -65,6 +66,7 @@ MMBitmapRef capture_screen_wayland(int32_t x, int32_t y, int32_t w, int32_t h,
                                    int32_t display_id, int8_t isPid,
                                    int32_t backend, int32_t *err);
 int robotgo_wayland_screencopy_ready(void);
+uint32_t robotgo_wayland_screencopy_version(void);
 #endif
 // Portal capture is available on Linux regardless of Wayland build tag.
 MMBitmapRef capture_screen_portal(int32_t x, int32_t y, int32_t w, int32_t h,
@@ -83,6 +85,7 @@ static inline MMBitmapRef capture_screen_wayland(int32_t x, int32_t y,
   return NULL;
 }
 static inline int robotgo_wayland_screencopy_ready(void) { return 0; }
+static inline uint32_t robotgo_wayland_screencopy_version(void) { return 0; }
 #endif
 #elif defined(IS_WINDOWS)
 #include <string.h>
@@ -128,6 +131,7 @@ static inline MMBitmapRef capture_screen_wayland(int32_t x, int32_t y, int32_t w
   return NULL;
 }
 static inline int robotgo_wayland_screencopy_ready(void) { return 0; }
+static inline uint32_t robotgo_wayland_screencopy_version(void) { return 0; }
 #endif
 
 #if defined(IS_MACOSX) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > 140400

--- a/screen/screengrab_wayland_impl.c
+++ b/screen/screengrab_wayland_impl.c
@@ -16,6 +16,7 @@
 #include <limits.h>
 #include <poll.h>
 #include <stdint.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -651,6 +652,8 @@ struct capture {
   int err_code;
 };
 
+static _Atomic uint32_t robotgo_last_screencopy_version = 0;
+
 static void attach_xdg_output(struct capture *cap, struct output *out) {
   if (!cap || !out || !cap->xdg_output_manager || !out->wl_output || out->xdg_output) {
     return;
@@ -1137,6 +1140,7 @@ int robotgo_wayland_screencopy_ready(void) {
   struct capture cap = {0};
   cap.drm_fd = -1;
   wl_list_init(&cap.outputs);
+  atomic_store(&robotgo_last_screencopy_version, 0);
 
   cap.display = wl_display_connect(NULL);
   if (!cap.display) {
@@ -1154,10 +1158,18 @@ int robotgo_wayland_screencopy_ready(void) {
     return 0;
   }
 
+  if (cap.manager) {
+    atomic_store(&robotgo_last_screencopy_version,
+                 zwlr_screencopy_manager_v1_get_version(cap.manager));
+  }
   int ready = cap.manager != NULL && !wl_list_empty(&cap.outputs) &&
               (cap.shm != NULL || cap.dmabuf != NULL);
   cleanup_capture(&cap);
   return ready;
+}
+
+uint32_t robotgo_wayland_screencopy_version(void) {
+  return atomic_load(&robotgo_last_screencopy_version);
 }
 
 // capture_screen_wayland_impl performs the actual capture logic. The backend

--- a/wayland_compositor.go
+++ b/wayland_compositor.go
@@ -1,0 +1,103 @@
+package robotgo
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+const (
+	envDesktop           = "XDG_CURRENT_DESKTOP"
+	envSessionDesktop    = "XDG_SESSION_DESKTOP"
+	envSwaySock          = "SWAYSOCK"
+	envHyprlandSignature = "HYPRLAND_INSTANCE_SIGNATURE"
+
+	compositorWlroots     = "wlroots"
+	compositorMutter      = "mutter"
+	compositorKWin        = "kwin"
+	compositorHyprland    = "hyprland"
+	compositorSway        = "sway"
+	compositorWayfire     = "wayfire"
+	compositorRiver       = "river"
+	compositorLabwc       = "labwc"
+	compositorDwl         = "dwl"
+	compositorGamescope   = "gamescope"
+	compositorUnknown     = "unknown"
+	desktopTokenSway      = "sway"
+	desktopTokenGNOME     = "gnome"
+	desktopTokenKDE       = "kde"
+	desktopTokenPlasma    = "plasma"
+	desktopTokenWayfire   = "wayfire"
+	desktopTokenHyprland  = "hyprland"
+	desktopTokenRiver     = "river"
+	desktopTokenLabwc     = "labwc"
+	desktopTokenDwl       = "dwl"
+	desktopTokenGamescope = "gamescope"
+)
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func detectWaylandCompositor() string {
+	if runtime.GOOS != "linux" || DetectDisplayServer() != DisplayServerWayland {
+		return ""
+	}
+
+	desktop := strings.ToLower(os.Getenv(envDesktop))
+	session := strings.ToLower(os.Getenv(envSessionDesktop))
+
+	if isSwaySession(desktop, session) {
+		return compositorSway
+	}
+	if isHyprlandSession(desktop, session) {
+		return compositorHyprland
+	}
+	if containsAny(desktop, desktopTokenWayfire) ||
+		containsAny(session, desktopTokenWayfire) {
+		return compositorWayfire
+	}
+	if containsAny(desktop, desktopTokenRiver) ||
+		containsAny(session, desktopTokenRiver) {
+		return compositorRiver
+	}
+	if containsAny(desktop, desktopTokenLabwc) ||
+		containsAny(session, desktopTokenLabwc) {
+		return compositorLabwc
+	}
+	if containsAny(desktop, desktopTokenDwl) ||
+		containsAny(session, desktopTokenDwl) {
+		return compositorDwl
+	}
+	if containsAny(desktop, desktopTokenGamescope) ||
+		containsAny(session, desktopTokenGamescope) {
+		return compositorGamescope
+	}
+	if containsAny(desktop, desktopTokenGNOME) ||
+		containsAny(session, desktopTokenGNOME) {
+		return compositorMutter
+	}
+	if containsAny(desktop, desktopTokenKDE, desktopTokenPlasma) ||
+		containsAny(session, desktopTokenKDE, desktopTokenPlasma) {
+		return compositorKWin
+	}
+
+	return compositorUnknown
+}
+
+func isSwaySession(desktop, session string) bool {
+	return os.Getenv(envSwaySock) != "" ||
+		containsAny(desktop, desktopTokenSway) ||
+		containsAny(session, desktopTokenSway)
+}
+
+func isHyprlandSession(desktop, session string) bool {
+	return os.Getenv(envHyprlandSignature) != "" ||
+		containsAny(desktop, desktopTokenHyprland) ||
+		containsAny(session, desktopTokenHyprland)
+}

--- a/wayland_compositor_nocgo_test.go
+++ b/wayland_compositor_nocgo_test.go
@@ -1,0 +1,29 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestPureGoWaylandCompositorDetectionMatchesNativeContract(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Wayland compositor detection is Linux-specific")
+	}
+	t.Setenv(envWaylandDisplay, "wayland-test")
+	t.Setenv(envDisplay, "")
+	t.Setenv(envDesktop, "")
+	t.Setenv(envSessionDesktop, "")
+	t.Setenv(envHyprlandSignature, "")
+	t.Setenv(envSwaySock, "sway-test.sock")
+	if got := detectWaylandCompositor(); got != compositorSway {
+		t.Fatalf("SWAYSOCK compositor = %q, want %q", got, compositorSway)
+	}
+
+	t.Setenv(envSwaySock, "")
+	t.Setenv(envDesktop, "GNOME")
+	if got := detectWaylandCompositor(); got != compositorMutter {
+		t.Fatalf("GNOME compositor = %q, want %q", got, compositorMutter)
+	}
+}

--- a/window_backend.go
+++ b/window_backend.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -15,31 +14,6 @@ import (
 )
 
 const (
-	envDesktop                     = "XDG_CURRENT_DESKTOP"
-	envSessionDesktop              = "XDG_SESSION_DESKTOP"
-	envSwaySock                    = "SWAYSOCK"
-	envHyprlandSignature           = "HYPRLAND_INSTANCE_SIGNATURE"
-	compositorWlroots              = "wlroots"
-	compositorMutter               = "mutter"
-	compositorKWin                 = "kwin"
-	compositorHyprland             = "hyprland"
-	compositorSway                 = "sway"
-	compositorWayfire              = "wayfire"
-	compositorRiver                = "river"
-	compositorLabwc                = "labwc"
-	compositorDwl                  = "dwl"
-	compositorGamescope            = "gamescope"
-	compositorUnknown              = "unknown"
-	desktopTokenSway               = "sway"
-	desktopTokenGNOME              = "gnome"
-	desktopTokenKDE                = "kde"
-	desktopTokenPlasma             = "plasma"
-	desktopTokenWayfire            = "wayfire"
-	desktopTokenHyprland           = "hyprland"
-	desktopTokenRiver              = "river"
-	desktopTokenLabwc              = "labwc"
-	desktopTokenDwl                = "dwl"
-	desktopTokenGamescope          = "gamescope"
 	windowBackendSway              = "sway"
 	windowBackendHypr              = "hyprland"
 	windowBackendWlroots           = "wlroots-generic"
@@ -82,15 +56,6 @@ var (
 		return exec.CommandContext(ctx, name, args...).Output()
 	}
 )
-
-func containsAny(haystack string, needles ...string) bool {
-	for _, n := range needles {
-		if strings.Contains(haystack, n) {
-			return true
-		}
-	}
-	return false
-}
 
 type windowBackend interface {
 	Name() string
@@ -691,58 +656,12 @@ func resolveWindowBackend() windowBackend {
 	return waylandCoreWindowBackend{compositor: compositor}
 }
 
-func detectWaylandCompositor() string {
-	if runtime.GOOS != "linux" || DetectDisplayServer() != DisplayServerWayland {
-		return ""
-	}
-
-	desktop := strings.ToLower(os.Getenv(envDesktop))
-	session := strings.ToLower(os.Getenv(envSessionDesktop))
-
-	if isSwaySession(desktop, session) {
-		return compositorSway
-	}
-	if isHyprlandSession(desktop, session) {
-		return compositorHyprland
-	}
-	if containsAny(desktop, desktopTokenWayfire) || containsAny(session, desktopTokenWayfire) {
-		return compositorWayfire
-	}
-	if containsAny(desktop, desktopTokenRiver) || containsAny(session, desktopTokenRiver) {
-		return compositorRiver
-	}
-	if containsAny(desktop, desktopTokenLabwc) || containsAny(session, desktopTokenLabwc) {
-		return compositorLabwc
-	}
-	if containsAny(desktop, desktopTokenDwl) || containsAny(session, desktopTokenDwl) {
-		return compositorDwl
-	}
-	if containsAny(desktop, desktopTokenGamescope) || containsAny(session, desktopTokenGamescope) {
-		return compositorGamescope
-	}
-	if containsAny(desktop, desktopTokenGNOME) || containsAny(session, desktopTokenGNOME) {
-		return compositorMutter
-	}
-	if containsAny(desktop, desktopTokenKDE, desktopTokenPlasma) || containsAny(session, desktopTokenKDE, desktopTokenPlasma) {
-		return compositorKWin
-	}
-
-	return compositorUnknown
-}
-
 func waylandCompositorFamily(compositor string) string {
 	switch compositor {
-	case compositorSway, compositorHyprland, compositorWayfire, compositorRiver, compositorLabwc, compositorDwl, compositorGamescope:
+	case compositorSway, compositorHyprland, compositorWayfire, compositorRiver,
+		compositorLabwc, compositorDwl, compositorGamescope:
 		return compositorWlroots
 	default:
 		return compositor
 	}
-}
-
-func isSwaySession(desktop, session string) bool {
-	return os.Getenv(envSwaySock) != "" || containsAny(desktop, desktopTokenSway) || containsAny(session, desktopTokenSway)
-}
-
-func isHyprlandSession(desktop, session string) bool {
-	return os.Getenv(envHyprlandSignature) != "" || containsAny(desktop, desktopTokenHyprland) || containsAny(session, desktopTokenHyprland)
 }

--- a/x11_display_check_linux_x11.go
+++ b/x11_display_check_linux_x11.go
@@ -99,6 +99,17 @@ func nativeX11CapabilityErrors() (displayErr error, inputErr error) {
 	return nil, nativeX11InputReadyLocked()
 }
 
+func nativeX11ProtocolVersion() (major, minor int, negotiated bool) {
+	unlock := lockNativeX11Display()
+	defer unlock()
+	var cMajor C.int
+	var cMinor C.int
+	if int(C.robotgo_x11_probe_input(&cMajor, &cMinor)) != int(C.ROBOTGO_X11_PROBE_OK) {
+		return int(cMajor), int(cMinor), false
+	}
+	return int(cMajor), int(cMinor), true
+}
+
 func x11MainDisplayAvailableLocked() bool {
 	return nativeX11DisplayReadyLocked() == nil
 }

--- a/x11_display_check_other.go
+++ b/x11_display_check_other.go
@@ -25,4 +25,8 @@ func nativeX11CapabilityErrors() (displayErr error, inputErr error) {
 	return err, err
 }
 
+func nativeX11ProtocolVersion() (major, minor int, negotiated bool) {
+	return 0, 0, false
+}
+
 func x11MainDisplayAvailableLocked() bool { return false }


### PR DESCRIPTION
## Goal

Deliver the first Phase 5 reliability-product slice: a versioned, sanitized runtime diagnostic contract and published support matrix.

## Changes

- add `GetRuntimeDiagnostics` schema v1 with stable feature ordering
- report selected backends/fallbacks, negotiated Wayland/portal/XTEST versions, permission state, and actionable remediation
- keep display addresses, restore tokens, stream identifiers, and unrelated environment data out of the report
- reuse the existing Screencopy probe through an atomic negotiated-version cache (no extra Wayland connection/roundtrip)
- unify CGO and Pure-Go Wayland compositor detection
- add a runnable JSON diagnostic example
- publish `docs/compatibility/runtime-v1.md` and update README, TEST, roadmap, and operational backlog

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- CGO and non-CGO `golangci-lint`
- full `-tags wayland` suite
- tagged Screencopy and Wayland root matrices
- Wayland public API race suite
- portal race suite
- Darwin/arm64 and Windows/amd64 non-CGO cross-builds
- C/CGO warning build with `-Wall -Wextra -Werror` (excluding pre-existing unused helper warnings)

## Remaining Phase 5 blockers

Protected GNOME/KDE/wlroots runner evidence, release evidence snapshots, and native sanitizer/leak gates remain separate follow-up work.