### PR TITLE
feat: add Pure-Go macOS window control

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ workflow. `GetRuntimeDiagnostics` provides the stable machine-readable report;
 | Platform/session | Build | Current behavior |
 |---|---|---|
 | macOS | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths; macOS permissions still apply |
-| macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture, display bounds, real Retina scale, and Quartz keyboard/pointer input with exact UTF-16 text, owned holds, process targeting, cleanup, and explicit Screen Recording/Accessibility diagnostics; media keys without a stable Quartz keycode and other unavailable GUI operations return `ErrNotSupported` |
+| macOS | `CGO_ENABLED=0` | Pure-Go CoreGraphics capture, display bounds, real Retina scale, Quartz keyboard/pointer input, and Accessibility window inspection/control with explicit permission diagnostics; maximize/topmost and media keys without stable native semantics return `ErrNotSupported` |
 | Windows | CGO-enabled default build | Native mouse, keyboard, capture, window, and process paths |
 | Windows | `CGO_ENABLED=0` | Pure-Go capture/display bounds, real Win32 DPI scale and pixel-at-pointer queries, foreground-layout-aware `SendInput` keyboard/text plus clipboard paste, complete pointer input, and Win32 window title/PID/handle/geometry/state/control operations with explicit errors |
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
@@ -95,7 +95,7 @@ compositor to expose the corresponding virtual-input protocols. See
 Persistent capture runtime evidence is tracked separately in the
 [Wayland capture compatibility matrix](docs/compatibility/wayland-capture.md).
 
-## Pure-Go macOS input
+## Pure-Go macOS input and windows
 
 With `CGO_ENABLED=0`, macOS keyboard and pointer automation use Quartz events directly
 through runtime-loaded system frameworks. `MouseReady`, `KeyboardReady`, and
@@ -117,6 +117,18 @@ drag, single/double click, owned button toggles, horizontal/vertical pixel
 scrolling, and global pointer location. Persistent holds are ownership-checked;
 `CloseMainDisplayE` releases RobotGo-owned keys and buttons before unloading
 the native frameworks.
+
+Pure-Go macOS window support uses a non-prompting Accessibility preflight and
+stable `CGWindowID` handles. It supports active/PID/handle resolution, title,
+AX frame bounds, activation, minimize/restore and minimized-state queries, plus
+graceful close through the window's Accessibility close button. macOS does not
+expose a reliable cross-application client rectangle, so `GetClient` returns the
+same AX frame as `GetBounds`. Maximized and global topmost state have no stable
+equivalent and return `ErrNotSupported` explicitly. Call `CloseMainDisplayE` to
+release both input and window framework references deterministically. The
+CGWindowID-to-Accessibility mapping uses the same runtime-resolved macOS bridge
+as the native backend; if that bridge is absent, capability probing reports the
+backend as unsupported instead of degrading silently.
 
 ```go
 if err := robotgo.KeyboardReady(); err != nil {
@@ -696,6 +708,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Pure-Go X11 window inspection and opt-in EWMH control](examples/purego_x11_window/main.go)
 - [Pure-Go Windows input readiness and opt-in demo](examples/purego_windows_input/main.go)
 - [Pure-Go Windows window inspection and opt-in control](examples/purego_windows_window/main.go)
+- [Pure-Go macOS window inspection and opt-in control](examples/purego_macos_window/main.go)
 - [Consent-aware RemoteDesktop portal input](examples/remote_desktop_input/main.go)
 - [Persistent ScreenCast/PipeWire capture](examples/screencast_capture/main.go)
 - [Bitmap-string and region color-search helpers](examples/capture_helpers/main.go)
@@ -725,6 +738,16 @@ operations require `-act` and an explicit action:
 CGO_ENABLED=0 go run ./examples/purego_x11_window
 CGO_ENABLED=0 go run ./examples/purego_x11_window -pid 1234
 CGO_ENABLED=0 go run ./examples/purego_x11_window -pid 1234 -act -maximize
+```
+
+The Pure-Go macOS window example is also inspection-only by default. It requires
+Accessibility permission; mutation requires an explicit `-action`:
+
+```bash
+CGO_ENABLED=0 go run ./examples/purego_macos_window
+CGO_ENABLED=0 go run ./examples/purego_macos_window -pid 1234
+CGO_ENABLED=0 go run ./examples/purego_macos_window -action minimize
+CGO_ENABLED=0 go run ./examples/purego_macos_window -action restore
 ```
 
 On Windows, the Pure-Go example performs readiness checks only unless `-move`,

