### PR TITLE
fix: support Hyprland Lua window dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Current technical differences include:
 - Sway, Hyprland, generic wlroots, and Wayland-core window backend resolution,
   with partial operations reported honestly instead of universal support being
   implied. Hyprland additionally supports reliable active-window maximize
-  query, set, and restore through `hyprctl`.
+  query, set, restore, and close through provider-aware `hyprctl` dispatch for
+  both legacy `hyprlang` and Hyprland 0.55+ Lua configurations.
 - A defined non-CGO contract: Pure-Go capture is available through CoreGraphics
   on macOS, native APIs on Windows, and X11. Windows and Linux/X11 additionally
   have keyboard/pointer backends; Wayland capture uses the consent-aware
@@ -549,7 +550,11 @@ Global pointer position and global foreign-window control are not universally
 available in Wayland core. `LocationE` and unsupported window operations return
 `ErrNotSupported`. Sway, Hyprland, and some wlroots environments have partial
 window support through compositor-specific tools; inspect capabilities instead
-of assuming parity with X11.
+of assuming parity with X11. Hyprland window mutations query
+`hyprctl status -j` and select the active `hyprlang` or Lua dispatcher syntax;
+older Hyprland versions without the status request keep the legacy path.
+Transport failures and successful but malformed/unknown provider responses
+fail before mutation.
 
 Pure-Go Windows builds provide window introspection and control through Win32:
 active handle/PID, title, outer/client bounds, activation, minimize/maximize,
@@ -781,7 +786,8 @@ support claims machine-readable and tied to exact source, test logs, and build
 identity. Published releases receive a checksummed evidence bundle. The
 remaining infrastructure blocker is protected real GNOME/KDE/wlroots evidence.
 Phase 4 already exposes the parity surface; Hyprland provides trustworthy
-active-window maximize query, set, and restore while Sway and generic wlroots
+active-window maximize query, set, and restore with provider-aware dispatch for
+legacy `hyprlang` and 0.55+ Lua configurations, while Sway and generic wlroots
 retain explicit unsupported query results where their available IPC lacks an
 equivalent state. The preceding Linux/X11 evaluation is complete: shared behavior is blocking CI,
 current guardian-path decision evidence is versioned, and native CGO remains

--- a/TEST.md
+++ b/TEST.md
@@ -530,7 +530,9 @@ intentionally preserving a foreign replacement is not itself an error.
 - `ROBOTGO_HYPRLAND_MAXIMIZE_E2E=1`
   - Opt-in for Hyprland active-window maximize query/set/restore integration.
     The test refuses to alter an initially fullscreen window and restores an
-    initial normal or maximized state during cleanup.
+    initial normal or maximized state during cleanup. It exercises the
+    provider-aware dispatcher selected by `hyprctl status -j`, including
+    Hyprland 0.55+ Lua configurations.
 - `ROBOTGO_REQUIRE_X11_INTEGRATION=1`
   - Makes missing `DISPLAY` or XTEST support fail the X11 integration suites;
     CI always enables it.

--- a/docs/compatibility/runtime-v1.md
+++ b/docs/compatibility/runtime-v1.md
@@ -45,7 +45,7 @@ than inferring it from an operating-system label.
 | PipeWire development/runtime libraries and `pipewire` tag | Persistent ScreenCast frames | One-shot Screenshot/native screencopy remain eligible; persistent capture reports unsupported |
 | X11/XTEST | Native or Pure-Go X11 input | Readiness and diagnostics report missing/old XTEST explicitly |
 | Tesseract/Leptonica and `ocr` tag | OCR helpers | Core automation remains available without OCR |
-| Sway/Hyprland/wlroots command tools | Compositor-specific foreign-window operations | Wayland-core capability reports unsupported operations explicitly |
+| Sway/Hyprland/wlroots command tools | Compositor-specific foreign-window operations; Hyprland mutations detect `hyprlang` versus 0.55+ Lua dispatch | Wayland-core capability reports unsupported operations explicitly |
 
 ## Diagnostic contract
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -36,7 +36,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE/wlroots evidence |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and keyboard/pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz keyboard/pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture and XGB/XTEST input; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS keyboard-injection evidence and assess further backends selectively |
-| 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver | Compositor-backed state operations and cross-platform/runtime matrix coverage |
+| 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, provider-aware Hyprland 0.55+ Lua window dispatch | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline | Dedicated compositor jobs and the first published release evidence asset |
 
 No delivery phase is complete until all of its exit criteria are blocking and
