### PR TITLE
ci: add native sanitizer leak gates

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,6 +56,58 @@ jobs:
         run: go test -race ./...
       - name: Stress race-testable Pure-Go X11 core
         run: go test -race -count=20 -timeout=2m ./internal/x11input
+  sanitizer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CGO_ENABLED: "1"
+      ASAN_OPTIONS: detect_leaks=1:halt_on_error=1:strict_string_checks=1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.25.x
+      - name: Install native sanitizer dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libx11-dev libxtst-dev \
+            libwayland-dev libxkbcommon-dev wayland-protocols \
+            libgbm-dev libdrm-dev
+      - name: Run default native suite with AddressSanitizer and LeakSanitizer
+        run: go test -asan -count=1 ./...
+      - name: Run hermetic Wayland ownership paths with sanitizers
+        run: |
+          set -euo pipefail
+          expected="$(printf '%s\n' \
+            TestScreencopyDmabufFailureDoesNotCloseStdin \
+            TestScreencopyTimeoutIsBounded \
+            TestScreencopyWlShm | LC_ALL=C sort)"
+          listed="$(go test -asan -tags 'wayland test' ./screen \
+            -list '^TestScreencopy(WlShm|TimeoutIsBounded|DmabufFailureDoesNotCloseStdin)$')"
+          printf '%s\n' "$listed"
+          actual="$(printf '%s\n' "$listed" | \
+            awk '/^TestScreencopy/ { print }' | LC_ALL=C sort)"
+          if [ "$actual" != "$expected" ]; then
+            echo "sanitizer test manifest mismatch" >&2
+            printf 'expected:\n%s\nactual:\n%s\n' \
+              "$expected" "${actual:-<empty>}" >&2
+            exit 1
+          fi
+          output="$(go test -asan -tags 'wayland test' ./screen \
+            -run '^TestScreencopy(WlShm|TimeoutIsBounded|DmabufFailureDoesNotCloseStdin)$' \
+            -count=1 -timeout=60s -v)"
+          printf '%s\n' "$output"
+          while IFS= read -r test_name; do
+            if ! grep -Eq "^--- PASS: ${test_name} \\(.*\\)$" <<<"$output"; then
+              echo "sanitizer test did not pass: ${test_name}" >&2
+              exit 1
+            fi
+          done <<EOF
+          $expected
+          EOF
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/TEST.md
+++ b/TEST.md
@@ -38,6 +38,25 @@ CGO_ENABLED=1 golangci-lint run --timeout=5m ./...
 CGO_ENABLED=0 golangci-lint run --timeout=5m ./...
 ```
 
+Linux native ownership boundaries are a blocking AddressSanitizer and
+LeakSanitizer target. Reproduce the default gate on a CGO-capable Linux
+`amd64` host with GCC:
+
+```bash
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 \
+  go test -asan -count=1 ./...
+
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 \
+  go test -asan -tags "wayland test" ./screen \
+  -run '^TestScreencopy(WlShm|TimeoutIsBounded|DmabufFailureDoesNotCloseStdin)$' \
+  -count=1 -timeout=60s -v
+```
+
+The tagged tests use hermetic Wayland protocol servers and must all pass; CI
+checks their manifest so a missing or renamed ownership test cannot silently
+reduce coverage. The gate covers allocation/free, timeout cleanup, and file
+descriptor ownership without requiring a graphical session or render node.
+
 The non-CGO suite runs on Linux, macOS, and Windows in CI. It also verifies
 runtime build/feature introspection, pixel-color parity, and hermetic Pure-Go
 capture dispatch for CoreGraphics, X11, Windows, and the Wayland screenshot
@@ -87,9 +106,9 @@ every balanced-comparison benchmark once. The same job starts a reachable Xvfb w
 and verifies that native readiness rejects it without injecting input. Missing
 runtime prerequisites fail instead of turning these checks into successful
 skips. Performance numbers are report-only; correctness is blocking. Repository
-branch protection requires the stable three-OS, lint, vet, race, Wayland, and
-X11 evidence checks. Opt-in real-compositor jobs remain excluded until matching
-self-hosted runners are registered.
+branch protection requires the stable three-OS, lint, vet, race, sanitizer,
+Wayland, and X11 evidence checks. Opt-in real-compositor jobs remain excluded
+until matching self-hosted runners are registered.
 
 Pure-Go Windows input has hermetic tests for Win32 `INPUT` layout,
 foreground-layout key mapping, Unicode surrogate pairs, partial-injection

--- a/docs/compatibility/runtime-v1.md
+++ b/docs/compatibility/runtime-v1.md
@@ -13,9 +13,9 @@ available. A pending row is not a passing row.
 
 | Platform/session | Build mode | Status | Blocking evidence and limits |
 |---|---|---|---|
-| Linux/X11 | Native CGO | supported | Default Linux tests, race/vet/lint, Xvfb/XTEST public contract, XTEST-disabled negative contract |
+| Linux/X11 | Native CGO | supported | Default Linux tests, race/vet/lint, ASan/LeakSanitizer ownership gate, Xvfb/XTEST public contract, XTEST-disabled negative contract |
 | Linux/X11 | Pure Go | supported | Non-CGO Linux tests plus non-skipping Xvfb/XTEST input, capture, bounds, cleanup, and crash-guardian contracts |
-| Linux/Wayland/wlroots | Native CGO, `wayland` | supported for advertised protocols | Weston integration plus hermetic screencopy, virtual input, bounds, scale, transform, fallback, and ownership tests; compositor-specific protocols remain capability-gated |
+| Linux/Wayland/wlroots | Native CGO, `wayland` | supported for advertised protocols | Weston integration plus hermetic screencopy, virtual input, bounds, scale, transform, fallback, and manifest-checked ASan/LeakSanitizer ownership tests; compositor-specific protocols remain capability-gated |
 | Linux/Wayland | Pure Go | supported for portal APIs | Non-CGO portal capture/input contracts; user consent and portal backend availability remain runtime requirements |
 | GNOME/Wayland | CGO and Pure Go portal paths | implemented / evidence pending | Protected GNOME runner required for RemoteDesktop and persistent ScreenCast evidence |
 | KDE Plasma/Wayland | CGO and Pure Go portal paths | implemented / evidence pending | Protected KDE runner required for RemoteDesktop and persistent ScreenCast evidence |

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -26,18 +26,18 @@ The July 2026 hardening work establishes the foundation for this roadmap:
   portal input on Wayland, and an XGB/XTEST input backend for X11-primary Linux
   sessions; remaining unavailable GUI operations return `ErrNotSupported`.
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
-  Weston integration, race, and vet variants.
+  Weston integration, race, vet, and native sanitizer/leak variants.
 
 ## Execution Status (2026-07-17)
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
-| Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet jobs, protected stable CI checks | Keep required jobs green |
+| Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet/sanitizer jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
-| 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, and a non-skipping geometry/transform CI matrix | Real GNOME/KDE/wlroots evidence and sanitizer-backed native leak gate |
+| 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE/wlroots evidence |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and keyboard/pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz keyboard/pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture and XGB/XTEST input; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS keyboard-injection evidence and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
-| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants | Dedicated compositor jobs, sanitizer/leak gates, release evidence snapshots |
+| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates | Dedicated compositor jobs and release evidence snapshots |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
@@ -294,9 +294,11 @@ versions, non-prompting permission state, and remediation without exposing
 display addresses, restore tokens, stream identifiers, or unrelated environment
 values. The published `docs/compatibility/runtime-v1.md` matrix distinguishes
 blocking support from pending runtime evidence. CI covers three operating
-systems, non-CGO, tagged Wayland/portal, and Weston integration. Dedicated
-GNOME/KDE/wlroots jobs, release evidence snapshots, and native sanitizer gates
-remain open.
+systems, non-CGO, tagged Wayland/portal, Weston integration, and a blocking
+Linux native ASan/LeakSanitizer gate. The sanitizer job verifies its hermetic
+Wayland ownership-test manifest and covers allocation/free, timeout cleanup,
+and descriptor ownership. Dedicated GNOME/KDE/wlroots jobs and release evidence
+snapshots remain open.
 
 Releases require:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -153,8 +153,8 @@ backends.
   - 6. Keep the published runtime compatibility matrix and diagnostic schema
     versioned. Schema v1 now reports negotiated protocol versions, permission
     state, and actionable remediation without sensitive session data.
-  - 7. Promote race/vet and native leak/sanitizer checks to blocking release
-    gates, with dedicated GNOME/KDE/wlroots jobs.
+  - 7. Keep race/vet and the manifest-checked native ASan/LeakSanitizer ownership
+    suites blocking. Provision the remaining dedicated GNOME/KDE/wlroots jobs.
 
 - Recently completed parity work:
   - Window state/query APIs expose `IsTopMostE`, `IsMinimizedE`,
@@ -220,8 +220,9 @@ backends.
     manifest; guardian/host/X-server loss and X11 transport stalls beyond the
     cleanup deadline remain outside that scoped guarantee.
   - Provision the existing dedicated GNOME, KDE, and wlroots runtime workflow.
-  - Keep the race/vet CI jobs green and protect them; add leak/sanitizer and
-    bounds-across-outputs gates.
+  - Keep the race/vet and native ASan/LeakSanitizer CI jobs green and protected.
+    The sanitizer gate covers the default CGO suite plus hermetic screencopy
+    allocation/free, bounded timeout cleanup, and FD ownership paths.
 - Examples/Docs:
   - Add backend selection flags in examples (dmabuf, wl_shm, portal).
   - Keep `examples/purego_x11_input` side-effect-free by default; live

--- a/screen/capture_test.go
+++ b/screen/capture_test.go
@@ -25,9 +25,11 @@ func TestCaptureScreen(t *testing.T) {
 		t.Setenv("WAYLAND_DISPLAY", "")
 		// Force the portal fallback to avoid X_GetImage crashes on constrained servers.
 		t.Setenv("ROBOTGO_FORCE_PORTAL", "1")
-		if _, err := robotgo.CaptureScreen(); err != nil {
+		bitmap, err := robotgo.CaptureScreen()
+		if err != nil {
 			t.Skipf("X11 capture skipped: %v", err)
 		}
+		t.Cleanup(func() { robotgo.FreeBitmap(bitmap) })
 		if lb := robotgo.LastBackend(); lb != robotgo.BackendPortal {
 			t.Fatalf("expected portal backend, got %v", lb)
 		}
@@ -42,9 +44,14 @@ func TestCaptureScreen(t *testing.T) {
 			t.Skip("WAYLAND_DISPLAY not set")
 		}
 		t.Setenv("DISPLAY", "")
-		if _, err := robotgo.CaptureScreen(); err != nil && strings.Contains(err.Error(), "no display server found") {
-			t.Fatalf("unexpected no display server error: %v", err)
+		bitmap, err := robotgo.CaptureScreen()
+		if err != nil {
+			if strings.Contains(err.Error(), "no display server found") {
+				t.Fatalf("unexpected no display server error: %v", err)
+			}
+			return
 		}
+		t.Cleanup(func() { robotgo.FreeBitmap(bitmap) })
 	})
 
 	t.Run("PortalForce", func(t *testing.T) {

--- a/screen/screengrab_wayland_test.go
+++ b/screen/screengrab_wayland_test.go
@@ -88,12 +88,14 @@ func TestScreencopyDmabuf(t *testing.T) {
 
 	waitForMockServer(t, dir, sock)
 
-	if _, err := CaptureScreen(); err != nil {
+	bitmap, err := CaptureScreen()
+	if err != nil {
 		if errors.Is(err, robotgo.ErrDmabufImport) || errors.Is(err, robotgo.ErrDmabufMap) || errors.Is(err, robotgo.ErrDmabufDevice) || errors.Is(err, robotgo.ErrDmabufModifiers) {
 			t.Skip("dmabuf allocation not available")
 		}
 		t.Fatalf("capture failed: %v", err)
 	}
+	t.Cleanup(func() { robotgo.FreeBitmap(bitmap) })
 	if got := robotgo.LastBackend(); got != robotgo.BackendScreencopy {
 		t.Fatalf("backend = %q, want %q", got, robotgo.BackendScreencopy)
 	}
@@ -115,9 +117,11 @@ func TestScreencopyWlShm(t *testing.T) {
 
 	waitForMockServer(t, dir, sock)
 
-	if _, err := CaptureScreen(); err != nil {
+	bitmap, err := CaptureScreen()
+	if err != nil {
 		t.Fatalf("capture failed: %v", err)
 	}
+	t.Cleanup(func() { robotgo.FreeBitmap(bitmap) })
 	if got := robotgo.LastBackend(); got != robotgo.BackendScreencopy {
 		t.Fatalf("backend = %q, want %q", got, robotgo.BackendScreencopy)
 	}


### PR DESCRIPTION
## Goal
Make native C/CGO ownership regressions a blocking, reproducible Linux CI failure.

## Changes
- add a dedicated ASan/LeakSanitizer job for the full default CGO suite
- add a manifest-checked hermetic Wayland allocation/timeout/FD-ownership sanitizer suite
- fix four test-owned C bitmaps exposed by LeakSanitizer
- document the local commands and update roadmap/compatibility status

## Risk
Low. Production behavior is unchanged; the new CI gate is stricter and intentionally fails on native leaks or a reduced ownership-test manifest.

## Validation
- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...` and `CGO_ENABLED=0 go vet ./...`
- CGO and Pure-Go golangci-lint
- `go test -asan -count=1 ./...`
- manifest-checked tagged Wayland ASan/LSan suite
- actionlint