### PR TITLE
fix: clean up sensitive test artifacts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,45 @@
-The pull request will be closed without any reasons if it does not satisfy any of following requirements:
+## Summary
 
-1. Make sure you are targeting the `master` branch, pull requests on release branches are only allowed for bug fixes.
-2. Add new features, please provide the reasons and test code.
-3. Please read contributing guidelines: [CONTRIBUTING](https://github.com/go-vgo/robotgo/blob/master/CONTRIBUTING.md) and sign the CLA.
-4. Describe what your pull request does and which issue you're targeting (if any and **Please use English**)
-5. ... if it is not related to any particular issues, explain why we should not reject your pull request.
-6. The Commits must **use English**, must be test and No useless submissions.
+<!-- Describe the practical behavior or user-facing result. -->
 
-**You MUST delete the content above including this line before posting, otherwise your pull request will be invalid.**
+## Why
 
-**Please provide Issues links to:**
+<!-- Link the issue when one exists and explain why this change belongs here. -->
 
-- Issues: #1
+Related issue:
 
-**Provide test code:**
+## Changes
 
-```Go
+-
 
-```
+## Platform and backend impact
 
-## Description
+<!-- Note affected OSes, display servers, build tags, fallbacks, and explicit
+unsupported behavior. Use "none" only after checking. -->
 
-...
+## Risk and cleanup
+
+<!-- Cover compatibility, resource ownership, sensitive-data handling, and
+rollback or fallback behavior. -->
+
+## Validation
+
+<!-- Keep only commands and real-runtime evidence that were actually run. -->
+
+- [ ] `go test ./...`
+- [ ] Relevant tagged suites from `TEST.md`
+- [ ] `go vet ./...`
+- [ ] Linter or static analysis
+- [ ] Cross-platform or non-CGO compilation where affected
+- [ ] No sensitive test or development artifacts remain
+
+## Review readiness
+
+- [ ] Targets `main`
+- [ ] Commits and PR text are in English
+- [ ] Tests cover normal and failure/fallback behavior
+- [ ] User-facing documentation is updated where required
+- [ ] Build tags and platform boundaries were reviewed
+- [ ] Resource and file-descriptor cleanup was reviewed
+- [ ] CI and all reviewer comments, including Codex when configured, will be
+      checked before merge

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,5 +41,6 @@ rollback or fallback behavior. -->
 - [ ] User-facing documentation is updated where required
 - [ ] Build tags and platform boundaries were reviewed
 - [ ] Resource and file-descriptor cleanup was reviewed
-- [ ] CI and all reviewer comments, including Codex when configured, will be
-      checked before merge
+- [ ] CI, review threads, and automated-review results or reactions, including
+      Codex when configured, will be checked against the current head before
+      merge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,10 @@ For functions that expose dimensions or rectangles:
 
 ## 10) Documentation and Change Hygiene
 
+The operational branch, pull-request, CI, reviewer, merge, and cleanup loop is
+defined in `docs/workflow_conventions.md`. Follow it for normal repository work;
+this file remains authoritative for engineering and safety rules.
+
 Any backend behavior change should update affected docs:
 
 1. `README.md` for user-visible backend behavior/env vars.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,19 @@ Minimum local validation for meaningful changes:
 Repository-default command baseline in this repo currently uses direct `go`
 commands (no required root `Makefile` workflow).
 
+Sensitive-data cleanup is mandatory:
+
+1. Default unit tests must not persist the developer's real desktop, clipboard
+   contents, input events, OCR inputs, or similar private data.
+2. Integration tests and diagnostics that intentionally exercise real private
+   data must remove every sensitive artifact on success, failure, timeout, and
+   cancellation paths.
+3. Prefer in-memory fixtures and `t.TempDir()`/`t.Cleanup()` for unavoidable
+   files. Files returned by external backends remain RobotGo's cleanup
+   responsibility.
+4. Regression tests must verify that sensitive artifacts no longer exist after
+   processing, including error paths.
+
 Common targeted suites:
 
 1. `go test -tags "portal" ./screen/portal -v`

--- a/README.md
+++ b/README.md
@@ -633,9 +633,11 @@ In a `CGO_ENABLED=0` build, `Capture`, `CaptureImg`, `CaptureScreen`,
 Pure-Go CoreGraphics, Windows, or X11 screenshot backend where available.
 Wayland sessions use this fork's hardened screenshot portal and preserve
 `ROBOTGO_DISABLE_PORTAL`; unsupported targets return `ErrNotSupported`
-explicitly. On macOS, capture returns `ErrPermissionDenied` with remediation
-when Screen Recording access is absent; capability inspection never requests
-that permission implicitly.
+explicitly. Portal-provided temporary screenshot files are unlinked immediately
+after opening, including decode-error paths, so sensitive desktop images are
+not left behind. On macOS, capture returns `ErrPermissionDenied` with
+remediation when Screen Recording access is absent; capability inspection
+never requests that permission implicitly.
 
 Use `CaptureImg()` with no arguments for a full-screen capture. Region capture
 requires at least `x, y, width, height`; partial argument lists, non-positive

--- a/TEST.md
+++ b/TEST.md
@@ -68,6 +68,12 @@ the real Quartz keyboard/pointer and Accessibility symbols and performs a
 non-prompting permission preflight without posting input. None of these runtime
 checks requires a Screen Recording or Accessibility grant.
 
+Default Linux screen tests use hermetic portal fixtures rather than persisting
+the developer's real desktop. Portal regression tests require temporary
+screenshot files to be absent after successful decoding and after decode
+failures. The production portal reader unlinks the sensitive file immediately
+after opening it.
+
 The real scale probe can be reproduced on a macOS GUI runner without granting
 Screen Recording or Accessibility access:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,16 @@
 # Docs
 
-Documents are not necessarily updated synchronously, slower than godoc, please see examples and godoc.
+Use the following documents as the primary entry points:
+
+- [Workflow conventions](workflow_conventions.md) for branches, pull requests,
+  CI, reviewer feedback, merges, and cleanup.
+- [Test guide](../TEST.md) for validation commands and runtime prerequisites.
+- [Product roadmap](plan/product-roadmap.md) for delivery phases.
+- [Wayland status](wayland-tasks.md) for backend support and open Wayland work.
+
+API details are available through examples and Go documentation. Lasting
+backend behavior and support contracts are documented in this directory.
+
 ## Wayland Portal
 
 RobotGo capture flow on Linux:

--- a/docs/workflow_conventions.md
+++ b/docs/workflow_conventions.md
@@ -1,0 +1,168 @@
+# RobotGo Workflow Conventions
+
+Version: 1.0  
+Status: Active  
+Audience: contributors, reviewers, and coding agents
+
+## 1. Purpose and ownership
+
+This document is the canonical operational workflow for RobotGo branches,
+pull requests, CI, reviews, merges, and branch cleanup.
+
+Documentation ownership is split as follows:
+
+- `AGENTS.md` defines non-negotiable engineering and safety rules.
+- `docs/workflow_conventions.md` defines the operational Git and GitHub loop.
+- `TEST.md` defines validation commands and runtime prerequisites.
+- `docs/plan/product-roadmap.md` and `docs/wayland-tasks.md` define product
+  direction and delivery status.
+
+Repository state, tests, Git history, and GitHub are the durable record. Do not
+leave important workflow state only in chat or local memory.
+
+## 2. Default workflow
+
+Normal implementation work follows this loop:
+
+`sync main -> feature branch -> implementation and tests -> local review -> commit and push -> draft PR -> CI -> ready for review -> reviewer feedback -> merge -> sync main -> branch cleanup`
+
+1. Start from a clean, current local `main`.
+2. Create a narrowly named feature, fix, docs, test, or chore branch.
+3. Implement one coherent slice and update its tests and lasting documentation.
+4. Run the default and area-specific validation required by `AGENTS.md` and
+   `TEST.md`.
+5. Review the complete branch diff, including generated files, build tags,
+   platform boundaries, resource ownership, and sensitive-data cleanup.
+6. Commit with an English Conventional Commit message and push the branch.
+7. Open a draft PR against `main` with behavior, risk, fallback, and validation
+   evidence.
+8. Inspect every CI job. Fix failures owned by the branch and push the fixes.
+9. Once the branch is locally complete and CI is healthy, mark the PR ready for
+   review. A draft PR is not evidence that configured reviewers have reviewed
+   it.
+10. Inspect all review surfaces, address actionable findings, and repeat CI and
+    review inspection after every review-driven push.
+11. Merge only when the gate in section 5 is satisfied.
+12. Sync local `main`, verify the merge, and remove the completed feature branch
+    when it is no longer needed.
+
+Do not push normal implementation work directly to `main`. Do not mix the next
+unrelated product slice into a PR that is already at the review boundary.
+
+## 3. Pull request content
+
+A PR description must state:
+
+- the user-visible or behavioral result
+- why the change is needed
+- important platform and backend consequences
+- explicit fallback or unsupported behavior
+- resource, privacy, and compatibility risks
+- local validation performed
+- intentionally omitted runtime evidence or follow-up work
+
+Use English for branch names, commits, PR titles, and PR descriptions. Keep the
+description current when later commits materially change the result or risk.
+
+## 4. CI and review polling
+
+CI status and review status are separate. Both must be inspected explicitly.
+
+### 4.1 CI
+
+- Verify authenticated GitHub access before relying on automation.
+- Inspect check summaries first; fetch full logs only for failed, cancelled, or
+  suspicious jobs.
+- Treat a skipped job as acceptable only when its trigger or runner conditions
+  intentionally do not apply.
+- A local green test run does not replace GitHub Actions, and GitHub Actions do
+  not replace relevant local or real-runtime evidence.
+
+### 4.2 GitHub reviews
+
+For every open PR, inspect all of the following:
+
+1. top-level PR conversation comments
+2. submitted reviews and their state
+3. inline review threads, including `isResolved` and `isOutdated`
+4. requested reviewers and the overall review decision
+5. Codex review output when Codex is configured or requested as a reviewer
+
+Do not rely on a flat comment list: it can omit thread resolution and inline
+context. Use a thread-aware GitHub query (`reviewThreads`) or an equivalent
+tool.
+
+No Codex comment on a draft PR means only that no comment exists yet. It does
+not mean Codex reviewed the change. Mark the PR ready, confirm that the expected
+review was requested or triggered, and check again before merge.
+
+Classify each finding as:
+
+- actionable and in scope: fix it on the PR branch
+- valid but out of scope: record a concrete follow-up and explain why it is not
+  part of the current PR
+- informational, duplicate, stale, or already fixed: verify that classification
+  against the current head before dismissing it
+- ambiguous or conflicting: resolve the trade-off before changing behavior
+
+After a review-driven push:
+
+1. rerun the affected local checks
+2. push the fix
+3. wait for required CI to evaluate the new head
+4. re-read reviews and unresolved threads
+5. verify that earlier approvals or comments still apply to the current head
+
+Never report a PR as fully reviewed merely because its CI is green.
+
+## 5. Merge gate
+
+A PR is ready to merge only when all applicable conditions are true:
+
+- the PR is not a draft
+- the branch targets `main` and is mergeable
+- required CI checks pass on the current head
+- skipped checks are understood and appropriate
+- there is no active `CHANGES_REQUESTED` review
+- there are no unresolved actionable review threads
+- configured or explicitly requested reviewers, including Codex, have had the
+  opportunity to review the ready PR
+- default and relevant tagged tests pass
+- public behavior and test instructions are documented where required
+- no test or development run leaves sensitive desktop, clipboard, OCR, input,
+  credential, diagnostic, or similar artifacts behind
+
+After merge, verify GitHub reports the PR as merged and local `main` contains the
+merge before deleting branches.
+
+## 6. Sensitive test and development data
+
+The cleanup contract in `AGENTS.md` applies throughout this workflow:
+
+- prefer hermetic fixtures and in-memory data
+- use `t.TempDir()` and `t.Cleanup()` for unavoidable test files
+- clean sensitive artifacts on success, error, timeout, and cancellation
+- treat files returned by an external desktop backend as RobotGo's cleanup
+  responsibility
+- add regression assertions that the artifact no longer exists
+- inspect unexpected files before deleting them, then remove confirmed
+  RobotGo-created sensitive content and derivative caches
+
+When a real desktop integration test is necessary, make that opt-in and document
+its privacy impact and cleanup behavior in `TEST.md`.
+
+## 7. Practical closeout checklist
+
+Before declaring a PR complete:
+
+- [ ] Working tree is clean and the intended commits are pushed.
+- [ ] PR description matches the current head.
+- [ ] PR is ready for review, not draft.
+- [ ] CI was checked on the current head.
+- [ ] Top-level comments, reviews, and thread-aware inline comments were read.
+- [ ] Codex feedback was checked when Codex is configured or requested.
+- [ ] All actionable findings were fixed or explicitly tracked.
+- [ ] Relevant checks were rerun after the last fix.
+- [ ] No sensitive test or development artifacts remain.
+- [ ] Merge state and local `main` were verified after merge.
+

--- a/docs/workflow_conventions.md
+++ b/docs/workflow_conventions.md
@@ -86,7 +86,8 @@ For every open PR, inspect all of the following:
 2. submitted reviews and their state
 3. inline review threads, including `isResolved` and `isOutdated`
 4. requested reviewers and the overall review decision
-5. Codex review output when Codex is configured or requested as a reviewer
+5. PR reactions used by automated reviewers to signal a clean review
+6. Codex review output when Codex is configured or requested as a reviewer
 
 Do not rely on a flat comment list: it can omit thread resolution and inline
 context. Use a thread-aware GitHub query (`reviewThreads`) or an equivalent
@@ -95,6 +96,14 @@ tool.
 No Codex comment on a draft PR means only that no comment exists yet. It does
 not mean Codex reviewed the change. Mark the PR ready, confirm that the expected
 review was requested or triggered, and check again before merge.
+
+In this repository, Codex reviews are submitted by
+`chatgpt-codex-connector[bot]`. A review with suggestions is visible as a
+submitted review and inline threads; a clean review may be represented only by
+the bot's thumbs-up reaction. Confirm that the review names the current head
+commit, or that the clean reaction happened after the latest review trigger
+with no later push. A result for an older commit is stale; trigger a fresh
+review and wait for its result.
 
 Classify each finding as:
 
@@ -126,7 +135,8 @@ A PR is ready to merge only when all applicable conditions are true:
 - there is no active `CHANGES_REQUESTED` review
 - there are no unresolved actionable review threads
 - configured or explicitly requested reviewers, including Codex, have had the
-  opportunity to review the ready PR
+  opportunity to review the ready PR, and their result applies to the current
+  head
 - default and relevant tagged tests pass
 - public behavior and test instructions are documented where required
 - no test or development run leaves sensitive desktop, clipboard, OCR, input,
@@ -160,9 +170,10 @@ Before declaring a PR complete:
 - [ ] PR is ready for review, not draft.
 - [ ] CI was checked on the current head.
 - [ ] Top-level comments, reviews, and thread-aware inline comments were read.
-- [ ] Codex feedback was checked when Codex is configured or requested.
+- [ ] Automated-review reactions were checked.
+- [ ] Codex feedback or its clean-review reaction was checked against the
+      current head when Codex is configured or requested.
 - [ ] All actionable findings were fixed or explicitly tracked.
 - [ ] Relevant checks were rerun after the last fix.
 - [ ] No sensitive test or development artifacts remain.
 - [ ] Merge state and local `main` were verified after merge.
-

--- a/img.go
+++ b/img.go
@@ -13,6 +13,7 @@ package robotgo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"image/png"
@@ -239,8 +240,8 @@ func GetTextImgContext(ctx context.Context, img image.Image, args ...string) (re
 				retErr = closeErr
 			}
 		}
