### PR TITLE
feat: add Pure-Go X11 window control

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -238,6 +238,8 @@ jobs:
               printf "%s\n" "$listed"
               expected="$(printf "%s\n" \
                 TestPureGoX11RejectsImplicitDependencyPortalFallback \
+                TestPureGoX11WindowCapabilitySelection \
+                TestPureGoX11WindowCapabilityRejectsWaylandConflict \
                 TestPureGoX11MultiLayoutConfiguration \
                 TestPureGoX11Capabilities \
                 TestPureGoX11PointerInput \
@@ -256,7 +258,8 @@ jobs:
                 TestPureGoX11PreservesForeignInputState \
                 TestPureGoX11EventDrainDoesNotStall \
                 TestPureGoX11CloseMainDisplayReconnects \
-                TestPureGoX11SessionSwitchReleasesOwnedInput | LC_ALL=C sort)"
+                TestPureGoX11SessionSwitchReleasesOwnedInput \
+                TestPureGoX11WindowIntrospectionAndControl | LC_ALL=C sort)"
               actual="$(printf "%s\n" "$listed" | awk "/^TestPureGoX11/ { print }" | LC_ALL=C sort)"
               if [ "$actual" != "$expected" ]; then
                 echo "Pure-Go X11 test manifest mismatch" >&2

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ workflow. `GetRuntimeDiagnostics` provides the stable machine-readable report;
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
 | Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds, real Win32 DPI scale and pixel-at-pointer queries, foreground-layout-aware `SendInput` keyboard/text plus clipboard paste, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
-| Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds plus XTEST mouse, keyboard, text/Unicode, pointer-location, smooth-move/drag, vertical scroll, and live readiness probes; horizontal scroll is explicitly unsupported |
+| Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds, XTEST input, and window title/PID/handle/geometry/state/control through X11/EWMH; horizontal scroll and window mutations without a consistent EWMH window manager are explicitly unsupported |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |
 | Other supported platforms without CGO | `CGO_ENABLED=0` | Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
 
@@ -381,6 +381,19 @@ disabled, even when `DISPLAY` points to Xwayland.
 If cleanup reports that a scratch keycode is pressed or became a modifier,
 release or restore that external state and retry `CloseMainDisplayE`.
 
+The same non-CGO X11 build provides active-window and PID/handle resolution,
+title lookup, client and frame geometry, activation, minimize/maximize state,
+topmost state, and graceful close. Read-only operations require an accessible
+X server. Mutations additionally require a consistent EWMH window-manager
+identity that advertises the requested operation and fail with
+`ErrNotSupported` when either condition is absent;
+RobotGo does not send an optimistic request to an absent or non-advertising
+manager. EWMH operations remain asynchronous window-manager requests.
+Restoring a minimized window requests activation, matching EWMH semantics.
+Window properties are treated as untrusted server data: malformed values are
+rejected, and invalid frame extents fall back to client geometry. Each
+operation closes its short-lived X11 connection deterministically.
+
 RobotGo briefly grabs the X server around mapping/state checks and composite
 synthetic events so another X client cannot race those transactions. Core X11
 cannot attribute simultaneous physical input, or another press while RobotGo
@@ -403,9 +416,11 @@ operations share a locked configured-display lifecycle; separate XGB resolver
 connections use the same configured target and close deterministically.
 
 Error-returning window APIs no longer report success for native operations that
-have no implementation. In particular, the current X11 minimize/maximize path
-returns `ErrNotSupported` instead of silently doing nothing. Native `GetTitleE`
-also returns an explicit error when a title is empty or cannot be retrieved.
+have no implementation. In particular, the native CGO X11
+minimize/maximize path returns `ErrNotSupported` instead of silently doing
+nothing; the Pure-Go EWMH path described above implements those operations.
+Native `GetTitleE` also returns an explicit error when a title is empty or
+cannot be retrieved.
 
 ### Wayland
 
@@ -676,6 +691,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
 - [Versioned runtime diagnostics](examples/runtime_diagnostics/main.go)
 - [Pure-Go X11 input probe and opt-in demo](examples/purego_x11_input/main.go)
+- [Pure-Go X11 window inspection and opt-in EWMH control](examples/purego_x11_window/main.go)
 - [Pure-Go Windows input readiness and opt-in demo](examples/purego_windows_input/main.go)
 - [Pure-Go Windows window inspection and opt-in control](examples/purego_windows_window/main.go)
 - [Consent-aware RemoteDesktop portal input](examples/remote_desktop_input/main.go)
@@ -699,6 +715,15 @@ CGO_ENABLED=0 go run ./examples/purego_x11_input -act -text "Hello"
 
 Keyboard actions keep scratch mappings alive for two seconds before verified
 cleanup. Increase `-settle` when the focused XKB client may process input later.
+
+The Pure-Go X11 window example only inspects by default. State-changing
+operations require `-act` and an explicit action:
+
+```bash
+CGO_ENABLED=0 go run ./examples/purego_x11_window
+CGO_ENABLED=0 go run ./examples/purego_x11_window -pid 1234
+CGO_ENABLED=0 go run ./examples/purego_x11_window -pid 1234 -act -maximize
+```
 
 On Windows, the Pure-Go example performs readiness checks only unless `-move`,
 `-text`, `-paste`, or `-color` is supplied. `-paste` replaces the text
@@ -743,7 +768,7 @@ uses `us,de` layouts; a separate job applies the same public behavioral
 contract and benchmark smoke to native CGO and Pure-Go binaries. It also proves
 that native readiness rejects a reachable X server with XTEST disabled. Missing
 X11 runtime support fails instead of skipping; see
