### PR TITLE
chore: refresh GitHub Actions runtimes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,10 @@ jobs:
   vet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Install Linux development dependencies
@@ -39,10 +39,10 @@ jobs:
   race:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Install Linux development dependencies
@@ -63,10 +63,10 @@ jobs:
       CGO_ENABLED: "1"
       ASAN_OPTIONS: detect_leaks=1:halt_on_error=1:strict_string_checks=1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Install native sanitizer dependencies
@@ -111,11 +111,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Install system dependencies for cgo typecheck
@@ -143,11 +143,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
         id: go
@@ -177,11 +177,11 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Test Pure-Go build
@@ -278,11 +278,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Install X11 evidence dependencies
@@ -344,10 +344,10 @@ jobs:
   ocr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Install OCR development dependencies
@@ -361,11 +361,11 @@ jobs:
   wayland-integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Install Wayland test dependencies

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Install native build dependencies
@@ -104,7 +104,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Install Linux native build dependencies
@@ -283,7 +283,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - uses: actions/download-artifact@v8

--- a/.github/workflows/remote-desktop-e2e.yml
+++ b/.github/workflows/remote-desktop-e2e.yml
@@ -29,11 +29,11 @@ jobs:
     runs-on: [self-hosted, linux, wayland, "${{ matrix.desktop }}"]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Verify interactive Wayland session
@@ -69,7 +69,7 @@ jobs:
             tee "$RUNNER_TEMP/remote-desktop-report/test.log"
       - name: Upload compatibility evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: remote-desktop-${{ matrix.desktop }}
           path: ${{ runner.temp }}/remote-desktop-report

--- a/.github/workflows/screencast-e2e.yml
+++ b/.github/workflows/screencast-e2e.yml
@@ -29,11 +29,11 @@ jobs:
     runs-on: [self-hosted, linux, wayland, "${{ matrix.desktop }}"]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
       - name: Verify interactive Wayland session
@@ -71,7 +71,7 @@ jobs:
             tee "$RUNNER_TEMP/screencast-report/test.log"
       - name: Upload compatibility evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: screencast-${{ matrix.desktop }}
           path: ${{ runner.temp }}/screencast-report


### PR DESCRIPTION
## Goal

Remove the remaining Node 20 deprecation warnings and keep every repository workflow on the current official GitHub Actions runtime majors.

## Changes

- upgrade `actions/checkout` from v4 to v7
- upgrade `actions/setup-go` from v6 to v7
- upgrade E2E artifact uploads from v4 to v7
- apply the same runtime baseline to Go CI, release evidence, RemoteDesktop E2E, and ScreenCast E2E

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml`
- `go test -count=1 ./...`
- `CGO_ENABLED=0 go test -count=1 ./...`
- `git diff --check`

## Risk

Low. This is a focused workflow-only update. Existing inputs and permissions remain unchanged; the full repository CI matrix will verify the new action majors on Linux, macOS, and Windows.