-		if removeErr := os.Remove(path); retErr == nil && removeErr != nil {
-			retErr = removeErr
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			retErr = errors.Join(retErr, fmt.Errorf("remove private OCR image: %w", removeErr))
 		}
 	}()
 	if err := png.Encode(file, img); err != nil {

--- a/robotgo_ocr_cli_test.go
+++ b/robotgo_ocr_cli_test.go
@@ -58,3 +58,29 @@ func TestGetTextImgContextRemovesPrivateTemporaryFile(t *testing.T) {
 		t.Fatalf("temporary OCR image still exists or stat failed: %v", err)
 	}
 }
+
+func TestGetTextImgContextRemovesPrivateTemporaryFileAfterCancellation(t *testing.T) {
+	directory := t.TempDir()
+	tesseract := filepath.Join(directory, "tesseract")
+	marker := filepath.Join(directory, "image-path")
+	script := "#!/bin/sh\nprintf '%s' \"$1\" > \"$ROBOTGO_OCR_TEST_MARKER\"\nexec /bin/sleep 30\n"
+	if err := os.WriteFile(tesseract, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", directory)
+	t.Setenv("ROBOTGO_OCR_TEST_MARKER", marker)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err := GetTextImgContext(ctx, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetTextImgContext error = %v, want deadline", err)
+	}
+	pathBytes, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(string(pathBytes)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary OCR image still exists after cancellation or stat failed: %v", err)
+	}
+}

--- a/screen/capture_test.go
+++ b/screen/capture_test.go
@@ -23,8 +23,11 @@ func TestCaptureScreen(t *testing.T) {
 		}
 
 		t.Setenv("WAYLAND_DISPLAY", "")
-		// Force the portal fallback to avoid X_GetImage crashes on constrained servers.
+		// Exercise portal selection through the hermetic stub. Default unit tests
+		// must not persist the developer's real desktop.
 		t.Setenv("ROBOTGO_FORCE_PORTAL", "1")
+		t.Setenv("ROBOTGO_DISABLE_PORTAL", "1")
+		t.Setenv("ROBOTGO_PORTAL_STUB_GREEN", "1")
 		bitmap, err := robotgo.CaptureScreen()
 		if err != nil {
 			t.Skipf("X11 capture skipped: %v", err)
@@ -44,6 +47,9 @@ func TestCaptureScreen(t *testing.T) {
 			t.Skip("WAYLAND_DISPLAY not set")
 		}
 		t.Setenv("DISPLAY", "")
+		t.Setenv("ROBOTGO_FORCE_PORTAL", "1")
+		t.Setenv("ROBOTGO_DISABLE_PORTAL", "1")
+		t.Setenv("ROBOTGO_PORTAL_STUB_GREEN", "1")
 		bitmap, err := robotgo.CaptureScreen()
 		if err != nil {
 			if strings.Contains(err.Error(), "no display server found") {
@@ -52,6 +58,9 @@ func TestCaptureScreen(t *testing.T) {
 			return
 		}
 		t.Cleanup(func() { robotgo.FreeBitmap(bitmap) })
+		if lb := robotgo.LastBackend(); lb != robotgo.BackendPortal {
+			t.Fatalf("expected portal backend, got %v", lb)
+		}
 	})
 
 	t.Run("PortalForce", func(t *testing.T) {

--- a/screen/portal/screenshot_portal.go
+++ b/screen/portal/screenshot_portal.go
@@ -274,9 +274,37 @@ func decodeFileURI(rawURI string) (image.Image, error) {
 		return nil, errors.New("portal: empty screenshot path")
 	}
 
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("portal: inspect screenshot: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("portal: screenshot is not a regular file: %q", path)
+	}
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("portal: open screenshot: %w", err)
+		openErr := fmt.Errorf("portal: open screenshot: %w", err)
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return nil, errors.Join(
+				openErr,
+				fmt.Errorf("portal: remove sensitive screenshot after open failure: %w", removeErr),
+			)
+		}
+		return nil, openErr
+	}
+	// The portal artifact contains the user's desktop. Unlink it immediately
+	// after opening so it cannot remain on disk if decoding or later processing
+	// fails. Linux keeps the opened contents available through f until close.
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		closeErr := f.Close()
+		removeErr := fmt.Errorf("portal: remove sensitive screenshot: %w", err)
+		if closeErr != nil {
+			return nil, errors.Join(
+				removeErr,
+				fmt.Errorf("portal: close screenshot after cleanup failure: %w", closeErr),
+			)
+		}
+		return nil, removeErr
 	}
 	img, decodeErr := png.Decode(f)
 	closeErr := f.Close()

--- a/screen/portal/screenshot_portal_test.go
+++ b/screen/portal/screenshot_portal_test.go
@@ -4,6 +4,7 @@ package portal
 
 import (
 	"context"
+	"errors"
 	"image"
 	"image/color"
 	"image/png"
@@ -59,7 +60,7 @@ func (p *fakeScreenshotPortal) screenshot(_ context.Context, options map[string]
 }
 func (p *fakeScreenshotPortal) close() error { return nil }
 
-func writeTestPNG(t *testing.T) string {
+func writeTestPNG(t *testing.T) (string, string) {
 	t.Helper()
 	path := t.TempDir() + "/portal image.png"
 	f, err := os.Create(path)
@@ -75,15 +76,17 @@ func writeTestPNG(t *testing.T) string {
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}
-	return (&url.URL{Scheme: "file", Path: path}).String()
+	return (&url.URL{Scheme: "file", Path: path}).String(), path
 }
 
 func TestCaptureRegionImageSubscribesBeforeRequestAndCrops(t *testing.T) {
-	portal := &fakeScreenshotPortal{uri: writeTestPNG(t)}
+	uri, artifactPath := writeTestPNG(t)
+	portal := &fakeScreenshotPortal{uri: uri}
 	img, err := captureRegionImage(context.Background(), portal, 2, 1, 1, 1)
 	if err != nil {
 		t.Fatalf("captureRegionImage failed: %v", err)
 	}
+	assertSensitiveArtifactRemoved(t, artifactPath)
 	if got := img.Bounds(); got != image.Rect(2, 1, 3, 2) {
 		t.Fatalf("unexpected crop bounds: %v", got)
 	}
@@ -174,5 +177,24 @@ func TestCropImageOnlyTreatsZeroByZeroAsFullScreenshot(t *testing.T) {
 func TestDecodeFileURIRejectsNonFileScheme(t *testing.T) {
 	if _, err := decodeFileURI("https://example.com/screenshot.png"); err == nil {
 		t.Fatal("expected unsupported URI error")
+	}
+}
+
+func TestDecodeFileURIRemovesSensitiveArtifactOnDecodeFailure(t *testing.T) {
+	path := t.TempDir() + "/invalid portal image.png"
+	if err := os.WriteFile(path, []byte("sensitive but not a PNG"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	uri := (&url.URL{Scheme: "file", Path: path}).String()
+	if _, err := decodeFileURI(uri); err == nil {
+		t.Fatal("expected PNG decode error")
+	}
+	assertSensitiveArtifactRemoved(t, path)
+}
+
+func assertSensitiveArtifactRemoved(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("sensitive portal artifact still exists at %q: %v", path, err)
 	}
 }


### PR DESCRIPTION
## What changed

- unlink portal-provided screenshot files immediately after opening them, including decode and open-error paths
- make default Linux screen tests use hermetic portal fixtures instead of the real desktop portal
- verify screenshot artifacts disappear after successful processing and decode failures
- harden private OCR temporary-image cleanup and cover cancellation
- document the sensitive-data cleanup contract for tests and diagnostics
- add canonical branch/PR/CI/reviewer/merge workflow conventions and replace the stale upstream PR template

## Root cause

The default screen test forced the real Screenshot portal. On sway, `xdg-desktop-portal-wlr` invokes `grim` and writes a hard-coded `/tmp/out.png`; RobotGo decoded the file but did not remove it. This left a full multi-monitor desktop capture and allowed thumbnail copies to be created.

## Impact

A normal default test run no longer requests a real portal screenshot. When production capture does receive a portal screenshot URI, RobotGo unlinks the sensitive file immediately after opening it, while retaining the open descriptor long enough to decode the image. OCR temporary images are also cleaned on cancellation and error paths.

The repository workflow now requires separate CI and thread-aware review checks, including Codex feedback when configured, before merge.

No upload or network path is involved; the screenshot flow remains local over D-Bus.

## Validation

- `go test -count=1 ./...`
- `CGO_ENABLED=0 go test -count=1 ./...`
- `go test -race -tags portal -count=1 ./screen/portal`
- `go test -race -count=1 ./screen/portal .`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run`
- `CGO_ENABLED=0 golangci-lint run`
- `git diff --check`
- live `inotifywait` observation of a full default suite: no `/tmp/out.png` filesystem events
- verified `/tmp/out.png` and its matching thumbnail-cache entries are absent