--- a/TEST.md
+++ b/TEST.md
@@ -90,6 +90,21 @@ CGO_ENABLED=0 go test \
   -run '^TestPureGoDarwinInputRuntime$' -count=1 -v .
 ```
 
+The Pure-Go window preflight resolves the real CoreGraphics, CoreFoundation,
+and Accessibility symbols, reports permission without prompting, and verifies
+that framework cleanup can be repeated and reopened:
+
+```bash
+CGO_ENABLED=0 go test \
+  -run '^TestPureGoDarwinWindow(CapabilityUsesNonPromptingPreflight|CleanupIsReusable)$' \
+  -count=1 -v .
+```
+
+GitHub-hosted macOS runs this preflight without controlling another
+application. Permission-granted activation, minimize/restore, and close remain
+opt-in runtime evidence until a self-owned macOS test-window harness is
+available; tests must not mutate an unrelated developer window.
+
 After granting Accessibility access, the opt-in real input tests move to the
 center of the main display and restore the original location, and exercise one
 ownership-checked Shift hold/release without typing text:

--- a/api_contract_nocgo_test.go
+++ b/api_contract_nocgo_test.go
@@ -13,7 +13,7 @@ func TestNonCGOPortableAPIContract(t *testing.T) {
 	_ = capabilities.Hook
 	_ = capabilities.Events
 
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		invalidTargets := []error{
 			SetActiveE(0),
 			MinWindowE(0),
@@ -21,7 +21,11 @@ func TestNonCGOPortableAPIContract(t *testing.T) {
 		}
 		for _, err := range invalidTargets {
 			if err == nil || errors.Is(err, ErrNotSupported) {
-				t.Fatalf("Pure-Go Windows invalid-target error = %v, want explicit backend error", err)
+				t.Fatalf(
+					"Pure-Go %s invalid-target error = %v, want explicit backend error",
+					runtime.GOOS,
+					err,
+				)
 			}
 		}
 	} else {

--- a/backend_info.go
+++ b/backend_info.go
@@ -15,6 +15,7 @@ const (
 	featureBackendPureGoPrefix       = "pure-go-"
 	featureBackendPureGoCoreGraphics = "pure-go-coregraphics"
 	featureBackendPureGoQuartzInput  = "pure-go-quartz-input"
+	featureBackendPureGoMacOSWindow  = "pure-go-macos-accessibility-window"
 	featureBackendPureGoWindows      = "pure-go-windows"
 	featureBackendPureGoX11          = "pure-go-x11"
 	featureBackendGoProcess          = "go-process"

--- a/docs/compatibility/runtime-v1.md
+++ b/docs/compatibility/runtime-v1.md
@@ -20,7 +20,7 @@ available. A pending row is not a passing row.
 | GNOME/Wayland | CGO and Pure Go portal paths | implemented / evidence pending | Protected GNOME runner required for RemoteDesktop and persistent ScreenCast evidence |
 | KDE Plasma/Wayland | CGO and Pure Go portal paths | implemented / evidence pending | Protected KDE runner required for RemoteDesktop and persistent ScreenCast evidence |
 | macOS | Native CGO | supported | Hosted macOS build/test; Screen Recording and Accessibility are runtime permissions |
-| macOS | Pure Go | supported, granted-input evidence pending | CoreGraphics capture/bounds/scale and Quartz input contracts; real symbol and non-prompting permission preflight are blocking; permission-granted injection is opt-in |
+| macOS | Pure Go | supported, granted-input/window evidence pending | CoreGraphics capture/bounds/scale, Quartz input, and Accessibility window contracts; real symbol and non-prompting permission preflights are blocking; permission-granted input and self-owned-window mutations remain opt-in |
 | Windows | Native CGO | supported | Hosted Windows build/test |
 | Windows | Pure Go | supported | Hosted non-CGO tests plus real input-desktop pointer/pixel and self-owned window/control evidence |
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -36,7 +36,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet/sanitizer jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE/wlroots evidence |
-| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display and keyboard/pointer implemented; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display plus Quartz keyboard/pointer input and Accessibility diagnostics; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS keyboard-injection evidence and assess further backends selectively |
+| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, provider-aware Hyprland 0.55+ Lua window dispatch | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline | Dedicated compositor jobs and the first published release evidence asset |
 
@@ -153,6 +153,18 @@ state, PID ownership, partial-event rollback, Unicode and cleanup. An opt-in
 Accessibility-gated test posts and releases a real modifier without typing into
 another application. Media/brightness keys and F21-F24 remain explicitly
 unsupported because Quartz exposes no safe stable keycode for them.
+The Pure-Go macOS window backend uses the same non-prompting Accessibility
+contract and stable `CGWindowID` handles for active/PID/handle resolution,
+titles, AX frame bounds, activation, minimize/restore, minimized-state queries,
+and graceful close. It releases its dynamically loaded framework references
+through `CloseMainDisplayE`. Client geometry intentionally equals the AX frame;
+maximize and topmost remain explicit unsupported operations because macOS does
+not expose trustworthy cross-application equivalents. CGWindowID mapping uses
+the same runtime-resolved macOS bridge as the CGO backend and fails explicitly
+if that bridge is unavailable. Hermetic tests cover the contract and hosted
+macOS resolves the real symbols and permission preflight.
+Permission-granted mutations still require a self-owned runtime window before
+they can become blocking evidence.
 
 Windows non-CGO builds now provide a foreground-layout-aware `SendInput` keyboard and text
 backend, clipboard-assisted Unicode paste, pixel-at-pointer queries, plus exact pointer movement/location, smooth movement and drag,

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -24,6 +24,10 @@ Current implementation baseline:
   button toggles, horizontal/vertical scroll, pointer location, deterministic
   cleanup, and explicit Accessibility denial. Media/brightness keys without
   stable Quartz keycodes remain explicitly unsupported.
+- macOS non-CGO builds provide Accessibility-backed active/PID/CGWindowID
+  window resolution, title, AX frame bounds, activation, minimize/restore,
+  minimized-state query, and close. Permission is preflighted without prompting;
+  maximize/topmost remain explicitly unsupported.
 - Linux/X11 non-CGO builds provide a Pure-Go XGB/XTEST keyboard and pointer
   backend with live readiness probes, text/Unicode, smooth movement/drag,
   scrolling, pointer location, explicit state errors, and deterministic

--- a/examples/purego_macos_window/main.go
+++ b/examples/purego_macos_window/main.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"runtime"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	pid := flag.Int("pid", 0, "inspect a window owned by this process ID")
+	handle := flag.Uint64("handle", 0, "inspect an explicit CGWindowID")
+	action := flag.String(
+		"action",
+		"",
+		"explicit mutation: activate, minimize, restore, or close",
+	)
+	flag.Parse()
+
+	if runtime.GOOS != "darwin" {
+		log.Fatal("this example requires macOS")
+	}
+	info := robotgo.GetRuntimeBackendInfo()
+	if info.BuildImplementation != robotgo.RuntimeImplementationPureGo {
+		log.Fatal("run this example with CGO_ENABLED=0")
+	}
+	capability := robotgo.GetRuntimeCapabilities().Window
+	fmt.Printf(
+		"window backend=%s available=%v reason=%s\n",
+		capability.Backend,
+		capability.Available,
+		capability.Reason,
+	)
+	if !capability.Available {
+		log.Fatal("Pure-Go macOS window control is unavailable; grant Accessibility access if requested")
+	}
+	defer func() {
+		if err := robotgo.CloseMainDisplayE(); err != nil {
+			log.Printf("window backend cleanup: %v", err)
+		}
+	}()
+
+	target, isHandle, resolved, err := resolveTarget(*pid, *handle)
+	if err != nil {
+		log.Fatal(err)
+	}
+	args := []int(nil)
+	if isHandle {
+		args = []int{1}
+	}
+	title, err := robotgo.GetTitleE(append([]int{target}, args...)...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	x, y, width, height := robotgo.GetBounds(target, args...)
+	if width <= 0 || height <= 0 {
+		log.Fatalf(
+			"window %#x returned invalid bounds (%d, %d, %d, %d)",
+			resolved,
+			x,
+			y,
+			width,
+			height,
+		)
+	}
+	fmt.Printf(
+		"window=%#x title=%q bounds=(%d,%d %dx%d)\n",
+		resolved,
+		title,
+		x,
+		y,
+		width,
+		height,
+	)
+
+	if *action == "" {
+		fmt.Println("inspection only; pass -action to request an explicit mutation")
+		return
+	}
+	if err := performAction(target, isHandle, *action); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s requested for window %#x\n", *action, resolved)
+}
+
+func resolveTarget(pid int, rawHandle uint64) (target int, isHandle bool, resolved int, err error) {
+	if pid < 0 {
+		return 0, false, 0, errors.New("-pid must not be negative")
+	}
+	if pid > 0 && rawHandle != 0 {
+		return 0, false, 0, errors.New("-pid and -handle are mutually exclusive")
+	}
+	const maximumCGWindowID = uint64(1<<32 - 1)
+	if rawHandle > maximumCGWindowID || rawHandle > uint64(^uint(0)>>1) {
+		return 0, false, 0, fmt.Errorf("CGWindowID %#x is outside the supported range", rawHandle)
+	}
+	if rawHandle != 0 {
+		target = int(rawHandle)
+		return target, true, target, nil
+	}
+	if pid > 0 {
+		resolved = robotgo.GetHWNDByPid(pid)
+		if resolved == 0 {
+			return 0, false, 0, fmt.Errorf("no accessible window found for pid %d", pid)
+		}
+		return resolved, true, resolved, nil
+	}
+	resolved = robotgo.GetHandle()
+	if resolved == 0 {
+		return 0, false, 0, errors.New("no accessible active window found")
+	}
+	return resolved, true, resolved, nil
+}
+
+func performAction(target int, isHandle bool, action string) error {
+	intArgs := []int(nil)
+	stateArgs := []interface{}{true}
+	if isHandle {
+		intArgs = []int{1}
+		stateArgs = append(stateArgs, 1)
+	}
+	switch action {
+	case "activate":
+		return robotgo.ActivePid(target, intArgs...)
+	case "minimize":
+		return robotgo.MinWindowE(target, stateArgs...)
+	case "restore":
+		stateArgs[0] = false
+		return robotgo.MinWindowE(target, stateArgs...)
+	case "close":
+		return robotgo.CloseWindowE(append([]int{target}, intArgs...)...)
+	default:
+		return fmt.Errorf(
+			"unknown -action %q; use activate, minimize, restore, or close",
+			action,
+		)
+	}
+}

--- a/internal/darwinwindow/backend.go
+++ b/internal/darwinwindow/backend.go
@@ -1,0 +1,373 @@
+// Package darwinwindow provides RobotGo's Pure-Go macOS window backend.
+package darwinwindow
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+var (
+	// ErrPermission reports missing macOS Accessibility permission.
+	ErrPermission = errors.New("Pure-Go macOS window control requires Accessibility permission")
+	// ErrUnsupported reports a window operation without a trustworthy macOS equivalent.
+	ErrUnsupported = errors.New("Pure-Go macOS window operation is unsupported")
+)
+
+// System abstracts the macOS Accessibility and CoreGraphics calls used by
+// Backend.
+type System interface {
+	Ready() error
+	ActiveWindow() (windowbackend.Handle, error)
+	WindowExists(windowbackend.Handle) (bool, error)
+	FindWindowByPID(int32) (windowbackend.Handle, error)
+	WindowPID(windowbackend.Handle) (int32, error)
+	WindowTitle(windowbackend.Handle) (string, error)
+	WindowRect(windowbackend.Handle) (windowbackend.Rect, error)
+	RaiseWindow(windowbackend.Handle) error
+	SetMinimized(windowbackend.Handle, bool) error
+	IsMinimized(windowbackend.Handle) (bool, error)
+	CloseWindow(windowbackend.Handle) error
+	Close() error
+}
+
+// Backend resolves macOS window targets and enforces RobotGo's public window
+// contract.
+type Backend struct {
+	system System
+
+	mu       sync.RWMutex
+	selected windowbackend.Handle
+}
+
+var _ windowbackend.Backend = (*Backend)(nil)
+
+// New constructs a Backend around a macOS window system implementation.
+func New(system System) *Backend {
+	return &Backend{system: system}
+}
+
+// NewNative constructs a lazily initialized backend backed by macOS system
+// frameworks.
+func NewNative() *Backend {
+	return New(newNativeSystem())
+}
+
+// Ready resolves the required system symbols and performs a non-prompting
+// Accessibility permission preflight.
+func (backend *Backend) Ready() error {
+	if backend == nil || backend.system == nil {
+		return errors.Join(
+			windowbackend.ErrUnsupported,
+			fmt.Errorf("%w: backend has no system implementation", ErrUnsupported),
+		)
+	}
+	if err := backend.system.Ready(); err != nil {
+		switch {
+		case errors.Is(err, ErrPermission):
+			return errors.Join(windowbackend.ErrPermission, err)
+		case errors.Is(err, ErrUnsupported):
+			return errors.Join(windowbackend.ErrUnsupported, err)
+		}
+		return err
+	}
+	return nil
+}
+
+// CloseSystem releases dynamically loaded framework references. A later
+// operation reopens them lazily.
+func (backend *Backend) CloseSystem() error {
+	if backend == nil || backend.system == nil {
+		return nil
+	}
+	return backend.system.Close()
+}
+
+// Active returns the focused window of the frontmost application.
+func (backend *Backend) Active() (windowbackend.Handle, error) {
+	if err := backend.Ready(); err != nil {
+		return 0, err
+	}
+	handle, err := backend.system.ActiveWindow()
+	if err != nil {
+		return 0, fmt.Errorf(
+			"%w: active macOS window: %w",
+			windowbackend.ErrWindowNotFound,
+			classifySystemError(err),
+		)
+	}
+	if err := backend.validateReady(handle); err != nil {
+		return 0, fmt.Errorf("%w: active macOS window", err)
+	}
+	return handle, nil
+}
+
+// Resolve maps either a PID or explicit CGWindowID to a valid AX window.
+func (backend *Backend) Resolve(target int, isHandle bool) (windowbackend.Handle, error) {
+	if target <= 0 {
+		return 0, fmt.Errorf("%w: target must be positive, got %d", windowbackend.ErrWindowNotFound, target)
+	}
+	if err := backend.Ready(); err != nil {
+		return 0, err
+	}
+	if isHandle {
+		handle := windowbackend.Handle(uintptr(target))
+		if uint64(handle) > math.MaxUint32 {
+			return 0, fmt.Errorf("%w: CGWindowID %#x exceeds uint32", windowbackend.ErrInvalidWindow, uintptr(handle))
+		}
+		if err := backend.validateReady(handle); err != nil {
+			return 0, err
+		}
+		return handle, nil
+	}
+	if int64(target) > math.MaxInt32 {
+		return 0, fmt.Errorf("%w: pid %d exceeds macOS pid_t", windowbackend.ErrWindowNotFound, target)
+	}
+	handle, err := backend.system.FindWindowByPID(int32(target))
+	if err != nil {
+		return 0, fmt.Errorf(
+			"%w: pid %d: %w",
+			windowbackend.ErrWindowNotFound,
+			target,
+			classifySystemError(err),
+		)
+	}
+	if err := backend.validateReady(handle); err != nil {
+		return 0, fmt.Errorf("%w: pid %d resolved to CGWindowID %#x", err, target, uintptr(handle))
+	}
+	return handle, nil
+}
+
+// Select stores a successfully resolved compatibility handle.
+func (backend *Backend) Select(target int, isHandle bool) error {
+	handle, err := backend.Resolve(target, isHandle)
+	if err != nil {
+		return err
+	}
+	backend.mu.Lock()
+	backend.selected = handle
+	backend.mu.Unlock()
+	return nil
+}
+
+// Selected returns the compatibility handle stored by Select.
+func (backend *Backend) Selected() windowbackend.Handle {
+	backend.mu.RLock()
+	defer backend.mu.RUnlock()
+	return backend.selected
+}
+
+// PID returns the owning process ID for a valid window.
+func (backend *Backend) PID(handle windowbackend.Handle) (int, error) {
+	if err := backend.validate(handle); err != nil {
+		return 0, err
+	}
+	pid, err := backend.system.WindowPID(handle)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"%w: get pid for CGWindowID %#x: %w",
+			windowbackend.ErrOperation,
+			uintptr(handle),
+			classifySystemError(err),
+		)
+	}
+	if pid <= 0 {
+		return 0, fmt.Errorf("%w: CGWindowID %#x has no process", windowbackend.ErrWindowNotFound, uintptr(handle))
+	}
+	return int(pid), nil
+}
+
+// Title returns the Accessibility title for a valid window.
+func (backend *Backend) Title(handle windowbackend.Handle) (string, error) {
+	if err := backend.validate(handle); err != nil {
+		return "", err
+	}
+	title, err := backend.system.WindowTitle(handle)
+	if err != nil {
+		return "", fmt.Errorf(
+			"%w: get title for CGWindowID %#x: %w",
+			windowbackend.ErrOperation,
+			uintptr(handle),
+			classifySystemError(err),
+		)
+	}
+	if title == "" {
+		return "", fmt.Errorf("%w: CGWindowID %#x has no title", windowbackend.ErrWindowNotFound, uintptr(handle))
+	}
+	return title, nil
+}
+
+// Bounds returns AX window-frame geometry. macOS Accessibility does not expose
+// a separate cross-application client rectangle, so client and outer requests
+// intentionally return the same frame.
+func (backend *Backend) Bounds(handle windowbackend.Handle, _ bool) (windowbackend.Rect, error) {
+	if err := backend.validate(handle); err != nil {
+		return windowbackend.Rect{}, err
+	}
+	rect, err := backend.system.WindowRect(handle)
+	if err != nil {
+		return windowbackend.Rect{}, fmt.Errorf(
+			"%w: get bounds for CGWindowID %#x: %w",
+			windowbackend.ErrOperation,
+			uintptr(handle),
+			classifySystemError(err),
+		)
+	}
+	if rect.Width <= 0 || rect.Height <= 0 {
+		return windowbackend.Rect{}, fmt.Errorf(
+			"%w: CGWindowID %#x returned invalid bounds %+v",
+			windowbackend.ErrOperation,
+			uintptr(handle),
+			rect,
+		)
+	}
+	return rect, nil
+}
+
+// Activate raises a valid window through macOS Accessibility.
+func (backend *Backend) Activate(handle windowbackend.Handle) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := backend.system.RaiseWindow(handle); err != nil {
+		return fmt.Errorf(
+			"%w: activate CGWindowID %#x: %w",
+			windowbackend.ErrOperation,
+			uintptr(handle),
+			classifySystemError(err),
+		)
+	}
+	return nil
+}
+
+// SetState supports minimized state. macOS does not expose a stable
+// cross-application maximized state equivalent to RobotGo's contract.
+func (backend *Backend) SetState(
+	handle windowbackend.Handle,
+	state windowbackend.State,
+	enabled bool,
+) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	switch state {
+	case windowbackend.StateMinimized:
+		if err := backend.system.SetMinimized(handle, enabled); err != nil {
+			return fmt.Errorf(
+				"%w: set minimized state for CGWindowID %#x: %w",
+				windowbackend.ErrOperation,
+				uintptr(handle),
+				classifySystemError(err),
+			)
+		}
+		return nil
+	case windowbackend.StateMaximized:
+		return fmt.Errorf("%w: %w: maximized state has no reliable macOS Accessibility equivalent", windowbackend.ErrUnsupported, ErrUnsupported)
+	default:
+		return fmt.Errorf("%w: unknown macOS window state %d", windowbackend.ErrOperation, state)
+	}
+}
+
+// State supports minimized-state queries and explicitly rejects maximized
+// state.
+func (backend *Backend) State(
+	handle windowbackend.Handle,
+	state windowbackend.State,
+) (bool, error) {
+	if err := backend.validate(handle); err != nil {
+		return false, err
+	}
+	switch state {
+	case windowbackend.StateMinimized:
+		enabled, err := backend.system.IsMinimized(handle)
+		if err != nil {
+			return false, fmt.Errorf(
+				"%w: query minimized state for CGWindowID %#x: %w",
+				windowbackend.ErrOperation,
+				uintptr(handle),
+				classifySystemError(err),
+			)
+		}
+		return enabled, nil
+	case windowbackend.StateMaximized:
+		return false, fmt.Errorf("%w: %w: maximized state has no reliable macOS Accessibility equivalent", windowbackend.ErrUnsupported, ErrUnsupported)
+	default:
+		return false, fmt.Errorf("%w: unknown macOS window state %d", windowbackend.ErrOperation, state)
+	}
+}
+
+// TopMost returns an explicit unsupported error because macOS Accessibility
+// does not expose a trustworthy global topmost state.
+func (backend *Backend) TopMost(handle windowbackend.Handle) (bool, error) {
+	if err := backend.validate(handle); err != nil {
+		return false, err
+	}
+	return false, fmt.Errorf("%w: %w: topmost state is unavailable through macOS Accessibility", windowbackend.ErrUnsupported, ErrUnsupported)
+}
+
+// SetTopMost returns an explicit unsupported error because macOS Accessibility
+// does not expose a trustworthy global topmost mutation.
+func (backend *Backend) SetTopMost(handle windowbackend.Handle, _ bool) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	return fmt.Errorf("%w: %w: topmost state is unavailable through macOS Accessibility", windowbackend.ErrUnsupported, ErrUnsupported)
+}
+
+// Close presses the Accessibility close button for a valid window.
+func (backend *Backend) Close(handle windowbackend.Handle) error {
+	if err := backend.validate(handle); err != nil {
+		return err
+	}
+	if err := backend.system.CloseWindow(handle); err != nil {
+		return fmt.Errorf(
+			"%w: close CGWindowID %#x: %w",
+			windowbackend.ErrOperation,
+			uintptr(handle),
+			classifySystemError(err),
+		)
+	}
+	return nil
+}
+
+func (backend *Backend) validate(handle windowbackend.Handle) error {
+	if err := backend.Ready(); err != nil {
+		return err
+	}
+	return backend.validateReady(handle)
+}
+
+func (backend *Backend) validateReady(handle windowbackend.Handle) error {
+	if handle == 0 || uint64(handle) > math.MaxUint32 {
+		return fmt.Errorf("%w: CGWindowID %#x", windowbackend.ErrInvalidWindow, uintptr(handle))
+	}
+	valid, err := backend.system.WindowExists(handle)
+	if err != nil {
+		return fmt.Errorf(
+			"%w: validate CGWindowID %#x: %w",
+			windowbackend.ErrOperation,
+			uintptr(handle),
+			classifySystemError(err),
+		)
+	}
+	if !valid {
+		return fmt.Errorf("%w: CGWindowID %#x", windowbackend.ErrInvalidWindow, uintptr(handle))
+	}
+	return nil
+}
+
+func classifySystemError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrPermission):
+		return errors.Join(windowbackend.ErrPermission, err)
+	case errors.Is(err, ErrUnsupported):
+		return errors.Join(windowbackend.ErrUnsupported, err)
+	default:
+		return err
+	}
+}

--- a/internal/darwinwindow/backend.go
+++ b/internal/darwinwindow/backend.go
@@ -110,13 +110,13 @@ func (backend *Backend) Resolve(target int, isHandle bool) (windowbackend.Handle
 	if target <= 0 {
 		return 0, fmt.Errorf("%w: target must be positive, got %d", windowbackend.ErrWindowNotFound, target)
 	}
-	if err := backend.Ready(); err != nil {
-		return 0, err
-	}
 	if isHandle {
 		handle := windowbackend.Handle(uintptr(target))
 		if uint64(handle) > math.MaxUint32 {
 			return 0, fmt.Errorf("%w: CGWindowID %#x exceeds uint32", windowbackend.ErrInvalidWindow, uintptr(handle))
+		}
+		if err := backend.Ready(); err != nil {
+			return 0, err
 		}
 		if err := backend.validateReady(handle); err != nil {
 			return 0, err
@@ -125,6 +125,9 @@ func (backend *Backend) Resolve(target int, isHandle bool) (windowbackend.Handle
 	}
 	if int64(target) > math.MaxInt32 {
 		return 0, fmt.Errorf("%w: pid %d exceeds macOS pid_t", windowbackend.ErrWindowNotFound, target)
+	}
+	if err := backend.Ready(); err != nil {
+		return 0, err
 	}
 	handle, err := backend.system.FindWindowByPID(int32(target))
 	if err != nil {
@@ -334,6 +337,9 @@ func (backend *Backend) Close(handle windowbackend.Handle) error {
 }
 
 func (backend *Backend) validate(handle windowbackend.Handle) error {
+	if err := validateHandle(handle); err != nil {
+		return err
+	}
 	if err := backend.Ready(); err != nil {
 		return err
 	}
@@ -341,8 +347,8 @@ func (backend *Backend) validate(handle windowbackend.Handle) error {
 }
 
 func (backend *Backend) validateReady(handle windowbackend.Handle) error {
-	if handle == 0 || uint64(handle) > math.MaxUint32 {
-		return fmt.Errorf("%w: CGWindowID %#x", windowbackend.ErrInvalidWindow, uintptr(handle))
+	if err := validateHandle(handle); err != nil {
+		return err
 	}
 	valid, err := backend.system.WindowExists(handle)
 	if err != nil {
@@ -354,6 +360,13 @@ func (backend *Backend) validateReady(handle windowbackend.Handle) error {
 		)
 	}
 	if !valid {
+		return fmt.Errorf("%w: CGWindowID %#x", windowbackend.ErrInvalidWindow, uintptr(handle))
+	}
+	return nil
+}
+
+func validateHandle(handle windowbackend.Handle) error {
+	if handle == 0 || uint64(handle) > math.MaxUint32 {
 		return fmt.Errorf("%w: CGWindowID %#x", windowbackend.ErrInvalidWindow, uintptr(handle))
 	}
 	return nil

--- a/internal/darwinwindow/backend_test.go
+++ b/internal/darwinwindow/backend_test.go
@@ -167,6 +167,9 @@ func TestBackendPermissionAndValidation(t *testing.T) {
 	system.readyErr = ErrPermission
 	backend := New(system)
 
+	if err := backend.Activate(0); !errors.Is(err, windowbackend.ErrInvalidWindow) {
+		t.Fatalf("Activate(0) = %v, want validation before permission preflight", err)
+	}
 	if _, err := backend.Active(); !errors.Is(err, ErrPermission) {
 		t.Fatalf("Active() = %v, want permission error", err)
 	}

--- a/internal/darwinwindow/backend_test.go
+++ b/internal/darwinwindow/backend_test.go
@@ -1,0 +1,233 @@
+package darwinwindow
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+type fakeSystem struct {
+	readyErr  error
+	active    windowbackend.Handle
+	activeErr error
+	exists    map[windowbackend.Handle]bool
+	existsErr error
+	byPID     map[int32]windowbackend.Handle
+	findErr   error
+	pids      map[windowbackend.Handle]int32
+	pidErr    error
+	titles    map[windowbackend.Handle]string
+	titleErr  error
+	rects     map[windowbackend.Handle]windowbackend.Rect
+	rectErr   error
+	minimized map[windowbackend.Handle]bool
+	stateErr  error
+	raiseErr  error
+	closeErr  error
+	closed    bool
+}
+
+func newFakeSystem() *fakeSystem {
+	return &fakeSystem{
+		active: 41,
+		exists: map[windowbackend.Handle]bool{41: true, 42: true},
+		byPID:  map[int32]windowbackend.Handle{1001: 41, 1002: 42},
+		pids:   map[windowbackend.Handle]int32{41: 1001, 42: 1002},
+		titles: map[windowbackend.Handle]string{41: "RobotGo", 42: "Second"},
+		rects: map[windowbackend.Handle]windowbackend.Rect{
+			41: {X: -20, Y: 10, Width: 800, Height: 600},
+			42: {X: 40, Y: 50, Width: 320, Height: 240},
+		},
+		minimized: make(map[windowbackend.Handle]bool),
+	}
+}
+
+func (system *fakeSystem) Ready() error { return system.readyErr }
+func (system *fakeSystem) ActiveWindow() (windowbackend.Handle, error) {
+	return system.active, system.activeErr
+}
+func (system *fakeSystem) WindowExists(handle windowbackend.Handle) (bool, error) {
+	return system.exists[handle], system.existsErr
+}
+func (system *fakeSystem) FindWindowByPID(pid int32) (windowbackend.Handle, error) {
+	return system.byPID[pid], system.findErr
+}
+func (system *fakeSystem) WindowPID(handle windowbackend.Handle) (int32, error) {
+	return system.pids[handle], system.pidErr
+}
+func (system *fakeSystem) WindowTitle(handle windowbackend.Handle) (string, error) {
+	return system.titles[handle], system.titleErr
+}
+func (system *fakeSystem) WindowRect(handle windowbackend.Handle) (windowbackend.Rect, error) {
+	return system.rects[handle], system.rectErr
+}
+func (system *fakeSystem) RaiseWindow(windowbackend.Handle) error { return system.raiseErr }
+func (system *fakeSystem) SetMinimized(handle windowbackend.Handle, enabled bool) error {
+	if system.stateErr == nil {
+		system.minimized[handle] = enabled
+	}
+	return system.stateErr
+}
+func (system *fakeSystem) IsMinimized(handle windowbackend.Handle) (bool, error) {
+	return system.minimized[handle], system.stateErr
+}
+func (system *fakeSystem) CloseWindow(windowbackend.Handle) error { return system.closeErr }
+func (system *fakeSystem) Close() error {
+	system.closed = true
+	return nil
+}
+
+func TestBackendIntrospectionAndSelection(t *testing.T) {
+	system := newFakeSystem()
+	backend := New(system)
+
+	active, err := backend.Active()
+	if err != nil || active != 41 {
+		t.Fatalf("Active() = %#x, %v", active, err)
+	}
+	resolved, err := backend.Resolve(1002, false)
+	if err != nil || resolved != 42 {
+		t.Fatalf("Resolve(pid) = %#x, %v", resolved, err)
+	}
+	resolved, err = backend.Resolve(41, true)
+	if err != nil || resolved != 41 {
+		t.Fatalf("Resolve(handle) = %#x, %v", resolved, err)
+	}
+	if err := backend.Select(1002, false); err != nil {
+		t.Fatalf("Select(pid): %v", err)
+	}
+	if selected := backend.Selected(); selected != 42 {
+		t.Fatalf("Selected() = %#x, want 0x2a", selected)
+	}
+	pid, err := backend.PID(41)
+	if err != nil || pid != 1001 {
+		t.Fatalf("PID() = %d, %v", pid, err)
+	}
+	title, err := backend.Title(41)
+	if err != nil || title != "RobotGo" {
+		t.Fatalf("Title() = %q, %v", title, err)
+	}
+	for _, client := range []bool{false, true} {
+		rect, err := backend.Bounds(41, client)
+		if err != nil || rect != system.rects[41] {
+			t.Fatalf("Bounds(client=%v) = %+v, %v", client, rect, err)
+		}
+	}
+}
+
+func TestBackendSupportedMutations(t *testing.T) {
+	system := newFakeSystem()
+	backend := New(system)
+
+	if err := backend.Activate(41); err != nil {
+		t.Fatalf("Activate(): %v", err)
+	}
+	if err := backend.SetState(41, windowbackend.StateMinimized, true); err != nil {
+		t.Fatalf("SetState(minimized): %v", err)
+	}
+	minimized, err := backend.State(41, windowbackend.StateMinimized)
+	if err != nil || !minimized {
+		t.Fatalf("State(minimized) = %v, %v", minimized, err)
+	}
+	if err := backend.SetState(41, windowbackend.StateMinimized, false); err != nil {
+		t.Fatalf("restore minimized: %v", err)
+	}
+	if minimized, err := backend.State(41, windowbackend.StateMinimized); err != nil || minimized {
+		t.Fatalf("restored State(minimized) = %v, %v", minimized, err)
+	}
+	if err := backend.Close(41); err != nil {
+		t.Fatalf("Close(): %v", err)
+	}
+	if err := backend.CloseSystem(); err != nil || !system.closed {
+		t.Fatalf("backend lifecycle Close() = %v, closed=%v", err, system.closed)
+	}
+}
+
+func TestBackendUnsupportedStateIsExplicit(t *testing.T) {
+	backend := New(newFakeSystem())
+
+	if err := backend.SetState(41, windowbackend.StateMaximized, true); !errors.Is(err, windowbackend.ErrUnsupported) {
+		t.Fatalf("SetState(maximized) = %v, want unsupported", err)
+	}
+	if _, err := backend.State(41, windowbackend.StateMaximized); !errors.Is(err, windowbackend.ErrUnsupported) {
+		t.Fatalf("State(maximized) = %v, want unsupported", err)
+	}
+	if _, err := backend.TopMost(41); !errors.Is(err, windowbackend.ErrUnsupported) {
+		t.Fatalf("TopMost() = %v, want unsupported", err)
+	}
+	if err := backend.SetTopMost(41, true); !errors.Is(err, windowbackend.ErrUnsupported) {
+		t.Fatalf("SetTopMost() = %v, want unsupported", err)
+	}
+}
+
+func TestBackendPermissionAndValidation(t *testing.T) {
+	system := newFakeSystem()
+	system.readyErr = ErrPermission
+	backend := New(system)
+
+	if _, err := backend.Active(); !errors.Is(err, ErrPermission) {
+		t.Fatalf("Active() = %v, want permission error", err)
+	}
+	system.readyErr = nil
+
+	tests := []struct {
+		name     string
+		target   int
+		isHandle bool
+		want     error
+	}{
+		{name: "zero pid", target: 0, want: windowbackend.ErrWindowNotFound},
+		{name: "negative pid", target: -1, want: windowbackend.ErrWindowNotFound},
+		{name: "missing pid", target: 9000, want: windowbackend.ErrInvalidWindow},
+		{name: "missing handle", target: 9000, isHandle: true, want: windowbackend.ErrInvalidWindow},
+	}
+	if strconvIntSize() == 64 {
+		tests = append(tests, struct {
+			name     string
+			target   int
+			isHandle bool
+			want     error
+		}{
+			name: "oversized handle", target: int(uint64(math.MaxUint32) + 1),
+			isHandle: true, want: windowbackend.ErrInvalidWindow,
+		})
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := backend.Resolve(test.target, test.isHandle); !errors.Is(err, test.want) {
+				t.Fatalf("Resolve(%d, %v) = %v, want %v", test.target, test.isHandle, err, test.want)
+			}
+		})
+	}
+}
+
+func TestBackendWrapsOperationFailures(t *testing.T) {
+	system := newFakeSystem()
+	system.titleErr = errors.New("AX title failed")
+	backend := New(system)
+	if _, err := backend.Title(41); !errors.Is(err, windowbackend.ErrOperation) {
+		t.Fatalf("Title() = %v, want operation error", err)
+	}
+
+	system.titleErr = ErrPermission
+	if _, err := backend.Title(41); !errors.Is(err, windowbackend.ErrPermission) {
+		t.Fatalf("Title() after permission revocation = %v, want permission error", err)
+	}
+
+	system.titleErr = ErrUnsupported
+	if _, err := backend.Title(41); !errors.Is(err, windowbackend.ErrUnsupported) {
+		t.Fatalf("Title() with unsupported native API = %v, want unsupported error", err)
+	}
+
+	system.titleErr = nil
+	system.rects[41] = windowbackend.Rect{Width: 0, Height: 10}
+	if _, err := backend.Bounds(41, false); !errors.Is(err, windowbackend.ErrOperation) {
+		t.Fatalf("Bounds() = %v, want operation error", err)
+	}
+}
+
+func strconvIntSize() int {
+	return 32 << (^uint(0) >> 63)
+}

--- a/internal/darwinwindow/native_api_darwin.go
+++ b/internal/darwinwindow/native_api_darwin.go
@@ -26,6 +26,7 @@ type nativeAPI struct {
 	axUIElementSetAttributeValue           func(uintptr, uintptr, uintptr) int32
 	axUIElementGetWindow                   func(uintptr, *uint32) int32
 	axValueGetType                         func(uintptr) uint32
+	axValueGetTypeID                       func() uintptr
 	axValueGetValue                        func(uintptr, uint32, unsafe.Pointer) bool
 	getFrontProcess                        func(*processSerialNumber) int32
 	getProcessForPID                       func(int32, *processSerialNumber) int32
@@ -109,6 +110,7 @@ func openNativeAPI() (*nativeAPI, error) {
 		{api.applicationServicesHandle, &api.axUIElementSetAttributeValue, "AXUIElementSetAttributeValue"},
 		{api.applicationServicesHandle, &api.axUIElementGetWindow, "_AXUIElementGetWindow"},
 		{api.applicationServicesHandle, &api.axValueGetType, "AXValueGetType"},
+		{api.applicationServicesHandle, &api.axValueGetTypeID, "AXValueGetTypeID"},
 		{api.applicationServicesHandle, &api.axValueGetValue, "AXValueGetValue"},
 		{api.applicationServicesHandle, &api.getFrontProcess, "GetFrontProcess"},
 		{api.applicationServicesHandle, &api.getProcessForPID, "GetProcessForPID"},

--- a/internal/darwinwindow/native_api_darwin.go
+++ b/internal/darwinwindow/native_api_darwin.go
@@ -1,0 +1,203 @@
+//go:build darwin
+
+package darwinwindow
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+type nativeAPI struct {
+	applicationServicesHandle uintptr
+	coreFoundationHandle      uintptr
+	coreGraphicsHandle        uintptr
+
+	axIsProcessTrusted                     func() bool
+	axUIElementCreateApplication           func(int32) uintptr
+	axUIElementCopyAttributeValue          func(uintptr, uintptr, *uintptr) int32
+	axUIElementCopyAttributeValues         func(uintptr, uintptr, int64, int64, *uintptr) int32
+	axUIElementGetAttributeValueCount      func(uintptr, uintptr, *int64) int32
+	axUIElementGetPID                      func(uintptr, *int32) int32
+	axUIElementGetTypeID                   func() uintptr
+	axUIElementPerformAction               func(uintptr, uintptr) int32
+	axUIElementSetAttributeValue           func(uintptr, uintptr, uintptr) int32
+	axUIElementGetWindow                   func(uintptr, *uint32) int32
+	axValueGetType                         func(uintptr) uint32
+	axValueGetValue                        func(uintptr, uint32, unsafe.Pointer) bool
+	getFrontProcess                        func(*processSerialNumber) int32
+	getProcessForPID                       func(int32, *processSerialNumber) int32
+	getProcessPID                          func(*processSerialNumber, *int32) int32
+	setFrontProcessWithOptions             func(*processSerialNumber, uint32) int32
+	cgWindowListCreateDescriptionFromArray func(uintptr) uintptr
+	cfArrayCreate                          func(uintptr, *uintptr, int64, uintptr) uintptr
+	cfArrayGetCount                        func(uintptr) int64
+	cfArrayGetValueAtIndex                 func(uintptr, int64) uintptr
+	cfBooleanGetValue                      func(uintptr) bool
+	cfBooleanGetTypeID                     func() uintptr
+	cfDictionaryGetValue                   func(uintptr, uintptr) uintptr
+	cfGetTypeID                            func(uintptr) uintptr
+	cfNumberGetValue                       func(uintptr, int64, unsafe.Pointer) bool
+	cfNumberGetTypeID                      func() uintptr
+	cfRelease                              func(uintptr)
+	cfRetain                               func(uintptr) uintptr
+	cfStringGetCString                     func(uintptr, *byte, int64, uint32) bool
+	cfStringGetLength                      func(uintptr) int64
+	cfStringGetMaximumSizeForEncoding      func(int64, uint32) int64
+	cfStringGetTypeID                      func() uintptr
+
+	axCloseButtonAttribute   uintptr
+	axFocusedWindowAttribute uintptr
+	axMainWindowAttribute    uintptr
+	axMinimizedAttribute     uintptr
+	axPositionAttribute      uintptr
+	axPressAction            uintptr
+	axRaiseAction            uintptr
+	axSizeAttribute          uintptr
+	axTitleAttribute         uintptr
+	axWindowsAttribute       uintptr
+	cfBooleanFalse           uintptr
+	cfBooleanTrue            uintptr
+	cgWindowOwnerPID         uintptr
+}
+
+func openNativeAPI() (*nativeAPI, error) {
+	api := &nativeAPI{}
+	var err error
+	api.applicationServicesHandle, err = purego.Dlopen(
+		applicationServicesFramework,
+		purego.RTLD_NOW|purego.RTLD_LOCAL,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: load ApplicationServices: %w", ErrUnsupported, err)
+	}
+	api.coreGraphicsHandle, err = purego.Dlopen(
+		coreGraphicsFramework,
+		purego.RTLD_NOW|purego.RTLD_LOCAL,
+	)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("%w: load CoreGraphics: %w", ErrUnsupported, err),
+			api.close(),
+		)
+	}
+	api.coreFoundationHandle, err = purego.Dlopen(
+		coreFoundationFramework,
+		purego.RTLD_NOW|purego.RTLD_LOCAL,
+	)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("%w: load CoreFoundation: %w", ErrUnsupported, err),
+			api.close(),
+		)
+	}
+	functions := []struct {
+		handle uintptr
+		target any
+		name   string
+	}{
+		{api.applicationServicesHandle, &api.axIsProcessTrusted, "AXIsProcessTrusted"},
+		{api.applicationServicesHandle, &api.axUIElementCreateApplication, "AXUIElementCreateApplication"},
+		{api.applicationServicesHandle, &api.axUIElementCopyAttributeValue, "AXUIElementCopyAttributeValue"},
+		{api.applicationServicesHandle, &api.axUIElementCopyAttributeValues, "AXUIElementCopyAttributeValues"},
+		{api.applicationServicesHandle, &api.axUIElementGetAttributeValueCount, "AXUIElementGetAttributeValueCount"},
+		{api.applicationServicesHandle, &api.axUIElementGetPID, "AXUIElementGetPid"},
+		{api.applicationServicesHandle, &api.axUIElementGetTypeID, "AXUIElementGetTypeID"},
+		{api.applicationServicesHandle, &api.axUIElementPerformAction, "AXUIElementPerformAction"},
+		{api.applicationServicesHandle, &api.axUIElementSetAttributeValue, "AXUIElementSetAttributeValue"},
+		{api.applicationServicesHandle, &api.axUIElementGetWindow, "_AXUIElementGetWindow"},
+		{api.applicationServicesHandle, &api.axValueGetType, "AXValueGetType"},
+		{api.applicationServicesHandle, &api.axValueGetValue, "AXValueGetValue"},
+		{api.applicationServicesHandle, &api.getFrontProcess, "GetFrontProcess"},
+		{api.applicationServicesHandle, &api.getProcessForPID, "GetProcessForPID"},
+		{api.applicationServicesHandle, &api.getProcessPID, "GetProcessPID"},
+		{api.applicationServicesHandle, &api.setFrontProcessWithOptions, "SetFrontProcessWithOptions"},
+		{api.coreGraphicsHandle, &api.cgWindowListCreateDescriptionFromArray, "CGWindowListCreateDescriptionFromArray"},
+		{api.coreFoundationHandle, &api.cfArrayCreate, "CFArrayCreate"},
+		{api.coreFoundationHandle, &api.cfArrayGetCount, "CFArrayGetCount"},
+		{api.coreFoundationHandle, &api.cfArrayGetValueAtIndex, "CFArrayGetValueAtIndex"},
+		{api.coreFoundationHandle, &api.cfBooleanGetValue, "CFBooleanGetValue"},
+		{api.coreFoundationHandle, &api.cfBooleanGetTypeID, "CFBooleanGetTypeID"},
+		{api.coreFoundationHandle, &api.cfDictionaryGetValue, "CFDictionaryGetValue"},
+		{api.coreFoundationHandle, &api.cfGetTypeID, "CFGetTypeID"},
+		{api.coreFoundationHandle, &api.cfNumberGetValue, "CFNumberGetValue"},
+		{api.coreFoundationHandle, &api.cfNumberGetTypeID, "CFNumberGetTypeID"},
+		{api.coreFoundationHandle, &api.cfRelease, "CFRelease"},
+		{api.coreFoundationHandle, &api.cfRetain, "CFRetain"},
+		{api.coreFoundationHandle, &api.cfStringGetCString, "CFStringGetCString"},
+		{api.coreFoundationHandle, &api.cfStringGetLength, "CFStringGetLength"},
+		{api.coreFoundationHandle, &api.cfStringGetMaximumSizeForEncoding, "CFStringGetMaximumSizeForEncoding"},
+		{api.coreFoundationHandle, &api.cfStringGetTypeID, "CFStringGetTypeID"},
+	}
+	for _, function := range functions {
+		if err := bindNativeFunction(function.handle, function.target, function.name); err != nil {
+			return nil, errors.Join(err, api.close())
+		}
+	}
+	values := []struct {
+		handle uintptr
+		target *uintptr
+		name   string
+	}{
+		{api.applicationServicesHandle, &api.axCloseButtonAttribute, "kAXCloseButtonAttribute"},
+		{api.applicationServicesHandle, &api.axFocusedWindowAttribute, "kAXFocusedWindowAttribute"},
+		{api.applicationServicesHandle, &api.axMainWindowAttribute, "kAXMainWindowAttribute"},
+		{api.applicationServicesHandle, &api.axMinimizedAttribute, "kAXMinimizedAttribute"},
+		{api.applicationServicesHandle, &api.axPositionAttribute, "kAXPositionAttribute"},
+		{api.applicationServicesHandle, &api.axPressAction, "kAXPressAction"},
+		{api.applicationServicesHandle, &api.axRaiseAction, "kAXRaiseAction"},
+		{api.applicationServicesHandle, &api.axSizeAttribute, "kAXSizeAttribute"},
+		{api.applicationServicesHandle, &api.axTitleAttribute, "kAXTitleAttribute"},
+		{api.applicationServicesHandle, &api.axWindowsAttribute, "kAXWindowsAttribute"},
+		{api.coreFoundationHandle, &api.cfBooleanFalse, "kCFBooleanFalse"},
+		{api.coreFoundationHandle, &api.cfBooleanTrue, "kCFBooleanTrue"},
+		{api.coreGraphicsHandle, &api.cgWindowOwnerPID, "kCGWindowOwnerPID"},
+	}
+	for _, value := range values {
+		if err := bindNativeValue(value.handle, value.target, value.name); err != nil {
+			return nil, errors.Join(err, api.close())
+		}
+	}
+	return api, nil
+}
+
+func bindNativeFunction(handle uintptr, target any, name string) error {
+	symbol, err := purego.Dlsym(handle, name)
+	if err != nil {
+		return fmt.Errorf("%w: resolve macOS function %s: %w", ErrUnsupported, name, err)
+	}
+	purego.RegisterFunc(target, symbol)
+	return nil
+}
+
+func bindNativeValue(handle uintptr, target *uintptr, name string) error {
+	symbol, err := purego.Dlsym(handle, name)
+	if err != nil {
+		return fmt.Errorf("%w: resolve macOS value %s: %w", ErrUnsupported, name, err)
+	}
+	value := *(*uintptr)(unsafe.Pointer(symbol))
+	if value == 0 {
+		return fmt.Errorf("%w: macOS value %s is nil", ErrUnsupported, name)
+	}
+	*target = value
+	return nil
+}
+
+func (api *nativeAPI) close() error {
+	var closeErr error
+	if api.coreFoundationHandle != 0 {
+		closeErr = errors.Join(closeErr, purego.Dlclose(api.coreFoundationHandle))
+		api.coreFoundationHandle = 0
+	}
+	if api.coreGraphicsHandle != 0 {
+		closeErr = errors.Join(closeErr, purego.Dlclose(api.coreGraphicsHandle))
+		api.coreGraphicsHandle = 0
+	}
+	if api.applicationServicesHandle != 0 {
+		closeErr = errors.Join(closeErr, purego.Dlclose(api.applicationServicesHandle))
+		api.applicationServicesHandle = 0
+	}
+	return closeErr
+}

--- a/internal/darwinwindow/native_api_darwin.go
+++ b/internal/darwinwindow/native_api_darwin.go
@@ -5,6 +5,7 @@ package darwinwindow
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/ebitengine/purego"
@@ -14,6 +15,7 @@ type nativeAPI struct {
 	applicationServicesHandle uintptr
 	coreFoundationHandle      uintptr
 	coreGraphicsHandle        uintptr
+	ownedCFValues             []uintptr
 
 	axIsProcessTrusted                     func() bool
 	axUIElementCreateApplication           func(int32) uintptr
@@ -45,6 +47,7 @@ type nativeAPI struct {
 	cfRelease                              func(uintptr)
 	cfRetain                               func(uintptr) uintptr
 	cfStringGetCString                     func(uintptr, *byte, int64, uint32) bool
+	cfStringCreateWithCString              func(uintptr, *byte, uint32) uintptr
 	cfStringGetLength                      func(uintptr) int64
 	cfStringGetMaximumSizeForEncoding      func(int64, uint32) int64
 	cfStringGetTypeID                      func() uintptr
@@ -128,6 +131,7 @@ func openNativeAPI() (*nativeAPI, error) {
 		{api.coreFoundationHandle, &api.cfNumberGetTypeID, "CFNumberGetTypeID"},
 		{api.coreFoundationHandle, &api.cfRelease, "CFRelease"},
 		{api.coreFoundationHandle, &api.cfRetain, "CFRetain"},
+		{api.coreFoundationHandle, &api.cfStringCreateWithCString, "CFStringCreateWithCString"},
 		{api.coreFoundationHandle, &api.cfStringGetCString, "CFStringGetCString"},
 		{api.coreFoundationHandle, &api.cfStringGetLength, "CFStringGetLength"},
 		{api.coreFoundationHandle, &api.cfStringGetMaximumSizeForEncoding, "CFStringGetMaximumSizeForEncoding"},
@@ -143,16 +147,6 @@ func openNativeAPI() (*nativeAPI, error) {
 		target *uintptr
 		name   string
 	}{
-		{api.applicationServicesHandle, &api.axCloseButtonAttribute, "kAXCloseButtonAttribute"},
-		{api.applicationServicesHandle, &api.axFocusedWindowAttribute, "kAXFocusedWindowAttribute"},
-		{api.applicationServicesHandle, &api.axMainWindowAttribute, "kAXMainWindowAttribute"},
-		{api.applicationServicesHandle, &api.axMinimizedAttribute, "kAXMinimizedAttribute"},
-		{api.applicationServicesHandle, &api.axPositionAttribute, "kAXPositionAttribute"},
-		{api.applicationServicesHandle, &api.axPressAction, "kAXPressAction"},
-		{api.applicationServicesHandle, &api.axRaiseAction, "kAXRaiseAction"},
-		{api.applicationServicesHandle, &api.axSizeAttribute, "kAXSizeAttribute"},
-		{api.applicationServicesHandle, &api.axTitleAttribute, "kAXTitleAttribute"},
-		{api.applicationServicesHandle, &api.axWindowsAttribute, "kAXWindowsAttribute"},
 		{api.coreFoundationHandle, &api.cfBooleanFalse, "kCFBooleanFalse"},
 		{api.coreFoundationHandle, &api.cfBooleanTrue, "kCFBooleanTrue"},
 		{api.coreGraphicsHandle, &api.cgWindowOwnerPID, "kCGWindowOwnerPID"},
@@ -162,7 +156,48 @@ func openNativeAPI() (*nativeAPI, error) {
 			return nil, errors.Join(err, api.close())
 		}
 	}
+	strings := []struct {
+		target *uintptr
+		value  string
+	}{
+		{&api.axCloseButtonAttribute, axCloseButtonAttributeName},
+		{&api.axFocusedWindowAttribute, axFocusedWindowAttributeName},
+		{&api.axMainWindowAttribute, axMainWindowAttributeName},
+		{&api.axMinimizedAttribute, axMinimizedAttributeName},
+		{&api.axPositionAttribute, axPositionAttributeName},
+		{&api.axPressAction, axPressActionName},
+		{&api.axRaiseAction, axRaiseActionName},
+		{&api.axSizeAttribute, axSizeAttributeName},
+		{&api.axTitleAttribute, axTitleAttributeName},
+		{&api.axWindowsAttribute, axWindowsAttributeName},
+	}
+	for _, value := range strings {
+		ref, stringErr := api.createString(value.value)
+		if stringErr != nil {
+			return nil, errors.Join(stringErr, api.close())
+		}
+		*value.target = ref
+	}
 	return api, nil
+}
+
+func (api *nativeAPI) createString(value string) (uintptr, error) {
+	bytes := append([]byte(value), 0)
+	ref := api.cfStringCreateWithCString(
+		0,
+		&bytes[0],
+		cfStringEncodingUTF8,
+	)
+	runtime.KeepAlive(bytes)
+	if ref == 0 {
+		return 0, fmt.Errorf(
+			"%w: create macOS string constant %q",
+			ErrUnsupported,
+			value,
+		)
+	}
+	api.ownedCFValues = append(api.ownedCFValues, ref)
+	return ref, nil
 }
 
 func bindNativeFunction(handle uintptr, target any, name string) error {
@@ -189,6 +224,12 @@ func bindNativeValue(handle uintptr, target *uintptr, name string) error {
 
 func (api *nativeAPI) close() error {
 	var closeErr error
+	if api.cfRelease != nil {
+		for index := len(api.ownedCFValues) - 1; index >= 0; index-- {
+			api.cfRelease(api.ownedCFValues[index])
+		}
+	}
+	api.ownedCFValues = nil
 	if api.coreFoundationHandle != 0 {
 		closeErr = errors.Join(closeErr, purego.Dlclose(api.coreFoundationHandle))
 		api.coreFoundationHandle = 0

--- a/internal/darwinwindow/system_darwin.go
+++ b/internal/darwinwindow/system_darwin.go
@@ -16,19 +16,21 @@ const (
 	coreFoundationFramework      = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
 	coreGraphicsFramework        = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
 
-	axErrorSuccess                 int32  = 0
-	axErrorInvalidUIElement        int32  = -25202
-	axErrorActionUnsupported       int32  = -25206
-	axErrorNotImplemented          int32  = -25208
-	axErrorAPIDisabled             int32  = -25211
-	axValueCGPointType             uint32 = 1
-	axValueCGSizeType              uint32 = 2
-	cfNumberSInt32Type             int64  = 3
-	cfStringEncodingUTF8           uint32 = 0x08000100
-	setFrontProcessFrontWindowOnly uint32 = 1 << 0
-	maximumAXWindows                      = 4096
-	maximumAXStringBytes                  = 1 << 20
-	maximumExactCoordinate                = 1 << 53
+	axErrorSuccess                           int32  = 0
+	axErrorInvalidUIElement                  int32  = -25202
+	axErrorAttributeUnsupported              int32  = -25205
+	axErrorActionUnsupported                 int32  = -25206
+	axErrorNotImplemented                    int32  = -25208
+	axErrorAPIDisabled                       int32  = -25211
+	axErrorParameterizedAttributeUnsupported int32  = -25213
+	axValueCGPointType                       uint32 = 1
+	axValueCGSizeType                        uint32 = 2
+	cfNumberSInt32Type                       int64  = 3
+	cfStringEncodingUTF8                     uint32 = 0x08000100
+	setFrontProcessFrontWindowOnly           uint32 = 1 << 0
+	maximumAXWindows                                = 4096
+	maximumAXStringBytes                            = 1 << 20
+	maximumExactCoordinate                          = 1 << 53
 )
 
 var errWindowUnavailable = errors.New("macOS window is unavailable")
@@ -161,6 +163,14 @@ func (system *nativeSystem) WindowRect(handle windowbackend.Handle) (windowbacke
 		return windowbackend.Rect{}, err
 	}
 	defer api.cfRelease(positionValue)
+	if err := requireCFType(
+		api,
+		positionValue,
+		api.axValueGetTypeID(),
+		"AXPosition",
+	); err != nil {
+		return windowbackend.Rect{}, err
+	}
 	if valueType := api.axValueGetType(positionValue); valueType != axValueCGPointType {
 		return windowbackend.Rect{}, fmt.Errorf(
 			"AX position has type %d, want CGPoint type %d",
@@ -173,6 +183,14 @@ func (system *nativeSystem) WindowRect(handle windowbackend.Handle) (windowbacke
 		return windowbackend.Rect{}, err
 	}
 	defer api.cfRelease(sizeValue)
+	if err := requireCFType(
+		api,
+		sizeValue,
+		api.axValueGetTypeID(),
+		"AXSize",
+	); err != nil {
+		return windowbackend.Rect{}, err
+	}
 	if valueType := api.axValueGetType(sizeValue); valueType != axValueCGSizeType {
 		return windowbackend.Rect{}, fmt.Errorf(
 			"AX size has type %d, want CGSize type %d",

--- a/internal/darwinwindow/system_darwin.go
+++ b/internal/darwinwindow/system_darwin.go
@@ -16,6 +16,17 @@ const (
 	coreFoundationFramework      = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
 	coreGraphicsFramework        = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
 
+	axCloseButtonAttributeName   = "AXCloseButton"
+	axFocusedWindowAttributeName = "AXFocusedWindow"
+	axMainWindowAttributeName    = "AXMainWindow"
+	axMinimizedAttributeName     = "AXMinimized"
+	axPositionAttributeName      = "AXPosition"
+	axPressActionName            = "AXPress"
+	axRaiseActionName            = "AXRaise"
+	axSizeAttributeName          = "AXSize"
+	axTitleAttributeName         = "AXTitle"
+	axWindowsAttributeName       = "AXWindows"
+
 	axErrorSuccess                           int32  = 0
 	axErrorInvalidUIElement                  int32  = -25202
 	axErrorAttributeUnsupported              int32  = -25205

--- a/internal/darwinwindow/system_darwin.go
+++ b/internal/darwinwindow/system_darwin.go
@@ -1,0 +1,344 @@
+//go:build darwin
+
+package darwinwindow
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+const (
+	applicationServicesFramework = "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices"
+	coreFoundationFramework      = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+	coreGraphicsFramework        = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+
+	axErrorSuccess                 int32  = 0
+	axErrorInvalidUIElement        int32  = -25202
+	axErrorActionUnsupported       int32  = -25206
+	axErrorNotImplemented          int32  = -25208
+	axErrorAPIDisabled             int32  = -25211
+	axValueCGPointType             uint32 = 1
+	axValueCGSizeType              uint32 = 2
+	cfNumberSInt32Type             int64  = 3
+	cfStringEncodingUTF8           uint32 = 0x08000100
+	setFrontProcessFrontWindowOnly uint32 = 1 << 0
+	maximumAXWindows                      = 4096
+	maximumAXStringBytes                  = 1 << 20
+	maximumExactCoordinate                = 1 << 53
+)
+
+var errWindowUnavailable = errors.New("macOS window is unavailable")
+
+type processSerialNumber struct {
+	HighLongOfPSN uint32
+	LowLongOfPSN  uint32
+}
+
+type point struct {
+	X float64
+	Y float64
+}
+
+type size struct {
+	Width  float64
+	Height float64
+}
+
+type nativeSystem struct {
+	mu  sync.Mutex
+	api *nativeAPI
+}
+
+func newNativeSystem() System { return &nativeSystem{} }
+
+func (system *nativeSystem) Ready() error {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	_, err := system.readyLocked()
+	return err
+}
+
+func (system *nativeSystem) ActiveWindow() (windowbackend.Handle, error) {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return 0, err
+	}
+	var psn processSerialNumber
+	if status := api.getFrontProcess(&psn); status != 0 {
+		return 0, fmt.Errorf("GetFrontProcess failed with OSStatus %d", status)
+	}
+	var pid int32
+	if status := api.getProcessPID(&psn, &pid); status != 0 || pid <= 0 {
+		return 0, fmt.Errorf("GetProcessPID failed with OSStatus %d and pid %d", status, pid)
+	}
+	return applicationWindowLocked(api, pid)
+}
+
+func (system *nativeSystem) WindowExists(handle windowbackend.Handle) (bool, error) {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return false, err
+	}
+	element, err := windowElementLocked(api, handle)
+	if err != nil {
+		if errors.Is(err, ErrPermission) || errors.Is(err, ErrUnsupported) {
+			return false, err
+		}
+		if errors.Is(err, errWindowUnavailable) {
+			return false, nil
+		}
+		return false, err
+	}
+	api.cfRelease(element)
+	return true, nil
+}
+
+func (system *nativeSystem) FindWindowByPID(pid int32) (windowbackend.Handle, error) {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return 0, err
+	}
+	if pid <= 0 {
+		return 0, fmt.Errorf("%w: invalid pid %d", errWindowUnavailable, pid)
+	}
+	return applicationWindowLocked(api, pid)
+}
+
+func (system *nativeSystem) WindowPID(handle windowbackend.Handle) (int32, error) {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return 0, err
+	}
+	return windowPIDLocked(api, handle)
+}
+
+func (system *nativeSystem) WindowTitle(handle windowbackend.Handle) (string, error) {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return "", err
+	}
+	element, err := windowElementLocked(api, handle)
+	if err != nil {
+		return "", err
+	}
+	defer api.cfRelease(element)
+	value, err := copyAttributeLocked(api, element, api.axTitleAttribute)
+	if err != nil {
+		return "", err
+	}
+	defer api.cfRelease(value)
+	return cfStringLocked(api, value)
+}
+
+func (system *nativeSystem) WindowRect(handle windowbackend.Handle) (windowbackend.Rect, error) {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return windowbackend.Rect{}, err
+	}
+	element, err := windowElementLocked(api, handle)
+	if err != nil {
+		return windowbackend.Rect{}, err
+	}
+	defer api.cfRelease(element)
+	positionValue, err := copyAttributeLocked(api, element, api.axPositionAttribute)
+	if err != nil {
+		return windowbackend.Rect{}, err
+	}
+	defer api.cfRelease(positionValue)
+	if valueType := api.axValueGetType(positionValue); valueType != axValueCGPointType {
+		return windowbackend.Rect{}, fmt.Errorf(
+			"AX position has type %d, want CGPoint type %d",
+			valueType,
+			axValueCGPointType,
+		)
+	}
+	sizeValue, err := copyAttributeLocked(api, element, api.axSizeAttribute)
+	if err != nil {
+		return windowbackend.Rect{}, err
+	}
+	defer api.cfRelease(sizeValue)
+	if valueType := api.axValueGetType(sizeValue); valueType != axValueCGSizeType {
+		return windowbackend.Rect{}, fmt.Errorf(
+			"AX size has type %d, want CGSize type %d",
+			valueType,
+			axValueCGSizeType,
+		)
+	}
+	var position point
+	if !api.axValueGetValue(positionValue, axValueCGPointType, unsafe.Pointer(&position)) {
+		return windowbackend.Rect{}, errors.New("AXValueGetValue could not decode window position")
+	}
+	var dimensions size
+	if !api.axValueGetValue(sizeValue, axValueCGSizeType, unsafe.Pointer(&dimensions)) {
+		return windowbackend.Rect{}, errors.New("AXValueGetValue could not decode window size")
+	}
+	return enclosingRect(position, dimensions)
+}
+
+func (system *nativeSystem) RaiseWindow(handle windowbackend.Handle) error {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return err
+	}
+	element, err := windowElementLocked(api, handle)
+	if err != nil {
+		return err
+	}
+	defer api.cfRelease(element)
+	raiseErr := axCallError(
+		"raise AX window",
+		api.axUIElementPerformAction(element, api.axRaiseAction),
+	)
+	var pid int32
+	pidErr := axCallError(
+		"get AX window pid",
+		api.axUIElementGetPID(element, &pid),
+	)
+	if pidErr == nil && pid <= 0 {
+		pidErr = fmt.Errorf("get AX window pid returned invalid pid %d", pid)
+	}
+	var activateErr error
+	if pidErr == nil {
+		var psn processSerialNumber
+		if status := api.getProcessForPID(pid, &psn); status != 0 {
+			activateErr = fmt.Errorf("GetProcessForPID(%d) failed with OSStatus %d", pid, status)
+		} else if status := api.setFrontProcessWithOptions(
+			&psn,
+			setFrontProcessFrontWindowOnly,
+		); status != 0 {
+			activateErr = fmt.Errorf(
+				"SetFrontProcessWithOptions(%d) failed with OSStatus %d",
+				pid,
+				status,
+			)
+		}
+	}
+	return errors.Join(raiseErr, pidErr, activateErr)
+}
+
+func (system *nativeSystem) SetMinimized(handle windowbackend.Handle, enabled bool) error {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return err
+	}
+	element, err := windowElementLocked(api, handle)
+	if err != nil {
+		return err
+	}
+	defer api.cfRelease(element)
+	value := api.cfBooleanFalse
+	if enabled {
+		value = api.cfBooleanTrue
+	}
+	if result := api.axUIElementSetAttributeValue(element, api.axMinimizedAttribute, value); result != axErrorSuccess {
+		return axCallError("set AXMinimized", result)
+	}
+	return nil
+}
+
+func (system *nativeSystem) IsMinimized(handle windowbackend.Handle) (bool, error) {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return false, err
+	}
+	element, err := windowElementLocked(api, handle)
+	if err != nil {
+		return false, err
+	}
+	defer api.cfRelease(element)
+	value, err := copyAttributeLocked(api, element, api.axMinimizedAttribute)
+	if err != nil {
+		return false, err
+	}
+	defer api.cfRelease(value)
+	if err := requireCFType(
+		api,
+		value,
+		api.cfBooleanGetTypeID(),
+		"AXMinimized",
+	); err != nil {
+		return false, err
+	}
+	return api.cfBooleanGetValue(value), nil
+}
+
+func (system *nativeSystem) CloseWindow(handle windowbackend.Handle) error {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	api, err := system.readyLocked()
+	if err != nil {
+		return err
+	}
+	element, err := windowElementLocked(api, handle)
+	if err != nil {
+		return err
+	}
+	defer api.cfRelease(element)
+	button, err := copyAttributeLocked(api, element, api.axCloseButtonAttribute)
+	if err != nil {
+		return err
+	}
+	defer api.cfRelease(button)
+	if err := requireCFType(
+		api,
+		button,
+		api.axUIElementGetTypeID(),
+		"AXCloseButton",
+	); err != nil {
+		return err
+	}
+	if result := api.axUIElementPerformAction(button, api.axPressAction); result != axErrorSuccess {
+		return axCallError("press AX close button", result)
+	}
+	return nil
+}
+
+func (system *nativeSystem) Close() error {
+	system.mu.Lock()
+	defer system.mu.Unlock()
+	if system.api == nil {
+		return nil
+	}
+	err := system.api.close()
+	system.api = nil
+	return err
+}
+
+func (system *nativeSystem) readyLocked() (*nativeAPI, error) {
+	if system.api == nil {
+		api, err := openNativeAPI()
+		if err != nil {
+			return nil, err
+		}
+		system.api = api
+	}
+	if !system.api.axIsProcessTrusted() {
+		return nil, fmt.Errorf(
+			"%w: grant this application access in System Settings > Privacy & Security > Accessibility",
+			ErrPermission,
+		)
+	}
+	return system.api, nil
+}

--- a/internal/darwinwindow/system_darwin_test.go
+++ b/internal/darwinwindow/system_darwin_test.go
@@ -1,0 +1,102 @@
+//go:build darwin
+
+package darwinwindow
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+func TestEnclosingRect(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		position   point
+		dimensions size
+		want       windowbackend.Rect
+		wantErr    bool
+	}{
+		{
+			name:       "fractional outward rounding",
+			position:   point{X: 10.25, Y: -20.75},
+			dimensions: size{Width: 100.5, Height: 50.25},
+			want:       windowbackend.Rect{X: 10, Y: -21, Width: 101, Height: 51},
+		},
+		{
+			name:       "integral",
+			position:   point{X: -100, Y: 200},
+			dimensions: size{Width: 640, Height: 480},
+			want:       windowbackend.Rect{X: -100, Y: 200, Width: 640, Height: 480},
+		},
+		{
+			name:       "zero width",
+			dimensions: size{Height: 10},
+			wantErr:    true,
+		},
+		{
+			name:       "non-finite position",
+			position:   point{X: math.NaN()},
+			dimensions: size{Width: 10, Height: 10},
+			wantErr:    true,
+		},
+		{
+			name:       "unrepresentable edge",
+			position:   point{X: maximumExactCoordinate},
+			dimensions: size{Width: 1, Height: 1},
+			wantErr:    true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := enclosingRect(test.position, test.dimensions)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("enclosingRect() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if got != test.want {
+				t.Fatalf("enclosingRect() = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAXCallErrorClassification(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		result int32
+		want   error
+	}{
+		{name: "success", result: axErrorSuccess},
+		{name: "permission", result: axErrorAPIDisabled, want: ErrPermission},
+		{name: "unsupported action", result: axErrorActionUnsupported, want: ErrUnsupported},
+		{name: "unsupported implementation", result: axErrorNotImplemented, want: ErrUnsupported},
+		{name: "stale element", result: axErrorInvalidUIElement, want: errWindowUnavailable},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := axCallError("test", test.result)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("axCallError(%d) = %v, want %v", test.result, err, test.want)
+			}
+		})
+	}
+}
+
+func TestCopyAttributeRejectsNilSuccessValue(t *testing.T) {
+	t.Parallel()
+	api := &nativeAPI{
+		axUIElementCopyAttributeValue: func(uintptr, uintptr, *uintptr) int32 {
+			return axErrorSuccess
+		},
+	}
+	if _, err := copyAttributeLocked(api, 1, 2); err == nil {
+		t.Fatal("copyAttributeLocked accepted a nil value from a successful AX call")
+	}
+}

--- a/internal/darwinwindow/system_darwin_test.go
+++ b/internal/darwinwindow/system_darwin_test.go
@@ -45,7 +45,7 @@ func TestEnclosingRect(t *testing.T) {
 		{
 			name:       "unrepresentable edge",
 			position:   point{X: maximumExactCoordinate},
-			dimensions: size{Width: 1, Height: 1},
+			dimensions: size{Width: 2, Height: 1},
 			wantErr:    true,
 		},
 	}
@@ -73,6 +73,7 @@ func TestAXCallErrorClassification(t *testing.T) {
 	}{
 		{name: "success", result: axErrorSuccess},
 		{name: "permission", result: axErrorAPIDisabled, want: ErrPermission},
+		{name: "unsupported attribute", result: axErrorAttributeUnsupported, want: ErrUnsupported},
 		{name: "unsupported action", result: axErrorActionUnsupported, want: ErrUnsupported},
 		{name: "unsupported implementation", result: axErrorNotImplemented, want: ErrUnsupported},
 		{name: "stale element", result: axErrorInvalidUIElement, want: errWindowUnavailable},

--- a/internal/darwinwindow/system_notdarwin.go
+++ b/internal/darwinwindow/system_notdarwin.go
@@ -1,0 +1,51 @@
+//go:build !darwin
+
+package darwinwindow
+
+import (
+	"fmt"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+type unsupportedSystem struct{}
+
+func newNativeSystem() System { return unsupportedSystem{} }
+
+func (unsupportedSystem) Ready() error {
+	return fmt.Errorf("%w: macOS frameworks are unavailable", ErrUnsupported)
+}
+
+func (unsupportedSystem) ActiveWindow() (windowbackend.Handle, error) {
+	return 0, ErrUnsupported
+}
+
+func (unsupportedSystem) WindowExists(windowbackend.Handle) (bool, error) {
+	return false, ErrUnsupported
+}
+
+func (unsupportedSystem) FindWindowByPID(int32) (windowbackend.Handle, error) {
+	return 0, ErrUnsupported
+}
+
+func (unsupportedSystem) WindowPID(windowbackend.Handle) (int32, error) {
+	return 0, ErrUnsupported
+}
+
+func (unsupportedSystem) WindowTitle(windowbackend.Handle) (string, error) {
+	return "", ErrUnsupported
+}
+
+func (unsupportedSystem) WindowRect(windowbackend.Handle) (windowbackend.Rect, error) {
+	return windowbackend.Rect{}, ErrUnsupported
+}
+
+func (unsupportedSystem) RaiseWindow(windowbackend.Handle) error { return ErrUnsupported }
+func (unsupportedSystem) SetMinimized(windowbackend.Handle, bool) error {
+	return ErrUnsupported
+}
+func (unsupportedSystem) IsMinimized(windowbackend.Handle) (bool, error) {
+	return false, ErrUnsupported
+}
+func (unsupportedSystem) CloseWindow(windowbackend.Handle) error { return ErrUnsupported }
+func (unsupportedSystem) Close() error                           { return nil }

--- a/internal/darwinwindow/values_darwin.go
+++ b/internal/darwinwindow/values_darwin.go
@@ -1,0 +1,285 @@
+//go:build darwin
+
+package darwinwindow
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"runtime"
+	"unsafe"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+func applicationWindowLocked(api *nativeAPI, pid int32) (windowbackend.Handle, error) {
+	application := api.axUIElementCreateApplication(pid)
+	if application == 0 {
+		return 0, fmt.Errorf("%w: AXUIElementCreateApplication(%d)", errWindowUnavailable, pid)
+	}
+	defer api.cfRelease(application)
+	attributes := []uintptr{api.axFocusedWindowAttribute, api.axMainWindowAttribute}
+	var lastErr error
+	for _, attribute := range attributes {
+		element, err := copyAttributeLocked(api, application, attribute)
+		if err != nil {
+			lastErr = errors.Join(lastErr, err)
+			continue
+		}
+		if err := requireCFType(
+			api,
+			element,
+			api.axUIElementGetTypeID(),
+			"focused/main AX window",
+		); err != nil {
+			api.cfRelease(element)
+			lastErr = errors.Join(lastErr, err)
+			continue
+		}
+		var windowID uint32
+		result := api.axUIElementGetWindow(element, &windowID)
+		api.cfRelease(element)
+		if result == axErrorSuccess {
+			if windowID != 0 {
+				return windowbackend.Handle(windowID), nil
+			}
+			lastErr = errors.Join(
+				lastErr,
+				errors.New("map AX window returned a zero CGWindowID"),
+			)
+			continue
+		}
+		lastErr = errors.Join(lastErr, axCallError("map AX window to CGWindowID", result))
+	}
+	return 0, fmt.Errorf("%w: pid %d has no focused or main window: %w", errWindowUnavailable, pid, lastErr)
+}
+
+func windowElementLocked(api *nativeAPI, handle windowbackend.Handle) (uintptr, error) {
+	pid, err := windowPIDLocked(api, handle)
+	if err != nil {
+		return 0, err
+	}
+	application := api.axUIElementCreateApplication(pid)
+	if application == 0 {
+		return 0, fmt.Errorf("%w: create AX application for pid %d", errWindowUnavailable, pid)
+	}
+	defer api.cfRelease(application)
+	var count int64
+	if result := api.axUIElementGetAttributeValueCount(
+		application,
+		api.axWindowsAttribute,
+		&count,
+	); result != axErrorSuccess {
+		return 0, classifyWindowLookupError(
+			"count AX windows",
+			axCallError("count AX windows", result),
+		)
+	}
+	if count <= 0 || count > maximumAXWindows {
+		return 0, fmt.Errorf(
+			"%w: AX window count %d is outside 1..%d",
+			errWindowUnavailable,
+			count,
+			maximumAXWindows,
+		)
+	}
+	var windows uintptr
+	result := api.axUIElementCopyAttributeValues(
+		application,
+		api.axWindowsAttribute,
+		0,
+		count,
+		&windows,
+	)
+	if result != axErrorSuccess {
+		return 0, classifyWindowLookupError(
+			fmt.Sprintf("copy AX windows for pid %d", pid),
+			axCallError("copy AX windows", result),
+		)
+	}
+	if windows == 0 {
+		return 0, fmt.Errorf(
+			"%w: copy AX windows for pid %d returned a nil array",
+			errWindowUnavailable,
+			pid,
+		)
+	}
+	defer api.cfRelease(windows)
+	count = api.cfArrayGetCount(windows)
+	var mappingErr error
+	for index := int64(0); index < count; index++ {
+		element := api.cfArrayGetValueAtIndex(windows, index)
+		if element == 0 {
+			continue
+		}
+		if requireCFType(
+			api,
+			element,
+			api.axUIElementGetTypeID(),
+			"AXWindows element",
+		) != nil {
+			continue
+		}
+		var candidate uint32
+		result := api.axUIElementGetWindow(element, &candidate)
+		if result == axErrorSuccess && windowbackend.Handle(candidate) == handle {
+			return api.cfRetain(element), nil
+		}
+		if result != axErrorSuccess {
+			err := axCallError("map AX window to CGWindowID", result)
+			if errors.Is(err, ErrPermission) || errors.Is(err, ErrUnsupported) {
+				return 0, err
+			}
+			mappingErr = errors.Join(mappingErr, err)
+		}
+	}
+	err = fmt.Errorf(
+		"%w: CGWindowID %#x has no matching AX window",
+		errWindowUnavailable,
+		uintptr(handle),
+	)
+	return 0, errors.Join(err, mappingErr)
+}
+
+func windowPIDLocked(api *nativeAPI, handle windowbackend.Handle) (int32, error) {
+	if handle == 0 || uint64(handle) > math.MaxUint32 {
+		return 0, fmt.Errorf("%w: invalid CGWindowID %#x", errWindowUnavailable, uintptr(handle))
+	}
+	windowID := uintptr(uint32(handle))
+	windowList := api.cfArrayCreate(0, &windowID, 1, 0)
+	runtime.KeepAlive(&windowID)
+	if windowList == 0 {
+		return 0, fmt.Errorf(
+			"%w: create CoreGraphics request for CGWindowID %#x",
+			errWindowUnavailable,
+			uintptr(handle),
+		)
+	}
+	defer api.cfRelease(windowList)
+	info := api.cgWindowListCreateDescriptionFromArray(windowList)
+	if info == 0 {
+		return 0, fmt.Errorf("%w: no CoreGraphics description for CGWindowID %#x", errWindowUnavailable, uintptr(handle))
+	}
+	defer api.cfRelease(info)
+	if api.cfArrayGetCount(info) < 1 {
+		return 0, fmt.Errorf("%w: empty CoreGraphics description for CGWindowID %#x", errWindowUnavailable, uintptr(handle))
+	}
+	description := api.cfArrayGetValueAtIndex(info, 0)
+	if description == 0 {
+		return 0, fmt.Errorf("%w: nil CoreGraphics description for CGWindowID %#x", errWindowUnavailable, uintptr(handle))
+	}
+	number := api.cfDictionaryGetValue(description, api.cgWindowOwnerPID)
+	if number == 0 {
+		return 0, fmt.Errorf("%w: CGWindowID %#x has no owner pid", errWindowUnavailable, uintptr(handle))
+	}
+	if err := requireCFType(api, number, api.cfNumberGetTypeID(), "kCGWindowOwnerPID"); err != nil {
+		return 0, fmt.Errorf("%w: %w", errWindowUnavailable, err)
+	}
+	var pid int32
+	if !api.cfNumberGetValue(number, cfNumberSInt32Type, unsafe.Pointer(&pid)) || pid <= 0 {
+		return 0, fmt.Errorf("%w: CGWindowID %#x has invalid owner pid %d", errWindowUnavailable, uintptr(handle), pid)
+	}
+	return pid, nil
+}
+
+func copyAttributeLocked(api *nativeAPI, element, attribute uintptr) (uintptr, error) {
+	var value uintptr
+	result := api.axUIElementCopyAttributeValue(element, attribute, &value)
+	if result != axErrorSuccess {
+		return 0, axCallError("copy AX attribute", result)
+	}
+	if value == 0 {
+		return 0, errors.New("copy AX attribute returned a nil value")
+	}
+	return value, nil
+}
+
+func classifyWindowLookupError(context string, err error) error {
+	if errors.Is(err, ErrPermission) || errors.Is(err, ErrUnsupported) {
+		return err
+	}
+	return fmt.Errorf("%w: %s: %w", errWindowUnavailable, context, err)
+}
+
+func cfStringLocked(api *nativeAPI, value uintptr) (string, error) {
+	if err := requireCFType(api, value, api.cfStringGetTypeID(), "AX title"); err != nil {
+		return "", err
+	}
+	length := api.cfStringGetLength(value)
+	if length < 0 || length >= maximumAXStringBytes {
+		return "", fmt.Errorf("CoreFoundation returned invalid string length %d", length)
+	}
+	maximum := api.cfStringGetMaximumSizeForEncoding(length, cfStringEncodingUTF8)
+	if maximum < 0 || maximum >= maximumAXStringBytes {
+		return "", fmt.Errorf("CoreFoundation UTF-8 string size %d is invalid", maximum)
+	}
+	buffer := make([]byte, maximum+1)
+	if !api.cfStringGetCString(value, &buffer[0], int64(len(buffer)), cfStringEncodingUTF8) {
+		return "", errors.New("CFStringGetCString could not encode AX title as UTF-8")
+	}
+	runtime.KeepAlive(buffer)
+	for index, value := range buffer {
+		if value == 0 {
+			return string(buffer[:index]), nil
+		}
+	}
+	return "", errors.New("CFStringGetCString did not terminate AX title")
+}
+
+func requireCFType(api *nativeAPI, value, expected uintptr, name string) error {
+	if value == 0 || expected == 0 {
+		return fmt.Errorf("%s has an invalid CoreFoundation reference", name)
+	}
+	if actual := api.cfGetTypeID(value); actual != expected {
+		return fmt.Errorf(
+			"%s has CoreFoundation type %d, want %d",
+			name,
+			actual,
+			expected,
+		)
+	}
+	return nil
+}
+
+func axCallError(operation string, result int32) error {
+	if result == axErrorSuccess {
+		return nil
+	}
+	switch result {
+	case axErrorAPIDisabled:
+		return fmt.Errorf("%w: %s failed with AXError %d", ErrPermission, operation, result)
+	case axErrorActionUnsupported, axErrorNotImplemented:
+		return fmt.Errorf("%w: %s failed with AXError %d", ErrUnsupported, operation, result)
+	case axErrorInvalidUIElement:
+		return fmt.Errorf("%w: %s failed with AXError %d", errWindowUnavailable, operation, result)
+	default:
+		return fmt.Errorf("%s failed with AXError %d", operation, result)
+	}
+}
+
+func enclosingRect(position point, dimensions size) (windowbackend.Rect, error) {
+	values := []float64{position.X, position.Y, dimensions.Width, dimensions.Height}
+	for _, value := range values {
+		if math.IsNaN(value) || math.IsInf(value, 0) ||
+			value < -maximumExactCoordinate || value > maximumExactCoordinate {
+			return windowbackend.Rect{}, fmt.Errorf("macOS Accessibility returned invalid window geometry %v", values)
+		}
+	}
+	if dimensions.Width <= 0 || dimensions.Height <= 0 {
+		return windowbackend.Rect{}, fmt.Errorf("macOS Accessibility returned non-positive window size %v", dimensions)
+	}
+	minX := math.Floor(position.X)
+	minY := math.Floor(position.Y)
+	maxX := math.Ceil(position.X + dimensions.Width)
+	maxY := math.Ceil(position.Y + dimensions.Height)
+	if maxX > maximumExactCoordinate || maxY > maximumExactCoordinate ||
+		minX < -maximumExactCoordinate || minY < -maximumExactCoordinate {
+		return windowbackend.Rect{}, fmt.Errorf("macOS Accessibility window edges cannot be represented exactly")
+	}
+	return windowbackend.Rect{
+		X:      int(minX),
+		Y:      int(minY),
+		Width:  int(maxX - minX),
+		Height: int(maxY - minY),
+	}, nil
+}

--- a/internal/darwinwindow/values_darwin.go
+++ b/internal/darwinwindow/values_darwin.go
@@ -248,7 +248,10 @@ func axCallError(operation string, result int32) error {
 	switch result {
 	case axErrorAPIDisabled:
 		return fmt.Errorf("%w: %s failed with AXError %d", ErrPermission, operation, result)
-	case axErrorActionUnsupported, axErrorNotImplemented:
+	case axErrorAttributeUnsupported,
+		axErrorActionUnsupported,
+		axErrorNotImplemented,
+		axErrorParameterizedAttributeUnsupported:
 		return fmt.Errorf("%w: %s failed with AXError %d", ErrUnsupported, operation, result)
 	case axErrorInvalidUIElement:
 		return fmt.Errorf("%w: %s failed with AXError %d", errWindowUnavailable, operation, result)

--- a/internal/windowbackend/backend.go
+++ b/internal/windowbackend/backend.go
@@ -13,6 +13,8 @@ var (
 	ErrOperation = errors.New("window operation failed")
 	// ErrUnsupported reports a missing platform or window-manager capability.
 	ErrUnsupported = errors.New("window operation unsupported")
+	// ErrPermission reports a platform security policy that denied window access.
+	ErrPermission = errors.New("window operation permission denied")
 )
 
 // Handle is an opaque native top-level window identifier.

--- a/robotgo_nocgo_parity.go
+++ b/robotgo_nocgo_parity.go
@@ -55,8 +55,11 @@ func CloseMainDisplay() { _ = CloseMainDisplayE() }
 // behind. If cleanup reports a pressed-key or modifier-map conflict, remove
 // that conflict and retry CloseMainDisplayE. On Pure-Go Windows it releases
 // RobotGo-owned persistent key and button holds; process termination cannot run
-// this in-process cleanup.
-func CloseMainDisplayE() error { return closePureGoPlatformInput() }
+// this in-process cleanup. On Pure-Go macOS it also unloads window-control
+// framework references after releasing owned input state.
+func CloseMainDisplayE() error {
+	return errors.Join(closePureGoPlatformInput(), closePureGoPlatformWindow())
+}
 
 func InvalidateScreenBoundsCache() {}
 func Drag(x, y int, args ...string) {

--- a/runtime_diagnostics_other.go
+++ b/runtime_diagnostics_other.go
@@ -65,6 +65,15 @@ func darwinRuntimePermissions(
 			),
 			Reason: capabilities.Mouse.Reason,
 		},
+		{
+			Feature: runtimeFeatureWindow,
+			Name:    "Accessibility",
+			State: permissionFromCapability(
+				capabilities.Window,
+				"backend is ready",
+			),
+			Reason: capabilities.Window.Reason,
+		},
 	}
 }
 

--- a/window_backend_darwin_nocgo.go
+++ b/window_backend_darwin_nocgo.go
@@ -1,0 +1,46 @@
+//go:build darwin && !cgo
+
+package robotgo
+
+import (
+	"errors"
+
+	"github.com/marang/robotgo/internal/darwinwindow"
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+var pureGoDarwinWindowBackend = darwinwindow.NewNative()
+
+func platformPureGoWindowBackend() windowbackend.Backend {
+	return pureGoDarwinWindowBackend
+}
+
+func closePureGoPlatformWindow() error {
+	return translatePureGoWindowError(pureGoDarwinWindowBackend.CloseSystem())
+}
+
+func platformPureGoWindowCapability() FeatureCapability {
+	capability := FeatureCapability{
+		Backend: featureBackendPureGoMacOSWindow,
+		Notes: "active/PID/CGWindowID resolution, title, AX frame bounds, " +
+			"activation, minimize/restore, minimized state, and close are supported; " +
+			"client bounds equal the AX frame; maximize and topmost are explicitly unsupported; " +
+			"CGWindowID-to-Accessibility mapping requires the runtime-resolved macOS bridge",
+	}
+	err := pureGoDarwinWindowBackend.Ready()
+	switch {
+	case err == nil:
+		capability.Available = true
+		capability.Reason = "Pure-Go macOS Accessibility window backend is ready"
+	case errors.Is(err, darwinwindow.ErrPermission):
+		capability.Reason = ErrPermissionDenied.Error()
+		capability.Notes += "; grant Accessibility access in System Settings > Privacy & Security"
+	case errors.Is(err, darwinwindow.ErrUnsupported):
+		capability.Reason = translatePureGoWindowError(
+			errors.Join(windowbackend.ErrUnsupported, err),
+		).Error()
+	default:
+		capability.Reason = err.Error()
+	}
+	return capability
+}

--- a/window_backend_darwin_nocgo_test.go
+++ b/window_backend_darwin_nocgo_test.go
@@ -1,0 +1,67 @@
+//go:build darwin && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/marang/robotgo/internal/darwinwindow"
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+func TestPureGoDarwinWindowCapabilityUsesNonPromptingPreflight(t *testing.T) {
+	capability := GetRuntimeCapabilities().Window
+	if capability.Backend != featureBackendPureGoMacOSWindow {
+		t.Fatalf("window capability = %+v", capability)
+	}
+	if capability.Available {
+		if !strings.Contains(capability.Reason, "backend is ready") {
+			t.Fatalf("available window capability = %+v", capability)
+		}
+	} else if capability.Reason != ErrPermissionDenied.Error() &&
+		!strings.Contains(capability.Reason, ErrNotSupported.Error()) {
+		t.Fatalf("unavailable window capability = %+v", capability)
+	}
+
+	permissions := darwinRuntimePermissions(GetRuntimeCapabilities())
+	var found bool
+	for _, permission := range permissions {
+		if permission.Feature != runtimeFeatureWindow {
+			continue
+		}
+		found = true
+		if permission.Name != "Accessibility" {
+			t.Fatalf("window permission = %+v", permission)
+		}
+	}
+	if !found {
+		t.Fatal("runtime diagnostics omitted macOS window Accessibility permission")
+	}
+}
+
+func TestTranslatePureGoDarwinWindowErrors(t *testing.T) {
+	permission := errors.Join(windowbackend.ErrPermission, darwinwindow.ErrPermission)
+	if err := translatePureGoWindowError(permission); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("permission translation = %v", err)
+	}
+	unsupported := errors.Join(windowbackend.ErrUnsupported, darwinwindow.ErrUnsupported)
+	if err := translatePureGoWindowError(unsupported); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("unsupported translation = %v", err)
+	}
+}
+
+func TestPureGoDarwinWindowCleanupIsReusable(t *testing.T) {
+	before := GetRuntimeCapabilities().Window
+	if err := closePureGoPlatformWindow(); err != nil {
+		t.Fatalf("close Pure-Go macOS window backend: %v", err)
+	}
+	after := GetRuntimeCapabilities().Window
+	if before.Available != after.Available || before.Backend != after.Backend {
+		t.Fatalf("window capability changed after cleanup: before=%+v after=%+v", before, after)
+	}
+	if err := closePureGoPlatformWindow(); err != nil {
+		t.Fatalf("second close Pure-Go macOS window backend: %v", err)
+	}
+}

--- a/window_backend_default_nocgo.go
+++ b/window_backend_default_nocgo.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux && !cgo
+//go:build !windows && !linux && !darwin && !cgo
 
 package robotgo
 
@@ -14,3 +14,5 @@ func platformPureGoWindowCapability() FeatureCapability {
 		Notes:  "no matching Pure-Go window backend is active in this build",
 	}
 }
+
+func closePureGoPlatformWindow() error { return nil }

--- a/window_backend_linux_x11_nocgo.go
+++ b/window_backend_linux_x11_nocgo.go
@@ -39,3 +39,5 @@ func platformPureGoWindowCapability() FeatureCapability {
 		Notes:     "runtime X server access is validated per operation; mutations require a consistent EWMH manager that advertises the operation",
 	}
 }
+
+func closePureGoPlatformWindow() error { return nil }

--- a/window_backend_nocgo.go
+++ b/window_backend_nocgo.go
@@ -21,6 +21,43 @@ type publicPureGoWindowBackend struct {
 	windowbackend.Backend
 }
 
+func (backend publicPureGoWindowBackend) Active() (windowbackend.Handle, error) {
+	handle, err := backend.Backend.Active()
+	return handle, translatePureGoWindowError(err)
+}
+
+func (backend publicPureGoWindowBackend) Resolve(
+	target int,
+	isHandle bool,
+) (windowbackend.Handle, error) {
+	handle, err := backend.Backend.Resolve(target, isHandle)
+	return handle, translatePureGoWindowError(err)
+}
+
+func (backend publicPureGoWindowBackend) Select(target int, isHandle bool) error {
+	return translatePureGoWindowError(backend.Backend.Select(target, isHandle))
+}
+
+func (backend publicPureGoWindowBackend) PID(handle windowbackend.Handle) (int, error) {
+	pid, err := backend.Backend.PID(handle)
+	return pid, translatePureGoWindowError(err)
+}
+
+func (backend publicPureGoWindowBackend) Title(
+	handle windowbackend.Handle,
+) (string, error) {
+	title, err := backend.Backend.Title(handle)
+	return title, translatePureGoWindowError(err)
+}
+
+func (backend publicPureGoWindowBackend) Bounds(
+	handle windowbackend.Handle,
+	client bool,
+) (windowbackend.Rect, error) {
+	rect, err := backend.Backend.Bounds(handle, client)
+	return rect, translatePureGoWindowError(err)
+}
+
 func (backend publicPureGoWindowBackend) Activate(handle windowbackend.Handle) error {
 	return translatePureGoWindowError(backend.Backend.Activate(handle))
 }
@@ -58,10 +95,17 @@ func (backend publicPureGoWindowBackend) Close(handle windowbackend.Handle) erro
 }
 
 func translatePureGoWindowError(err error) error {
-	if err == nil || !errors.Is(err, windowbackend.ErrUnsupported) {
+	if err == nil {
 		return err
 	}
-	return fmt.Errorf("%w: %w", ErrNotSupported, err)
+	switch {
+	case errors.Is(err, windowbackend.ErrPermission):
+		return fmt.Errorf("%w: %w", ErrPermissionDenied, err)
+	case errors.Is(err, windowbackend.ErrUnsupported):
+		return fmt.Errorf("%w: %w", ErrNotSupported, err)
+	default:
+		return err
+	}
 }
 
 func pureGoWindowCapability() FeatureCapability {

--- a/window_backend_nocgo_test.go
+++ b/window_backend_nocgo_test.go
@@ -1,0 +1,81 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+type permissionWindowBackend struct{}
+
+func (permissionWindowBackend) Active() (windowbackend.Handle, error) {
+	return 0, windowbackend.ErrPermission
+}
+func (permissionWindowBackend) Resolve(int, bool) (windowbackend.Handle, error) {
+	return 0, windowbackend.ErrPermission
+}
+func (permissionWindowBackend) Select(int, bool) error { return windowbackend.ErrPermission }
+func (permissionWindowBackend) Selected() windowbackend.Handle {
+	return 0
+}
+func (permissionWindowBackend) PID(windowbackend.Handle) (int, error) {
+	return 0, windowbackend.ErrPermission
+}
+func (permissionWindowBackend) Title(windowbackend.Handle) (string, error) {
+	return "", windowbackend.ErrPermission
+}
+func (permissionWindowBackend) Bounds(windowbackend.Handle, bool) (windowbackend.Rect, error) {
+	return windowbackend.Rect{}, windowbackend.ErrPermission
+}
+func (permissionWindowBackend) Activate(windowbackend.Handle) error {
+	return windowbackend.ErrPermission
+}
+func (permissionWindowBackend) SetState(windowbackend.Handle, windowbackend.State, bool) error {
+	return windowbackend.ErrPermission
+}
+func (permissionWindowBackend) State(windowbackend.Handle, windowbackend.State) (bool, error) {
+	return false, windowbackend.ErrPermission
+}
+func (permissionWindowBackend) TopMost(windowbackend.Handle) (bool, error) {
+	return false, windowbackend.ErrPermission
+}
+func (permissionWindowBackend) SetTopMost(windowbackend.Handle, bool) error {
+	return windowbackend.ErrPermission
+}
+func (permissionWindowBackend) Close(windowbackend.Handle) error {
+	return windowbackend.ErrPermission
+}
+
+func TestPublicPureGoWindowBackendTranslatesPermissionForEveryOperation(t *testing.T) {
+	backend := publicPureGoWindowBackend{Backend: permissionWindowBackend{}}
+	assertPermission := func(name string, err error) {
+		t.Helper()
+		if !errors.Is(err, ErrPermissionDenied) ||
+			!errors.Is(err, windowbackend.ErrPermission) {
+			t.Fatalf("%s error = %v, want public and internal permission causes", name, err)
+		}
+	}
+
+	_, err := backend.Active()
+	assertPermission("Active", err)
+	_, err = backend.Resolve(1, false)
+	assertPermission("Resolve", err)
+	assertPermission("Select", backend.Select(1, false))
+	_, err = backend.PID(1)
+	assertPermission("PID", err)
+	_, err = backend.Title(1)
+	assertPermission("Title", err)
+	_, err = backend.Bounds(1, false)
+	assertPermission("Bounds", err)
+	assertPermission("Activate", backend.Activate(1))
+	assertPermission("SetState", backend.SetState(1, windowbackend.StateMinimized, true))
+	_, err = backend.State(1, windowbackend.StateMinimized)
+	assertPermission("State", err)
+	_, err = backend.TopMost(1)
+	assertPermission("TopMost", err)
+	assertPermission("SetTopMost", backend.SetTopMost(1, true))
+	assertPermission("Close", backend.Close(1))
+}

--- a/window_backend_windows_nocgo.go
+++ b/window_backend_windows_nocgo.go
@@ -21,3 +21,5 @@ func platformPureGoWindowCapability() FeatureCapability {
 		Notes:     "PID targets prefer visible unowned top-level windows; Windows foreground-activation policy still applies",
 	}
 }
+
+func closePureGoPlatformWindow() error { return nil }


### PR DESCRIPTION
## Goal

Complete the next Phase 3 Pure-Go slice by adding explicit, permission-aware macOS window inspection and control without CGO.

## What changed

- added a testable Accessibility/CoreGraphics backend using stable `CGWindowID` handles
- supports active/PID/handle resolution, PID and title lookup, AX frame bounds, activation, minimize/restore, minimized-state queries, and graceful close
- reports maximize and topmost as explicit `ErrNotSupported` operations
- performs a non-prompting Accessibility preflight and maps permission failures to `ErrPermissionDenied`
- validates CoreFoundation/Accessibility value types, bounds AX window enumeration, and cleans up all retained objects and dynamically loaded frameworks
- fixes activation semantics by raising the selected window and bringing its owning process forward
- uses an exact CoreGraphics description request for a single window instead of an invalid standalone `IncludingWindow` list option
- wires deterministic cleanup through `CloseMainDisplayE`
- adds a safe inspection-only example with opt-in mutations
- updates README, testing guidance, compatibility documentation, and the product roadmap

## User impact

`CGO_ENABLED=0` macOS builds now have useful window APIs rather than generic unsupported stubs. Capability and diagnostic APIs explain missing Accessibility permission without triggering a prompt. Client bounds intentionally equal the AX frame because macOS exposes no reliable cross-application client rectangle.

The `CGWindowID` to Accessibility mapping uses the same runtime-resolved macOS bridge as the existing native backend. If that bridge is absent, the backend fails explicitly as unsupported.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run`
- `CGO_ENABLED=0 golangci-lint run`
- Darwin non-CGO test cross-compilation for `amd64` and `arm64`, including root and `internal/darwinwindow`

## Runtime evidence

Hosted macOS CI can resolve the real symbols, execute the non-prompting permission preflight, and verify cleanup/reopen behavior. Permission-granted mutations remain intentionally non-blocking until a self-owned macOS test-window harness exists; automated tests must not alter an unrelated developer window.