@@ -251,7 +251,9 @@ The compatibility surface now includes:
 - Hyprland active-window maximize query, set, and restore backed by its
   compositor-reported state. Fullscreen remains distinct from maximized;
   Sway/generic wlroots queries stay explicitly unsupported rather than
-  inferring state.
+  inferring state. Mutating close/maximize operations select the active
+  `hyprlang` or Hyprland 0.55+ Lua dispatcher syntax and fail closed on
+  provider-query transport failures or malformed successful detection.
 - Bitmap string helpers (`CaptureBitmapStr`, `FindBitmapStr`, `BitmapFromStr`,
   `ToStrBitmap`).
 - Region/tolerance color search through `FindColorCS`/`FindcolorCS`.

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -74,9 +74,12 @@ Current implementation baseline:
   explicit.
 - `hyprland` uses the compositor's reported fullscreen mode for
   `IsMaximizedE` and supports both maximize and restore through `hyprctl`.
-  Fullscreen is not reported as maximized. Sway and generic wlroots keep
-  returning `ErrNotSupported` because their available IPC does not expose a
-  trustworthy equivalent state.
+  Close/maximize mutations select the active `hyprlang` or Hyprland 0.55+ Lua
+  dispatcher from `hyprctl status -j`; older versions without that request use
+  the legacy syntax. Transport failures and malformed successful status
+  responses fail before mutation. Fullscreen is not reported as maximized.
+  Sway and generic wlroots keep returning `ErrNotSupported` because their
+  available IPC does not expose a trustworthy equivalent state.
 - Bitmap string helpers are available via `CaptureBitmapStr`,
   `FindBitmapStr`, `BitmapFromStr`, and `ToStrBitmap`.
 - Region/tolerance color search is available via `FindColorCS`/`FindcolorCS`.
@@ -108,7 +111,7 @@ Window backend support matrix (current):
 | Backend | Resolver trigger | Active title | Active close | Minimize | Maximize/restore | `IsMaximizedE` |
 |---|---|---|---|---|---|---|
 | `sway` | `SWAYSOCK` or sway desktop/session | Yes (`swaymsg`) | Yes (`swaymsg kill`) | `wlrctl`, set only | `wlrctl`, set only | No (`ErrNotSupported`) |
-| `hyprland` | `HYPRLAND_INSTANCE_SIGNATURE` or hyprland desktop/session | Yes (`hyprctl activewindow -j`) | Yes (`hyprctl dispatch killactive`) | `wlrctl`, set only | Yes (`hyprctl`, set and restore) | Yes (`hyprctl activewindow -j`) |
+| `hyprland` | `HYPRLAND_INSTANCE_SIGNATURE` or hyprland desktop/session | Yes (`hyprctl activewindow -j`) | Yes (provider-aware `hyprctl`) | `wlrctl`, set only | Yes (provider-aware `hyprctl`, set and restore) | Yes (`hyprctl activewindow -j`) |
 | `wlroots-generic` | wlroots-family compositor (wayfire/river/labwc/dwl/gamescope) | No (`ErrNotSupported`) | No (`ErrNotSupported`) | `wlrctl`, set only | `wlrctl`, set only | No (`ErrNotSupported`) |
 | `wayland-core/*` | wayland session without specific/family backend support | No (`ErrNotSupported`) | No (`ErrNotSupported`) | No (`ErrNotSupported`) | No (`ErrNotSupported`) | No (`ErrNotSupported`) |
 

