### PR TITLE
feat: add versioned release evidence snapshots

### DIFF
--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -1,0 +1,433 @@
+name: Release evidence
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-evidence-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-evidence-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.25.x
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libx11-dev libxtst-dev \
+            libwayland-dev libxkbcommon-dev wayland-protocols \
+            libgbm-dev libdrm-dev
+      - name: Validate release evidence generator and verifier
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/release-evidence-validation"
+          mkdir -p "$output"
+          test_command='go test -count=1 ./internal/releaseevidence ./internal/cmd/releaseevidence'
+          go test -count=1 \
+            ./internal/releaseevidence ./internal/cmd/releaseevidence \
+            2>&1 | tee "$output/test.log"
+          test -z "$(git status --porcelain --untracked-files=all)"
+          commit="$(git rev-parse HEAD)"
+          tree="$(git rev-parse 'HEAD^{tree}')"
+          test "$commit" = "$GITHUB_SHA"
+          go run ./internal/cmd/releaseevidence generate \
+            -out "$output/evidence.json" \
+            -test-log "$output/test.log" \
+            -commit "$commit" \
+            -tree "$tree" \
+            -ref "$GITHUB_REF" \
+            -run-id "$GITHUB_RUN_ID" \
+            -run-attempt "$GITHUB_RUN_ATTEMPT" \
+            -matrix linux-native-validation \
+            -test-command "$test_command" \
+            -expected-cgo true
+          go run ./internal/cmd/releaseevidence verify \
+            -evidence "$output/evidence.json" \
+            -expected-matrix linux-native-validation \
+            -expected-commit "$commit" \
+            -expected-tree "$tree" \
+            -expected-ref "$GITHUB_REF" \
+            -expected-test-command "$test_command"
+
+  snapshot:
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cgo: "1"
+            expected_cgo: "true"
+            label: linux-native
+          - os: ubuntu-latest
+            cgo: "0"
+            expected_cgo: "false"
+            label: linux-purego
+          - os: macOS-latest
+            cgo: "1"
+            expected_cgo: "true"
+            label: macos-native
+          - os: macOS-latest
+            cgo: "0"
+            expected_cgo: "false"
+            label: macos-purego
+          - os: windows-latest
+            cgo: "1"
+            expected_cgo: "true"
+            label: windows-native
+          - os: windows-latest
+            cgo: "0"
+            expected_cgo: "false"
+            label: windows-purego
+    name: snapshot (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.25.x
+      - name: Install Linux native build dependencies
+        if: runner.os == 'Linux' && matrix.cgo == '1'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libx11-dev libxtst-dev \
+            libwayland-dev libxkbcommon-dev wayland-protocols \
+            libgbm-dev libdrm-dev
+      - name: Test exact source and generate evidence
+        shell: bash
+        env:
+          CGO_ENABLED: ${{ matrix.cgo }}
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/release-evidence-${{ matrix.label }}"
+          mkdir -p "$output"
+          test_command='go test -count=1 ./...'
+          go test -count=1 ./... 2>&1 | tee "$output/test.log"
+          test -z "$(git status --porcelain --untracked-files=all)"
+          commit="$(git rev-parse HEAD)"
+          tree="$(git rev-parse 'HEAD^{tree}')"
+          test "$commit" = "$GITHUB_SHA"
+          go run ./internal/cmd/releaseevidence generate \
+            -out "$output/evidence.json" \
+            -test-log "$output/test.log" \
+            -commit "$commit" \
+            -tree "$tree" \
+            -ref "$GITHUB_REF" \
+            -run-id "$GITHUB_RUN_ID" \
+            -run-attempt "$GITHUB_RUN_ATTEMPT" \
+            -matrix "${{ matrix.label }}" \
+            -test-command "$test_command" \
+            -expected-cgo "${{ matrix.expected_cgo }}"
+          go run ./internal/cmd/releaseevidence verify \
+            -evidence "$output/evidence.json" \
+            -expected-matrix "${{ matrix.label }}" \
+            -expected-commit "$commit" \
+            -expected-tree "$tree" \
+            -expected-ref "$GITHUB_REF" \
+            -expected-test-command "$test_command"
+      - name: Upload matrix evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-evidence-${{ matrix.label }}
+          path: ${{ runner.temp }}/release-evidence-${{ matrix.label }}
+          if-no-files-found: error
+          retention-days: 90
+
+  protected-checks:
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs: release-evidence-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    permissions:
+      checks: read
+      contents: read
+      statuses: read
+    steps:
+      - name: Record successful protected checks for exact commit
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/release-required-checks"
+          mkdir -p "$output"
+          deadline=$((SECONDS + 600))
+          while :; do
+            gh api -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
+              > "$output/check-runs-source.json"
+            gh api -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status?per_page=100" \
+              > "$output/status-source.json"
+            : > "$output/rows.jsonl"
+            pending=0
+            while IFS= read -r check_name; do
+              row="$(jq -c --arg name "$check_name" '
+                [.check_runs[] | select(.name == $name)] |
+                sort_by(.started_at // .completed_at // "") |
+                last |
+                if . == null then empty else {
+                  name: .name,
+                  conclusion: .conclusion,
+                  provider: .app.slug,
+                  url: .html_url
+                } end
+              ' "$output/check-runs-source.json")"
+              conclusion="$(jq -r '.conclusion // ""' <<<"${row:-null}")"
+              if [ -z "$conclusion" ]; then
+                pending=1
+                continue
+              fi
+              if [ "$conclusion" != success ]; then
+                echo "required check failed: $check_name ($conclusion)" >&2
+                exit 1
+              fi
+              printf '%s\n' "$row" >> "$output/rows.jsonl"
+            done <<'EOF'
+          lint
+          nocgo (macOS-latest)
+          nocgo (ubuntu-latest)
+          nocgo (windows-latest)
+          ocr
+          race
+          release-evidence-validation
+          sanitizer
+          test (macOS-latest)
+          test (ubuntu-latest)
+          test (windows-latest)
+          vet
+          wayland-integration
+          x11-backend-evidence
+          EOF
+            status_row="$(jq -c '
+              [.statuses[] | select(.context == "ci/circleci: build")] |
+              sort_by(.created_at // "") |
+              last |
+              if . == null then empty else {
+                name: .context,
+                conclusion: .state,
+                provider: "circleci",
+                url: .target_url
+              } end
+            ' "$output/status-source.json")"
+            status_state="$(jq -r '.conclusion // ""' <<<"${status_row:-null}")"
+            case "$status_state" in
+              success)
+                printf '%s\n' "$status_row" >> "$output/rows.jsonl"
+                ;;
+              ""|pending)
+                pending=1
+                ;;
+              *)
+                echo "required status failed: ci/circleci: build ($status_state)" >&2
+                exit 1
+                ;;
+            esac
+            if [ "$pending" -eq 0 ]; then
+              break
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "timed out waiting for required release checks" >&2
+              exit 1
+            fi
+            echo "waiting for required release checks"
+            sleep 10
+          done
+          jq -s --arg commit "$GITHUB_SHA" '{
+            schema_version: "1",
+            commit: $commit,
+            checks: sort_by(.name)
+          }' "$output/rows.jsonl" > "$output/required-checks.json"
+          rm "$output/check-runs-source.json" \
+            "$output/status-source.json" "$output/rows.jsonl"
+      - name: Upload protected-check evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-required-checks
+          path: ${{ runner.temp }}/release-required-checks
+          if-no-files-found: error
+          retention-days: 90
+
+  package:
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs: [protected-checks, release-evidence-validation, snapshot]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      archive: ${{ steps.bundle.outputs.archive }}
+      checksum: ${{ steps.bundle.outputs.checksum }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.25.x
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-evidence-*
+          path: evidence
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-required-checks
+          path: required-checks
+      - name: Verify and package complete release matrix
+        id: bundle
+        shell: bash
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          set -euo pipefail
+          expected="$(printf '%s\n' \
+            linux-native linux-purego \
+            macos-native macos-purego \
+            windows-native windows-purego | LC_ALL=C sort)"
+          actual="$(find evidence -mindepth 1 -maxdepth 1 -type d \
+            -name 'release-evidence-*' -printf '%f\n' | \
+            sed 's/^release-evidence-//' | LC_ALL=C sort)"
+          if [ "$actual" != "$expected" ]; then
+            echo "release evidence matrix mismatch" >&2
+            printf 'expected:\n%s\nactual:\n%s\n' \
+              "$expected" "${actual:-<empty>}" >&2
+            exit 1
+          fi
+          commit="$(git rev-parse HEAD)"
+          tree="$(git rev-parse 'HEAD^{tree}')"
+          test "$commit" = "$GITHUB_SHA"
+          required_files="$(find required-checks -mindepth 1 -maxdepth 1 \
+            -printf '%f\n' | LC_ALL=C sort)"
+          if [ "$required_files" != 'required-checks.json' ]; then
+            echo "unexpected protected-check evidence files" >&2
+            exit 1
+          fi
+          expected_checks="$(printf '%s\n' \
+            'ci/circleci: build' \
+            lint \
+            'nocgo (macOS-latest)' \
+            'nocgo (ubuntu-latest)' \
+            'nocgo (windows-latest)' \
+            ocr race release-evidence-validation sanitizer \
+            'test (macOS-latest)' \
+            'test (ubuntu-latest)' \
+            'test (windows-latest)' \
+            vet wayland-integration x11-backend-evidence | LC_ALL=C sort)"
+          actual_checks="$(jq -r '.checks[].name' \
+            required-checks/required-checks.json | LC_ALL=C sort)"
+          if [ "$actual_checks" != "$expected_checks" ]; then
+            echo "protected-check evidence manifest mismatch" >&2
+            printf 'expected:\n%s\nactual:\n%s\n' \
+              "$expected_checks" "${actual_checks:-<empty>}" >&2
+            exit 1
+          fi
+          jq -e --arg commit "$commit" '
+            .schema_version == "1" and
+            .commit == $commit and
+            (.checks | length) == 15 and
+            all(.checks[];
+              .conclusion == "success" and
+              (.provider | type) == "string" and
+              (.provider | length) > 0 and
+              (.url | type) == "string" and
+              (.url | length) > 0
+            )
+          ' required-checks/required-checks.json >/dev/null
+          test_command='go test -count=1 ./...'
+          while IFS= read -r label; do
+            directory="evidence/release-evidence-$label"
+            files="$(find "$directory" -mindepth 1 -maxdepth 1 \
+              -printf '%f\n' | LC_ALL=C sort)"
+            if [ "$files" != $'evidence.json\ntest.log' ]; then
+              echo "unexpected files in release evidence cell $label" >&2
+              printf 'actual:\n%s\n' "${files:-<empty>}" >&2
+              exit 1
+            fi
+            go run ./internal/cmd/releaseevidence verify \
+              -evidence "$directory/evidence.json" \
+              -expected-matrix "$label" \
+              -expected-commit "$commit" \
+              -expected-tree "$tree" \
+              -expected-ref "$GITHUB_REF" \
+              -expected-test-command "$test_command"
+          done <<EOF
+          $expected
+          EOF
+          short_commit="${GITHUB_SHA:0:12}"
+          safe_ref="${GITHUB_REF_NAME//\//-}"
+          case "$safe_ref" in
+            ""|*[!A-Za-z0-9._-]*)
+              echo "release ref cannot form a safe evidence filename" >&2
+              exit 1
+              ;;
+          esac
+          if [ "${#safe_ref}" -gt 128 ]; then
+            echo "release ref is too long for a stable evidence filename" >&2
+            exit 1
+          fi
+          archive="robotgo-release-evidence-${safe_ref}-${short_commit}.tar.gz"
+          cp required-checks/required-checks.json evidence/
+          mkdir -p bundle
+          tar --sort=name --mtime='UTC 1970-01-01' \
+            --owner=0 --group=0 --numeric-owner \
+            -C evidence -czf "bundle/$archive" .
+          (
+            cd bundle
+            sha256sum "$archive" > "$archive.sha256"
+          )
+          printf 'archive=%s\nchecksum=%s\n' \
+            "$archive" "$archive.sha256" >> "$GITHUB_OUTPUT"
+      - name: Upload complete release evidence bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-evidence-bundle
+          path: bundle
+          if-no-files-found: error
+          retention-days: 90
+
+  publish:
+    if: github.event_name == 'release'
+    needs: package
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-evidence-bundle
+          path: bundle
+      - name: Verify and attach evidence to published release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cd bundle
+          sha256sum -c "${{ needs.package.outputs.checksum }}"
+          gh release upload "$GITHUB_REF_NAME" \
+            "${{ needs.package.outputs.archive }}" \
+            "${{ needs.package.outputs.checksum }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/README.md
+++ b/README.md
@@ -769,16 +769,21 @@ Real Wayland input results are tracked in the
 - [Go API reference](https://pkg.go.dev/github.com/marang/robotgo)
 - [Key names and conversion](docs/keys.md)
 - [Testing guide](TEST.md)
+- [Release evidence format and verification](docs/compatibility/release-evidence-v1.md)
 - [X11 native-vs-Pure-Go evidence](docs/performance/x11-native-vs-purego.md)
 - [Current Wayland support and backlog](docs/wayland-tasks.md)
 - [Product roadmap](docs/plan/product-roadmap.md)
 - [Wayland implementation history](docs/wayland-history.md)
 
-The active product slice is Phase 4 API and compositor parity. Hyprland now
-provides trustworthy active-window maximize query, set, and restore while
-Sway and generic wlroots retain explicit unsupported query results because
-their available IPC does not expose an equivalent maximize state. The
-preceding Linux/X11 evaluation is complete: shared behavior is blocking CI,
+The active product slice is Phase 5 reliability hardening. Runtime Diagnostics
+v1, native sanitizer/leak gates, and a six-cell release-evidence workflow make
+support claims machine-readable and tied to exact source, test logs, and build
+identity. Published releases receive a checksummed evidence bundle. The
+remaining infrastructure blocker is protected real GNOME/KDE/wlroots evidence.
+Phase 4 already exposes the parity surface; Hyprland provides trustworthy
+active-window maximize query, set, and restore while Sway and generic wlroots
+retain explicit unsupported query results where their available IPC lacks an
+equivalent state. The preceding Linux/X11 evaluation is complete: shared behavior is blocking CI,
 current guardian-path decision evidence is versioned, and native CGO remains
 the default while Pure-Go supports CGO-disabled builds. The Pure-Go X11 core is
 race-testable and its separate guardian performs bounded, claim-checked cleanup

--- a/TEST.md
+++ b/TEST.md
@@ -554,6 +554,49 @@ Run tag-gated suites as needed for the area you changed. Native or Pure-Go X11
 input changes must also run the required `x11integration` comparison command
 above.
 
+## Release Evidence
+
+The `Release evidence` workflow validates its schema on every pull request and
+`main` push. Published releases and manual dispatches additionally run the
+default suite for native CGO and Pure-Go builds on Linux, macOS, and Windows,
+then verify and package all six evidence cells.
+
+On a clean Linux native checkout, reproduce the generator/verifier path with:
+
+```bash
+set -euo pipefail
+output=/tmp/robotgo-release-evidence-local
+rm -rf "$output"
+mkdir -p "$output"
+test_command='go test -count=1 ./internal/releaseevidence ./internal/cmd/releaseevidence'
+go test -count=1 \
+  ./internal/releaseevidence ./internal/cmd/releaseevidence \
+  2>&1 | tee "$output/test.log"
+test -z "$(git status --porcelain --untracked-files=all)"
+go run ./internal/cmd/releaseevidence generate \
+  -out "$output/evidence.json" \
+  -test-log "$output/test.log" \
+  -commit "$(git rev-parse HEAD)" \
+  -tree "$(git rev-parse 'HEAD^{tree}')" \
+  -ref "refs/heads/$(git branch --show-current)" \
+  -run-id 1 \
+  -run-attempt 1 \
+  -matrix linux-native-validation \
+  -test-command "$test_command" \
+  -expected-cgo true
+go run ./internal/cmd/releaseevidence verify \
+  -evidence "$output/evidence.json" \
+  -expected-matrix linux-native-validation \
+  -expected-commit "$(git rev-parse HEAD)" \
+  -expected-tree "$(git rev-parse 'HEAD^{tree}')" \
+  -expected-ref "refs/heads/$(git branch --show-current)" \
+  -expected-test-command "$test_command"
+```
+
+The versioned schema, matrix, release-asset behavior, and consumer verification
+commands are documented in
+[Release Evidence v1](docs/compatibility/release-evidence-v1.md).
+
 ## Sequential Crash-Tracking Run (No Parallelism)
 
 When debugging intermittent crashes/aborts, run tests sequentially and persist

--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -1,0 +1,79 @@
+# Release Evidence v1
+
+Schema version: **1**
+
+RobotGo release evidence records the exact source and test result behind a
+published release instead of relying on an unversioned statement that CI was
+green. The workflow lives in `.github/workflows/release-evidence.yml`.
+
+## Evidence matrix
+
+Every published release and manually dispatched release-evidence run executes
+the default suite in six independent cells:
+
+| Platform | Native CGO | Pure Go |
+|---|---:|---:|
+| Linux | yes | yes |
+| macOS | yes | yes |
+| Windows | yes | yes |
+
+Each cell emits `evidence.json` and `test.log`. The JSON document records:
+
+- the exact Git commit, Git tree, and full ref;
+- GitHub Actions run ID, attempt, and matrix identity;
+- Go version, `GOOS`, `GOARCH`, CGO state, and active implementation;
+- the passed command and SHA-256 digest of its complete test log;
+- the sanitized Runtime Diagnostics v1 report.
+
+The bundle also contains `required-checks.json`. It records the successful
+protected status set for the exact commit: CircleCI, lint, vet, race,
+ASan/LeakSanitizer, OCR, all three default and Pure-Go platform legs, Wayland,
+X11 evidence, and the release-evidence validator. Missing, pending, cancelled,
+or failed required checks abort snapshot publication.
+
+The required-check manifest in the workflow and the `main` branch-protection
+contexts are one contract. Add, rename, or remove a stable check in both places
+in the same change.
+
+The generator rejects a matrix whose operating system or CGO state disagrees
+with the running binary. The verifier rejects unknown fields, trailing JSON,
+unsupported matrix labels, path traversal, non-regular files, schema drift, and
+test-log digest mismatches.
+
+## Published assets
+
+After all six cells, the protected-check contract, and the validation job pass,
+the workflow verifies every cell again and creates:
+
+```text
+robotgo-release-evidence-<tag>-<commit>.tar.gz
+robotgo-release-evidence-<tag>-<commit>.tar.gz.sha256
+```
+
+For a GitHub `release.published` event these files are attached to the existing
+release. The write-authorized publish job does not check out or execute
+repository code; it only verifies the already packaged SHA-256 and uploads the
+two assets. Manual runs retain the bundle as a GitHub Actions artifact for 90
+days and do not modify a release.
+
+## Verification
+
+After extracting a bundle at the repository root, verify each matrix cell with:
+
+```bash
+CGO_ENABLED=0 go run ./internal/cmd/releaseevidence verify \
+  -evidence release-evidence-linux-native/evidence.json \
+  -expected-matrix linux-native
+```
+
+Repeat for `linux-purego`, `macos-native`, `macos-purego`,
+`windows-native`, and `windows-purego`. Verify the outer archive before
+extracting it:
+
+```bash
+sha256sum -c robotgo-release-evidence-*.tar.gz.sha256
+```
+
+This hosted-runner evidence does not replace the protected real GNOME, KDE, and
+wlroots RemoteDesktop/ScreenCast matrix. Those rows remain pending until the
+matching runners are provisioned.

--- a/docs/compatibility/runtime-v1.md
+++ b/docs/compatibility/runtime-v1.md
@@ -65,3 +65,6 @@ and diagnostic schema version.
 
 Detailed real-compositor evidence remains in
 [Wayland input](wayland-input.md) and [Wayland capture](wayland-capture.md).
+Exact source, build identity, test-log digests, and the embedded sanitized
+runtime report for published releases are defined by
+[Release Evidence v1](release-evidence-v1.md).

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -37,7 +37,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE/wlroots evidence |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and keyboard/pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz keyboard/pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture and XGB/XTEST input; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS keyboard-injection evidence and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
-| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates | Dedicated compositor jobs and release evidence snapshots |
+| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline | Dedicated compositor jobs and the first published release evidence asset |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
@@ -297,8 +297,14 @@ blocking support from pending runtime evidence. CI covers three operating
 systems, non-CGO, tagged Wayland/portal, Weston integration, and a blocking
 Linux native ASan/LeakSanitizer gate. The sanitizer job verifies its hermetic
 Wayland ownership-test manifest and covers allocation/free, timeout cleanup,
-and descriptor ownership. Dedicated GNOME/KDE/wlroots jobs and release evidence
-snapshots remain open.
+and descriptor ownership. Release Evidence v1 records exact commit/tree/ref,
+toolchain and runtime identity, sanitized diagnostics, the passed command, and
+the test-log SHA-256 for native/Pure-Go Linux, macOS, and Windows cells. It also
+requires and records the complete protected CircleCI/lint/vet/race/sanitizer/
+platform/Wayland/X11 check set for the exact commit. A published release
+receives the verified bundle and checksum; manual runs remain read-only
+artifacts. Dedicated GNOME/KDE/wlroots jobs and the first published release
+asset remain open.
 
 Releases require:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -152,7 +152,9 @@ backends.
     ABA replacement is not observable in X11.
   - 6. Keep the published runtime compatibility matrix and diagnostic schema
     versioned. Schema v1 now reports negotiated protocol versions, permission
-    state, and actionable remediation without sensitive session data.
+    state, and actionable remediation without sensitive session data. Release
+    Evidence v1 binds that report and test-log digests to exact source across
+    the six native/Pure-Go hosted platform cells.
   - 7. Keep race/vet and the manifest-checked native ASan/LeakSanitizer ownership
     suites blocking. Provision the remaining dedicated GNOME/KDE/wlroots jobs.
 

--- a/internal/cmd/releaseevidence/main.go
+++ b/internal/cmd/releaseevidence/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/marang/robotgo/internal/releaseevidence"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "releaseevidence: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(arguments []string, stdout, stderr io.Writer) error {
+	if len(arguments) == 0 {
+		return errors.New("expected generate or verify subcommand")
+	}
+	switch arguments[0] {
+	case "generate":
+		return runGenerate(arguments[1:], stdout, stderr)
+	case "verify":
+		return runVerify(arguments[1:], stdout, stderr)
+	default:
+		return fmt.Errorf("unknown subcommand %q", arguments[0])
+	}
+}
+
+func runGenerate(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("releaseevidence generate", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	var (
+		outputPath  string
+		testLogPath string
+		commit      string
+		tree        string
+		ref         string
+		runID       string
+		matrix      string
+		testCommand string
+		expectedCGO string
+		runAttempt  int
+	)
+	flags.StringVar(&outputPath, "out", "", "output evidence JSON path")
+	flags.StringVar(&testLogPath, "test-log", "", "complete passed test log")
+	flags.StringVar(&commit, "commit", "", "checked-out Git commit object ID")
+	flags.StringVar(&tree, "tree", "", "checked-out Git tree object ID")
+	flags.StringVar(&ref, "ref", "", "checked-out full Git ref")
+	flags.StringVar(&runID, "run-id", "", "GitHub Actions run ID")
+	flags.IntVar(&runAttempt, "run-attempt", 0, "GitHub Actions run attempt")
+	flags.StringVar(&matrix, "matrix", "", "release matrix cell label")
+	flags.StringVar(&testCommand, "test-command", "", "test command represented by the log")
+	flags.StringVar(&expectedCGO, "expected-cgo", "", "required runtime CGO state: true or false")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+	if outputPath == "" {
+		return errors.New("-out is required")
+	}
+	if testLogPath == "" {
+		return errors.New("-test-log is required")
+	}
+	cgoEnabled, err := strconv.ParseBool(expectedCGO)
+	if err != nil || (expectedCGO != "true" && expectedCGO != "false") {
+		return errors.New("-expected-cgo must be true or false")
+	}
+
+	snapshot, err := releaseevidence.Generate(context.Background(), releaseevidence.Config{
+		Commit:      commit,
+		Tree:        tree,
+		Ref:         ref,
+		RunID:       runID,
+		RunAttempt:  runAttempt,
+		Matrix:      matrix,
+		TestCommand: testCommand,
+		TestLogPath: testLogPath,
+		ExpectedCGO: cgoEnabled,
+	})
+	if err != nil {
+		return err
+	}
+	if err := releaseevidence.Write(outputPath, snapshot); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(stdout, "wrote release evidence %s\n", outputPath); err != nil {
+		return fmt.Errorf("write stdout: %w", err)
+	}
+	return nil
+}
+
+func runVerify(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("releaseevidence verify", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var (
+		evidencePath        string
+		expectedMatrix      string
+		expectedCommit      string
+		expectedTree        string
+		expectedRef         string
+		expectedTestCommand string
+	)
+	flags.StringVar(&evidencePath, "evidence", "", "release evidence JSON path")
+	flags.StringVar(&expectedMatrix, "expected-matrix", "", "required release matrix cell")
+	flags.StringVar(&expectedCommit, "expected-commit", "", "optional exact Git commit")
+	flags.StringVar(&expectedTree, "expected-tree", "", "optional exact Git tree")
+	flags.StringVar(&expectedRef, "expected-ref", "", "optional exact full Git ref")
+	flags.StringVar(&expectedTestCommand, "expected-test-command", "", "optional exact test command")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+	if evidencePath == "" {
+		return errors.New("-evidence is required")
+	}
+	if expectedMatrix == "" {
+		return errors.New("-expected-matrix is required")
+	}
+	snapshot, err := releaseevidence.Verify(evidencePath, releaseevidence.Expectations{
+		Matrix:      expectedMatrix,
+		Commit:      expectedCommit,
+		Tree:        expectedTree,
+		Ref:         expectedRef,
+		TestCommand: expectedTestCommand,
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(
+		stdout,
+		"verified release evidence schema=%s commit=%s matrix=%s\n",
+		snapshot.SchemaVersion,
+		snapshot.Source.Commit,
+		snapshot.CI.Matrix,
+	); err != nil {
+		return fmt.Errorf("write stdout: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/releaseevidence/main_test.go
+++ b/internal/cmd/releaseevidence/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsUnknownSubcommand(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	err := run([]string{"unknown"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "unknown subcommand") {
+		t.Fatalf("run error = %v, want unknown subcommand", err)
+	}
+}
+
+func TestRunGenerateRequiresExpectedCGO(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	err := run([]string{
+		"generate",
+		"-out", "evidence.json",
+		"-test-log", "test.log",
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "-expected-cgo") {
+		t.Fatalf("run error = %v, want expected-CGO validation", err)
+	}
+}
+
+func TestRunVerifyRequiresEvidence(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	err := run([]string{"verify"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "-evidence") {
+		t.Fatalf("run error = %v, want evidence-path validation", err)
+	}
+}
+
+func TestRunVerifyRequiresExpectedMatrix(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	err := run([]string{"verify", "-evidence", "evidence.json"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "-expected-matrix") {
+		t.Fatalf("run error = %v, want expected-matrix validation", err)
+	}
+}

--- a/internal/releaseevidence/evidence.go
+++ b/internal/releaseevidence/evidence.go
@@ -1,0 +1,440 @@
+// Package releaseevidence creates and verifies versioned RobotGo release
+// evidence snapshots.
+package releaseevidence
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+const (
+	// SchemaVersion identifies the release-evidence JSON contract.
+	SchemaVersion = "1"
+
+	evidenceProvider = "github-actions"
+	maxLabelLength   = 128
+	maxTextLength    = 1024
+	maxEvidenceBytes = 2 * 1024 * 1024
+)
+
+var (
+	gitObjectPattern = regexp.MustCompile(`^(?:[0-9a-f]{40}|[0-9a-f]{64})$`)
+	labelPattern     = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	digestPattern    = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+// Source identifies the exact repository state used for a release check.
+type Source struct {
+	Commit string `json:"commit"`
+	Tree   string `json:"tree"`
+	Ref    string `json:"ref"`
+}
+
+// CI identifies the GitHub Actions execution and matrix cell.
+type CI struct {
+	Provider   string `json:"provider"`
+	RunID      string `json:"run_id"`
+	RunAttempt int    `json:"run_attempt"`
+	Matrix     string `json:"matrix"`
+}
+
+// Toolchain identifies the Go toolchain that generated the evidence.
+type Toolchain struct {
+	GoVersion string `json:"go_version"`
+}
+
+// Test records the passed command and the digest of its complete log.
+type Test struct {
+	Command   string `json:"command"`
+	Result    string `json:"result"`
+	LogFile   string `json:"log_file"`
+	LogSHA256 string `json:"log_sha256"`
+}
+
+// Snapshot is the versioned, machine-readable release-evidence document.
+type Snapshot struct {
+	SchemaVersion string                     `json:"schema_version"`
+	Source        Source                     `json:"source"`
+	CI            CI                         `json:"ci"`
+	Toolchain     Toolchain                  `json:"toolchain"`
+	Test          Test                       `json:"test"`
+	Diagnostics   robotgo.RuntimeDiagnostics `json:"runtime_diagnostics"`
+}
+
+// Config contains trusted workflow inputs used to create a Snapshot.
+type Config struct {
+	Commit      string
+	Tree        string
+	Ref         string
+	RunID       string
+	RunAttempt  int
+	Matrix      string
+	TestCommand string
+	TestLogPath string
+	ExpectedCGO bool
+}
+
+// Expectations bind a verified evidence file to its expected matrix cell and
+// optionally to an exact source and test command.
+type Expectations struct {
+	Matrix      string
+	Commit      string
+	Tree        string
+	Ref         string
+	TestCommand string
+}
+
+// Generate builds a release-evidence snapshot and verifies that the running
+// RobotGo build matches the requested CGO matrix cell.
+func Generate(ctx context.Context, config Config) (Snapshot, error) {
+	if err := validateConfig(config); err != nil {
+		return Snapshot{}, err
+	}
+
+	logDigest, logName, err := digestRegularFile(config.TestLogPath)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("test log: %w", err)
+	}
+
+	diagnostics := robotgo.GetRuntimeDiagnostics(ctx)
+	if diagnostics.SchemaVersion != robotgo.RuntimeDiagnosticsSchemaVersion {
+		return Snapshot{}, fmt.Errorf(
+			"runtime diagnostics schema %q, want %q",
+			diagnostics.SchemaVersion,
+			robotgo.RuntimeDiagnosticsSchemaVersion,
+		)
+	}
+	if diagnostics.Runtime.CGOEnabled != config.ExpectedCGO {
+		return Snapshot{}, fmt.Errorf(
+			"runtime CGO state is %t, want %t",
+			diagnostics.Runtime.CGOEnabled,
+			config.ExpectedCGO,
+		)
+	}
+
+	snapshot := Snapshot{
+		SchemaVersion: SchemaVersion,
+		Source: Source{
+			Commit: config.Commit,
+			Tree:   config.Tree,
+			Ref:    config.Ref,
+		},
+		CI: CI{
+			Provider:   evidenceProvider,
+			RunID:      config.RunID,
+			RunAttempt: config.RunAttempt,
+			Matrix:     config.Matrix,
+		},
+		Toolchain: Toolchain{GoVersion: runtime.Version()},
+		Test: Test{
+			Command:   config.TestCommand,
+			Result:    "pass",
+			LogFile:   logName,
+			LogSHA256: logDigest,
+		},
+		Diagnostics: diagnostics,
+	}
+	if err := validateSnapshot(snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+// Write stores a snapshot as indented JSON without replacing an existing
+// evidence file.
+func Write(path string, snapshot Snapshot) error {
+	if path == "" {
+		return errors.New("evidence output path is required")
+	}
+	if err := validateSnapshot(snapshot); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal evidence: %w", err)
+	}
+	data = append(data, '\n')
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create evidence %q: %w", path, err)
+	}
+	_, writeErr := file.Write(data)
+	closeErr := file.Close()
+	if writeErr != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("write evidence %q: %w", path, writeErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("close evidence %q: %w", path, closeErr)
+	}
+	return nil
+}
+
+// Verify reads an evidence file, validates its schema and expected identity,
+// and verifies the adjacent test log against the recorded SHA-256 digest.
+func Verify(path string, expected Expectations) (Snapshot, error) {
+	if expected.Matrix == "" {
+		return Snapshot{}, errors.New("expected matrix is required")
+	}
+	if _, _, err := matrixRuntime(expected.Matrix); err != nil {
+		return Snapshot{}, err
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("inspect evidence %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return Snapshot{}, fmt.Errorf("evidence %q is not a regular file", path)
+	}
+	if info.Size() > maxEvidenceBytes {
+		return Snapshot{}, fmt.Errorf("evidence %q exceeds %d bytes", path, maxEvidenceBytes)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("read evidence %q: %w", path, err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var snapshot Snapshot
+	if err := decoder.Decode(&snapshot); err != nil {
+		return Snapshot{}, fmt.Errorf("decode evidence %q: %w", path, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return Snapshot{}, fmt.Errorf("decode evidence %q: trailing JSON value", path)
+		}
+		return Snapshot{}, fmt.Errorf("decode evidence %q: %w", path, err)
+	}
+	if err := validateSnapshot(snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	if err := validateExpectations(snapshot, expected); err != nil {
+		return Snapshot{}, err
+	}
+
+	logPath := filepath.Join(filepath.Dir(path), snapshot.Test.LogFile)
+	digest, name, err := digestRegularFile(logPath)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("test log: %w", err)
+	}
+	if name != snapshot.Test.LogFile {
+		return Snapshot{}, errors.New("test log filename does not match evidence")
+	}
+	if digest != snapshot.Test.LogSHA256 {
+		return Snapshot{}, fmt.Errorf(
+			"test log SHA-256 %s, want %s",
+			digest,
+			snapshot.Test.LogSHA256,
+		)
+	}
+	return snapshot, nil
+}
+
+func validateExpectations(snapshot Snapshot, expected Expectations) error {
+	comparisons := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "matrix", got: snapshot.CI.Matrix, want: expected.Matrix},
+		{name: "commit", got: snapshot.Source.Commit, want: expected.Commit},
+		{name: "tree", got: snapshot.Source.Tree, want: expected.Tree},
+		{name: "ref", got: snapshot.Source.Ref, want: expected.Ref},
+		{name: "test command", got: snapshot.Test.Command, want: expected.TestCommand},
+	}
+	for _, comparison := range comparisons {
+		if comparison.want != "" && comparison.got != comparison.want {
+			return fmt.Errorf(
+				"%s %q, want %q",
+				comparison.name,
+				comparison.got,
+				comparison.want,
+			)
+		}
+	}
+	return nil
+}
+
+func validateConfig(config Config) error {
+	if !gitObjectPattern.MatchString(config.Commit) {
+		return errors.New("commit must be a lowercase 40- or 64-character Git object ID")
+	}
+	if !gitObjectPattern.MatchString(config.Tree) {
+		return errors.New("tree must be a lowercase 40- or 64-character Git object ID")
+	}
+	if err := validateText("ref", config.Ref); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(config.Ref, "refs/") {
+		return errors.New("ref must start with refs/")
+	}
+	runID, err := strconv.ParseUint(config.RunID, 10, 64)
+	if err != nil || runID == 0 || strconv.FormatUint(runID, 10) != config.RunID {
+		return errors.New("run ID must be a positive decimal integer")
+	}
+	if config.RunAttempt <= 0 {
+		return errors.New("run attempt must be positive")
+	}
+	if len(config.Matrix) > maxLabelLength || !labelPattern.MatchString(config.Matrix) {
+		return errors.New("matrix must contain only letters, digits, dot, underscore, or hyphen")
+	}
+	return validateText("test command", config.TestCommand)
+}
+
+func validateSnapshot(snapshot Snapshot) error {
+	if snapshot.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("release evidence schema %q, want %q", snapshot.SchemaVersion, SchemaVersion)
+	}
+	config := Config{
+		Commit:      snapshot.Source.Commit,
+		Tree:        snapshot.Source.Tree,
+		Ref:         snapshot.Source.Ref,
+		RunID:       snapshot.CI.RunID,
+		RunAttempt:  snapshot.CI.RunAttempt,
+		Matrix:      snapshot.CI.Matrix,
+		TestCommand: snapshot.Test.Command,
+	}
+	if err := validateConfig(config); err != nil {
+		return err
+	}
+	if snapshot.CI.Provider != evidenceProvider {
+		return fmt.Errorf("CI provider %q, want %q", snapshot.CI.Provider, evidenceProvider)
+	}
+	if err := validateText("go toolchain version", snapshot.Toolchain.GoVersion); err != nil {
+		return err
+	}
+	if snapshot.Test.Result != "pass" {
+		return fmt.Errorf("test result %q, want pass", snapshot.Test.Result)
+	}
+	if snapshot.Test.LogFile == "" ||
+		filepath.Base(snapshot.Test.LogFile) != snapshot.Test.LogFile ||
+		strings.ContainsAny(snapshot.Test.LogFile, `/\`) {
+		return errors.New("test log must be a base filename")
+	}
+	if !digestPattern.MatchString(snapshot.Test.LogSHA256) {
+		return errors.New("test log SHA-256 must be 64 lowercase hexadecimal characters")
+	}
+	if snapshot.Diagnostics.SchemaVersion != robotgo.RuntimeDiagnosticsSchemaVersion {
+		return fmt.Errorf(
+			"runtime diagnostics schema %q, want %q",
+			snapshot.Diagnostics.SchemaVersion,
+			robotgo.RuntimeDiagnosticsSchemaVersion,
+		)
+	}
+	expectedGOOS, expectedCGO, err := matrixRuntime(snapshot.CI.Matrix)
+	if err != nil {
+		return err
+	}
+	if snapshot.Diagnostics.Runtime.GOOS != expectedGOOS {
+		return fmt.Errorf(
+			"matrix %q requires GOOS %q, got %q",
+			snapshot.CI.Matrix,
+			expectedGOOS,
+			snapshot.Diagnostics.Runtime.GOOS,
+		)
+	}
+	if snapshot.Diagnostics.Runtime.CGOEnabled != expectedCGO {
+		return fmt.Errorf(
+			"matrix %q requires CGO state %t, got %t",
+			snapshot.CI.Matrix,
+			expectedCGO,
+			snapshot.Diagnostics.Runtime.CGOEnabled,
+		)
+	}
+	identityFields := []struct {
+		name  string
+		value string
+	}{
+		{name: "runtime GOARCH", value: snapshot.Diagnostics.Runtime.GOARCH},
+		{name: "RobotGo version", value: snapshot.Diagnostics.Runtime.RobotGoVersion},
+		{
+			name:  "runtime build implementation",
+			value: string(snapshot.Diagnostics.Runtime.BuildImplementation),
+		},
+	}
+	for _, field := range identityFields {
+		if err := validateText(field.name, field.value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateText(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", name)
+	}
+	if len(value) > maxTextLength {
+		return fmt.Errorf("%s exceeds %d bytes", name, maxTextLength)
+	}
+	for _, character := range value {
+		if character < 0x20 || character == 0x7f {
+			return fmt.Errorf("%s contains a control character", name)
+		}
+	}
+	return nil
+}
+
+func matrixRuntime(matrix string) (string, bool, error) {
+	switch matrix {
+	case "linux-native", "linux-native-validation":
+		return "linux", true, nil
+	case "linux-purego":
+		return "linux", false, nil
+	case "macos-native":
+		return "darwin", true, nil
+	case "macos-purego":
+		return "darwin", false, nil
+	case "windows-native":
+		return "windows", true, nil
+	case "windows-purego":
+		return "windows", false, nil
+	default:
+		return "", false, fmt.Errorf("unsupported release matrix %q", matrix)
+	}
+}
+
+func digestRegularFile(path string) (string, string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", "", fmt.Errorf("inspect %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", "", fmt.Errorf("%q is not a regular file", path)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", "", fmt.Errorf("open %q: %w", path, err)
+	}
+	hash := sha256.New()
+	_, copyErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return "", "", fmt.Errorf("hash %q: %w", path, copyErr)
+	}
+	if closeErr != nil {
+		return "", "", fmt.Errorf("close %q: %w", path, closeErr)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), filepath.Base(path), nil
+}

--- a/internal/releaseevidence/evidence_test.go
+++ b/internal/releaseevidence/evidence_test.go
@@ -1,0 +1,218 @@
+package releaseevidence
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+const (
+	testCommit = "0123456789abcdef0123456789abcdef01234567"
+	testTree   = "89abcdef0123456789abcdef0123456789abcdef"
+)
+
+func TestGenerateWriteAndVerify(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	logPath := filepath.Join(directory, "test.log")
+	if err := os.WriteFile(logPath, []byte("PASS\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedCGO := robotgo.GetRuntimeCapabilities().Runtime.CGOEnabled
+	matrix := currentMatrix(expectedCGO)
+	snapshot, err := Generate(context.Background(), Config{
+		Commit:      testCommit,
+		Tree:        testTree,
+		Ref:         "refs/tags/v1.2.3",
+		RunID:       "12345",
+		RunAttempt:  2,
+		Matrix:      matrix,
+		TestCommand: "go test -count=1 ./...",
+		TestLogPath: logPath,
+		ExpectedCGO: expectedCGO,
+	})
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if snapshot.Toolchain.GoVersion != runtime.Version() {
+		t.Fatalf("Go version = %q, want %q", snapshot.Toolchain.GoVersion, runtime.Version())
+	}
+	if snapshot.Diagnostics.Runtime.CGOEnabled != expectedCGO {
+		t.Fatalf("CGO enabled = %t, want %t", snapshot.Diagnostics.Runtime.CGOEnabled, expectedCGO)
+	}
+
+	evidencePath := filepath.Join(directory, "evidence.json")
+	if err := Write(evidencePath, snapshot); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	verified, err := Verify(evidencePath, Expectations{Matrix: matrix})
+	if err != nil {
+		t.Fatalf("Verify failed: %v", err)
+	}
+	if verified.Source.Commit != testCommit {
+		t.Fatalf("commit = %q, want %q", verified.Source.Commit, testCommit)
+	}
+}
+
+func TestVerifyRejectsTamperedLog(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	logPath := filepath.Join(directory, "test.log")
+	if err := os.WriteFile(logPath, []byte("PASS\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := validSnapshot(t, logPath)
+	evidencePath := filepath.Join(directory, "evidence.json")
+	if err := Write(evidencePath, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, []byte("FAIL\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Verify(evidencePath, Expectations{
+		Matrix: snapshot.CI.Matrix,
+	}); err == nil || !strings.Contains(err.Error(), "SHA-256") {
+		t.Fatalf("Verify error = %v, want SHA-256 mismatch", err)
+	}
+}
+
+func TestVerifyRejectsUnknownAndTrailingJSON(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	logPath := filepath.Join(directory, "test.log")
+	if err := os.WriteFile(logPath, []byte("PASS\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := validSnapshot(t, logPath)
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unknownPath := filepath.Join(directory, "unknown.json")
+	unknown := append([]byte(nil), data[:len(data)-1]...)
+	unknown = append(unknown, []byte(`,"unexpected":true}`)...)
+	if err := os.WriteFile(unknownPath, unknown, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Verify(unknownPath, Expectations{
+		Matrix: snapshot.CI.Matrix,
+	}); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("Verify unknown-field error = %v", err)
+	}
+
+	trailingPath := filepath.Join(directory, "trailing.json")
+	if err := os.WriteFile(trailingPath, append(data, []byte(`{}`)...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Verify(trailingPath, Expectations{
+		Matrix: snapshot.CI.Matrix,
+	}); err == nil || !strings.Contains(err.Error(), "trailing JSON") {
+		t.Fatalf("Verify trailing-value error = %v", err)
+	}
+}
+
+func TestGenerateRejectsWrongCGOMatrix(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "test.log")
+	if err := os.WriteFile(logPath, []byte("PASS\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	actualCGO := robotgo.GetRuntimeCapabilities().Runtime.CGOEnabled
+	_, err := Generate(context.Background(), Config{
+		Commit:      testCommit,
+		Tree:        testTree,
+		Ref:         "refs/heads/main",
+		RunID:       "1",
+		RunAttempt:  1,
+		Matrix:      currentMatrix(actualCGO),
+		TestCommand: "go test ./...",
+		TestLogPath: logPath,
+		ExpectedCGO: !actualCGO,
+	})
+	if err == nil || !strings.Contains(err.Error(), "runtime CGO state") {
+		t.Fatalf("Generate error = %v, want CGO mismatch", err)
+	}
+}
+
+func TestValidateSnapshotRejectsLogTraversal(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "test.log")
+	if err := os.WriteFile(logPath, []byte("PASS\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := validSnapshot(t, logPath)
+	snapshot.Test.LogFile = "../test.log"
+	if err := validateSnapshot(snapshot); err == nil || !strings.Contains(err.Error(), "base filename") {
+		t.Fatalf("validateSnapshot error = %v, want base filename rejection", err)
+	}
+	snapshot.Test.LogFile = `..\test.log`
+	if err := validateSnapshot(snapshot); err == nil || !strings.Contains(err.Error(), "base filename") {
+		t.Fatalf("validateSnapshot Windows-style error = %v, want base filename rejection", err)
+	}
+}
+
+func TestVerifyRejectsUnexpectedIdentity(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	logPath := filepath.Join(directory, "test.log")
+	if err := os.WriteFile(logPath, []byte("PASS\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := validSnapshot(t, logPath)
+	evidencePath := filepath.Join(directory, "evidence.json")
+	if err := Write(evidencePath, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Verify(evidencePath, Expectations{
+		Matrix: snapshot.CI.Matrix,
+		Commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	if err == nil || !strings.Contains(err.Error(), "commit") {
+		t.Fatalf("Verify error = %v, want commit mismatch", err)
+	}
+}
+
+func validSnapshot(t *testing.T, logPath string) Snapshot {
+	t.Helper()
+	snapshot, err := Generate(context.Background(), Config{
+		Commit:      testCommit,
+		Tree:        testTree,
+		Ref:         "refs/heads/main",
+		RunID:       "123",
+		RunAttempt:  1,
+		Matrix:      currentMatrix(robotgo.GetRuntimeCapabilities().Runtime.CGOEnabled),
+		TestCommand: "go test ./...",
+		TestLogPath: logPath,
+		ExpectedCGO: robotgo.GetRuntimeCapabilities().Runtime.CGOEnabled,
+	})
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	return snapshot
+}
+
+func currentMatrix(cgoEnabled bool) string {
+	platform := runtime.GOOS
+	if platform == "darwin" {
+		platform = "macos"
+	}
+	implementation := "purego"
+	if cgoEnabled {
+		implementation = "native"
+	}
+	return platform + "-" + implementation
+}


### PR DESCRIPTION
## Goal
Bind release support claims to exact source, protected CI results, runtime identity, and complete test logs.

## Changes
- add Release Evidence schema v1 plus strict generator/verifier tooling
- run native CGO and Pure-Go release snapshots on Linux, macOS, and Windows
- bind every cell to the same commit/tree/ref, matrix identity, command, and test-log SHA-256
- require and archive the exact protected CircleCI/lint/vet/race/sanitizer/platform/Wayland/X11 check manifest
- package deterministic checksummed bundles; attach them to published releases
- isolate the write-authorized publish job from checkout and repository-code execution
- document generation, verification, limitations, and roadmap status

## Risk
Medium, limited to CI/release automation. The published-release path mutates release assets only after all evidence gates pass. Production library APIs and runtime behavior are unchanged.

## Validation
- full default and non-CGO suites
- CGO and non-CGO vet/lint
- race and ASan on generator/verifier
- Actionlint
- native and Pure-Go generator round trips
- six-cell bundle simulation
- live GitHub required-check API simulation

## Remaining external evidence
Protected real GNOME/KDE/wlroots runners are still not provisioned; Release Evidence v1 explicitly keeps those rows pending.