### PR TITLE
fix: keep release snapshot tests source-clean

### DIFF
--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: actions/setup-go@v6
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
@@ -148,7 +148,7 @@ jobs:
             -expected-ref "$GITHUB_REF" \
             -expected-test-command "$test_command"
       - name: Upload matrix evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-evidence-${{ matrix.label }}
           path: ${{ runner.temp }}/release-evidence-${{ matrix.label }}
@@ -263,7 +263,7 @@ jobs:
           rm "$output/check-runs-source.json" \
             "$output/status-source.json" "$output/rows.jsonl"
       - name: Upload protected-check evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-required-checks
           path: ${{ runner.temp }}/release-required-checks
@@ -279,18 +279,18 @@ jobs:
       archive: ${{ steps.bundle.outputs.archive }}
       checksum: ${{ steps.bundle.outputs.checksum }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
       - uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: release-evidence-*
           path: evidence
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: release-required-checks
           path: required-checks
@@ -399,7 +399,7 @@ jobs:
           printf 'archive=%s\nchecksum=%s\n' \
             "$archive" "$archive.sha256" >> "$GITHUB_OUTPUT"
       - name: Upload complete release evidence bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-evidence-bundle
           path: bundle
@@ -414,7 +414,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: release-evidence-bundle
           path: bundle

--- a/robotgo_test.go
+++ b/robotgo_test.go
@@ -17,6 +17,7 @@ package robotgo
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/vcaesar/tt"
@@ -188,12 +189,13 @@ func TestImage(t *testing.T) {
 	tt.NotNil(t, bit)
 
 	img := ToImage(bit)
-	err = SavePng(img, "robot_test.png")
+	output := t.TempDir()
+	err = SavePng(img, filepath.Join(output, "robot_test.png"))
 	tt.Nil(t, err)
 
 	img1, err := CaptureImg(10, 10, 20, 20)
 	tt.Nil(t, err)
-	e := Save(img1, "robot_img.jpeg", 50)
+	e := Save(img1, filepath.Join(output, "robot_img.jpeg"), 50)
 	tt.Nil(t, e)
 
 	tt.Equal(t, 20, Width(img1))


### PR DESCRIPTION
## Goal
Fix the two native release-evidence cells exposed by the first real six-platform manual run.

## Cause
`TestImage` wrote successful macOS/Windows capture outputs into the repository root. Both native test suites passed, but the evidence workflow correctly rejected the resulting dirty source tree.

## Changes
- write image-test outputs under `t.TempDir()`
- update the new release workflow to the current official Node 24 action majors (`checkout@v7`, `upload-artifact@v7`, `download-artifact@v8`)

## Validation
- default and non-CGO suites
- CGO and non-CGO vet/lint
- Actionlint
- first manual Release Evidence run: four platform/build cells and protected-check evidence passed; macOS/Windows native isolated this source-cleanliness defect

After merge, the complete manual workflow will be rerun before this slice is considered complete.