--- a/examples/wayland_window_state/main.go
+++ b/examples/wayland_window_state/main.go
@@ -9,8 +9,8 @@ import (
 )
 
 func main() {
-	maximize := flag.Bool("maximize", false, "maximize the active Hyprland window")
-	restore := flag.Bool("restore", false, "restore the active Hyprland window")
+	maximize := flag.Bool("maximize", false, "maximize the active Hyprland window (hyprlang or Lua config)")
+	restore := flag.Bool("restore", false, "restore the active Hyprland window (hyprlang or Lua config)")
 	flag.Parse()
 
 	if *maximize && *restore {

--- a/robotgo_wayland_window_policy_test.go
+++ b/robotgo_wayland_window_policy_test.go
@@ -144,6 +144,9 @@ func TestWaylandHyprlandMaximizedPublicAPI(t *testing.T) {
 			}
 			t.Fatalf("unexpected test state internal=%d client=%d", internal, client)
 		}
+		if len(args) == 2 && args[0] == argStatus && args[1] == argJSON {
+			return []byte(`{"configProvider":"hyprlang"}`), nil
+		}
 		if len(args) == 4 &&
 			args[0] == argDispatch &&
 			args[1] == argFullscreenState &&

--- a/window_backend.go
+++ b/window_backend.go
@@ -22,7 +22,7 @@ const (
 	notesWlrootsBackend            = "wlroots generic backend selected; operation support to be implemented via wlroots-compatible paths"
 	reasonCompositorSpecific       = "compositor-specific backend selected with partial operation support"
 	notesSwayPartialSupport        = "supports active-window title retrieval and close; active minimize/maximize available when wlrctl is present"
-	notesHyprPartialSupport        = "supports active-window title, close, and reliable maximize query/set/restore; active minimize requires wlrctl"
+	notesHyprPartialSupport        = "supports active-window title, close, and reliable maximize query/set/restore across Hyprland hyprlang/Lua config providers; active minimize requires wlrctl"
 	cmdSwayMsg                     = "swaymsg"
 	cmdHyprCtl                     = "hyprctl"
 	cmdWlrCtl                      = "wlrctl"
@@ -30,6 +30,7 @@ const (
 	argRawJSON                     = "-r"
 	argType                        = "-t"
 	argGetTree                     = "get_tree"
+	argStatus                      = "status"
 	argActiveWindow                = "activewindow"
 	argWindow                      = "window"
 	argMinimize                    = "minimize"
@@ -41,6 +42,12 @@ const (
 	argFullscreenState             = "fullscreenstate"
 	argHyprlandNone                = "0"
 	argHyprlandMaximized           = "1"
+	hyprlandConfigProviderLua      = "lua"
+	hyprlandConfigProviderLegacy   = "hyprlang"
+	hyprlandStatusUnsupported      = "unknown request"
+	hyprlandLuaCloseActive         = `hl.dsp.window.close({})`
+	hyprlandLuaMaximizeActive      = `hl.dsp.window.fullscreen_state({ internal = 1, client = 1, action = "set" })`
+	hyprlandLuaRestoreActive       = `hl.dsp.window.fullscreen_state({ internal = 0, client = 0, action = "set" })`
 	windowCommandTimeout           = 2 * time.Second
 	hyprlandFullscreenNone         = 0
 	hyprlandFullscreenMaximized    = 1
@@ -49,10 +56,11 @@ const (
 )
 
 var (
-	errWindowTitleUnavailable = errors.New("window title unavailable from compositor backend")
-	errWindowStateUnavailable = errors.New("window state unavailable from compositor backend")
-	errWindowOperationFailed  = errors.New("window operation failed for compositor backend")
-	runWindowCommand          = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	errWindowTitleUnavailable    = errors.New("window title unavailable from compositor backend")
+	errWindowStateUnavailable    = errors.New("window state unavailable from compositor backend")
+	errWindowOperationFailed     = errors.New("window operation failed for compositor backend")
+	errHyprlandStatusUnavailable = errors.New("hyprland status request unavailable")
+	runWindowCommand             = func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		return exec.CommandContext(ctx, name, args...).Output()
 	}
 )
@@ -421,15 +429,23 @@ func (hyprlandWindowBackend) Maximize(pid int, state bool, isPid bool) error {
 	if state {
 		mode = argHyprlandMaximized
 	}
+	luaExpression := hyprlandLuaRestoreActive
+	if state {
+		luaExpression = hyprlandLuaMaximizeActive
+	}
+	args, err := resolveHyprlandDispatchArgs(
+		[]string{argFullscreenState, mode, mode},
+		luaExpression,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
 	defer cancel()
 	if _, err := runWindowCommand(
 		ctx,
 		cmdHyprCtl,
-		argDispatch,
-		argFullscreenState,
-		mode,
-		mode,
+		args...,
 	); err != nil {
 		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
 	}
@@ -459,10 +475,17 @@ func (hyprlandWindowBackend) Close(args ...int) error {
 	if len(args) > 0 {
 		return waylandWindowNotSupported("close window by pid/handle")
 	}
+	dispatchArgs, err := resolveHyprlandDispatchArgs(
+		[]string{argKillActive},
+		hyprlandLuaCloseActive,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
 	defer cancel()
-	if _, err := runWindowCommand(ctx, cmdHyprCtl, argDispatch, argKillActive); err != nil {
-		return fmt.Errorf("%w: %v", errWindowOperationFailed, err)
+	if _, err := runWindowCommand(ctx, cmdHyprCtl, dispatchArgs...); err != nil {
+		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
 	}
 	return nil
 }
@@ -593,6 +616,59 @@ type hyprlandActiveWindow struct {
 	Title            string `json:"title"`
 	Fullscreen       *int   `json:"fullscreen"`
 	FullscreenClient *int   `json:"fullscreenClient"`
+}
+
+type hyprlandStatus struct {
+	ConfigProvider string `json:"configProvider"`
+}
+
+func resolveHyprlandDispatchArgs(legacy []string, luaExpression string) ([]string, error) {
+	provider, err := getHyprlandConfigProvider()
+	if errors.Is(err, errHyprlandStatusUnavailable) {
+		// Hyprland before 0.55 has no status request and only accepts the
+		// historical dispatcher syntax. Only its exact "unknown request"
+		// response reaches this fallback; transport failures remain fail-closed.
+		return append([]string{argDispatch}, legacy...), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	switch provider {
+	case hyprlandConfigProviderLegacy:
+		return append([]string{argDispatch}, legacy...), nil
+	case hyprlandConfigProviderLua:
+		return []string{argDispatch, luaExpression}, nil
+	default:
+		return nil, fmt.Errorf(
+			"unknown hyprland config provider %q",
+			provider,
+		)
+	}
+}
+
+func getHyprlandConfigProvider() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
+	defer cancel()
+	out, err := runWindowCommand(ctx, cmdHyprCtl, argStatus, argJSON)
+	if err != nil {
+		return "", fmt.Errorf("query hyprland status: %w", err)
+	}
+	if strings.TrimSpace(string(out)) == hyprlandStatusUnsupported {
+		return "", fmt.Errorf(
+			"%w: %s",
+			errHyprlandStatusUnavailable,
+			hyprlandStatusUnsupported,
+		)
+	}
+	var status hyprlandStatus
+	if err := json.Unmarshal(out, &status); err != nil {
+		return "", fmt.Errorf("invalid hyprland status json: %w", err)
+	}
+	provider := strings.ToLower(strings.TrimSpace(status.ConfigProvider))
+	if provider == "" {
+		return "", errors.New("hyprland status omitted config provider")
+	}
+	return provider, nil
 }
 
 func validHyprlandFullscreenMode(mode int) bool {

--- a/window_backend_test.go
+++ b/window_backend_test.go
@@ -5,6 +5,7 @@ package robotgo
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -452,19 +453,108 @@ func TestHyprlandWindowBackendCloseActive(t *testing.T) {
 	old := runWindowCommand
 	t.Cleanup(func() { runWindowCommand = old })
 
+	var calls [][]string
 	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		_ = ctx
 		if name != cmdHyprCtl {
 			t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
 		}
-		if len(args) != 2 || args[0] != argDispatch || args[1] != argKillActive {
-			t.Fatalf("unexpected args: %#v", args)
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) == 2 && args[0] == argStatus && args[1] == argJSON {
+			return []byte(`{"configProvider":"hyprlang"}`), nil
 		}
 		return []byte("ok"), nil
 	}
 
 	if err := newHyprlandWindowBackend().Close(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [][]string{
+		{argStatus, argJSON},
+		{argDispatch, argKillActive},
+	}
+	assertWindowCommandCalls(t, calls, want)
+}
+
+func TestHyprlandWindowBackendCloseActiveLua(t *testing.T) {
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	var calls [][]string
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdHyprCtl {
+			t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
+		}
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) == 2 && args[0] == argStatus && args[1] == argJSON {
+			return []byte(`{"configProvider":"lua"}`), nil
+		}
+		return []byte("ok"), nil
+	}
+
+	if err := newHyprlandWindowBackend().Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [][]string{
+		{argStatus, argJSON},
+		{argDispatch, hyprlandLuaCloseActive},
+	}
+	assertWindowCommandCalls(t, calls, want)
+}
+
+func TestHyprlandWindowBackendCloseFailsClosedOnStatusError(t *testing.T) {
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	transportErr := errors.New("status transport failed")
+	tests := []struct {
+		name       string
+		output     string
+		commandErr error
+		wantCause  error
+	}{
+		{
+			name:       "transport failure",
+			commandErr: transportErr,
+			wantCause:  transportErr,
+		},
+		{
+			name:   "malformed response",
+			output: `{"configProvider":`,
+		},
+		{
+			name:   "unknown provider",
+			output: `{"configProvider":"future"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				_ = ctx
+				calls++
+				if name != cmdHyprCtl {
+					t.Fatalf("command = %q, want %q", name, cmdHyprCtl)
+				}
+				if len(args) != 2 || args[0] != argStatus || args[1] != argJSON {
+					t.Fatalf("status args = %#v", args)
+				}
+				return []byte(tt.output), tt.commandErr
+			}
+
+			err := newHyprlandWindowBackend().Close()
+			if !errors.Is(err, errWindowOperationFailed) {
+				t.Fatalf("Close() error = %v, want errWindowOperationFailed", err)
+			}
+			if tt.wantCause != nil && !errors.Is(err, tt.wantCause) {
+				t.Fatalf("Close() error = %v, want cause %v", err, tt.wantCause)
+			}
+			if calls != 1 {
+				t.Fatalf("Close() issued %d commands after status failure, want 1", calls)
+			}
+		})
 	}
 }
 
@@ -525,6 +615,9 @@ func TestHyprlandWindowBackendMaximizeSetAndRestore(t *testing.T) {
 				t.Fatalf("unexpected test state internal=%d client=%d", internal, client)
 			}
 		}
+		if len(args) == 2 && args[0] == argStatus && args[1] == argJSON {
+			return []byte(`{"configProvider":"hyprlang"}`), nil
+		}
 		calls = append(calls, append([]string(nil), args...))
 		if len(args) == 4 && args[0] == argDispatch && args[1] == argFullscreenState {
 			switch args[2] {
@@ -549,19 +642,60 @@ func TestHyprlandWindowBackendMaximizeSetAndRestore(t *testing.T) {
 		{argDispatch, argFullscreenState, argHyprlandMaximized, argHyprlandMaximized},
 		{argDispatch, argFullscreenState, argHyprlandNone, argHyprlandNone},
 	}
-	if len(calls) != len(want) {
-		t.Fatalf("calls = %#v, want %#v", calls, want)
-	}
-	for i := range want {
-		if len(calls[i]) != len(want[i]) {
-			t.Fatalf("call %d = %#v, want %#v", i, calls[i], want[i])
+	assertWindowCommandCalls(t, calls, want)
+}
+
+func TestHyprlandWindowBackendMaximizeSetAndRestoreLua(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	var calls [][]string
+	internal := hyprlandFullscreenNone
+	client := hyprlandFullscreenNone
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdHyprCtl {
+			t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
 		}
-		for j := range want[i] {
-			if calls[i][j] != want[i][j] {
-				t.Fatalf("call %d = %#v, want %#v", i, calls[i], want[i])
-			}
+		if len(args) == 2 && args[0] == argActiveWindow && args[1] == argJSON {
+			return []byte(fmt.Sprintf(
+				`{"fullscreen":%d,"fullscreenClient":%d}`,
+				internal,
+				client,
+			)), nil
 		}
+		if len(args) == 2 && args[0] == argStatus && args[1] == argJSON {
+			return []byte(`{"configProvider":"lua"}`), nil
+		}
+		calls = append(calls, append([]string(nil), args...))
+		switch {
+		case len(args) == 2 && args[0] == argDispatch && args[1] == hyprlandLuaMaximizeActive:
+			internal, client = hyprlandFullscreenMaximized, hyprlandFullscreenMaximized
+		case len(args) == 2 && args[0] == argDispatch && args[1] == hyprlandLuaRestoreActive:
+			internal, client = hyprlandFullscreenNone, hyprlandFullscreenNone
+		default:
+			t.Fatalf("unexpected hyprctl args: %#v", args)
+		}
+		return []byte("ok"), nil
 	}
+
+	b := newHyprlandWindowBackend()
+	if err := b.Maximize(0, true, false); err != nil {
+		t.Fatalf("maximize failed: %v", err)
+	}
+	if err := b.Maximize(0, false, false); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+
+	want := [][]string{
+		{argDispatch, hyprlandLuaMaximizeActive},
+		{argDispatch, hyprlandLuaRestoreActive},
+	}
+	assertWindowCommandCalls(t, calls, want)
 }
 
 func TestHyprlandWindowBackendMaximizeAvoidsLegacyToggle(t *testing.T) {
@@ -643,6 +777,9 @@ func TestHyprlandWindowBackendMaximizePreservesCommandError(t *testing.T) {
 		if len(args) == 2 && args[0] == argActiveWindow && args[1] == argJSON {
 			return []byte(`{"fullscreen":0,"fullscreenClient":0}`), nil
 		}
+		if len(args) == 2 && args[0] == argStatus && args[1] == argJSON {
+			return []byte(`{"configProvider":"hyprlang"}`), nil
+		}
 		return nil, wantErr
 	}
 
@@ -652,6 +789,103 @@ func TestHyprlandWindowBackendMaximizePreservesCommandError(t *testing.T) {
 	}
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("Maximize() error = %v, want wrapped command error", err)
+	}
+}
+
+func TestHyprlandDispatchArgsCompatibility(t *testing.T) {
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	statusErr := errors.New("status unsupported")
+	tests := []struct {
+		name       string
+		output     string
+		commandErr error
+		want       []string
+		wantErr    bool
+	}{
+		{
+			name:   "lua",
+			output: `{"configProvider":"lua"}`,
+			want:   []string{argDispatch, hyprlandLuaCloseActive},
+		},
+		{
+			name:   "hyprlang",
+			output: `{"configProvider":"hyprlang"}`,
+			want:   []string{argDispatch, argKillActive},
+		},
+		{
+			name:   "pre-status hyprland",
+			output: hyprlandStatusUnsupported,
+			want:   []string{argDispatch, argKillActive},
+		},
+		{
+			name:       "status command failure",
+			commandErr: statusErr,
+			wantErr:    true,
+		},
+		{
+			name:    "malformed successful status",
+			output:  `{"configProvider":`,
+			wantErr: true,
+		},
+		{
+			name:    "missing provider",
+			output:  `{}`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown provider",
+			output:  `{"configProvider":"future"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				_ = ctx
+				if name != cmdHyprCtl {
+					t.Fatalf("command = %q, want %q", name, cmdHyprCtl)
+				}
+				if len(args) != 2 || args[0] != argStatus || args[1] != argJSON {
+					t.Fatalf("status args = %#v", args)
+				}
+				return []byte(tt.output), tt.commandErr
+			}
+
+			got, err := resolveHyprlandDispatchArgs(
+				[]string{argKillActive},
+				hyprlandLuaCloseActive,
+			)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveHyprlandDispatchArgs() = %#v, nil; want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveHyprlandDispatchArgs() error = %v", err)
+			}
+			assertWindowCommandCalls(t, [][]string{got}, [][]string{tt.want})
+		})
+	}
+}
+
+func assertWindowCommandCalls(t *testing.T, got, want [][]string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("calls = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if len(got[i]) != len(want[i]) {
+			t.Fatalf("call %d = %#v, want %#v", i, got[i], want[i])
+		}
+		for j := range want[i] {
+			if got[i][j] != want[i][j] {
+				t.Fatalf("call %d = %#v, want %#v", i, got[i], want[i])
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Goal

Keep Hyprland active-window close and maximize/restore working across both legacy `hyprlang` configurations and Hyprland 0.55+ Lua configurations.

Hyprland 0.55 changed `hyprctl dispatch` under the Lua config provider: legacy dispatcher names such as `killactive` and `fullscreenstate` are no longer valid Lua expressions. The active provider is runtime state, not just a version property.

## Changes

- Query `hyprctl status -j` before mutating Hyprland window operations.
- Use the existing legacy dispatcher syntax for `configProvider=hyprlang`.
- Use `hl.dsp.window.close` and idempotent `hl.dsp.window.fullscreen_state(..., action="set")` expressions for `configProvider=lua`.
- Preserve compatibility with pre-0.55 Hyprland's exact `unknown request` response.
- Fail closed before mutation on status transport errors, malformed JSON, missing providers, or unknown future providers.
- Keep state queries distinct from mutations and retain bounded command timeouts.
- Extend hermetic backend/public-API tests, the existing opt-in Hyprland E2E path, runnable example text, README, TEST guide, compatibility matrix, and roadmap.

Official contract references:
- https://wiki.hypr.land/Configuring/Advanced-and-Cool/Using-hyprctl/
- https://wiki.hypr.land/Configuring/Basics/Dispatchers/

## Validation

- `go test -count=1 ./...`
- `CGO_ENABLED=0 go test -count=1 ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run`
- `go test -race -count=1 ./...`
- `go test -count=1 -tags "wayland integration" ./...`

All passed locally. A real Hyprland E2E still requires an opt-in Hyprland desktop runner via `ROBOTGO_HYPRLAND_MAXIMIZE_E2E=1`; the existing test restores its initial supported state.