-[the testing guide](TEST.md#x11integration-native-and-pure-go-x11-input) for
+[the testing guide](TEST.md#x11integration-native-and-pure-go-x11-input-and-window) for
 the exact commands and prerequisites. The crash proof additionally inspects
 `/proc/<pid>/task/<tid>/children` under a Linux child subreaper to verify that
 the reported guardian is the exact child that exits and is reaped. The
@@ -789,15 +814,18 @@ Phase 4 already exposes the parity surface; Hyprland provides trustworthy
 active-window maximize query, set, and restore with provider-aware dispatch for
 legacy `hyprlang` and 0.55+ Lua configurations, while Sway and generic wlroots
 retain explicit unsupported query results where their available IPC lacks an
-equivalent state. The preceding Linux/X11 evaluation is complete: shared behavior is blocking CI,
-current guardian-path decision evidence is versioned, and native CGO remains
-the default while Pure-Go supports CGO-disabled builds. The Pure-Go X11 core is
-race-testable and its separate guardian performs bounded, claim-checked cleanup
-after an application-process crash. Its request transport now reuses bounded
-state and avoids double payload encoding, with versioned evidence showing lower
-allocation cost. Balanced transient press/release pairs now share one guardian
-request while preserving per-step crash-cleanup ownership and the existing
-preflight/server-grab policy. Required remote checks now protect `main`.
+equivalent state. The preceding Linux/X11 evaluation is complete: shared
+behavior is blocking CI, current guardian-path decision evidence is versioned,
+and native CGO remains the default while Pure-Go supports CGO-disabled builds.
+Pure-Go X11 now covers capture, input, and window introspection/control; its
+EWMH mutations fail explicitly without a trustworthy window manager. The input
+core is race-testable and its separate guardian performs bounded, claim-checked
+cleanup after an application-process crash. Its request transport now reuses
+bounded state and avoids double payload encoding, with versioned evidence
+showing lower allocation cost. Balanced transient press/release pairs now share
+one guardian request while preserving per-step crash-cleanup ownership and the
+existing preflight/server-grab policy. Required remote checks now protect
+`main`.
 Pure-Go Windows input is a delivered platform slice, with hermetic transaction
 tests and a blocking real input-desktop pointer probe on the Windows CI runner.
 Pure-Go Windows window introspection/control is the next delivered slice, with

--- a/TEST.md
+++ b/TEST.md
@@ -387,7 +387,7 @@ Status:
 - Blocking in the `wayland-integration` CI job. The suite is hermetic and does
   not require a running graphical compositor.
 
-### `x11integration` (native and Pure-Go X11 input)
+### `x11integration` (native and Pure-Go X11 input and window)
 
 Purpose:
 
@@ -421,6 +421,10 @@ Purpose:
   final image that is unpressed and absent from the modifier map
 - Side-effect-free capability selection plus explicit readiness probes against
   the live X server
+- Pure-Go active-window, PID/handle, title, client/frame geometry, activation,
+  minimize/maximize, topmost, and close behavior against a self-owned fake EWMH
+  window manager, including explicit unsupported behavior for unadvertised
+  operations and after manager loss
 - Adversarial replacement of a reserved mapping before injection; the default
   non-CGO unit suite separately covers modifier-map exclusion and bounded-scroll
   validation

--- a/docs/compatibility/runtime-v1.md
+++ b/docs/compatibility/runtime-v1.md
@@ -43,6 +43,7 @@ than inferring it from an operating-system label.
 | Wayland client, XKB, GBM/DRM development libraries | Native Wayland build | Build tag is unavailable; Pure-Go portal paths remain possible |
 | `xdg-desktop-portal` plus desktop backend | Screenshot, RemoteDesktop, ScreenCast | Capability is unavailable with remediation; RobotGo does not pretend success |
 | PipeWire development/runtime libraries and `pipewire` tag | Persistent ScreenCast frames | One-shot Screenshot/native screencopy remain eligible; persistent capture reports unsupported |
+| X11 server and EWMH window manager | Pure-Go X11 window introspection/control | Read-only operations report X11 access/property errors; mutations return explicit unsupported errors without a consistent manager that advertises the operation |
 | X11/XTEST | Native or Pure-Go X11 input | Readiness and diagnostics report missing/old XTEST explicitly |
 | Tesseract/Leptonica and `ocr` tag | OCR helpers | Core automation remains available without OCR |
 | Sway/Hyprland/wlroots command tools | Compositor-specific foreign-window operations; Hyprland mutations detect `hyprlang` versus 0.55+ Lua dispatch | Wayland-core capability reports unsupported operations explicitly |

--- a/docs/performance/x11-native-vs-purego.md
+++ b/docs/performance/x11-native-vs-purego.md
@@ -39,7 +39,7 @@ Install a C compiler, X11/XTest development files, `git`, `xvfb`, `xauth`,
 The crash-recovery contract also requires executable Linux procfs
 (`/proc/self/exe` and readable `/proc/<pid>/task/<tid>/children`), Linux
 abstract Unix sockets with `SO_PEERCRED`, and child-subreaper support. See the
-[X11 integration prerequisites](../../TEST.md#x11integration-native-and-pure-go-x11-input)
+[X11 integration prerequisites](../../TEST.md#x11integration-native-and-pure-go-x11-input-and-window)
 for the complete runtime contract.
 
 ```bash
@@ -74,7 +74,7 @@ outputs, the expected sample count, and all three metrics (`ns/op`, `B/op`,
 self-contained summary is explicitly report-only and never fails on
 elapsed-time ratios. The balanced comparison uses a normal XTEST-enabled
 server; reproduce the separate disabled-XTEST
-negative contract with the command in [TEST.md](../../TEST.md#x11integration-native-and-pure-go-x11-input).
+negative contract with the command in [TEST.md](../../TEST.md#x11integration-native-and-pure-go-x11-input-and-window).
 
 ## Interpretation rules
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -23,8 +23,9 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 - Mouse, keyboard, capture, and window operations expose explicit errors where
   legacy APIs previously could hide unsupported behavior.
 - Non-CGO builds provide supported capture backends, explicit RemoteDesktop
-  portal input on Wayland, and an XGB/XTEST input backend for X11-primary Linux
-  sessions; remaining unavailable GUI operations return `ErrNotSupported`.
+  portal input on Wayland, and XGB/XTEST input plus X11/EWMH window operations
+  for X11-primary Linux sessions; remaining unavailable GUI operations return
+  `ErrNotSupported`.
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
   Weston integration, race, vet, and native sanitizer/leak variants.
 
@@ -35,7 +36,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet/sanitizer jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE/wlroots evidence |
-| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and keyboard/pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz keyboard/pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture and XGB/XTEST input; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS keyboard-injection evidence and assess further backends selectively |
+| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and keyboard/pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz keyboard/pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS keyboard-injection evidence and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, provider-aware Hyprland 0.55+ Lua window dispatch | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline | Dedicated compositor jobs and the first published release evidence asset |
 
@@ -186,6 +187,18 @@ The runnable example inspects selected capabilities without opening X11 by
 default and requires an explicit `-act` flag before it runs live readiness
 checks or injects global input.
 
+The same X11-primary non-CGO build now provides active-window and PID/handle
+resolution, title lookup, client/frame geometry, activation,
+minimize/maximize, topmost state, and close. It strictly validates untrusted
+X11 properties, closes per-operation connections deterministically, and
+requires a consistent EWMH window-manager identity that advertises each
+requested mutation. Missing, inconsistent, or unadvertised support returns the
+public `ErrNotSupported` contract instead of optimistic success. A non-skipping
+Xvfb integration test owns a fake EWMH manager and target window, exercises the
+full public contract, and proves fail-closed behavior after manager loss. The
+runnable example is inspection-only unless `-act` and an explicit mutation are
+supplied.
+
 The Linux/X11 evaluation slice of Phase 3 is complete. Native CGO and Pure-Go
 X11 binaries pass one black-box public-API contract for capture, pointer,
 buttons, scroll, modifier order, and ASCII text without keyboard-map changes. A
@@ -231,9 +244,9 @@ Balanced transient press/release pairs now share one guardian request while
 retaining per-step ownership, verified release, preflight, server-grab, timeout,
 and crash-recovery contracts. This reduces another `5–14%` of allocations for
 the affected click, scroll, key-press, and text benchmarks. Stable remote checks
-now protect `main`; Windows input and self-owned window runtime evidence are
-blocking. Selectively evaluating additional platform backends keeps the broader
-Phase 3 partial.
+now protect `main`; Linux X11 input/window and Windows
+input/self-owned-window runtime evidence are blocking. Selectively evaluating
+additional platform backends keeps the broader Phase 3 partial.
 
 Exit criteria:
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -135,8 +135,11 @@ backends.
     `[new vs robotgo-pro]`
   - 5. Selectively port useful Pure-Go backends with behavioral parity tests,
     backend introspection, and benchmarks before changing defaults. Linux/X11
-    input is implemented; deep Pure-Go coverage and a shared native/Pure-Go
-    behavioral contract run in non-skipping Xvfb/XTEST CI. A balanced benchmark
+    input and window introspection/control are implemented; deep Pure-Go
+    coverage and shared native/Pure-Go input behavior run in non-skipping
+    Xvfb/XTEST CI. The window contract uses a self-owned fake EWMH manager and
+    verifies explicit unsupported behavior for unadvertised operations and
+    after manager loss. A balanced benchmark
     smoke is report-only. Native X11 now has atomic input preflight, one shared
     configured-display lifecycle/target, live XTEST readiness, and an XTEST-disabled negative
     contract. Current optimized guardian-path evidence retains native CGO as the
@@ -184,7 +187,9 @@ backends.
   - Validate the persistent ScreenCast/PipeWire stream path and repeated-frame
     behavior across GNOME/KDE/wlroots portal backends.
 - Keyboard Input:
-  - Add native Wayland Unicode typing via xkbcommon compose/keysyms.
+  - Keep the delivered native Wayland exact-Unicode keysym path covered,
+    including whole-text preflight and explicit unsupported/fallback behavior
+    when a code point is absent from the active keymap.
   - Verify native Wayland modifier synchronization and layout handling under
     various layouts.
 - Window APIs:
@@ -214,9 +219,10 @@ backends.
   - Keep the current headless Weston, screencopy, portal, and non-CGO CI
     commands green; eliminate unexpected hermetic skips. Stable jobs are
     required by `main` branch protection.
-  - Keep the non-CGO Xvfb/XTEST input test on a configured `us,de` keymap in
-    Linux CI; missing `DISPLAY` or XTEST must fail the matrix leg rather than
-    skip. Keep the shared native/Pure-Go contract and report-only benchmark
+  - Keep the non-CGO Xvfb/XTEST input and window contract on a configured
+    `us,de` keymap in Linux CI; missing `DISPLAY` or XTEST must fail the matrix
+    leg rather than skip. The window test owns its fake EWMH manager and target
+    window. Keep the shared native/Pure-Go input contract and report-only benchmark
     smoke green, including the native XTEST-disabled negative contract and
     display-lifecycle stress; the resulting stable remote checks are required
     by `main` branch protection.

--- a/examples/purego_x11_window/main.go
+++ b/examples/purego_x11_window/main.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	pid := flag.Int("pid", 0, "inspect a top-level X11 window by PID")
+	handle := flag.Int("handle", 0, "inspect a window by XID")
+	act := flag.Bool("act", false, "explicitly allow requested window-state changes")
+	activate := flag.Bool("activate", false, "ask the window manager to activate the target (requires -act)")
+	minimize := flag.Bool("minimize", false, "minimize and restore the target (requires -act)")
+	maximize := flag.Bool("maximize", false, "maximize and restore the target (requires -act)")
+	topmost := flag.Bool("topmost", false, "enable and restore ABOVE state (requires -act)")
+	settle := flag.Duration("settle", time.Second, "time to show each temporary state")
+	flag.Parse()
+
+	info := robotgo.GetRuntimeBackendInfo()
+	capability := robotgo.GetRuntimeCapabilities().Window
+	fmt.Printf(
+		"window backend: available=%t backend=%s reason=%q notes=%q\n",
+		capability.Available,
+		capability.Backend,
+		capability.Reason,
+		capability.Notes,
+	)
+	if runtime.GOOS != "linux" || info.CGOEnabled ||
+		info.DisplayServer != robotgo.DisplayServerX11 {
+		return fmt.Errorf(
+			"this example requires CGO_ENABLED=0 in an X11-primary Linux session; got %s cgo=%t display=%q",
+			runtime.GOOS,
+			info.CGOEnabled,
+			info.DisplayServer,
+		)
+	}
+	if !capability.Available {
+		return fmt.Errorf("Pure-Go X11 window backend is unavailable: %s", capability.Reason)
+	}
+	if *settle < 0 {
+		return errors.New("-settle must not be negative")
+	}
+
+	target, isHandle, err := selectedTarget(*pid, *handle)
+	if err != nil {
+		return err
+	}
+	if target == 0 {
+		target = robotgo.GetHandle()
+		isHandle = true
+	}
+	if target == 0 {
+		return errors.New("no active X11 client window is available")
+	}
+	args := []int(nil)
+	if isHandle {
+		args = []int{1}
+	}
+	title, err := robotgo.GetTitleE(append([]int{target}, args...)...)
+	if err != nil {
+		return fmt.Errorf("inspect title: %w", err)
+	}
+	x, y, width, height := robotgo.GetBounds(target, args...)
+	clientX, clientY, clientWidth, clientHeight := robotgo.GetClient(target, args...)
+	fmt.Printf(
+		"target=%d handle=%t title=%q bounds=(%d,%d %dx%d) client=(%d,%d %dx%d)\n",
+		target,
+		isHandle,
+		title,
+		x,
+		y,
+		width,
+		height,
+		clientX,
+		clientY,
+		clientWidth,
+		clientHeight,
+	)
+	resolved := target
+	if !isHandle {
+		resolved = robotgo.GetHWNDByPid(target)
+	}
+	if resolved == 0 {
+		return errors.New("the selected target could not be resolved to an XID")
+	}
+	if robotgo.GetHandle() == resolved {
+		minimizedState, minimizedErr := robotgo.IsMinimizedE()
+		printState("minimized", minimizedState, minimizedErr)
+		maximizedState, maximizedErr := robotgo.IsMaximizedE()
+		printState("maximized", maximizedState, maximizedErr)
+		topmostState, topmostErr := robotgo.IsTopMostE()
+		printState("topmost", topmostState, topmostErr)
+	} else {
+		fmt.Println("state: not queried (state APIs currently describe the active window)")
+	}
+
+	requested := *activate || *minimize || *maximize || *topmost
+	if !requested {
+		fmt.Println("inspection only: no window-manager request was sent")
+		return nil
+	}
+	if !*act {
+		return errors.New("no action performed: add -act after reviewing the requested window changes")
+	}
+	if *activate || *topmost {
+		if err := ensureActive(target, isHandle, resolved); err != nil {
+			return fmt.Errorf("activate target: %w", err)
+		}
+	}
+	if *minimize {
+		if err := exerciseState(target, isHandle, *settle, robotgo.MinWindowE); err != nil {
+			return fmt.Errorf("exercise minimized state: %w", err)
+		}
+	}
+	if *maximize {
+		if err := exerciseState(target, isHandle, *settle, robotgo.MaxWindowE); err != nil {
+			return fmt.Errorf("exercise maximized state: %w", err)
+		}
+	}
+	if *topmost {
+		original, err := robotgo.IsTopMostE()
+		if err != nil {
+			return fmt.Errorf("query initial topmost state: %w", err)
+		}
+		if err := robotgo.SetTopMostE(true); err != nil {
+			return fmt.Errorf("enable topmost state: %w", err)
+		}
+		time.Sleep(*settle)
+		if err := ensureActive(target, isHandle, resolved); err != nil {
+			return fmt.Errorf("reactivate target before restoring topmost state: %w", err)
+		}
+		if err := robotgo.SetTopMostE(original); err != nil {
+			return fmt.Errorf("restore topmost state: %w", err)
+		}
+	}
+	return nil
+}
+
+func ensureActive(target int, isHandle bool, resolved int) error {
+	if robotgo.GetHandle() == resolved {
+		return nil
+	}
+	args := []int(nil)
+	if isHandle {
+		args = []int{1}
+	}
+	if err := robotgo.ActivePid(target, args...); err != nil {
+		return err
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if robotgo.GetHandle() == resolved {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errors.New("window manager did not confirm activation within two seconds")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func selectedTarget(pid, handle int) (target int, isHandle bool, err error) {
+	if pid < 0 || handle < 0 {
+		return 0, false, errors.New("-pid and -handle must not be negative")
+	}
+	if pid > 0 && handle > 0 {
+		return 0, false, errors.New("use either -pid or -handle, not both")
+	}
+	if handle > 0 {
+		return handle, true, nil
+	}
+	return pid, false, nil
+}
+
+func printState(name string, value bool, err error) {
+	if err != nil {
+		fmt.Printf("%s: unavailable (%v)\n", name, err)
+		return
+	}
+	fmt.Printf("%s: %t\n", name, value)
+}
+
+func exerciseState(
+	target int,
+	isHandle bool,
+	settle time.Duration,
+	change func(int, ...interface{}) error,
+) error {
+	args := []interface{}{true}
+	if isHandle {
+		args = append(args, 1)
+	}
+	if err := change(target, args...); err != nil {
+		return err
+	}
+	time.Sleep(settle)
+	args[0] = false
+	return change(target, args...)
+}

--- a/internal/windowbackend/backend.go
+++ b/internal/windowbackend/backend.go
@@ -1,0 +1,56 @@
+// Package windowbackend defines the platform-neutral contract shared by
+// Pure-Go window implementations.
+package windowbackend
+
+import "errors"
+
+var (
+	// ErrWindowNotFound reports that no window matched the requested target.
+	ErrWindowNotFound = errors.New("window not found")
+	// ErrInvalidWindow reports a zero, stale, or otherwise invalid native handle.
+	ErrInvalidWindow = errors.New("invalid window handle")
+	// ErrOperation reports a failed native window operation.
+	ErrOperation = errors.New("window operation failed")
+	// ErrUnsupported reports a missing platform or window-manager capability.
+	ErrUnsupported = errors.New("window operation unsupported")
+)
+
+// Handle is an opaque native top-level window identifier.
+type Handle uintptr
+
+// Rect contains screen-relative window geometry.
+type Rect struct {
+	X      int
+	Y      int
+	Width  int
+	Height int
+}
+
+// State identifies a queryable and mutable presentation state.
+type State uint8
+
+const (
+	// StateMinimized identifies a minimized window.
+	StateMinimized State = iota
+	// StateMaximized identifies a maximized window.
+	StateMaximized
+)
+
+// Backend is the behavior required by the public Pure-Go window adapter.
+// Implementations keep platform-specific discovery, validation, and mutation
+// below this boundary.
+type Backend interface {
+	Active() (Handle, error)
+	Resolve(target int, isHandle bool) (Handle, error)
+	Select(target int, isHandle bool) error
+	Selected() Handle
+	PID(Handle) (int, error)
+	Title(Handle) (string, error)
+	Bounds(Handle, bool) (Rect, error)
+	Activate(Handle) error
+	SetState(Handle, State, bool) error
+	State(Handle, State) (bool, error)
+	TopMost(Handle) (bool, error)
+	SetTopMost(Handle, bool) error
+	Close(Handle) error
+}

--- a/internal/windowswindow/backend.go
+++ b/internal/windowswindow/backend.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/marang/robotgo/internal/windowbackend"
 )
 
 var (
@@ -16,24 +18,19 @@ var (
 )
 
 // Handle is a platform-neutral representation of a Windows HWND.
-type Handle uintptr
+type Handle = windowbackend.Handle
 
 // Rect contains screen-relative window geometry.
-type Rect struct {
-	X      int
-	Y      int
-	Width  int
-	Height int
-}
+type Rect = windowbackend.Rect
 
 // State identifies a queryable and mutable Windows presentation state.
-type State uint8
+type State = windowbackend.State
 
 const (
 	// StateMinimized identifies the minimized/iconic state.
-	StateMinimized State = iota
+	StateMinimized = windowbackend.StateMinimized
 	// StateMaximized identifies the maximized/zoomed state.
-	StateMaximized
+	StateMaximized = windowbackend.StateMaximized
 )
 
 // System abstracts the Win32 calls used by Backend.
@@ -60,6 +57,8 @@ type Backend struct {
 	mu       sync.RWMutex
 	selected Handle
 }
+
+var _ windowbackend.Backend = (*Backend)(nil)
 
 // New constructs a Backend around a Win32 system implementation.
 func New(system System) *Backend {

--- a/internal/x11window/backend_linux.go
+++ b/internal/x11window/backend_linux.go
@@ -1,0 +1,268 @@
+//go:build linux
+
+// Package x11window implements the Pure-Go X11 window contract.
+package x11window
+
+import (
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+var (
+	// ErrWindowNotFound reports that no X11 client matched the target.
+	ErrWindowNotFound = windowbackend.ErrWindowNotFound
+	// ErrInvalidWindow reports a zero, stale, or invalid XID.
+	ErrInvalidWindow = windowbackend.ErrInvalidWindow
+	// ErrOperation reports a failed X11 window operation.
+	ErrOperation = windowbackend.ErrOperation
+)
+
+// System abstracts X11 discovery, property queries, and EWMH requests.
+type System interface {
+	ActiveWindow() (windowbackend.Handle, error)
+	WindowExists(windowbackend.Handle) (bool, error)
+	FindWindowByPID(uint32) (windowbackend.Handle, error)
+	WindowProcessID(windowbackend.Handle) (uint32, error)
+	WindowText(windowbackend.Handle) (string, error)
+	WindowRect(windowbackend.Handle) (windowbackend.Rect, error)
+	ClientRect(windowbackend.Handle) (windowbackend.Rect, error)
+	ActivateWindow(windowbackend.Handle) error
+	SetWindowState(windowbackend.Handle, windowbackend.State, bool) error
+	WindowState(windowbackend.Handle, windowbackend.State) (bool, error)
+	IsTopMost(windowbackend.Handle) (bool, error)
+	SetTopMost(windowbackend.Handle, bool) error
+	CloseWindow(windowbackend.Handle) error
+}
+
+// Backend resolves public targets and validates every operation before it is
+// delegated to X11.
+type Backend struct {
+	system System
+
+	mu       sync.RWMutex
+	selected windowbackend.Handle
+}
+
+var _ windowbackend.Backend = (*Backend)(nil)
+
+// New constructs a Pure-Go X11 window backend.
+func New(system System) *Backend {
+	return &Backend{system: system}
+}
+
+// Active returns the current valid active or focused X11 window.
+func (backend *Backend) Active() (windowbackend.Handle, error) {
+	handle, err := backend.system.ActiveWindow()
+	if err != nil {
+		return 0, fmt.Errorf("%w: active X11 window: %w", ErrOperation, err)
+	}
+	if err := backend.validate(handle); err != nil {
+		return 0, fmt.Errorf("%w: active X11 window", err)
+	}
+	return handle, nil
+}
+
+// Resolve maps a positive process ID or explicit XID to a valid window.
+func (backend *Backend) Resolve(target int, isHandle bool) (windowbackend.Handle, error) {
+	if target <= 0 {
+		return 0, fmt.Errorf("%w: target must be positive, got %d", ErrWindowNotFound, target)
+	}
+	if uint64(target) > math.MaxUint32 {
+		return 0, fmt.Errorf("%w: target %d exceeds the X11 CARD32 range", ErrWindowNotFound, target)
+	}
+	if isHandle {
+		handle := windowbackend.Handle(uintptr(target))
+		if err := backend.validate(handle); err != nil {
+			return 0, err
+		}
+		return handle, nil
+	}
+	handle, err := backend.system.FindWindowByPID(uint32(target))
+	if err != nil {
+		return 0, fmt.Errorf("%w: pid %d: %w", ErrWindowNotFound, target, err)
+	}
+	if err := backend.validate(handle); err != nil {
+		return 0, fmt.Errorf("%w: pid %d resolved to %#x", err, target, uintptr(handle))
+	}
+	return handle, nil
+}
+
+// Select stores a resolved compatibility handle.
+func (backend *Backend) Select(target int, isHandle bool) error {
+	handle, err := backend.Resolve(target, isHandle)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	backend.selected = handle
+	backend.mu.Unlock()
+	return nil
+}
+
+// Selected returns the compatibility handle stored by Select.
+func (backend *Backend) Selected() windowbackend.Handle {
+	backend.mu.RLock()
+	defer backend.mu.RUnlock()
+	return backend.selected
+}
+
+// PID returns the owning process ID from _NET_WM_PID.
+func (backend *Backend) PID(handle windowbackend.Handle) (int, error) {
+	if err := backend.validate(handle); err != nil {
+		return 0, err
+	}
+	pid, err := backend.system.WindowProcessID(handle)
+	if err != nil {
+		return 0, fmt.Errorf("%w: get pid for XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	if pid == 0 {
+		return 0, fmt.Errorf("%w: XID %#x has no process", ErrWindowNotFound, uintptr(handle))
+	}
+	if uint64(pid) > uint64(^uint(0)>>1) {
+		return 0, fmt.Errorf("%w: pid %d exceeds the Go int range", ErrOperation, pid)
+	}
+	return int(pid), nil
+}
+
+// Title returns a non-empty EWMH or ICCCM title.
+func (backend *Backend) Title(handle windowbackend.Handle) (string, error) {
+	if err := backend.validate(handle); err != nil {
+		return "", err
+	}
+	title, err := backend.system.WindowText(handle)
+	if err != nil {
+		return "", fmt.Errorf("%w: get title for XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	if title == "" {
+		return "", fmt.Errorf("%w: XID %#x has no title", ErrWindowNotFound, uintptr(handle))
+	}
+	return title, nil
+}
+
+// Bounds returns outer or client geometry in root coordinates.
+func (backend *Backend) Bounds(handle windowbackend.Handle, client bool) (windowbackend.Rect, error) {
+	if err := backend.validate(handle); err != nil {
+		return windowbackend.Rect{}, err
+	}
+	var (
+		rect windowbackend.Rect
+		err  error
+	)
+	if client {
+		rect, err = backend.system.ClientRect(handle)
+	} else {
+		rect, err = backend.system.WindowRect(handle)
+	}
+	if err != nil {
+		return windowbackend.Rect{}, fmt.Errorf("%w: get bounds for XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	if rect.Width <= 0 || rect.Height <= 0 {
+		return windowbackend.Rect{}, fmt.Errorf(
+			"%w: XID %#x returned invalid bounds %+v",
+			ErrOperation,
+			uintptr(handle),
+			rect,
+		)
+	}
+	return rect, nil
+}
+
+// Activate requests EWMH activation for a valid window.
+func (backend *Backend) Activate(handle windowbackend.Handle) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := backend.system.ActivateWindow(handle); err != nil {
+		return fmt.Errorf("%w: activate XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	return nil
+}
+
+// SetState changes minimized or maximized state through the window manager.
+func (backend *Backend) SetState(handle windowbackend.Handle, state windowbackend.State, enabled bool) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := validateState(state); err != nil {
+		return err
+	}
+	if err := backend.system.SetWindowState(handle, state, enabled); err != nil {
+		return fmt.Errorf("%w: change state for XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	return nil
+}
+
+// State queries minimized or maximized state from _NET_WM_STATE.
+func (backend *Backend) State(handle windowbackend.Handle, state windowbackend.State) (bool, error) {
+	if err := backend.validate(handle); err != nil {
+		return false, err
+	}
+	if err := validateState(state); err != nil {
+		return false, err
+	}
+	enabled, err := backend.system.WindowState(handle, state)
+	if err != nil {
+		return false, fmt.Errorf("%w: query state for XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	return enabled, nil
+}
+
+// TopMost reports the EWMH ABOVE state.
+func (backend *Backend) TopMost(handle windowbackend.Handle) (bool, error) {
+	if err := backend.validate(handle); err != nil {
+		return false, err
+	}
+	enabled, err := backend.system.IsTopMost(handle)
+	if err != nil {
+		return false, fmt.Errorf("%w: query topmost for XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	return enabled, nil
+}
+
+// SetTopMost changes the EWMH ABOVE state.
+func (backend *Backend) SetTopMost(handle windowbackend.Handle, enabled bool) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := backend.system.SetTopMost(handle, enabled); err != nil {
+		return fmt.Errorf("%w: set topmost for XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	return nil
+}
+
+// Close requests a graceful EWMH close.
+func (backend *Backend) Close(handle windowbackend.Handle) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := backend.system.CloseWindow(handle); err != nil {
+		return fmt.Errorf("%w: close XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	return nil
+}
+
+func (backend *Backend) validate(handle windowbackend.Handle) error {
+	if handle == 0 || uint64(handle) > math.MaxUint32 {
+		return fmt.Errorf("%w: XID %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	valid, err := backend.system.WindowExists(handle)
+	if err != nil {
+		return fmt.Errorf("%w: validate XID %#x: %w", ErrOperation, uintptr(handle), err)
+	}
+	if !valid {
+		return fmt.Errorf("%w: XID %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	return nil
+}
+
+func validateState(state windowbackend.State) error {
+	switch state {
+	case windowbackend.StateMinimized, windowbackend.StateMaximized:
+		return nil
+	default:
+		return fmt.Errorf("%w: unknown X11 window state %d", ErrOperation, state)
+	}
+}

--- a/internal/x11window/backend_linux_test.go
+++ b/internal/x11window/backend_linux_test.go
@@ -1,0 +1,267 @@
+//go:build linux
+
+package x11window
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+type fakeSystem struct {
+	active        windowbackend.Handle
+	valid         map[windowbackend.Handle]bool
+	byPID         map[uint32]windowbackend.Handle
+	pids          map[windowbackend.Handle]uint32
+	titles        map[windowbackend.Handle]string
+	windowRects   map[windowbackend.Handle]windowbackend.Rect
+	clientRects   map[windowbackend.Handle]windowbackend.Rect
+	states        map[windowbackend.Handle]map[windowbackend.State]bool
+	topMost       map[windowbackend.Handle]bool
+	err           error
+	activated     windowbackend.Handle
+	stateHandle   windowbackend.Handle
+	state         windowbackend.State
+	stateEnabled  bool
+	topHandle     windowbackend.Handle
+	topEnabled    bool
+	closed        windowbackend.Handle
+	validationErr error
+}
+
+func (system *fakeSystem) ActiveWindow() (windowbackend.Handle, error) {
+	return system.active, system.err
+}
+func (system *fakeSystem) WindowExists(handle windowbackend.Handle) (bool, error) {
+	return system.valid[handle], system.validationErr
+}
+func (system *fakeSystem) FindWindowByPID(pid uint32) (windowbackend.Handle, error) {
+	if system.err != nil {
+		return 0, system.err
+	}
+	return system.byPID[pid], nil
+}
+func (system *fakeSystem) WindowProcessID(handle windowbackend.Handle) (uint32, error) {
+	return system.pids[handle], system.err
+}
+func (system *fakeSystem) WindowText(handle windowbackend.Handle) (string, error) {
+	return system.titles[handle], system.err
+}
+func (system *fakeSystem) WindowRect(handle windowbackend.Handle) (windowbackend.Rect, error) {
+	return system.windowRects[handle], system.err
+}
+func (system *fakeSystem) ClientRect(handle windowbackend.Handle) (windowbackend.Rect, error) {
+	return system.clientRects[handle], system.err
+}
+func (system *fakeSystem) ActivateWindow(handle windowbackend.Handle) error {
+	system.activated = handle
+	return system.err
+}
+func (system *fakeSystem) SetWindowState(handle windowbackend.Handle, state windowbackend.State, enabled bool) error {
+	system.stateHandle, system.state, system.stateEnabled = handle, state, enabled
+	return system.err
+}
+func (system *fakeSystem) WindowState(handle windowbackend.Handle, state windowbackend.State) (bool, error) {
+	return system.states[handle][state], system.err
+}
+func (system *fakeSystem) IsTopMost(handle windowbackend.Handle) (bool, error) {
+	return system.topMost[handle], system.err
+}
+func (system *fakeSystem) SetTopMost(handle windowbackend.Handle, enabled bool) error {
+	system.topHandle, system.topEnabled = handle, enabled
+	return system.err
+}
+func (system *fakeSystem) CloseWindow(handle windowbackend.Handle) error {
+	system.closed = handle
+	return system.err
+}
+
+func newFakeBackend() (*Backend, *fakeSystem) {
+	const handle = windowbackend.Handle(0x42)
+	system := &fakeSystem{
+		active:      handle,
+		valid:       map[windowbackend.Handle]bool{handle: true},
+		byPID:       map[uint32]windowbackend.Handle{1234: handle},
+		pids:        map[windowbackend.Handle]uint32{handle: 1234},
+		titles:      map[windowbackend.Handle]string{handle: "RobotGo X11"},
+		windowRects: map[windowbackend.Handle]windowbackend.Rect{handle: {X: 8, Y: 9, Width: 640, Height: 480}},
+		clientRects: map[windowbackend.Handle]windowbackend.Rect{handle: {X: 12, Y: 30, Width: 620, Height: 450}},
+		states: map[windowbackend.Handle]map[windowbackend.State]bool{
+			handle: {
+				windowbackend.StateMinimized: true,
+				windowbackend.StateMaximized: false,
+			},
+		},
+		topMost: map[windowbackend.Handle]bool{handle: true},
+	}
+	return New(system), system
+}
+
+func TestBackendIntrospectionContract(t *testing.T) {
+	backend, _ := newFakeBackend()
+
+	handle, err := backend.Active()
+	if err != nil || handle != 0x42 {
+		t.Fatalf("Active() = %#x, %v", handle, err)
+	}
+	if resolved, err := backend.Resolve(1234, false); err != nil || resolved != handle {
+		t.Fatalf("Resolve(pid) = %#x, %v", resolved, err)
+	}
+	if resolved, err := backend.Resolve(int(handle), true); err != nil || resolved != handle {
+		t.Fatalf("Resolve(handle) = %#x, %v", resolved, err)
+	}
+	if err := backend.Select(int(handle), true); err != nil || backend.Selected() != handle {
+		t.Fatalf("Select/Selected = %#x, %v", backend.Selected(), err)
+	}
+	if pid, err := backend.PID(handle); err != nil || pid != 1234 {
+		t.Fatalf("PID() = %d, %v", pid, err)
+	}
+	if title, err := backend.Title(handle); err != nil || title != "RobotGo X11" {
+		t.Fatalf("Title() = %q, %v", title, err)
+	}
+	if rect, err := backend.Bounds(handle, false); err != nil ||
+		rect != (windowbackend.Rect{X: 8, Y: 9, Width: 640, Height: 480}) {
+		t.Fatalf("Bounds(window) = %+v, %v", rect, err)
+	}
+	if rect, err := backend.Bounds(handle, true); err != nil ||
+		rect != (windowbackend.Rect{X: 12, Y: 30, Width: 620, Height: 450}) {
+		t.Fatalf("Bounds(client) = %+v, %v", rect, err)
+	}
+	if state, err := backend.State(handle, windowbackend.StateMinimized); err != nil || !state {
+		t.Fatalf("State(minimized) = %v, %v", state, err)
+	}
+	if state, err := backend.State(handle, windowbackend.StateMaximized); err != nil || state {
+		t.Fatalf("State(maximized) = %v, %v", state, err)
+	}
+	if state, err := backend.TopMost(handle); err != nil || !state {
+		t.Fatalf("TopMost() = %v, %v", state, err)
+	}
+}
+
+func TestBackendMutationContract(t *testing.T) {
+	backend, system := newFakeBackend()
+	const handle = windowbackend.Handle(0x42)
+
+	if err := backend.Activate(handle); err != nil || system.activated != handle {
+		t.Fatalf("Activate() target = %#x, err=%v", system.activated, err)
+	}
+	if err := backend.SetState(handle, windowbackend.StateMaximized, true); err != nil ||
+		system.stateHandle != handle || system.state != windowbackend.StateMaximized || !system.stateEnabled {
+		t.Fatalf(
+			"SetState() = handle %#x state %d enabled %v, err=%v",
+			system.stateHandle,
+			system.state,
+			system.stateEnabled,
+			err,
+		)
+	}
+	if err := backend.SetTopMost(handle, false); err != nil ||
+		system.topHandle != handle || system.topEnabled {
+		t.Fatalf("SetTopMost() = handle %#x enabled %v, err=%v", system.topHandle, system.topEnabled, err)
+	}
+	if err := backend.Close(handle); err != nil || system.closed != handle {
+		t.Fatalf("Close() target = %#x, err=%v", system.closed, err)
+	}
+}
+
+func TestBackendRejectsInvalidTargetsAndResults(t *testing.T) {
+	backend, system := newFakeBackend()
+	if _, err := backend.Resolve(0, false); !errors.Is(err, ErrWindowNotFound) {
+		t.Fatalf("Resolve(0) error = %v, want ErrWindowNotFound", err)
+	}
+	if strconvIntCanExceedUint32() {
+		target := int(uint64(math.MaxUint32) + 1)
+		if _, err := backend.Resolve(target, true); !errors.Is(err, ErrWindowNotFound) {
+			t.Fatalf("Resolve(overflow) error = %v, want ErrWindowNotFound", err)
+		}
+	}
+	if _, err := backend.Resolve(99, true); !errors.Is(err, ErrInvalidWindow) {
+		t.Fatalf("Resolve(stale) error = %v, want ErrInvalidWindow", err)
+	}
+	system.active = 0
+	if _, err := backend.Active(); !errors.Is(err, ErrInvalidWindow) {
+		t.Fatalf("Active(zero) error = %v, want ErrInvalidWindow", err)
+	}
+	system.active = 0x42
+	system.titles[0x42] = ""
+	if _, err := backend.Title(0x42); !errors.Is(err, ErrWindowNotFound) {
+		t.Fatalf("Title(empty) error = %v, want ErrWindowNotFound", err)
+	}
+	system.windowRects[0x42] = windowbackend.Rect{Width: 0, Height: 10}
+	if _, err := backend.Bounds(0x42, false); !errors.Is(err, ErrOperation) {
+		t.Fatalf("Bounds(invalid) error = %v, want ErrOperation", err)
+	}
+	if err := backend.SetState(0x42, windowbackend.State(99), true); !errors.Is(err, ErrOperation) {
+		t.Fatalf("SetState(unknown) error = %v, want ErrOperation", err)
+	}
+}
+
+func TestBackendWrapsSystemErrors(t *testing.T) {
+	backend, system := newFakeBackend()
+	system.err = errors.New("X11 transport failed")
+
+	operations := []error{
+		func() error { _, err := backend.Active(); return err }(),
+		func() error { _, err := backend.Resolve(1234, false); return err }(),
+		func() error { _, err := backend.PID(0x42); return err }(),
+		func() error { _, err := backend.Title(0x42); return err }(),
+		func() error { _, err := backend.Bounds(0x42, false); return err }(),
+		backend.Activate(0x42),
+		backend.SetState(0x42, windowbackend.StateMaximized, true),
+		func() error { _, err := backend.State(0x42, windowbackend.StateMaximized); return err }(),
+		func() error { _, err := backend.TopMost(0x42); return err }(),
+		backend.SetTopMost(0x42, true),
+		backend.Close(0x42),
+	}
+	for index, err := range operations {
+		if !errors.Is(err, ErrOperation) && !errors.Is(err, ErrWindowNotFound) {
+			t.Errorf("operation %d error = %v, want wrapped operation/not-found error", index, err)
+		}
+	}
+}
+
+func TestBackendPreservesUnsupportedCause(t *testing.T) {
+	backend, system := newFakeBackend()
+	system.err = windowbackend.ErrUnsupported
+
+	if err := backend.SetTopMost(0x42, true); !errors.Is(err, ErrOperation) ||
+		!errors.Is(err, windowbackend.ErrUnsupported) {
+		t.Fatalf("SetTopMost() error = %v, want operation and unsupported causes", err)
+	}
+}
+
+func TestBackendReportsValidationTransportError(t *testing.T) {
+	backend, system := newFakeBackend()
+	transportErr := errors.New("X11 connection closed")
+	system.validationErr = transportErr
+
+	_, err := backend.Resolve(0x42, true)
+	if !errors.Is(err, ErrOperation) || !errors.Is(err, transportErr) {
+		t.Fatalf("Resolve() validation error = %v, want operation and transport causes", err)
+	}
+}
+
+func strconvIntCanExceedUint32() bool {
+	return uint64(^uint(0)>>1) > math.MaxUint32
+}
+
+func TestAddFrameExtents(t *testing.T) {
+	client := windowbackend.Rect{X: -10, Y: 20, Width: 400, Height: 300}
+	got, err := addFrameExtents(client, x11FrameExtents{
+		left:   5,
+		right:  7,
+		top:    20,
+		bottom: 8,
+	})
+	want := windowbackend.Rect{X: -15, Y: 0, Width: 412, Height: 328}
+	if err != nil || got != want {
+		t.Fatalf("addFrameExtents() = %+v, %v, want %+v", got, err, want)
+	}
+	if _, err := addFrameExtents(client, x11FrameExtents{
+		left: maxFrameExtentPixels + 1,
+	}); !errors.Is(err, ErrOperation) {
+		t.Fatalf("oversized frame extent error = %v, want ErrOperation", err)
+	}
+}

--- a/internal/x11window/system_xgb_linux.go
+++ b/internal/x11window/system_xgb_linux.go
@@ -1,0 +1,817 @@
+//go:build linux
+
+package x11window
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgbutil"
+	"github.com/jezek/xgbutil/ewmh"
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+const (
+	atomActiveWindow      = "_NET_ACTIVE_WINDOW"
+	atomCloseWindow       = "_NET_CLOSE_WINDOW"
+	atomFrameExtents      = "_NET_FRAME_EXTENTS"
+	atomSupported         = "_NET_SUPPORTED"
+	atomSupportingWMCheck = "_NET_SUPPORTING_WM_CHECK"
+	atomWMName            = "_NET_WM_NAME"
+	atomWMPID             = "_NET_WM_PID"
+	atomWMState           = "_NET_WM_STATE"
+	atomWMStateAbove      = "_NET_WM_STATE_ABOVE"
+	atomWMStateHidden     = "_NET_WM_STATE_HIDDEN"
+	atomWMStateMaxHorz    = "_NET_WM_STATE_MAXIMIZED_HORZ"
+	atomWMStateMaxVert    = "_NET_WM_STATE_MAXIMIZED_VERT"
+	atomWMChangeState     = "WM_CHANGE_STATE"
+	atomLegacyWMName      = "WM_NAME"
+	atomUTF8String        = "UTF8_STRING"
+	icccmIconicState      = 3
+	maxPropertyBytes      = 1 << 20
+	maxFrameExtentPixels  = math.MaxUint16
+	maxWindowTreeNodes    = 1 << 16
+)
+
+// ErrWindowManagerUnavailable reports that a state/control request has no
+// consistent EWMH manager or is not advertised by that manager.
+var ErrWindowManagerUnavailable = fmt.Errorf(
+	"%w: EWMH window manager unavailable",
+	windowbackend.ErrUnsupported,
+)
+
+// Config controls X11 connection selection.
+type Config struct {
+	ResolveDisplay func() (string, error)
+}
+
+// NewNative constructs a backend that opens and closes an X11 connection for
+// each public operation.
+func NewNative(config Config) *Backend {
+	return New(&nativeSystem{resolveDisplay: config.ResolveDisplay})
+}
+
+type nativeSystem struct {
+	resolveDisplay func() (string, error)
+}
+
+func (system *nativeSystem) open() (*xgbutil.XUtil, error) {
+	if system.resolveDisplay == nil {
+		return nil, errors.New("X11 display resolver is nil")
+	}
+	display, err := system.resolveDisplay()
+	if err != nil {
+		return nil, err
+	}
+	if display == "" {
+		return nil, errors.New("X11 display resolver returned an empty display")
+	}
+	xu, err := xgbutil.NewConnDisplay(display)
+	if err != nil {
+		return nil, fmt.Errorf("connect to X11 display %q: %w", display, err)
+	}
+	return xu, nil
+}
+
+func (system *nativeSystem) ActiveWindow() (windowbackend.Handle, error) {
+	xu, err := system.open()
+	if err != nil {
+		return 0, err
+	}
+	defer xu.Conn().Close()
+
+	active, activeErr := ewmh.ActiveWindowGet(xu)
+	if activeErr == nil && active != xproto.WindowNone {
+		return windowbackend.Handle(active), nil
+	}
+	focus, focusErr := xproto.GetInputFocus(xu.Conn()).Reply()
+	if focusErr != nil {
+		return 0, errors.Join(activeErr, fmt.Errorf("query X11 input focus: %w", focusErr))
+	}
+	if focus == nil || focus.Focus == xproto.WindowNone || focus.Focus == xu.RootWin() {
+		return 0, fmt.Errorf("%w: X11 has no active client window", ErrWindowNotFound)
+	}
+	return windowbackend.Handle(focus.Focus), nil
+}
+
+func (system *nativeSystem) WindowExists(handle windowbackend.Handle) (bool, error) {
+	window, ok := x11Window(handle)
+	if !ok {
+		return false, nil
+	}
+	xu, err := system.open()
+	if err != nil {
+		return false, err
+	}
+	defer xu.Conn().Close()
+	reply, err := xproto.GetWindowAttributes(xu.Conn(), window).Reply()
+	if err != nil {
+		var invalidWindow xproto.WindowError
+		if errors.As(err, &invalidWindow) {
+			return false, nil
+		}
+		return false, fmt.Errorf("query X11 window attributes: %w", err)
+	}
+	return reply != nil, nil
+}
+
+func (system *nativeSystem) FindWindowByPID(pid uint32) (windowbackend.Handle, error) {
+	if pid == 0 {
+		return 0, fmt.Errorf("%w: pid is zero", ErrWindowNotFound)
+	}
+	xu, err := system.open()
+	if err != nil {
+		return 0, err
+	}
+	defer xu.Conn().Close()
+
+	windows, listErr := ewmh.ClientListGet(xu)
+	if listErr == nil {
+		if window := findWindowByPID(xu, windows, pid); window != xproto.WindowNone {
+			return windowbackend.Handle(window), nil
+		}
+	}
+	window, treeErr := findWindowByPIDInTree(xu, pid)
+	if treeErr != nil {
+		return 0, errors.Join(listErr, treeErr)
+	}
+	if window == xproto.WindowNone {
+		return 0, fmt.Errorf("%w: no X11 client for pid %d", ErrWindowNotFound, pid)
+	}
+	return windowbackend.Handle(window), nil
+}
+
+func (system *nativeSystem) WindowProcessID(handle windowbackend.Handle) (uint32, error) {
+	window, ok := x11Window(handle)
+	if !ok {
+		return 0, fmt.Errorf("%w: XID %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	xu, err := system.open()
+	if err != nil {
+		return 0, err
+	}
+	defer xu.Conn().Close()
+	return windowPID(xu, window)
+}
+
+func (system *nativeSystem) WindowText(handle windowbackend.Handle) (string, error) {
+	window, ok := x11Window(handle)
+	if !ok {
+		return "", fmt.Errorf("%w: XID %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	xu, err := system.open()
+	if err != nil {
+		return "", err
+	}
+	defer xu.Conn().Close()
+
+	utf8Atom, utf8Err := internAtom(xu.Conn(), atomUTF8String, true)
+	modernErr := utf8Err
+	if utf8Err == nil && utf8Atom != xproto.AtomNone {
+		value, propertyErr := stringProperty(
+			xu.Conn(),
+			window,
+			atomWMName,
+			utf8Atom,
+			true,
+		)
+		switch {
+		case propertyErr != nil:
+			modernErr = propertyErr
+		case value == "":
+			modernErr = fmt.Errorf("X11 property %s is empty", atomWMName)
+		case !utf8.ValidString(value):
+			modernErr = fmt.Errorf("X11 property %s is not valid UTF-8", atomWMName)
+		default:
+			return value, nil
+		}
+	} else if utf8Err == nil {
+		modernErr = fmt.Errorf("X11 atom %s is unavailable", atomUTF8String)
+	}
+	value, legacyErr := stringProperty(
+		xu.Conn(),
+		window,
+		atomLegacyWMName,
+		xproto.AtomString,
+		true,
+	)
+	if legacyErr != nil {
+		return "", errors.Join(modernErr, legacyErr)
+	}
+	if value == "" {
+		return "", errors.Join(
+			fmt.Errorf("%w: XID %#x has no title", ErrWindowNotFound, window),
+			modernErr,
+		)
+	}
+	return value, nil
+}
+
+func (system *nativeSystem) WindowRect(handle windowbackend.Handle) (windowbackend.Rect, error) {
+	window, ok := x11Window(handle)
+	if !ok {
+		return windowbackend.Rect{}, fmt.Errorf("%w: XID %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	xu, err := system.open()
+	if err != nil {
+		return windowbackend.Rect{}, err
+	}
+	defer xu.Conn().Close()
+	client, err := clientRect(xu, window)
+	if err != nil {
+		return windowbackend.Rect{}, err
+	}
+	extents, err := frameExtents(xu.Conn(), window)
+	if err != nil {
+		return client, nil
+	}
+	outer, err := addFrameExtents(client, extents)
+	if err != nil {
+		return client, nil
+	}
+	return outer, nil
+}
+
+func (system *nativeSystem) ClientRect(handle windowbackend.Handle) (windowbackend.Rect, error) {
+	window, ok := x11Window(handle)
+	if !ok {
+		return windowbackend.Rect{}, fmt.Errorf("%w: XID %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	xu, err := system.open()
+	if err != nil {
+		return windowbackend.Rect{}, err
+	}
+	defer xu.Conn().Close()
+	return clientRect(xu, window)
+}
+
+func (system *nativeSystem) ActivateWindow(handle windowbackend.Handle) error {
+	return system.withWindowManager(
+		handle,
+		[]string{atomActiveWindow},
+		func(xu *xgbutil.XUtil, window xproto.Window) error {
+			return ewmh.ActiveWindowReq(xu, window)
+		},
+	)
+}
+
+func (system *nativeSystem) SetWindowState(
+	handle windowbackend.Handle,
+	state windowbackend.State,
+	enabled bool,
+) error {
+	var required []string
+	switch state {
+	case windowbackend.StateMinimized:
+		if enabled {
+			required = []string{atomWMState, atomWMStateHidden}
+		} else {
+			required = []string{atomActiveWindow}
+		}
+	case windowbackend.StateMaximized:
+		required = []string{
+			atomWMState,
+			atomWMStateMaxHorz,
+			atomWMStateMaxVert,
+		}
+	default:
+		return fmt.Errorf("%w: unknown X11 window state %d", ErrOperation, state)
+	}
+	return system.withWindowManager(handle, required, func(xu *xgbutil.XUtil, window xproto.Window) error {
+		switch state {
+		case windowbackend.StateMinimized:
+			if !enabled {
+				return ewmh.ActiveWindowReq(xu, window)
+			}
+			return ewmh.ClientEvent(xu, window, atomWMChangeState, icccmIconicState)
+		case windowbackend.StateMaximized:
+			action := ewmh.StateRemove
+			if enabled {
+				action = ewmh.StateAdd
+			}
+			return ewmh.WmStateReqExtra(
+				xu,
+				window,
+				action,
+				atomWMStateMaxHorz,
+				atomWMStateMaxVert,
+				2,
+			)
+		}
+		return fmt.Errorf("%w: unknown X11 window state %d", ErrOperation, state)
+	})
+}
+
+func (system *nativeSystem) WindowState(
+	handle windowbackend.Handle,
+	state windowbackend.State,
+) (bool, error) {
+	window, ok := x11Window(handle)
+	if !ok {
+		return false, fmt.Errorf("%w: XID %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	xu, err := system.open()
+	if err != nil {
+		return false, err
+	}
+	defer xu.Conn().Close()
+	switch state {
+	case windowbackend.StateMinimized:
+		if err := requireWindowManager(xu, atomWMState, atomWMStateHidden); err != nil {
+			return false, err
+		}
+		atoms, err := windowStateAtoms(xu.Conn(), window)
+		if err != nil {
+			return false, err
+		}
+		return hasAtom(xu.Conn(), atoms, atomWMStateHidden)
+	case windowbackend.StateMaximized:
+		if err := requireWindowManager(
+			xu,
+			atomWMState,
+			atomWMStateMaxHorz,
+			atomWMStateMaxVert,
+		); err != nil {
+			return false, err
+		}
+		atoms, err := windowStateAtoms(xu.Conn(), window)
+		if err != nil {
+			return false, err
+		}
+		horizontal, err := hasAtom(xu.Conn(), atoms, atomWMStateMaxHorz)
+		if err != nil || !horizontal {
+			return false, err
+		}
+		return hasAtom(xu.Conn(), atoms, atomWMStateMaxVert)
+	default:
+		return false, fmt.Errorf("%w: unknown X11 window state %d", ErrOperation, state)
+	}
+}
+
+func (system *nativeSystem) IsTopMost(handle windowbackend.Handle) (bool, error) {
+	window, ok := x11Window(handle)
+	if !ok {
+		return false, fmt.Errorf("%w: XID %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	xu, err := system.open()
+	if err != nil {
+		return false, err
+	}
+	defer xu.Conn().Close()
+	if err := requireWindowManager(xu, atomWMState, atomWMStateAbove); err != nil {
+		return false, err
+	}
+	atoms, err := windowStateAtoms(xu.Conn(), window)
+	if err != nil {
+		return false, err
+	}
+	return hasAtom(xu.Conn(), atoms, atomWMStateAbove)
+}
+
+func (system *nativeSystem) SetTopMost(handle windowbackend.Handle, enabled bool) error {
+	return system.withWindowManager(
+		handle,
+		[]string{atomWMState, atomWMStateAbove},
+		func(xu *xgbutil.XUtil, window xproto.Window) error {
+			action := ewmh.StateRemove
+			if enabled {
+				action = ewmh.StateAdd
+			}
+			return ewmh.WmStateReq(xu, window, action, atomWMStateAbove)
+		},
+	)
+}
+
+func (system *nativeSystem) CloseWindow(handle windowbackend.Handle) error {
+	return system.withWindowManager(
+		handle,
+		[]string{atomCloseWindow},
+		func(xu *xgbutil.XUtil, window xproto.Window) error {
+			return ewmh.CloseWindow(xu, window)
+		},
+	)
+}
+
+func (system *nativeSystem) withWindowManager(
+	handle windowbackend.Handle,
+	required []string,
+	operation func(*xgbutil.XUtil, xproto.Window) error,
+) error {
+	window, ok := x11Window(handle)
+	if !ok {
+		return fmt.Errorf("%w: XID %#x", ErrInvalidWindow, uintptr(handle))
+	}
+	xu, err := system.open()
+	if err != nil {
+		return err
+	}
+	defer xu.Conn().Close()
+	if err := requireWindowManager(xu, required...); err != nil {
+		return err
+	}
+	return operation(xu, window)
+}
+
+func x11Window(handle windowbackend.Handle) (xproto.Window, bool) {
+	if handle == 0 || uint64(handle) > math.MaxUint32 {
+		return xproto.WindowNone, false
+	}
+	return xproto.Window(handle), true
+}
+
+func findWindowByPID(
+	xu *xgbutil.XUtil,
+	windows []xproto.Window,
+	pid uint32,
+) xproto.Window {
+	for _, window := range windows {
+		windowPID, err := windowPID(xu, window)
+		if err == nil && windowPID == pid {
+			return window
+		}
+	}
+	return xproto.WindowNone
+}
+
+func findWindowByPIDInTree(xu *xgbutil.XUtil, pid uint32) (xproto.Window, error) {
+	queue := []xproto.Window{xu.RootWin()}
+	seen := make(map[xproto.Window]struct{}, 128)
+	for len(queue) > 0 {
+		if len(seen) >= maxWindowTreeNodes {
+			return xproto.WindowNone, fmt.Errorf(
+				"%w: X11 window tree exceeds %d nodes",
+				ErrOperation,
+				maxWindowTreeNodes,
+			)
+		}
+		parent := queue[0]
+		queue = queue[1:]
+		if _, exists := seen[parent]; exists {
+			continue
+		}
+		seen[parent] = struct{}{}
+		reply, err := xproto.QueryTree(xu.Conn(), parent).Reply()
+		if err != nil || reply == nil {
+			continue
+		}
+		if window := findWindowByPID(xu, reply.Children, pid); window != xproto.WindowNone {
+			return window, nil
+		}
+		queue = append(queue, reply.Children...)
+	}
+	return xproto.WindowNone, nil
+}
+
+func windowPID(xu *xgbutil.XUtil, window xproto.Window) (uint32, error) {
+	values, err := cardinalProperty(xu.Conn(), window, atomWMPID, 1)
+	if err != nil {
+		return 0, err
+	}
+	if values[0] == 0 {
+		return 0, fmt.Errorf("%w: XID %#x has a zero _NET_WM_PID", ErrWindowNotFound, window)
+	}
+	return values[0], nil
+}
+
+func clientRect(xu *xgbutil.XUtil, window xproto.Window) (windowbackend.Rect, error) {
+	geometry, err := xproto.GetGeometry(xu.Conn(), xproto.Drawable(window)).Reply()
+	if err != nil {
+		return windowbackend.Rect{}, fmt.Errorf("query X11 geometry: %w", err)
+	}
+	if geometry == nil || geometry.Width == 0 || geometry.Height == 0 {
+		return windowbackend.Rect{}, fmt.Errorf("%w: XID %#x returned empty geometry", ErrOperation, window)
+	}
+	translated, err := xproto.TranslateCoordinates(
+		xu.Conn(),
+		window,
+		xu.RootWin(),
+		0,
+		0,
+	).Reply()
+	if err != nil {
+		return windowbackend.Rect{}, fmt.Errorf("translate X11 client coordinates: %w", err)
+	}
+	if translated == nil {
+		return windowbackend.Rect{}, errors.New("X11 returned no translated coordinates")
+	}
+	return windowbackend.Rect{
+		X:      int(translated.DstX),
+		Y:      int(translated.DstY),
+		Width:  int(geometry.Width),
+		Height: int(geometry.Height),
+	}, nil
+}
+
+type x11FrameExtents struct {
+	left   uint32
+	right  uint32
+	top    uint32
+	bottom uint32
+}
+
+func frameExtents(conn *xgb.Conn, window xproto.Window) (x11FrameExtents, error) {
+	values, err := cardinalProperty(conn, window, atomFrameExtents, 4)
+	if err != nil {
+		return x11FrameExtents{}, err
+	}
+	return x11FrameExtents{
+		left:   values[0],
+		right:  values[1],
+		top:    values[2],
+		bottom: values[3],
+	}, nil
+}
+
+func addFrameExtents(
+	client windowbackend.Rect,
+	extents x11FrameExtents,
+) (windowbackend.Rect, error) {
+	if extents.left > maxFrameExtentPixels ||
+		extents.right > maxFrameExtentPixels ||
+		extents.top > maxFrameExtentPixels ||
+		extents.bottom > maxFrameExtentPixels {
+		return windowbackend.Rect{}, fmt.Errorf("%w: X11 frame extents exceed protocol geometry", ErrOperation)
+	}
+	x := int64(client.X) - int64(extents.left)
+	y := int64(client.Y) - int64(extents.top)
+	width := int64(client.Width) + int64(extents.left) + int64(extents.right)
+	height := int64(client.Height) + int64(extents.top) + int64(extents.bottom)
+	if x < int64(minInt()) || x > int64(maxInt()) ||
+		y < int64(minInt()) || y > int64(maxInt()) ||
+		width <= 0 || width > int64(maxInt()) ||
+		height <= 0 || height > int64(maxInt()) {
+		return windowbackend.Rect{}, fmt.Errorf("%w: X11 frame extents overflow", ErrOperation)
+	}
+	return windowbackend.Rect{
+		X:      int(x),
+		Y:      int(y),
+		Width:  int(width),
+		Height: int(height),
+	}, nil
+}
+
+func requireWindowManager(xu *xgbutil.XUtil, required ...string) error {
+	manager, err := windowProperty(
+		xu.Conn(),
+		xu.RootWin(),
+		atomSupportingWMCheck,
+	)
+	if err != nil || manager == xproto.WindowNone {
+		return fmt.Errorf("%w: root check: %v", ErrWindowManagerUnavailable, err)
+	}
+	self, err := windowProperty(xu.Conn(), manager, atomSupportingWMCheck)
+	if err != nil || self != manager {
+		return fmt.Errorf(
+			"%w: manager check window %#x is inconsistent: self=%#x err=%v",
+			ErrWindowManagerUnavailable,
+			manager,
+			self,
+			err,
+		)
+	}
+	if reply, err := xproto.GetWindowAttributes(xu.Conn(), manager).Reply(); err != nil || reply == nil {
+		return fmt.Errorf(
+			"%w: manager check window %#x is invalid: %v",
+			ErrWindowManagerUnavailable,
+			manager,
+			err,
+		)
+	}
+	if len(required) == 0 {
+		return nil
+	}
+	supported, err := supportedAtoms(xu.Conn(), xu.RootWin())
+	if err != nil {
+		return fmt.Errorf("%w: %s: %v", ErrWindowManagerUnavailable, atomSupported, err)
+	}
+	for _, name := range required {
+		atom, err := internAtom(xu.Conn(), name, true)
+		if err != nil || atom == xproto.AtomNone || !containsAtom(supported, atom) {
+			return fmt.Errorf(
+				"%w: manager does not advertise %s: atom=%#x err=%v",
+				ErrWindowManagerUnavailable,
+				name,
+				atom,
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+func supportedAtoms(conn *xgb.Conn, root xproto.Window) ([]xproto.Atom, error) {
+	property, err := internAtom(conn, atomSupported, true)
+	if err != nil {
+		return nil, err
+	}
+	if property == xproto.AtomNone {
+		return nil, fmt.Errorf("X11 property %s is unavailable", atomSupported)
+	}
+	reply, err := xproto.GetProperty(
+		conn,
+		false,
+		root,
+		property,
+		xproto.AtomAtom,
+		0,
+		maxPropertyBytes/4,
+	).Reply()
+	if err != nil {
+		return nil, err
+	}
+	if reply == nil || reply.Type != xproto.AtomAtom || reply.Format != 32 ||
+		uint64(reply.ValueLen)*4 != uint64(len(reply.Value)) || reply.BytesAfter != 0 {
+		return nil, fmt.Errorf("X11 property %s is malformed", atomSupported)
+	}
+	atoms := make([]xproto.Atom, reply.ValueLen)
+	for index := range atoms {
+		atoms[index] = xproto.Atom(xgb.Get32(reply.Value[index*4:]))
+	}
+	return atoms, nil
+}
+
+func containsAtom(atoms []xproto.Atom, target xproto.Atom) bool {
+	for _, atom := range atoms {
+		if atom == target {
+			return true
+		}
+	}
+	return false
+}
+
+func windowProperty(conn *xgb.Conn, window xproto.Window, name string) (xproto.Window, error) {
+	property, err := internAtom(conn, name, true)
+	if err != nil {
+		return xproto.WindowNone, fmt.Errorf("resolve X11 property %s: %w", name, err)
+	}
+	if property == xproto.AtomNone {
+		return xproto.WindowNone, fmt.Errorf("X11 property %s is unavailable", name)
+	}
+	reply, err := xproto.GetProperty(
+		conn,
+		false,
+		window,
+		property,
+		xproto.AtomWindow,
+		0,
+		1,
+	).Reply()
+	if err != nil {
+		return xproto.WindowNone, err
+	}
+	if reply == nil || reply.Type != xproto.AtomWindow || reply.Format != 32 ||
+		reply.ValueLen != 1 || len(reply.Value) != 4 || reply.BytesAfter != 0 {
+		return xproto.WindowNone, fmt.Errorf("X11 property %s is malformed", name)
+	}
+	return xproto.Window(xgb.Get32(reply.Value)), nil
+}
+
+func cardinalProperty(
+	conn *xgb.Conn,
+	window xproto.Window,
+	name string,
+	count uint32,
+) ([]uint32, error) {
+	property, err := internAtom(conn, name, true)
+	if err != nil {
+		return nil, fmt.Errorf("resolve X11 property %s: %w", name, err)
+	}
+	if property == xproto.AtomNone {
+		return nil, fmt.Errorf("X11 property %s is unavailable", name)
+	}
+	reply, err := xproto.GetProperty(
+		conn,
+		false,
+		window,
+		property,
+		xproto.AtomCardinal,
+		0,
+		count,
+	).Reply()
+	if err != nil {
+		return nil, err
+	}
+	if reply == nil || reply.Type != xproto.AtomCardinal || reply.Format != 32 ||
+		reply.ValueLen != count || uint32(len(reply.Value)) != count*4 ||
+		reply.BytesAfter != 0 {
+		return nil, fmt.Errorf("X11 property %s is malformed", name)
+	}
+	values := make([]uint32, count)
+	for index := range values {
+		values[index] = xgb.Get32(reply.Value[index*4:])
+	}
+	return values, nil
+}
+
+func stringProperty(
+	conn *xgb.Conn,
+	window xproto.Window,
+	name string,
+	propertyType xproto.Atom,
+	onlyIfExists bool,
+) (string, error) {
+	property, err := internAtom(conn, name, onlyIfExists)
+	if err != nil {
+		return "", fmt.Errorf("resolve X11 property %s: %w", name, err)
+	}
+	if property == xproto.AtomNone {
+		return "", fmt.Errorf("X11 property %s is unavailable", name)
+	}
+	reply, err := xproto.GetProperty(
+		conn,
+		false,
+		window,
+		property,
+		propertyType,
+		0,
+		maxPropertyBytes/4,
+	).Reply()
+	if err != nil {
+		return "", err
+	}
+	if reply == nil || reply.Type != propertyType || reply.Format != 8 ||
+		reply.ValueLen != uint32(len(reply.Value)) || reply.BytesAfter != 0 {
+		return "", fmt.Errorf("X11 property %s is malformed", name)
+	}
+	return strings.TrimRight(string(reply.Value), "\x00"), nil
+}
+
+func windowStateAtoms(conn *xgb.Conn, window xproto.Window) ([]xproto.Atom, error) {
+	property, err := internAtom(conn, atomWMState, true)
+	if err != nil {
+		return nil, fmt.Errorf("resolve X11 property %s: %w", atomWMState, err)
+	}
+	if property == xproto.AtomNone {
+		return nil, nil
+	}
+	reply, err := xproto.GetProperty(
+		conn,
+		false,
+		window,
+		property,
+		xproto.AtomAtom,
+		0,
+		maxPropertyBytes/4,
+	).Reply()
+	if err != nil {
+		return nil, err
+	}
+	if reply != nil && reply.Type == xproto.AtomNone && reply.Format == 0 &&
+		reply.ValueLen == 0 && len(reply.Value) == 0 && reply.BytesAfter == 0 {
+		return nil, nil
+	}
+	if reply == nil || reply.Type != xproto.AtomAtom || reply.Format != 32 ||
+		uint64(reply.ValueLen)*4 != uint64(len(reply.Value)) || reply.BytesAfter != 0 {
+		return nil, fmt.Errorf("X11 property %s is malformed", atomWMState)
+	}
+	atoms := make([]xproto.Atom, reply.ValueLen)
+	for index := range atoms {
+		atoms[index] = xproto.Atom(xgb.Get32(reply.Value[index*4:]))
+	}
+	return atoms, nil
+}
+
+func hasAtom(conn *xgb.Conn, atoms []xproto.Atom, name string) (bool, error) {
+	target, err := internAtom(conn, name, true)
+	if err != nil {
+		return false, err
+	}
+	if target == xproto.AtomNone {
+		return false, nil
+	}
+	for _, atom := range atoms {
+		if atom == target {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func internAtom(conn *xgb.Conn, name string, onlyIfExists bool) (xproto.Atom, error) {
+	reply, err := xproto.InternAtom(
+		conn,
+		onlyIfExists,
+		uint16(len(name)),
+		name,
+	).Reply()
+	if err != nil {
+		return xproto.AtomNone, err
+	}
+	if reply == nil {
+		return xproto.AtomNone, fmt.Errorf("X11 returned no atom for %s", name)
+	}
+	return reply.Atom, nil
+}
+
+func minInt() int {
+	return -maxInt() - 1
+}
+
+func maxInt() int {
+	return int(^uint(0) >> 1)
+}

--- a/internal/x11window/system_xgb_linux.go
+++ b/internal/x11window/system_xgb_linux.go
@@ -85,7 +85,11 @@ func (system *nativeSystem) ActiveWindow() (windowbackend.Handle, error) {
 	}
 	defer xu.Conn().Close()
 
-	active, activeErr := ewmh.ActiveWindowGet(xu)
+	active, activeErr := windowProperty(
+		xu.Conn(),
+		xu.RootWin(),
+		atomActiveWindow,
+	)
 	if activeErr == nil && active != xproto.WindowNone {
 		return windowbackend.Handle(active), nil
 	}

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/marang/robotgo/clipboard"
 	inputportal "github.com/marang/robotgo/input/portal"
-	"github.com/marang/robotgo/internal/windowswindow"
+	"github.com/marang/robotgo/internal/windowbackend"
 )
 
 const Version = "v1.00.0.1189, MT. Baker!"
@@ -267,6 +267,7 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		if mouse.Backend != "" {
 			capabilities.Mouse = mouse
 		}
+		capabilities.Window = pureGoWindowCapability()
 	}
 	return capabilities
 }
@@ -373,7 +374,7 @@ func SetActiveE(handle Handle) error {
 	if err != nil {
 		return err
 	}
-	return backend.Activate(windowswindow.Handle(handle))
+	return backend.Activate(windowbackend.Handle(handle))
 }
 func ActivePid(target int, args ...int) error {
 	backend, err := pureGoWindowBackend()
@@ -392,11 +393,15 @@ func ActiveName(name string) error {
 		return err
 	}
 	for _, pid := range pids {
-		if err := ActivePid(pid); err == nil {
+		err := ActivePid(pid)
+		if err == nil {
 			return nil
 		}
+		if errors.Is(err, ErrNotSupported) {
+			return fmt.Errorf("activate process name %q: %w", name, err)
+		}
 	}
-	return fmt.Errorf("%w: no window found for process name %q", windowswindow.ErrWindowNotFound, name)
+	return fmt.Errorf("%w: no window found for process name %q", windowbackend.ErrWindowNotFound, name)
 }
 
 const (

--- a/robotgo_nocgo_parity.go
+++ b/robotgo_nocgo_parity.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/marang/robotgo/internal/windowswindow"
+	"github.com/marang/robotgo/internal/windowbackend"
 )
 
 // The functions in this file preserve the portable public surface for builds
@@ -23,7 +23,7 @@ func CloseWindowE(args ...int) error {
 	if err != nil {
 		return err
 	}
-	var handle windowswindow.Handle
+	var handle windowbackend.Handle
 	if len(args) == 0 {
 		handle, err = backend.Active()
 	} else {
@@ -149,14 +149,14 @@ func IsMinimized() bool {
 	return state
 }
 func IsMinimizedE() (bool, error) {
-	return pureGoActiveWindowState(windowswindow.StateMinimized)
+	return pureGoActiveWindowState(windowbackend.StateMinimized)
 }
 func IsMaximized() bool {
 	state, _ := IsMaximizedE()
 	return state
 }
 func IsMaximizedE() (bool, error) {
-	return pureGoActiveWindowState(windowswindow.StateMaximized)
+	return pureGoActiveWindowState(windowbackend.StateMaximized)
 }
 func SetTopMost(state bool) { _ = SetTopMostE(state) }
 func SetTopMostE(state bool) error {
@@ -306,17 +306,17 @@ func MinWindowE(target int, args ...interface{}) error {
 	if err != nil {
 		return err
 	}
-	return pureGoSetWindowState(target, state, len(args) > 1 || currentTreatAsHandle(), windowswindow.StateMinimized)
+	return pureGoSetWindowState(target, state, len(args) > 1 || currentTreatAsHandle(), windowbackend.StateMinimized)
 }
 func MaxWindowE(target int, args ...interface{}) error {
 	state, err := parseWindowStateArguments(args)
 	if err != nil {
 		return err
 	}
-	return pureGoSetWindowState(target, state, len(args) > 1 || currentTreatAsHandle(), windowswindow.StateMaximized)
+	return pureGoSetWindowState(target, state, len(args) > 1 || currentTreatAsHandle(), windowbackend.StateMaximized)
 }
 
-func pureGoActiveWindowState(state windowswindow.State) (bool, error) {
+func pureGoActiveWindowState(state windowbackend.State) (bool, error) {
 	backend, err := pureGoWindowBackend()
 	if err != nil {
 		return false, err
@@ -328,7 +328,7 @@ func pureGoActiveWindowState(state windowswindow.State) (bool, error) {
 	return backend.State(handle, state)
 }
 
-func pureGoSetWindowState(target int, enabled, isHandle bool, state windowswindow.State) error {
+func pureGoSetWindowState(target int, enabled, isHandle bool, state windowbackend.State) error {
 	backend, err := pureGoWindowBackend()
 	if err != nil {
 		return err

--- a/scripts/benchmark-x11-backends.sh
+++ b/scripts/benchmark-x11-backends.sh
@@ -39,6 +39,8 @@ readonly -a NATIVE_ONLY_BEHAVIOR_TESTS=(
 )
 readonly -a PUREGO_ONLY_BEHAVIOR_TESTS=(
 	'TestPureGoX11RejectsImplicitDependencyPortalFallback'
+	'TestPureGoX11WindowCapabilitySelection'
+	'TestPureGoX11WindowCapabilityRejectsWaylandConflict'
 	'TestPureGoX11MultiLayoutConfiguration'
 	'TestPureGoX11Capabilities'
 	'TestPureGoX11PointerInput'
@@ -58,6 +60,7 @@ readonly -a PUREGO_ONLY_BEHAVIOR_TESTS=(
 	'TestPureGoX11EventDrainDoesNotStall'
 	'TestPureGoX11CloseMainDisplayReconnects'
 	'TestPureGoX11SessionSwitchReleasesOwnedInput'
+	'TestPureGoX11WindowIntrospectionAndControl'
 )
 readonly -a EXPECTED_BENCHMARK_NAMES=(
 	'BenchmarkCaptureImgRuntime'

--- a/window_backend_default_nocgo.go
+++ b/window_backend_default_nocgo.go
@@ -1,9 +1,16 @@
-//go:build !windows && !cgo
+//go:build !windows && !linux && !cgo
 
 package robotgo
 
-import "github.com/marang/robotgo/internal/windowswindow"
+import "github.com/marang/robotgo/internal/windowbackend"
 
-func platformPureGoWindowBackend() *windowswindow.Backend {
+func platformPureGoWindowBackend() windowbackend.Backend {
 	return nil
+}
+
+func platformPureGoWindowCapability() FeatureCapability {
+	return FeatureCapability{
+		Reason: ErrNotSupported.Error(),
+		Notes:  "no matching Pure-Go window backend is active in this build",
+	}
 }

--- a/window_backend_linux_x11_nocgo.go
+++ b/window_backend_linux_x11_nocgo.go
@@ -1,0 +1,41 @@
+//go:build linux && !cgo
+
+package robotgo
+
+import (
+	"github.com/marang/robotgo/internal/windowbackend"
+	"github.com/marang/robotgo/internal/x11window"
+)
+
+var pureGoX11WindowBackend = x11window.NewNative(x11window.Config{
+	ResolveDisplay: resolvePureGoX11Display,
+})
+
+func platformPureGoWindowBackend() windowbackend.Backend {
+	if DetectDisplayServer() != DisplayServerX11 || pureGoX11EnvironmentConflict() {
+		return nil
+	}
+	return pureGoX11WindowBackend
+}
+
+func platformPureGoWindowCapability() FeatureCapability {
+	if DetectDisplayServer() != DisplayServerX11 {
+		return FeatureCapability{
+			Reason: ErrNotSupported.Error(),
+			Notes:  "Pure-Go X11 window control requires an X11-primary session",
+		}
+	}
+	if pureGoX11EnvironmentConflict() {
+		return FeatureCapability{
+			Backend: featureBackendPureGoX11,
+			Reason:  envXDGSessionType + " selects Wayland while DISPLAY selects X11",
+			Notes:   "Pure-Go X11 window control refuses implicit Xwayland fallback",
+		}
+	}
+	return FeatureCapability{
+		Available: true,
+		Backend:   featureBackendPureGoX11,
+		Reason:    "Pure-Go X11 window introspection and EWMH control are selected",
+		Notes:     "runtime X server access is validated per operation; mutations require a consistent EWMH manager that advertises the operation",
+	}
+}

--- a/window_backend_linux_x11_nocgo_test.go
+++ b/window_backend_linux_x11_nocgo_test.go
@@ -1,0 +1,54 @@
+//go:build linux && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+func TestPureGoX11WindowCapabilitySelection(t *testing.T) {
+	t.Setenv(envDisplay, ":robotgo-test")
+	t.Setenv(envWaylandDisplay, "")
+	t.Setenv(envXDGSessionType, "")
+
+	capability := pureGoWindowCapability()
+	if !capability.Available || capability.Backend != featureBackendPureGoX11 {
+		t.Fatalf("Pure-Go X11 window capability = %+v", capability)
+	}
+	if platformPureGoWindowBackend() == nil {
+		t.Fatal("Pure-Go X11 window backend was not selected")
+	}
+}
+
+func TestPureGoX11WindowCapabilityRejectsWaylandConflict(t *testing.T) {
+	t.Setenv(envDisplay, ":robotgo-test")
+	t.Setenv(envWaylandDisplay, "")
+	t.Setenv(envXDGSessionType, "wayland")
+
+	capability := pureGoWindowCapability()
+	if capability.Available || capability.Backend != featureBackendPureGoX11 {
+		t.Fatalf("conflicting Pure-Go X11 window capability = %+v", capability)
+	}
+	if platformPureGoWindowBackend() != nil {
+		t.Fatal("Pure-Go X11 window backend was selected during a Wayland conflict")
+	}
+	if err := ActivePid(1); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("ActivePid() conflict error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestTranslatePureGoWindowUnsupportedError(t *testing.T) {
+	cause := errors.Join(
+		windowbackend.ErrOperation,
+		windowbackend.ErrUnsupported,
+	)
+	err := translatePureGoWindowError(cause)
+	if !errors.Is(err, ErrNotSupported) ||
+		!errors.Is(err, windowbackend.ErrOperation) ||
+		!errors.Is(err, windowbackend.ErrUnsupported) {
+		t.Fatalf("translated error = %v, want all public and internal causes", err)
+	}
+}

--- a/window_backend_nocgo.go
+++ b/window_backend_nocgo.go
@@ -3,35 +3,72 @@
 package robotgo
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/marang/robotgo/internal/windowswindow"
+	"github.com/marang/robotgo/internal/windowbackend"
 )
 
-func pureGoWindowBackend() (*windowswindow.Backend, error) {
+func pureGoWindowBackend() (windowbackend.Backend, error) {
 	backend := platformPureGoWindowBackend()
 	if backend == nil {
 		return nil, fmt.Errorf("%w: no Pure-Go window backend is active", ErrNotSupported)
 	}
-	return backend, nil
+	return publicPureGoWindowBackend{Backend: backend}, nil
+}
+
+type publicPureGoWindowBackend struct {
+	windowbackend.Backend
+}
+
+func (backend publicPureGoWindowBackend) Activate(handle windowbackend.Handle) error {
+	return translatePureGoWindowError(backend.Backend.Activate(handle))
+}
+
+func (backend publicPureGoWindowBackend) SetState(
+	handle windowbackend.Handle,
+	state windowbackend.State,
+	enabled bool,
+) error {
+	return translatePureGoWindowError(backend.Backend.SetState(handle, state, enabled))
+}
+
+func (backend publicPureGoWindowBackend) State(
+	handle windowbackend.Handle,
+	state windowbackend.State,
+) (bool, error) {
+	enabled, err := backend.Backend.State(handle, state)
+	return enabled, translatePureGoWindowError(err)
+}
+
+func (backend publicPureGoWindowBackend) TopMost(handle windowbackend.Handle) (bool, error) {
+	enabled, err := backend.Backend.TopMost(handle)
+	return enabled, translatePureGoWindowError(err)
+}
+
+func (backend publicPureGoWindowBackend) SetTopMost(
+	handle windowbackend.Handle,
+	enabled bool,
+) error {
+	return translatePureGoWindowError(backend.Backend.SetTopMost(handle, enabled))
+}
+
+func (backend publicPureGoWindowBackend) Close(handle windowbackend.Handle) error {
+	return translatePureGoWindowError(backend.Backend.Close(handle))
+}
+
+func translatePureGoWindowError(err error) error {
+	if err == nil || !errors.Is(err, windowbackend.ErrUnsupported) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", ErrNotSupported, err)
 }
 
 func pureGoWindowCapability() FeatureCapability {
-	if platformPureGoWindowBackend() == nil {
-		return FeatureCapability{
-			Reason: ErrNotSupported.Error(),
-			Notes:  "no matching Pure-Go window backend is active in this build",
-		}
-	}
-	return FeatureCapability{
-		Available: true,
-		Backend:   featureBackendPureGoWindows,
-		Reason:    "Pure-Go Win32 window introspection and control are available",
-		Notes:     "PID targets prefer visible unowned top-level windows; Windows foreground-activation policy still applies",
-	}
+	return platformPureGoWindowCapability()
 }
 
-func pureGoWindowActive() (windowswindow.Handle, error) {
+func pureGoWindowActive() (windowbackend.Handle, error) {
 	backend, err := pureGoWindowBackend()
 	if err != nil {
 		return 0, err
@@ -39,7 +76,7 @@ func pureGoWindowActive() (windowswindow.Handle, error) {
 	return backend.Active()
 }
 
-func pureGoWindowResolve(target int, isHandle bool) (windowswindow.Handle, error) {
+func pureGoWindowResolve(target int, isHandle bool) (windowbackend.Handle, error) {
 	backend, err := pureGoWindowBackend()
 	if err != nil {
 		return 0, err

--- a/window_backend_windows_nocgo.go
+++ b/window_backend_windows_nocgo.go
@@ -2,10 +2,22 @@
 
 package robotgo
 
-import "github.com/marang/robotgo/internal/windowswindow"
+import (
+	"github.com/marang/robotgo/internal/windowbackend"
+	"github.com/marang/robotgo/internal/windowswindow"
+)
 
 var pureGoWindowsWindowBackend = windowswindow.NewNative()
 
-func platformPureGoWindowBackend() *windowswindow.Backend {
+func platformPureGoWindowBackend() windowbackend.Backend {
 	return pureGoWindowsWindowBackend
+}
+
+func platformPureGoWindowCapability() FeatureCapability {
+	return FeatureCapability{
+		Available: true,
+		Backend:   featureBackendPureGoWindows,
+		Reason:    "Pure-Go Win32 window introspection and control are available",
+		Notes:     "PID targets prefer visible unowned top-level windows; Windows foreground-activation policy still applies",
+	}
 }

--- a/x11_window_nocgo_integration_test.go
+++ b/x11_window_nocgo_integration_test.go
@@ -312,6 +312,41 @@ func TestPureGoX11WindowIntrospectionAndControl(t *testing.T) {
 	if handle := robotgo.GetHandle(); handle != int(harness.window) {
 		t.Fatalf("GetHandle() = %#x, want %#x", handle, harness.window)
 	}
+	setPureGoMalformedX11Property(
+		t,
+		harness,
+		harness.root,
+		"_NET_ACTIVE_WINDOW",
+		xproto.AtomCardinal,
+		32,
+		[]byte{1, 0, 0, 0},
+	)
+	if handle := robotgo.GetHandle(); handle != int(harness.window) {
+		t.Fatalf(
+			"GetHandle() with wrong _NET_ACTIVE_WINDOW type = %#x, want focused window %#x",
+			handle,
+			harness.window,
+		)
+	}
+	setPureGoMalformedX11Property(
+		t,
+		harness,
+		harness.root,
+		"_NET_ACTIVE_WINDOW",
+		xproto.AtomWindow,
+		32,
+		nil,
+	)
+	if handle := robotgo.GetHandle(); handle != int(harness.window) {
+		t.Fatalf(
+			"GetHandle() with empty _NET_ACTIVE_WINDOW = %#x, want focused window %#x",
+			handle,
+			harness.window,
+		)
+	}
+	if err := ewmh.ActiveWindowSet(manager.xu, harness.window); err != nil {
+		t.Fatalf("restore EWMH active window: %v", err)
+	}
 	if pid := robotgo.GetPid(); pid != os.Getpid() {
 		t.Fatalf("GetPid() = %d, want %d", pid, os.Getpid())
 	}
@@ -433,4 +468,35 @@ func TestPureGoX11WindowIntrospectionAndControl(t *testing.T) {
 			err,
 		)
 	}
+}
+
+func setPureGoMalformedX11Property(
+	t *testing.T,
+	harness *x11InputHarness,
+	window xproto.Window,
+	name string,
+	propertyType xproto.Atom,
+	format byte,
+	payload []byte,
+) {
+	t.Helper()
+	property := testX11Atom(t, harness.conn, name)
+	unitBytes := uint32(format / 8)
+	valueLen := uint32(0)
+	if unitBytes != 0 {
+		valueLen = uint32(len(payload)) / unitBytes
+	}
+	if err := xproto.ChangePropertyChecked(
+		harness.conn,
+		xproto.PropModeReplace,
+		window,
+		property,
+		propertyType,
+		format,
+		valueLen,
+		payload,
+	).Check(); err != nil {
+		t.Fatalf("set malformed %s: %v", name, err)
+	}
+	harness.conn.Sync()
 }

--- a/x11_window_nocgo_integration_test.go
+++ b/x11_window_nocgo_integration_test.go
@@ -1,0 +1,436 @@
+//go:build linux && !cgo && x11integration && !wayland
+
+package robotgo_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgbutil"
+	"github.com/jezek/xgbutil/ewmh"
+	"github.com/marang/robotgo"
+)
+
+const x11WindowStatePollTimeout = 2 * time.Second
+
+var testX11SupportedWindowAtoms = []string{
+	"_NET_ACTIVE_WINDOW",
+	"_NET_CLOSE_WINDOW",
+	"_NET_WM_STATE",
+	"_NET_WM_STATE_ABOVE",
+	"_NET_WM_STATE_HIDDEN",
+	"_NET_WM_STATE_MAXIMIZED_HORZ",
+	"_NET_WM_STATE_MAXIMIZED_VERT",
+}
+
+type testX11WindowManager struct {
+	t          *testing.T
+	xu         *xgbutil.XUtil
+	check      xproto.Window
+	activeAtom xproto.Atom
+	changeAtom xproto.Atom
+	closeAtom  xproto.Atom
+	stateAtom  xproto.Atom
+	events     chan xproto.Atom
+	done       chan struct{}
+}
+
+func newTestX11WindowManager(
+	t *testing.T,
+	harness *x11InputHarness,
+) *testX11WindowManager {
+	t.Helper()
+	xu, err := xgbutil.NewConnDisplay(os.Getenv("DISPLAY"))
+	if err != nil {
+		t.Fatalf("connect test X11 window manager: %v", err)
+	}
+	check, err := xproto.NewWindowId(xu.Conn())
+	if err != nil {
+		xu.Conn().Close()
+		t.Fatalf("allocate X11 window-manager check window: %v", err)
+	}
+	screen := xu.Screen()
+	if err := xproto.CreateWindowChecked(
+		xu.Conn(),
+		screen.RootDepth,
+		check,
+		screen.Root,
+		0,
+		0,
+		1,
+		1,
+		0,
+		xproto.WindowClassInputOutput,
+		screen.RootVisual,
+		0,
+		nil,
+	).Check(); err != nil {
+		xu.Conn().Close()
+		t.Fatalf("create X11 window-manager check window: %v", err)
+	}
+	if err := xproto.ChangeWindowAttributesChecked(
+		xu.Conn(),
+		screen.Root,
+		xproto.CwEventMask,
+		[]uint32{
+			xproto.EventMaskSubstructureNotify |
+				xproto.EventMaskSubstructureRedirect,
+		},
+	).Check(); err != nil {
+		_ = xproto.DestroyWindowChecked(xu.Conn(), check).Check()
+		xu.Conn().Close()
+		t.Fatalf("claim X11 window-manager root events: %v", err)
+	}
+	ownershipTransferred := false
+	defer func() {
+		if ownershipTransferred {
+			return
+		}
+		_ = xproto.DestroyWindowChecked(xu.Conn(), check).Check()
+		xu.Conn().Close()
+	}()
+	if err := ewmh.SupportingWmCheckSet(xu, screen.Root, check); err != nil {
+		t.Fatalf("set root EWMH window-manager check: %v", err)
+	}
+	if err := ewmh.SupportingWmCheckSet(xu, check, check); err != nil {
+		t.Fatalf("set self EWMH window-manager check: %v", err)
+	}
+	if err := ewmh.SupportedSet(xu, testX11SupportedWindowAtoms); err != nil {
+		t.Fatalf("set supported EWMH operations: %v", err)
+	}
+	if err := ewmh.ClientListSet(xu, []xproto.Window{harness.window}); err != nil {
+		t.Fatalf("set EWMH client list: %v", err)
+	}
+	if err := ewmh.ActiveWindowSet(xu, harness.window); err != nil {
+		t.Fatalf("set EWMH active window: %v", err)
+	}
+	if err := ewmh.WmPidSet(xu, harness.window, uint(os.Getpid())); err != nil {
+		t.Fatalf("set EWMH window pid: %v", err)
+	}
+	if err := ewmh.WmNameSet(xu, harness.window, "RobotGo Pure-Go X11"); err != nil {
+		t.Fatalf("set EWMH window title: %v", err)
+	}
+	if err := ewmh.FrameExtentsSet(xu, harness.window, &ewmh.FrameExtents{
+		Left:   5,
+		Right:  7,
+		Top:    20,
+		Bottom: 8,
+	}); err != nil {
+		t.Fatalf("set EWMH frame extents: %v", err)
+	}
+	if err := ewmh.WmStateSet(xu, harness.window, nil); err != nil {
+		t.Fatalf("initialize EWMH window state: %v", err)
+	}
+	manager := &testX11WindowManager{
+		t:          t,
+		xu:         xu,
+		check:      check,
+		activeAtom: testX11Atom(t, xu.Conn(), "_NET_ACTIVE_WINDOW"),
+		changeAtom: testX11Atom(t, xu.Conn(), "WM_CHANGE_STATE"),
+		closeAtom:  testX11Atom(t, xu.Conn(), "_NET_CLOSE_WINDOW"),
+		stateAtom:  testX11Atom(t, xu.Conn(), "_NET_WM_STATE"),
+		events:     make(chan xproto.Atom, 16),
+		done:       make(chan struct{}),
+	}
+	xu.Conn().Sync()
+	go manager.run()
+	t.Cleanup(manager.close)
+	ownershipTransferred = true
+	return manager
+}
+
+func (manager *testX11WindowManager) run() {
+	defer close(manager.done)
+	for {
+		event, err := manager.xu.Conn().WaitForEvent()
+		if event == nil && err == nil {
+			return
+		}
+		if err != nil {
+			return
+		}
+		message, ok := event.(xproto.ClientMessageEvent)
+		if !ok {
+			continue
+		}
+		if err := manager.apply(message); err != nil {
+			manager.t.Errorf("apply X11 window-manager request: %v", err)
+			continue
+		}
+		manager.xu.Conn().Sync()
+		select {
+		case manager.events <- message.Type:
+		default:
+			manager.t.Error("X11 window-manager event acknowledgement queue is full")
+		}
+	}
+}
+
+func (manager *testX11WindowManager) apply(message xproto.ClientMessageEvent) error {
+	switch message.Type {
+	case manager.activeAtom:
+		if err := ewmh.ActiveWindowSet(manager.xu, message.Window); err != nil {
+			return err
+		}
+		return manager.updateState(message.Window, ewmh.StateRemove, []string{
+			"_NET_WM_STATE_HIDDEN",
+		})
+	case manager.changeAtom:
+		if len(message.Data.Data32) == 0 || message.Data.Data32[0] != 3 {
+			return errors.New("unexpected WM_CHANGE_STATE payload")
+		}
+		return manager.updateState(message.Window, ewmh.StateAdd, []string{
+			"_NET_WM_STATE_HIDDEN",
+		})
+	case manager.stateAtom:
+		if len(message.Data.Data32) < 3 {
+			return errors.New("short _NET_WM_STATE payload")
+		}
+		names := make([]string, 0, 2)
+		for _, atom := range message.Data.Data32[1:3] {
+			if atom == 0 {
+				continue
+			}
+			name, err := xproto.GetAtomName(manager.xu.Conn(), xproto.Atom(atom)).Reply()
+			if err != nil || name == nil {
+				return errors.New("resolve _NET_WM_STATE atom")
+			}
+			names = append(names, string(name.Name))
+		}
+		return manager.updateState(message.Window, int(message.Data.Data32[0]), names)
+	case manager.closeAtom:
+		return nil
+	default:
+		return errors.New("unexpected X11 client message")
+	}
+}
+
+func (manager *testX11WindowManager) updateState(
+	window xproto.Window,
+	action int,
+	names []string,
+) error {
+	current, err := ewmh.WmStateGet(manager.xu, window)
+	if err != nil {
+		current = nil
+	}
+	state := make(map[string]bool, len(current)+len(names))
+	for _, name := range current {
+		state[name] = true
+	}
+	for _, name := range names {
+		switch action {
+		case ewmh.StateRemove:
+			delete(state, name)
+		case ewmh.StateAdd:
+			state[name] = true
+		case ewmh.StateToggle:
+			state[name] = !state[name]
+		default:
+			return errors.New("unknown _NET_WM_STATE action")
+		}
+	}
+	result := make([]string, 0, len(state))
+	for name, enabled := range state {
+		if enabled {
+			result = append(result, name)
+		}
+	}
+	return ewmh.WmStateSet(manager.xu, window, result)
+}
+
+func (manager *testX11WindowManager) waitFor(atom xproto.Atom) {
+	manager.t.Helper()
+	select {
+	case got := <-manager.events:
+		if got != atom {
+			manager.t.Fatalf("X11 window-manager request atom = %#x, want %#x", got, atom)
+		}
+	case <-time.After(x11WindowStatePollTimeout):
+		manager.t.Fatalf("X11 window-manager request %#x timed out", atom)
+	}
+}
+
+func (manager *testX11WindowManager) removeCheck() {
+	manager.t.Helper()
+	property := testX11Atom(manager.t, manager.xu.Conn(), "_NET_SUPPORTING_WM_CHECK")
+	if err := xproto.DeletePropertyChecked(
+		manager.xu.Conn(),
+		manager.xu.RootWin(),
+		property,
+	).Check(); err != nil {
+		manager.t.Fatalf("remove EWMH manager check: %v", err)
+	}
+	manager.xu.Conn().Sync()
+}
+
+func (manager *testX11WindowManager) removeSupported(name string) {
+	manager.t.Helper()
+	atoms := make([]string, 0, len(testX11SupportedWindowAtoms))
+	for _, candidate := range testX11SupportedWindowAtoms {
+		if candidate != name {
+			atoms = append(atoms, candidate)
+		}
+	}
+	if err := ewmh.SupportedSet(manager.xu, atoms); err != nil {
+		manager.t.Fatalf("remove supported EWMH operation %s: %v", name, err)
+	}
+	manager.xu.Conn().Sync()
+}
+
+func (manager *testX11WindowManager) close() {
+	_ = xproto.DestroyWindowChecked(manager.xu.Conn(), manager.check).Check()
+	manager.xu.Conn().Close()
+	select {
+	case <-manager.done:
+	case <-time.After(time.Second):
+		manager.t.Error("X11 window-manager event loop did not stop")
+	}
+}
+
+func testX11Atom(t *testing.T, conn *xgb.Conn, name string) xproto.Atom {
+	t.Helper()
+	reply, err := xproto.InternAtom(conn, false, uint16(len(name)), name).Reply()
+	if err != nil || reply == nil {
+		t.Fatalf("intern X11 atom %q: reply=%+v err=%v", name, reply, err)
+	}
+	return reply.Atom
+}
+
+func TestPureGoX11WindowIntrospectionAndControl(t *testing.T) {
+	harness := newX11InputHarness(t)
+	manager := newTestX11WindowManager(t, harness)
+
+	capability := robotgo.GetLinuxCapabilities().Window
+	if !capability.Available || capability.Backend != "pure-go-x11" {
+		t.Fatalf("Pure-Go X11 window capability = %+v", capability)
+	}
+	if handle := robotgo.GetHandle(); handle != int(harness.window) {
+		t.Fatalf("GetHandle() = %#x, want %#x", handle, harness.window)
+	}
+	if pid := robotgo.GetPid(); pid != os.Getpid() {
+		t.Fatalf("GetPid() = %d, want %d", pid, os.Getpid())
+	}
+	if handle := robotgo.GetHWNDByPid(os.Getpid()); handle != int(harness.window) {
+		t.Fatalf("GetHWNDByPid() = %#x, want %#x", handle, harness.window)
+	}
+	if title, err := robotgo.GetTitleE(); err != nil || title != "RobotGo Pure-Go X11" {
+		t.Fatalf("GetTitleE() = %q, %v", title, err)
+	}
+	if title, err := robotgo.GetTitleE(os.Getpid()); err != nil || title != "RobotGo Pure-Go X11" {
+		t.Fatalf("GetTitleE(pid) = %q, %v", title, err)
+	}
+	if title, err := robotgo.GetTitleE(int(harness.window), 1); err != nil ||
+		title != "RobotGo Pure-Go X11" {
+		t.Fatalf("GetTitleE(handle) = %q, %v", title, err)
+	}
+	if x, y, width, height := robotgo.GetClient(os.Getpid()); x != x11WindowX ||
+		y != x11WindowY || width != x11WindowWidth || height != x11WindowHeight {
+		t.Fatalf(
+			"GetClient(pid) = (%d,%d %dx%d), want (%d,%d %dx%d)",
+			x,
+			y,
+			width,
+			height,
+			x11WindowX,
+			x11WindowY,
+			x11WindowWidth,
+			x11WindowHeight,
+		)
+	}
+	if x, y, width, height := robotgo.GetBounds(os.Getpid()); x != x11WindowX-5 ||
+		y != x11WindowY-20 || width != x11WindowWidth+12 ||
+		height != x11WindowHeight+28 {
+		t.Fatalf(
+			"GetBounds(pid) = (%d,%d %dx%d), want (%d,%d %dx%d)",
+			x,
+			y,
+			width,
+			height,
+			x11WindowX-5,
+			x11WindowY-20,
+			x11WindowWidth+12,
+			x11WindowHeight+28,
+		)
+	}
+
+	if err := robotgo.SetActiveE(robotgo.Handle(harness.window)); err != nil {
+		t.Fatalf("SetActiveE: %v", err)
+	}
+	manager.waitFor(manager.activeAtom)
+
+	if err := robotgo.MinWindowE(os.Getpid(), true); err != nil {
+		t.Fatalf("MinWindowE(true): %v", err)
+	}
+	manager.waitFor(manager.changeAtom)
+	if minimized, err := robotgo.IsMinimizedE(); err != nil || !minimized {
+		t.Fatalf("IsMinimizedE() = %v, %v after minimize", minimized, err)
+	}
+	if err := robotgo.MinWindowE(os.Getpid(), false); err != nil {
+		t.Fatalf("MinWindowE(false): %v", err)
+	}
+	manager.waitFor(manager.activeAtom)
+	if minimized, err := robotgo.IsMinimizedE(); err != nil || minimized {
+		t.Fatalf("IsMinimizedE() = %v, %v after restore", minimized, err)
+	}
+
+	if err := robotgo.MaxWindowE(os.Getpid(), true); err != nil {
+		t.Fatalf("MaxWindowE(true): %v", err)
+	}
+	manager.waitFor(manager.stateAtom)
+	if maximized, err := robotgo.IsMaximizedE(); err != nil || !maximized {
+		t.Fatalf("IsMaximizedE() = %v, %v after maximize", maximized, err)
+	}
+	if err := robotgo.MaxWindowE(os.Getpid(), false); err != nil {
+		t.Fatalf("MaxWindowE(false): %v", err)
+	}
+	manager.waitFor(manager.stateAtom)
+	if maximized, err := robotgo.IsMaximizedE(); err != nil || maximized {
+		t.Fatalf("IsMaximizedE() = %v, %v after restore", maximized, err)
+	}
+
+	if err := robotgo.SetTopMostE(true); err != nil {
+		t.Fatalf("SetTopMostE(true): %v", err)
+	}
+	manager.waitFor(manager.stateAtom)
+	if topMost, err := robotgo.IsTopMostE(); err != nil || !topMost {
+		t.Fatalf("IsTopMostE() = %v, %v after enable", topMost, err)
+	}
+	if err := robotgo.SetTopMostE(false); err != nil {
+		t.Fatalf("SetTopMostE(false): %v", err)
+	}
+	manager.waitFor(manager.stateAtom)
+	if topMost, err := robotgo.IsTopMostE(); err != nil || topMost {
+		t.Fatalf("IsTopMostE() = %v, %v after disable", topMost, err)
+	}
+
+	if err := robotgo.CloseWindowE(); err != nil {
+		t.Fatalf("CloseWindowE(): %v", err)
+	}
+	manager.waitFor(manager.closeAtom)
+
+	manager.removeSupported("_NET_WM_STATE_ABOVE")
+	if _, err := robotgo.IsTopMostE(); !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf(
+			"IsTopMostE without advertised ABOVE support error = %v, want ErrNotSupported",
+			err,
+		)
+	}
+	if err := robotgo.SetTopMostE(true); !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf(
+			"SetTopMostE without advertised ABOVE support error = %v, want ErrNotSupported",
+			err,
+		)
+	}
+	manager.removeCheck()
+	if err := robotgo.SetActiveE(robotgo.Handle(harness.window)); !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf(
+			"SetActiveE without a consistent EWMH window manager error = %v, want ErrNotSupported",
+			err,
+		)
+	}
+}


### PR DESCRIPTION
## Goal

Complete the Linux/X11 Pure-Go platform slice with explicit window introspection and EWMH control while preserving native and cross-platform behavior.

## Delivered

- platform-neutral Pure-Go window backend contract shared with Windows
- X11 active/PID/handle/title/client/frame geometry introspection
- EWMH activation, minimize/maximize, topmost, and graceful close requests
- strict X11 property validation and deterministic per-operation connection cleanup
- fail-closed ErrNotSupported mapping when the EWMH manager identity is inconsistent or does not advertise the requested operation
- side-effect-free inspection example with opt-in mutations
- self-owned Xvfb fake-window-manager integration contract and blocking CI manifest
- README, testing guide, compatibility matrix, Wayland backlog, and product roadmap updates

## Validation

- go test -count=1 ./...
- CGO_ENABLED=0 go test -count=1 ./...
- go vet ./...
- CGO_ENABLED=0 go vet ./...
- golangci-lint run with CGO enabled and disabled
- targeted race tests for root, X11 window, and Windows window packages
- Windows and macOS non-CGO cross-build test compilation

The local environment does not provide xvfb-run. The existing non-skipping GitHub Xvfb job owns the real EWMH integration evidence and must pass before merge.

## Risk

EWMH mutations are asynchronous window-manager requests. The backend validates a live X11 target, a consistent manager identity, and advertised operation support before sending them; it does not claim compositor-independent completion semantics.