### PR TITLE
feat: add guarded CloseWindowKill to Pure-Go builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,13 @@ CGWindowID-to-Accessibility mapping uses the same runtime-resolved macOS bridge
 as the native backend; if that bridge is absent, capability probing reports the
 backend as unsupported instead of degrading silently.
 
-On every supported Pure-Go window backend, `CloseWindowKill` resolves the
-window's actual owner and process start time, requests a graceful close, waits
-for a bounded 1.5-second grace period, and force-terminates only if both PID and
-process identity still match. A failed identity probe aborts without
-force-killing, and detected PID reuse is treated as the original process having
-exited.
+On Windows and Linux/X11 Pure-Go window backends, `CloseWindowKill` resolves the
+window's actual owner and process start time, requests a graceful close, and
+waits for a bounded 1.5-second grace period. Windows binds the fallback to a
+verified process handle; Linux uses a verified `pidfd`. A failed identity probe
+or detected PID reuse aborts without force-killing. macOS still performs the
+graceful close, but returns `ErrNotSupported` if the process remains alive
+because macOS offers no equivalent stable process handle for a safe fallback.
 
 ```go
 if err := robotgo.KeyboardReady(); err != nil {

--- a/README.md
+++ b/README.md
@@ -131,12 +131,14 @@ as the native backend; if that bridge is absent, capability probing reports the
 backend as unsupported instead of degrading silently.
 
 On Windows and Linux/X11 Pure-Go window backends, `CloseWindowKill` resolves the
-window's actual owner, acquires a stable process reference before requesting
-the graceful close, revalidates window ownership, and waits for a bounded
-1.5-second grace period. Windows retains one verified process handle; Linux
-retains one `pidfd` through the wait and optional force-kill. Owner changes,
-failed probes, and pre-bind exits abort without a destructive fallback. macOS
-still performs the graceful close, but returns `ErrNotSupported` if the process
+window's actual owner, captures its process identity, acquires a stable process
+reference, verifies that the reference still represents that identity, and
+revalidates window ownership before requesting the graceful close. Windows
+retains one creation-time-verified process handle; Linux verifies the exact
+`/proc/<pid>` instance around `pidfd_open` and retains that `pidfd` through the
+bounded 1.5-second wait and optional force-kill. Owner/identity changes, failed
+probes, and pre-bind exits abort without a destructive fallback. macOS still
+performs the graceful close, but returns `ErrNotSupported` if the process
 remains alive because macOS offers no equivalent stable process handle for a
 safe fallback.
 

--- a/README.md
+++ b/README.md
@@ -131,12 +131,14 @@ as the native backend; if that bridge is absent, capability probing reports the
 backend as unsupported instead of degrading silently.
 
 On Windows and Linux/X11 Pure-Go window backends, `CloseWindowKill` resolves the
-window's actual owner and process start time, requests a graceful close, and
-waits for a bounded 1.5-second grace period. Windows binds the fallback to a
-verified process handle; Linux uses a verified `pidfd`. A failed identity probe
-or detected PID reuse aborts without force-killing. macOS still performs the
-graceful close, but returns `ErrNotSupported` if the process remains alive
-because macOS offers no equivalent stable process handle for a safe fallback.
+window's actual owner, acquires a stable process reference before requesting
+the graceful close, revalidates window ownership, and waits for a bounded
+1.5-second grace period. Windows retains one verified process handle; Linux
+retains one `pidfd` through the wait and optional force-kill. Owner changes,
+failed probes, and pre-bind exits abort without a destructive fallback. macOS
+still performs the graceful close, but returns `ErrNotSupported` if the process
+remains alive because macOS offers no equivalent stable process handle for a
+safe fallback.
 
 ```go
 if err := robotgo.KeyboardReady(); err != nil {

--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ CGWindowID-to-Accessibility mapping uses the same runtime-resolved macOS bridge
 as the native backend; if that bridge is absent, capability probing reports the
 backend as unsupported instead of degrading silently.
 
+On every supported Pure-Go window backend, `CloseWindowKill` resolves the
+window's actual owner and process start time, requests a graceful close, waits
+for a bounded 1.5-second grace period, and force-terminates only if both PID and
+process identity still match. A failed identity probe aborts without
+force-killing, and detected PID reuse is treated as the original process having
+exited.
+
 ```go
 if err := robotgo.KeyboardReady(); err != nil {
 	log.Fatal(err)

--- a/TEST.md
+++ b/TEST.md
@@ -108,8 +108,8 @@ available; tests must not mutate an unrelated developer window.
 Pure-Go `CloseWindowKill` tests use fake window/process backends. They cover
 PID, handle and active-window resolution, graceful exit, the bounded force-kill
 fallback, pre-close stable Linux `pidfd` binding, post-bind owner
-revalidation, deadline races, and fail-closed probe errors without terminating
-a real process:
+revalidation, pre-bind process-identity changes, deadline races, and
+fail-closed probe errors without terminating a real process:
 
 ```bash
 CGO_ENABLED=0 go test \

--- a/TEST.md
+++ b/TEST.md
@@ -105,6 +105,17 @@ application. Permission-granted activation, minimize/restore, and close remain
 opt-in runtime evidence until a self-owned macOS test-window harness is
 available; tests must not mutate an unrelated developer window.
 
+Pure-Go `CloseWindowKill` tests use fake window/process backends. They cover
+PID, handle and active-window resolution, graceful exit, the bounded force-kill
+fallback, deadline races, and fail-closed probe errors without terminating a
+real process:
+
+```bash
+CGO_ENABLED=0 go test \
+  -run '^(TestCloseWindowKill|TestCloseWindowProcessIdentity|TestWaitForWindowProcessExit)' \
+  -count=1 -v .
+```
+
 After granting Accessibility access, the opt-in real input tests move to the
 center of the main display and restore the original location, and exercise one
 ownership-checked Shift hold/release without typing text:

--- a/TEST.md
+++ b/TEST.md
@@ -107,12 +107,13 @@ available; tests must not mutate an unrelated developer window.
 
 Pure-Go `CloseWindowKill` tests use fake window/process backends. They cover
 PID, handle and active-window resolution, graceful exit, the bounded force-kill
-fallback, stable Linux `pidfd` binding, deadline races, and fail-closed probe
-errors without terminating a real process:
+fallback, pre-close stable Linux `pidfd` binding, post-bind owner
+revalidation, deadline races, and fail-closed probe errors without terminating
+a real process:
 
 ```bash
 CGO_ENABLED=0 go test \
-  -run '^(TestCloseWindowKill|TestCloseWindowProcessIdentity|TestCloseWindowProcessKillLinux|TestWaitForWindowProcessExit)' \
+  -run '^(TestCloseWindowKill|TestCloseWindowProcessIdentity|TestOpenCloseWindowProcessLinux|TestCloseWindowProcessLinux|TestWaitForWindowProcessExit)' \
   -count=1 -v .
 ```
 

--- a/TEST.md
+++ b/TEST.md
@@ -107,12 +107,12 @@ available; tests must not mutate an unrelated developer window.
 
 Pure-Go `CloseWindowKill` tests use fake window/process backends. They cover
 PID, handle and active-window resolution, graceful exit, the bounded force-kill
-fallback, deadline races, and fail-closed probe errors without terminating a
-real process:
+fallback, stable Linux `pidfd` binding, deadline races, and fail-closed probe
+errors without terminating a real process:
 
 ```bash
 CGO_ENABLED=0 go test \
-  -run '^(TestCloseWindowKill|TestCloseWindowProcessIdentity|TestWaitForWindowProcessExit)' \
+  -run '^(TestCloseWindowKill|TestCloseWindowProcessIdentity|TestCloseWindowProcessKillLinux|TestWaitForWindowProcessExit)' \
   -count=1 -v .
 ```
 

--- a/api_contract_nocgo_test.go
+++ b/api_contract_nocgo_test.go
@@ -18,6 +18,8 @@ func TestNonCGOPortableAPIContract(t *testing.T) {
 			SetActiveE(0),
 			MinWindowE(0),
 			MaxWindowE(0),
+			CloseWindowE(0),
+			CloseWindowKill(0),
 		}
 		for _, err := range invalidTargets {
 			if err == nil || errors.Is(err, ErrNotSupported) {

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -211,12 +211,13 @@ full public contract, and proves fail-closed behavior after manager loss. The
 runnable example is inspection-only unless `-act` and an explicit mutation are
 supplied.
 
-Across the supported Pure-Go macOS, Windows, and X11 window backends,
-`CloseWindowKill` now resolves the actual owner PID and process start time,
-requests a graceful close, uses a bounded wait with a final deadline probe, and
-force-kills only while both PID and identity still match. Probe failures and
-PID reuse abort without a destructive fallback, and hermetic tests never
-terminate a real process.
+Across the Pure-Go macOS, Windows, and X11 window backends, `CloseWindowKill`
+resolves the actual owner PID and process start time, requests a graceful close,
+and uses a bounded wait with a final deadline probe. Windows binds termination
+to a verified process handle and Linux uses a verified `pidfd`; probe failures
+and PID reuse abort without a destructive fallback. macOS returns explicit
+unsupported if graceful close is insufficient because it has no equivalent
+stable process handle. Hermetic tests never terminate a real process.
 
 The Linux/X11 evaluation slice of Phase 3 is complete. Native CGO and Pure-Go
 X11 binaries pass one black-box public-API contract for capture, pointer,

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -214,12 +214,15 @@ supplied.
 Across the Pure-Go macOS, Windows, and X11 window backends, `CloseWindowKill`
 resolves the actual owner PID and uses a bounded wait with a final deadline
 probe. Windows and Linux acquire a stable process reference before requesting
-the graceful close, revalidate the window owner after acquisition, and retain
-that same verified process handle or `pidfd` through the optional force-kill.
-Owner changes and probe failures abort without a destructive fallback. macOS
-captures process identity for the graceful wait and returns explicit unsupported
-if graceful close is insufficient because it has no equivalent stable process
-handle. Hermetic tests never terminate a real process.
+the graceful close, verify the bound reference against a process identity
+captured before acquisition, revalidate the window owner, and retain that same
+verified process handle or `pidfd` through the optional force-kill. Linux uses
+the exact procfs process-instance identity around `pidfd_open`; Windows uses
+the process creation time from the stable handle. Owner/identity changes and
+probe failures abort without a destructive fallback. macOS captures process
+identity for the graceful wait and returns explicit unsupported if graceful
+close is insufficient because it has no equivalent stable process handle.
+Hermetic tests never terminate a real process.
 
 The Linux/X11 evaluation slice of Phase 3 is complete. Native CGO and Pure-Go
 X11 binaries pass one black-box public-API contract for capture, pointer,

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -211,6 +211,13 @@ full public contract, and proves fail-closed behavior after manager loss. The
 runnable example is inspection-only unless `-act` and an explicit mutation are
 supplied.
 
+Across the supported Pure-Go macOS, Windows, and X11 window backends,
+`CloseWindowKill` now resolves the actual owner PID and process start time,
+requests a graceful close, uses a bounded wait with a final deadline probe, and
+force-kills only while both PID and identity still match. Probe failures and
+PID reuse abort without a destructive fallback, and hermetic tests never
+terminate a real process.
+
 The Linux/X11 evaluation slice of Phase 3 is complete. Native CGO and Pure-Go
 X11 binaries pass one black-box public-API contract for capture, pointer,
 buttons, scroll, modifier order, and ASCII text without keyboard-map changes. A

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -212,12 +212,14 @@ runnable example is inspection-only unless `-act` and an explicit mutation are
 supplied.
 
 Across the Pure-Go macOS, Windows, and X11 window backends, `CloseWindowKill`
-resolves the actual owner PID and process start time, requests a graceful close,
-and uses a bounded wait with a final deadline probe. Windows binds termination
-to a verified process handle and Linux uses a verified `pidfd`; probe failures
-and PID reuse abort without a destructive fallback. macOS returns explicit
-unsupported if graceful close is insufficient because it has no equivalent
-stable process handle. Hermetic tests never terminate a real process.
+resolves the actual owner PID and uses a bounded wait with a final deadline
+probe. Windows and Linux acquire a stable process reference before requesting
+the graceful close, revalidate the window owner after acquisition, and retain
+that same verified process handle or `pidfd` through the optional force-kill.
+Owner changes and probe failures abort without a destructive fallback. macOS
+captures process identity for the graceful wait and returns explicit unsupported
+if graceful close is insufficient because it has no equivalent stable process
+handle. Hermetic tests never terminate a real process.
 
 The Linux/X11 evaluation slice of Phase 3 is complete. Native CGO and Pure-Go
 X11 binaries pass one black-box public-API contract for capture, pointer,

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jezek/xgb v1.3.1
 	github.com/jezek/xgbutil v0.0.0-20260124183602-9fd151d6a51a
 	github.com/otiai10/gosseract/v2 v2.4.1
+	github.com/shirou/gopsutil/v4 v4.26.6
 	github.com/tailscale/win v0.0.0-20260619195133-2d76c33a64c1
 	github.com/vcaesar/gops v0.42.0
 	github.com/vcaesar/imgo v0.42.0
@@ -23,7 +24,6 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260627054121-477a66015f15 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect
 	github.com/tklauser/numcpus v0.12.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/process_identity_nocgo.go
+++ b/process_identity_nocgo.go
@@ -1,0 +1,28 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+func closeWindowProcessIdentity(pid int) (int64, error) {
+	if pid <= 0 || int64(pid) > math.MaxInt32 {
+		return 0, fmt.Errorf("invalid process id %d", pid)
+	}
+	instance, err := process.NewProcess(int32(pid))
+	if err != nil {
+		return 0, fmt.Errorf("open process %d for identity: %w", pid, err)
+	}
+	createdAt, err := instance.CreateTime()
+	if err != nil {
+		return 0, fmt.Errorf("read process %d creation time: %w", pid, err)
+	}
+	if createdAt <= 0 {
+		return 0, fmt.Errorf("process %d returned invalid creation time %d", pid, createdAt)
+	}
+	return createdAt, nil
+}

--- a/process_identity_nocgo.go
+++ b/process_identity_nocgo.go
@@ -1,4 +1,4 @@
-//go:build !cgo
+//go:build !cgo && !windows
 
 package robotgo
 

--- a/process_identity_nocgo_test.go
+++ b/process_identity_nocgo_test.go
@@ -1,0 +1,28 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCloseWindowProcessIdentityIsStableForCurrentProcess(t *testing.T) {
+	first, err := closeWindowProcessIdentity(os.Getpid())
+	if err != nil {
+		t.Fatalf("first process identity: %v", err)
+	}
+	second, err := closeWindowProcessIdentity(os.Getpid())
+	if err != nil {
+		t.Fatalf("second process identity: %v", err)
+	}
+	if first <= 0 || second != first {
+		t.Fatalf("process identities = (%d, %d), want equal positive values", first, second)
+	}
+}
+
+func TestCloseWindowProcessIdentityRejectsInvalidPID(t *testing.T) {
+	if _, err := closeWindowProcessIdentity(0); err == nil {
+		t.Fatal("closeWindowProcessIdentity(0) succeeded")
+	}
+}

--- a/process_identity_windows_nocgo.go
+++ b/process_identity_windows_nocgo.go
@@ -72,6 +72,9 @@ func closeWindowProcessKill(pid int, identity int64) error {
 		false,
 		nativePID,
 	)
+	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("open process %d for termination: %w", pid, err)
 	}

--- a/process_identity_windows_nocgo.go
+++ b/process_identity_windows_nocgo.go
@@ -3,12 +3,34 @@
 package robotgo
 
 import (
-	"errors"
 	"fmt"
 	"math"
 
 	"golang.org/x/sys/windows"
 )
+
+type windowsCloseWindowProcess struct {
+	pid    int
+	handle windows.Handle
+}
+
+func openCloseWindowProcess(pid int) (closeWindowProcess, error) {
+	nativePID, err := windowsCloseWindowProcessID(pid)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_TERMINATE|
+			windows.PROCESS_QUERY_LIMITED_INFORMATION|
+			windows.SYNCHRONIZE,
+		false,
+		nativePID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open stable process handle for pid %d: %w", pid, err)
+	}
+	return &windowsCloseWindowProcess{pid: pid, handle: handle}, nil
+}
 
 func closeWindowProcessIdentity(pid int) (int64, error) {
 	nativePID, err := windowsCloseWindowProcessID(pid)
@@ -30,27 +52,13 @@ func closeWindowProcessIdentity(pid int) (int64, error) {
 	return windowsProcessIdentityFromHandle(handle, pid)
 }
 
-func closeWindowProcessExists(pid int) (bool, error) {
-	nativePID, err := windowsCloseWindowProcessID(pid)
-	if err != nil {
-		return false, err
+func (process *windowsCloseWindowProcess) Running() (bool, error) {
+	if process == nil || process.handle == 0 {
+		return false, fmt.Errorf("%w: Windows process handle is closed", ErrNotSupported)
 	}
-	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, nativePID)
-	switch {
-	case errors.Is(err, windows.ERROR_ACCESS_DENIED):
-		return true, nil
-	case errors.Is(err, windows.ERROR_INVALID_PARAMETER):
-		return false, nil
-	case err != nil:
-		return false, fmt.Errorf("open process %d for existence check: %w", pid, err)
-	}
-	defer func() {
-		_ = windows.CloseHandle(handle)
-	}()
-
-	status, err := windows.WaitForSingleObject(handle, 0)
+	status, err := windows.WaitForSingleObject(process.handle, 0)
 	if err != nil {
-		return false, fmt.Errorf("wait for process %d: %w", pid, err)
+		return false, fmt.Errorf("wait for process %d: %w", process.pid, err)
 	}
 	switch status {
 	case uint32(windows.WAIT_TIMEOUT):
@@ -58,38 +66,31 @@ func closeWindowProcessExists(pid int) (bool, error) {
 	case windows.WAIT_OBJECT_0:
 		return false, nil
 	default:
-		return false, fmt.Errorf("wait for process %d returned status %#x", pid, status)
+		return false, fmt.Errorf("wait for process %d returned status %#x", process.pid, status)
 	}
 }
 
-func closeWindowProcessKill(pid int, identity int64) error {
-	nativePID, err := windowsCloseWindowProcessID(pid)
-	if err != nil {
-		return err
+func (process *windowsCloseWindowProcess) Kill() error {
+	if process == nil || process.handle == 0 {
+		return fmt.Errorf("%w: Windows process handle is closed", ErrNotSupported)
 	}
-	handle, err := windows.OpenProcess(
-		windows.PROCESS_TERMINATE|windows.PROCESS_QUERY_LIMITED_INFORMATION,
-		false,
-		nativePID,
-	)
-	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+	if err := windows.TerminateProcess(process.handle, 1); err != nil {
+		if running, waitErr := process.Running(); waitErr == nil && !running {
+			return nil
+		}
+		return fmt.Errorf("terminate process %d: %w", process.pid, err)
+	}
+	return nil
+}
+
+func (process *windowsCloseWindowProcess) Close() error {
+	if process == nil || process.handle == 0 {
 		return nil
 	}
-	if err != nil {
-		return fmt.Errorf("open process %d for termination: %w", pid, err)
-	}
-	defer func() {
-		_ = windows.CloseHandle(handle)
-	}()
-	currentIdentity, err := windowsProcessIdentityFromHandle(handle, pid)
-	if err != nil {
-		return fmt.Errorf("verify process %d before termination: %w", pid, err)
-	}
-	if currentIdentity != identity {
-		return nil
-	}
-	if err := windows.TerminateProcess(handle, 1); err != nil {
-		return fmt.Errorf("terminate process %d: %w", pid, err)
+	handle := process.handle
+	process.handle = 0
+	if err := windows.CloseHandle(handle); err != nil {
+		return fmt.Errorf("close process %d handle: %w", process.pid, err)
 	}
 	return nil
 }

--- a/process_identity_windows_nocgo.go
+++ b/process_identity_windows_nocgo.go
@@ -3,6 +3,7 @@
 package robotgo
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
@@ -14,7 +15,23 @@ type windowsCloseWindowProcess struct {
 	handle windows.Handle
 }
 
-func openCloseWindowProcess(pid int) (closeWindowProcess, error) {
+func captureCloseWindowProcessIdentity(
+	pid int,
+) (closeWindowProcessFingerprint, error) {
+	identity, err := closeWindowProcessIdentity(pid)
+	if err != nil {
+		return closeWindowProcessFingerprint{}, err
+	}
+	return closeWindowProcessFingerprint{primary: uint64(identity)}, nil
+}
+
+func openCloseWindowProcess(
+	pid int,
+	expected closeWindowProcessFingerprint,
+) (closeWindowProcess, error) {
+	if !expected.valid() {
+		return nil, fmt.Errorf("invalid expected Windows process identity for pid %d", pid)
+	}
 	nativePID, err := windowsCloseWindowProcessID(pid)
 	if err != nil {
 		return nil, err
@@ -28,6 +45,16 @@ func openCloseWindowProcess(pid int) (closeWindowProcess, error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("open stable process handle for pid %d: %w", pid, err)
+	}
+	current, identityErr := windowsProcessIdentityFromHandle(handle, pid)
+	if identityErr != nil {
+		return nil, errors.Join(identityErr, windows.CloseHandle(handle))
+	}
+	if uint64(current) != expected.primary {
+		return nil, errors.Join(
+			fmt.Errorf("process %d identity changed while opening stable handle", pid),
+			windows.CloseHandle(handle),
+		)
 	}
 	return &windowsCloseWindowProcess{pid: pid, handle: handle}, nil
 }

--- a/process_identity_windows_nocgo.go
+++ b/process_identity_windows_nocgo.go
@@ -1,0 +1,120 @@
+//go:build windows && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"golang.org/x/sys/windows"
+)
+
+func closeWindowProcessIdentity(pid int) (int64, error) {
+	nativePID, err := windowsCloseWindowProcessID(pid)
+	if err != nil {
+		return 0, err
+	}
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION,
+		false,
+		nativePID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("open process %d for identity: %w", pid, err)
+	}
+	defer func() {
+		_ = windows.CloseHandle(handle)
+	}()
+
+	return windowsProcessIdentityFromHandle(handle, pid)
+}
+
+func closeWindowProcessExists(pid int) (bool, error) {
+	nativePID, err := windowsCloseWindowProcessID(pid)
+	if err != nil {
+		return false, err
+	}
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, nativePID)
+	switch {
+	case errors.Is(err, windows.ERROR_ACCESS_DENIED):
+		return true, nil
+	case errors.Is(err, windows.ERROR_INVALID_PARAMETER):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("open process %d for existence check: %w", pid, err)
+	}
+	defer func() {
+		_ = windows.CloseHandle(handle)
+	}()
+
+	status, err := windows.WaitForSingleObject(handle, 0)
+	if err != nil {
+		return false, fmt.Errorf("wait for process %d: %w", pid, err)
+	}
+	switch status {
+	case uint32(windows.WAIT_TIMEOUT):
+		return true, nil
+	case windows.WAIT_OBJECT_0:
+		return false, nil
+	default:
+		return false, fmt.Errorf("wait for process %d returned status %#x", pid, status)
+	}
+}
+
+func closeWindowProcessKill(pid int, identity int64) error {
+	nativePID, err := windowsCloseWindowProcessID(pid)
+	if err != nil {
+		return err
+	}
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_TERMINATE|windows.PROCESS_QUERY_LIMITED_INFORMATION,
+		false,
+		nativePID,
+	)
+	if err != nil {
+		return fmt.Errorf("open process %d for termination: %w", pid, err)
+	}
+	defer func() {
+		_ = windows.CloseHandle(handle)
+	}()
+	currentIdentity, err := windowsProcessIdentityFromHandle(handle, pid)
+	if err != nil {
+		return fmt.Errorf("verify process %d before termination: %w", pid, err)
+	}
+	if currentIdentity != identity {
+		return nil
+	}
+	if err := windows.TerminateProcess(handle, 1); err != nil {
+		return fmt.Errorf("terminate process %d: %w", pid, err)
+	}
+	return nil
+}
+
+func windowsProcessIdentityFromHandle(
+	handle windows.Handle,
+	pid int,
+) (int64, error) {
+	var creation, exit, kernel, user windows.Filetime
+	if err := windows.GetProcessTimes(
+		handle,
+		&creation,
+		&exit,
+		&kernel,
+		&user,
+	); err != nil {
+		return 0, fmt.Errorf("read process %d creation time: %w", pid, err)
+	}
+	createdAt := creation.Nanoseconds()
+	if createdAt <= 0 {
+		return 0, fmt.Errorf("process %d returned invalid creation time %d", pid, createdAt)
+	}
+	return createdAt, nil
+}
+
+func windowsCloseWindowProcessID(pid int) (uint32, error) {
+	if pid <= 0 || uint64(pid) > math.MaxUint32 {
+		return 0, fmt.Errorf("invalid Windows process id %d", pid)
+	}
+	return uint32(pid), nil
+}

--- a/process_identity_windows_nocgo_test.go
+++ b/process_identity_windows_nocgo_test.go
@@ -1,0 +1,26 @@
+//go:build windows && !cgo
+
+package robotgo
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestWindowsCloseWindowProcessIDSupportsUint32Range(t *testing.T) {
+	if strconv.IntSize != 64 {
+		t.Skip("full uint32 PID range requires a 64-bit Go int")
+	}
+	const maximumWindowsPID = int(math.MaxUint32)
+	got, err := windowsCloseWindowProcessID(maximumWindowsPID)
+	if err != nil {
+		t.Fatalf("windowsCloseWindowProcessID(MaxUint32): %v", err)
+	}
+	if got != math.MaxUint32 {
+		t.Fatalf("native PID = %d, want %d", got, uint32(math.MaxUint32))
+	}
+	if _, err := windowsCloseWindowProcessID(maximumWindowsPID + 1); err == nil {
+		t.Fatal("windowsCloseWindowProcessID(MaxUint32 + 1) succeeded")
+	}
+}

--- a/process_runtime_default_nocgo.go
+++ b/process_runtime_default_nocgo.go
@@ -13,12 +13,31 @@ type identityCloseWindowProcess struct {
 	identity int64
 }
 
-func openCloseWindowProcess(pid int) (closeWindowProcess, error) {
+func captureCloseWindowProcessIdentity(
+	pid int,
+) (closeWindowProcessFingerprint, error) {
 	identity, err := closeWindowProcessIdentity(pid)
+	if err != nil {
+		return closeWindowProcessFingerprint{}, err
+	}
+	return closeWindowProcessFingerprint{primary: uint64(identity)}, nil
+}
+
+func openCloseWindowProcess(
+	pid int,
+	expected closeWindowProcessFingerprint,
+) (closeWindowProcess, error) {
+	current, err := captureCloseWindowProcessIdentity(pid)
 	if err != nil {
 		return nil, err
 	}
-	return &identityCloseWindowProcess{pid: pid, identity: identity}, nil
+	if current != expected {
+		return nil, fmt.Errorf("process %d identity changed during binding", pid)
+	}
+	return &identityCloseWindowProcess{
+		pid:      pid,
+		identity: int64(expected.primary),
+	}, nil
 }
 
 func (process *identityCloseWindowProcess) Running() (bool, error) {

--- a/process_runtime_default_nocgo.go
+++ b/process_runtime_default_nocgo.go
@@ -1,0 +1,34 @@
+//go:build !cgo && !windows
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+)
+
+func closeWindowProcessExists(pid int) (bool, error) {
+	return PidExists(pid)
+}
+
+func closeWindowProcessKill(pid int, identity int64) error {
+	currentIdentity, err := closeWindowProcessIdentity(pid)
+	if err != nil {
+		exists, existsErr := closeWindowProcessExists(pid)
+		if existsErr != nil {
+			return fmt.Errorf(
+				"verify process %d before termination: %w",
+				pid,
+				errors.Join(err, existsErr),
+			)
+		}
+		if !exists {
+			return nil
+		}
+		return fmt.Errorf("verify process %d before termination: %w", pid, err)
+	}
+	if currentIdentity != identity {
+		return nil
+	}
+	return Kill(pid)
+}

--- a/process_runtime_default_nocgo.go
+++ b/process_runtime_default_nocgo.go
@@ -3,19 +3,55 @@
 package robotgo
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 )
 
-func closeWindowProcessExists(pid int) (bool, error) {
-	return PidExists(pid)
+type identityCloseWindowProcess struct {
+	pid      int
+	identity int64
 }
 
-func closeWindowProcessKill(pid int, _ int64) error {
+func openCloseWindowProcess(pid int) (closeWindowProcess, error) {
+	identity, err := closeWindowProcessIdentity(pid)
+	if err != nil {
+		return nil, err
+	}
+	return &identityCloseWindowProcess{pid: pid, identity: identity}, nil
+}
+
+func (process *identityCloseWindowProcess) Running() (bool, error) {
+	exists, err := PidExists(process.pid)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	currentIdentity, err := closeWindowProcessIdentity(process.pid)
+	if err != nil {
+		stillExists, probeErr := PidExists(process.pid)
+		if probeErr != nil {
+			return false, errors.Join(err, probeErr)
+		}
+		if !stillExists {
+			return false, nil
+		}
+		return false, err
+	}
+	return currentIdentity == process.identity, nil
+}
+
+func (process *identityCloseWindowProcess) Kill() error {
 	return fmt.Errorf(
 		"%w: Pure-Go %s cannot bind force-kill to process %d without a stable process handle",
 		ErrNotSupported,
 		runtime.GOOS,
-		pid,
+		process.pid,
 	)
+}
+
+func (*identityCloseWindowProcess) Close() error {
+	return nil
 }

--- a/process_runtime_default_nocgo.go
+++ b/process_runtime_default_nocgo.go
@@ -1,34 +1,21 @@
-//go:build !cgo && !windows
+//go:build !cgo && !windows && !linux
 
 package robotgo
 
 import (
-	"errors"
 	"fmt"
+	"runtime"
 )
 
 func closeWindowProcessExists(pid int) (bool, error) {
 	return PidExists(pid)
 }
 
-func closeWindowProcessKill(pid int, identity int64) error {
-	currentIdentity, err := closeWindowProcessIdentity(pid)
-	if err != nil {
-		exists, existsErr := closeWindowProcessExists(pid)
-		if existsErr != nil {
-			return fmt.Errorf(
-				"verify process %d before termination: %w",
-				pid,
-				errors.Join(err, existsErr),
-			)
-		}
-		if !exists {
-			return nil
-		}
-		return fmt.Errorf("verify process %d before termination: %w", pid, err)
-	}
-	if currentIdentity != identity {
-		return nil
-	}
-	return Kill(pid)
+func closeWindowProcessKill(pid int, _ int64) error {
+	return fmt.Errorf(
+		"%w: Pure-Go %s cannot bind force-kill to process %d without a stable process handle",
+		ErrNotSupported,
+		runtime.GOOS,
+		pid,
+	)
 }

--- a/process_runtime_linux_nocgo.go
+++ b/process_runtime_linux_nocgo.go
@@ -13,12 +13,14 @@ const (
 	linuxPIDFDOpenFlags              = 0
 	linuxPIDFDSendSignalFlags        = 0
 	linuxPIDFDProcessExistenceSignal = unix.Signal(0)
+	linuxProcPIDPathFormat           = "/proc/%d"
 )
 
 type linuxPIDFDRuntime struct {
-	openPIDFD  func(int, int) (int, error)
-	closeFD    func(int) error
-	sendSignal func(int, unix.Signal, *unix.Siginfo, int) error
+	openPIDFD       func(int, int) (int, error)
+	closeFD         func(int) error
+	sendSignal      func(int, unix.Signal, *unix.Siginfo, int) error
+	processIdentity func(int) (closeWindowProcessFingerprint, error)
 }
 
 type linuxCloseWindowProcess struct {
@@ -27,25 +29,62 @@ type linuxCloseWindowProcess struct {
 	runtime linuxPIDFDRuntime
 }
 
-func openCloseWindowProcess(pid int) (closeWindowProcess, error) {
+func captureCloseWindowProcessIdentity(
+	pid int,
+) (closeWindowProcessFingerprint, error) {
+	if pid <= 0 {
+		return closeWindowProcessFingerprint{}, fmt.Errorf("invalid Linux process id %d", pid)
+	}
+	var status unix.Stat_t
+	if err := unix.Stat(fmt.Sprintf(linuxProcPIDPathFormat, pid), &status); err != nil {
+		return closeWindowProcessFingerprint{}, fmt.Errorf(
+			"stat Linux process %d identity: %w",
+			pid,
+			err,
+		)
+	}
+	identity := closeWindowProcessFingerprint{
+		primary:   uint64(status.Dev),
+		secondary: status.Ino,
+	}
+	if !identity.valid() {
+		return closeWindowProcessFingerprint{}, fmt.Errorf(
+			"linux process %d returned an invalid procfs identity",
+			pid,
+		)
+	}
+	return identity, nil
+}
+
+func openCloseWindowProcess(
+	pid int,
+	expected closeWindowProcessFingerprint,
+) (closeWindowProcess, error) {
 	return openCloseWindowProcessLinux(
 		pid,
+		expected,
 		linuxPIDFDRuntime{
-			openPIDFD:  unix.PidfdOpen,
-			closeFD:    unix.Close,
-			sendSignal: unix.PidfdSendSignal,
+			openPIDFD:       unix.PidfdOpen,
+			closeFD:         unix.Close,
+			sendSignal:      unix.PidfdSendSignal,
+			processIdentity: captureCloseWindowProcessIdentity,
 		},
 	)
 }
 
 func openCloseWindowProcessLinux(
 	pid int,
+	expected closeWindowProcessFingerprint,
 	runtime linuxPIDFDRuntime,
 ) (closeWindowProcess, error) {
 	if pid <= 0 {
 		return nil, fmt.Errorf("invalid Linux process id %d", pid)
 	}
-	if runtime.openPIDFD == nil || runtime.closeFD == nil || runtime.sendSignal == nil {
+	if !expected.valid() {
+		return nil, fmt.Errorf("invalid expected Linux process identity for pid %d", pid)
+	}
+	if runtime.openPIDFD == nil || runtime.closeFD == nil ||
+		runtime.sendSignal == nil || runtime.processIdentity == nil {
 		return nil, fmt.Errorf("%w: incomplete Linux pidfd runtime", ErrNotSupported)
 	}
 	pidfd, err := runtime.openPIDFD(pid, linuxPIDFDOpenFlags)
@@ -58,6 +97,19 @@ func openCloseWindowProcessLinux(
 			)
 		}
 		return nil, fmt.Errorf("open pidfd for process %d: %w", pid, err)
+	}
+	current, identityErr := runtime.processIdentity(pid)
+	if identityErr != nil {
+		return nil, errors.Join(
+			fmt.Errorf("verify pidfd process %d identity: %w", pid, identityErr),
+			runtime.closeFD(pidfd),
+		)
+	}
+	if current != expected {
+		return nil, errors.Join(
+			fmt.Errorf("process %d identity changed while opening pidfd", pid),
+			runtime.closeFD(pidfd),
+		)
 	}
 	return &linuxCloseWindowProcess{
 		pid:     pid,

--- a/process_runtime_linux_nocgo.go
+++ b/process_runtime_linux_nocgo.go
@@ -16,86 +16,100 @@ const (
 )
 
 type linuxPIDFDRuntime struct {
-	openPIDFD       func(int, int) (int, error)
-	closeFD         func(int) error
-	sendSignal      func(int, unix.Signal, *unix.Siginfo, int) error
-	processIdentity func(int) (int64, error)
+	openPIDFD  func(int, int) (int, error)
+	closeFD    func(int) error
+	sendSignal func(int, unix.Signal, *unix.Siginfo, int) error
 }
 
-func closeWindowProcessExists(pid int) (bool, error) {
-	return PidExists(pid)
+type linuxCloseWindowProcess struct {
+	pid     int
+	pidfd   int
+	runtime linuxPIDFDRuntime
 }
 
-func closeWindowProcessKill(pid int, identity int64) error {
-	return closeWindowProcessKillLinux(
+func openCloseWindowProcess(pid int) (closeWindowProcess, error) {
+	return openCloseWindowProcessLinux(
 		pid,
-		identity,
 		linuxPIDFDRuntime{
-			openPIDFD:       unix.PidfdOpen,
-			closeFD:         unix.Close,
-			sendSignal:      unix.PidfdSendSignal,
-			processIdentity: closeWindowProcessIdentity,
+			openPIDFD:  unix.PidfdOpen,
+			closeFD:    unix.Close,
+			sendSignal: unix.PidfdSendSignal,
 		},
 	)
 }
 
-func closeWindowProcessKillLinux(
+func openCloseWindowProcessLinux(
 	pid int,
-	identity int64,
 	runtime linuxPIDFDRuntime,
-) (resultErr error) {
-	if runtime.openPIDFD == nil || runtime.closeFD == nil ||
-		runtime.sendSignal == nil || runtime.processIdentity == nil {
-		return fmt.Errorf("%w: incomplete Linux pidfd runtime", ErrNotSupported)
+) (closeWindowProcess, error) {
+	if pid <= 0 {
+		return nil, fmt.Errorf("invalid Linux process id %d", pid)
+	}
+	if runtime.openPIDFD == nil || runtime.closeFD == nil || runtime.sendSignal == nil {
+		return nil, fmt.Errorf("%w: incomplete Linux pidfd runtime", ErrNotSupported)
 	}
 	pidfd, err := runtime.openPIDFD(pid, linuxPIDFDOpenFlags)
 	if err != nil {
-		if errors.Is(err, unix.ESRCH) {
-			return nil
-		}
 		if errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EINVAL) {
-			return fmt.Errorf(
-				"%w: Linux pidfd force-kill is unavailable: %w",
+			return nil, fmt.Errorf(
+				"%w: Linux pidfd process binding is unavailable: %w",
 				ErrNotSupported,
 				err,
 			)
 		}
-		return fmt.Errorf("open pidfd for process %d: %w", pid, err)
+		return nil, fmt.Errorf("open pidfd for process %d: %w", pid, err)
 	}
-	defer func() {
-		resultErr = errors.Join(resultErr, runtime.closeFD(pidfd))
-	}()
+	return &linuxCloseWindowProcess{
+		pid:     pid,
+		pidfd:   pidfd,
+		runtime: runtime,
+	}, nil
+}
 
-	currentIdentity, err := runtime.processIdentity(pid)
-	if err != nil {
-		probeErr := runtime.sendSignal(
-			pidfd,
-			linuxPIDFDProcessExistenceSignal,
-			nil,
-			linuxPIDFDSendSignalFlags,
-		)
-		if errors.Is(probeErr, unix.ESRCH) {
-			return nil
-		}
-		if probeErr != nil {
-			return fmt.Errorf(
-				"verify pidfd process %d after identity failure: %w",
-				pid,
-				errors.Join(err, probeErr),
-			)
-		}
-		return fmt.Errorf("verify pidfd process %d identity: %w", pid, err)
+func (process *linuxCloseWindowProcess) Running() (bool, error) {
+	if process == nil || process.pidfd < 0 {
+		return false, fmt.Errorf("%w: Linux pidfd process reference is closed", ErrNotSupported)
 	}
-	if currentIdentity != identity {
-		return nil
+	err := process.runtime.sendSignal(
+		process.pidfd,
+		linuxPIDFDProcessExistenceSignal,
+		nil,
+		linuxPIDFDSendSignalFlags,
+	)
+	switch {
+	case errors.Is(err, unix.ESRCH):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("probe pidfd process %d: %w", process.pid, err)
+	default:
+		return true, nil
 	}
-	if err := runtime.sendSignal(
-		pidfd,
+}
+
+func (process *linuxCloseWindowProcess) Kill() error {
+	if process == nil || process.pidfd < 0 {
+		return fmt.Errorf("%w: Linux pidfd process reference is closed", ErrNotSupported)
+	}
+	err := process.runtime.sendSignal(
+		process.pidfd,
 		unix.SIGKILL,
 		nil,
 		linuxPIDFDSendSignalFlags,
-	); err != nil && !errors.Is(err, unix.ESRCH) {
-		return fmt.Errorf("force-kill pidfd process %d: %w", pid, err)
+	)
+	if err != nil && !errors.Is(err, unix.ESRCH) {
+		return fmt.Errorf("force-kill pidfd process %d: %w", process.pid, err)
+	}
+	return nil
+}
+
+func (process *linuxCloseWindowProcess) Close() error {
+	if process == nil || process.pidfd < 0 {
+		return nil
+	}
+	pidfd := process.pidfd
+	process.pidfd = -1
+	if err := process.runtime.closeFD(pidfd); err != nil {
+		return fmt.Errorf("close pidfd for process %d: %w", process.pid, err)
 	}
 	return nil
 }

--- a/process_runtime_linux_nocgo.go
+++ b/process_runtime_linux_nocgo.go
@@ -1,0 +1,101 @@
+//go:build linux && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	linuxPIDFDOpenFlags              = 0
+	linuxPIDFDSendSignalFlags        = 0
+	linuxPIDFDProcessExistenceSignal = unix.Signal(0)
+)
+
+type linuxPIDFDRuntime struct {
+	openPIDFD       func(int, int) (int, error)
+	closeFD         func(int) error
+	sendSignal      func(int, unix.Signal, *unix.Siginfo, int) error
+	processIdentity func(int) (int64, error)
+}
+
+func closeWindowProcessExists(pid int) (bool, error) {
+	return PidExists(pid)
+}
+
+func closeWindowProcessKill(pid int, identity int64) error {
+	return closeWindowProcessKillLinux(
+		pid,
+		identity,
+		linuxPIDFDRuntime{
+			openPIDFD:       unix.PidfdOpen,
+			closeFD:         unix.Close,
+			sendSignal:      unix.PidfdSendSignal,
+			processIdentity: closeWindowProcessIdentity,
+		},
+	)
+}
+
+func closeWindowProcessKillLinux(
+	pid int,
+	identity int64,
+	runtime linuxPIDFDRuntime,
+) (resultErr error) {
+	if runtime.openPIDFD == nil || runtime.closeFD == nil ||
+		runtime.sendSignal == nil || runtime.processIdentity == nil {
+		return fmt.Errorf("%w: incomplete Linux pidfd runtime", ErrNotSupported)
+	}
+	pidfd, err := runtime.openPIDFD(pid, linuxPIDFDOpenFlags)
+	if err != nil {
+		if errors.Is(err, unix.ESRCH) {
+			return nil
+		}
+		if errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EINVAL) {
+			return fmt.Errorf(
+				"%w: Linux pidfd force-kill is unavailable: %w",
+				ErrNotSupported,
+				err,
+			)
+		}
+		return fmt.Errorf("open pidfd for process %d: %w", pid, err)
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, runtime.closeFD(pidfd))
+	}()
+
+	currentIdentity, err := runtime.processIdentity(pid)
+	if err != nil {
+		probeErr := runtime.sendSignal(
+			pidfd,
+			linuxPIDFDProcessExistenceSignal,
+			nil,
+			linuxPIDFDSendSignalFlags,
+		)
+		if errors.Is(probeErr, unix.ESRCH) {
+			return nil
+		}
+		if probeErr != nil {
+			return fmt.Errorf(
+				"verify pidfd process %d after identity failure: %w",
+				pid,
+				errors.Join(err, probeErr),
+			)
+		}
+		return fmt.Errorf("verify pidfd process %d identity: %w", pid, err)
+	}
+	if currentIdentity != identity {
+		return nil
+	}
+	if err := runtime.sendSignal(
+		pidfd,
+		unix.SIGKILL,
+		nil,
+		linuxPIDFDSendSignalFlags,
+	); err != nil && !errors.Is(err, unix.ESRCH) {
+		return fmt.Errorf("force-kill pidfd process %d: %w", pid, err)
+	}
+	return nil
+}

--- a/process_runtime_linux_nocgo_test.go
+++ b/process_runtime_linux_nocgo_test.go
@@ -11,22 +11,24 @@ import (
 )
 
 type fakeLinuxPIDFDRuntime struct {
-	openFD      int
-	openErr     error
-	identity    int64
-	identityErr error
-	sendErr     error
-	closeErr    error
-	closedFD    int
-	signals     []unix.Signal
+	openFD     int
+	openErr    error
+	sendErrs   []error
+	closeErr   error
+	opened     bool
+	closeCalls int
+	closedFD   int
+	signals    []unix.Signal
 }
 
 func (runtime *fakeLinuxPIDFDRuntime) dependencies() linuxPIDFDRuntime {
 	return linuxPIDFDRuntime{
 		openPIDFD: func(int, int) (int, error) {
+			runtime.opened = true
 			return runtime.openFD, runtime.openErr
 		},
 		closeFD: func(fd int) error {
+			runtime.closeCalls++
 			runtime.closedFD = fd
 			return runtime.closeErr
 		},
@@ -37,91 +39,137 @@ func (runtime *fakeLinuxPIDFDRuntime) dependencies() linuxPIDFDRuntime {
 			_ int,
 		) error {
 			runtime.signals = append(runtime.signals, signal)
-			return runtime.sendErr
-		},
-		processIdentity: func(int) (int64, error) {
-			return runtime.identity, runtime.identityErr
+			if len(runtime.sendErrs) == 0 {
+				return nil
+			}
+			err := runtime.sendErrs[0]
+			runtime.sendErrs = runtime.sendErrs[1:]
+			return err
 		},
 	}
 }
 
-func TestCloseWindowProcessKillLinuxUsesBoundPIDFD(t *testing.T) {
-	runtime := &fakeLinuxPIDFDRuntime{openFD: 9, identity: 100}
+func TestOpenCloseWindowProcessLinuxBindsBeforeUse(t *testing.T) {
+	runtime := &fakeLinuxPIDFDRuntime{openFD: 9}
 
-	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
+	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
 	if err != nil {
-		t.Fatalf("closeWindowProcessKillLinux() error = %v", err)
+		t.Fatalf("openCloseWindowProcessLinux() error = %v", err)
 	}
-	if got, want := runtime.signals, []unix.Signal{unix.SIGKILL}; !reflect.DeepEqual(got, want) {
+	if !runtime.opened {
+		t.Fatal("pidfd was not opened")
+	}
+
+	running, err := reference.Running()
+	if err != nil {
+		t.Fatalf("Running() error = %v", err)
+	}
+	if !running {
+		t.Fatal("Running() = false, want true")
+	}
+	if err := reference.Kill(); err != nil {
+		t.Fatalf("Kill() error = %v", err)
+	}
+	if got, want := runtime.signals, []unix.Signal{0, unix.SIGKILL}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("pidfd signals = %v, want %v", got, want)
+	}
+	if err := reference.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
 	}
 	if runtime.closedFD != 9 {
 		t.Fatalf("closed fd = %d, want 9", runtime.closedFD)
 	}
 }
 
-func TestCloseWindowProcessKillLinuxRejectsReusedPID(t *testing.T) {
-	runtime := &fakeLinuxPIDFDRuntime{openFD: 9, identity: 200}
-
-	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
-	if err != nil {
-		t.Fatalf("closeWindowProcessKillLinux() error = %v", err)
-	}
-	if len(runtime.signals) != 0 {
-		t.Fatalf("signals for reused PID = %v, want none", runtime.signals)
-	}
-}
-
-func TestCloseWindowProcessKillLinuxHandlesExitDuringIdentityProbe(t *testing.T) {
+func TestCloseWindowProcessLinuxHandlesBoundProcessExit(t *testing.T) {
 	runtime := &fakeLinuxPIDFDRuntime{
-		openFD:      9,
-		identityErr: errors.New("process exited"),
-		sendErr:     unix.ESRCH,
+		openFD:   9,
+		sendErrs: []error{unix.ESRCH, unix.ESRCH},
 	}
-
-	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
+	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
 	if err != nil {
-		t.Fatalf("closeWindowProcessKillLinux() error = %v", err)
+		t.Fatalf("openCloseWindowProcessLinux() error = %v", err)
 	}
-	if got, want := runtime.signals, []unix.Signal{linuxPIDFDProcessExistenceSignal}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("pidfd signals = %v, want %v", got, want)
+	t.Cleanup(func() {
+		if closeErr := reference.Close(); closeErr != nil {
+			t.Errorf("Close() error = %v", closeErr)
+		}
+	})
+
+	running, err := reference.Running()
+	if err != nil {
+		t.Fatalf("Running() error = %v", err)
+	}
+	if running {
+		t.Fatal("Running() = true after bound process exit")
+	}
+	if err := reference.Kill(); err != nil {
+		t.Fatalf("Kill() after exit error = %v", err)
 	}
 }
 
-func TestCloseWindowProcessKillLinuxReportsUnavailablePIDFD(t *testing.T) {
+func TestOpenCloseWindowProcessLinuxReportsUnavailablePIDFD(t *testing.T) {
 	runtime := &fakeLinuxPIDFDRuntime{openErr: unix.ENOSYS}
 
-	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
+	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	if reference != nil {
+		t.Fatalf("reference = %#v, want nil", reference)
+	}
 	if !errors.Is(err, ErrNotSupported) {
 		t.Fatalf("error = %v, want ErrNotSupported", err)
 	}
-	if runtime.closedFD != 0 {
-		t.Fatalf("closed fd = %d after failed open", runtime.closedFD)
+	if runtime.closeCalls != 0 {
+		t.Fatalf("close calls = %d after failed open", runtime.closeCalls)
 	}
 }
 
-func TestCloseWindowProcessKillLinuxHandlesExitBeforePIDFDOpen(t *testing.T) {
+func TestOpenCloseWindowProcessLinuxDoesNotTreatPreBindExitAsSuccess(t *testing.T) {
 	runtime := &fakeLinuxPIDFDRuntime{openErr: unix.ESRCH}
 
-	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
-	if err != nil {
-		t.Fatalf("closeWindowProcessKillLinux() error = %v", err)
+	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	if reference != nil {
+		t.Fatalf("reference = %#v, want nil", reference)
 	}
-	if runtime.closedFD != 0 {
-		t.Fatalf("closed fd = %d after failed open", runtime.closedFD)
+	if !errors.Is(err, unix.ESRCH) {
+		t.Fatalf("error = %v, want ESRCH", err)
 	}
 }
 
-func TestCloseWindowProcessKillLinuxReportsCloseFailure(t *testing.T) {
+func TestCloseWindowProcessLinuxReportsAndDoesNotRepeatCloseFailure(t *testing.T) {
 	closeErr := errors.New("close failed")
-	runtime := &fakeLinuxPIDFDRuntime{
-		openFD:   9,
-		identity: 100,
-		closeErr: closeErr,
+	runtime := &fakeLinuxPIDFDRuntime{openFD: 9, closeErr: closeErr}
+	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	if err != nil {
+		t.Fatalf("openCloseWindowProcessLinux() error = %v", err)
 	}
 
-	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
-	if !errors.Is(err, closeErr) {
-		t.Fatalf("error = %v, want close error", err)
+	if err := reference.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("first Close() error = %v, want close error", err)
+	}
+	runtime.closeErr = errors.New("unexpected repeated close")
+	if err := reference.Close(); err != nil {
+		t.Fatalf("second Close() error = %v, want nil", err)
+	}
+	if runtime.closeCalls != 1 {
+		t.Fatalf("close calls = %d, want 1", runtime.closeCalls)
+	}
+}
+
+func TestCloseWindowProcessLinuxClosesFileDescriptorZero(t *testing.T) {
+	runtime := &fakeLinuxPIDFDRuntime{openFD: 0}
+	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	if err != nil {
+		t.Fatalf("openCloseWindowProcessLinux() error = %v", err)
+	}
+
+	if err := reference.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if runtime.closeCalls != 1 || runtime.closedFD != 0 {
+		t.Fatalf(
+			"close result = calls %d, fd %d; want calls 1, fd 0",
+			runtime.closeCalls,
+			runtime.closedFD,
+		)
 	}
 }

--- a/process_runtime_linux_nocgo_test.go
+++ b/process_runtime_linux_nocgo_test.go
@@ -4,6 +4,7 @@ package robotgo
 
 import (
 	"errors"
+	"os"
 	"reflect"
 	"testing"
 
@@ -11,17 +12,22 @@ import (
 )
 
 type fakeLinuxPIDFDRuntime struct {
-	openFD     int
-	openErr    error
-	sendErrs   []error
-	closeErr   error
-	opened     bool
-	closeCalls int
-	closedFD   int
-	signals    []unix.Signal
+	openFD      int
+	openErr     error
+	identity    closeWindowProcessFingerprint
+	identityErr error
+	sendErrs    []error
+	closeErr    error
+	opened      bool
+	closeCalls  int
+	closedFD    int
+	signals     []unix.Signal
 }
 
 func (runtime *fakeLinuxPIDFDRuntime) dependencies() linuxPIDFDRuntime {
+	if !runtime.identity.valid() {
+		runtime.identity = linuxTestProcessIdentity()
+	}
 	return linuxPIDFDRuntime{
 		openPIDFD: func(int, int) (int, error) {
 			runtime.opened = true
@@ -46,13 +52,38 @@ func (runtime *fakeLinuxPIDFDRuntime) dependencies() linuxPIDFDRuntime {
 			runtime.sendErrs = runtime.sendErrs[1:]
 			return err
 		},
+		processIdentity: func(int) (closeWindowProcessFingerprint, error) {
+			return runtime.identity, runtime.identityErr
+		},
+	}
+}
+
+func linuxTestProcessIdentity() closeWindowProcessFingerprint {
+	return closeWindowProcessFingerprint{primary: 1, secondary: 2}
+}
+
+func TestCaptureCloseWindowProcessIdentityLinuxIsStable(t *testing.T) {
+	first, err := captureCloseWindowProcessIdentity(os.Getpid())
+	if err != nil {
+		t.Fatalf("first process identity: %v", err)
+	}
+	second, err := captureCloseWindowProcessIdentity(os.Getpid())
+	if err != nil {
+		t.Fatalf("second process identity: %v", err)
+	}
+	if !first.valid() || first != second {
+		t.Fatalf("Linux process identities = (%+v, %+v), want equal valid values", first, second)
 	}
 }
 
 func TestOpenCloseWindowProcessLinuxBindsBeforeUse(t *testing.T) {
 	runtime := &fakeLinuxPIDFDRuntime{openFD: 9}
 
-	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	reference, err := openCloseWindowProcessLinux(
+		42,
+		linuxTestProcessIdentity(),
+		runtime.dependencies(),
+	)
 	if err != nil {
 		t.Fatalf("openCloseWindowProcessLinux() error = %v", err)
 	}
@@ -86,7 +117,11 @@ func TestCloseWindowProcessLinuxHandlesBoundProcessExit(t *testing.T) {
 		openFD:   9,
 		sendErrs: []error{unix.ESRCH, unix.ESRCH},
 	}
-	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	reference, err := openCloseWindowProcessLinux(
+		42,
+		linuxTestProcessIdentity(),
+		runtime.dependencies(),
+	)
 	if err != nil {
 		t.Fatalf("openCloseWindowProcessLinux() error = %v", err)
 	}
@@ -111,7 +146,11 @@ func TestCloseWindowProcessLinuxHandlesBoundProcessExit(t *testing.T) {
 func TestOpenCloseWindowProcessLinuxReportsUnavailablePIDFD(t *testing.T) {
 	runtime := &fakeLinuxPIDFDRuntime{openErr: unix.ENOSYS}
 
-	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	reference, err := openCloseWindowProcessLinux(
+		42,
+		linuxTestProcessIdentity(),
+		runtime.dependencies(),
+	)
 	if reference != nil {
 		t.Fatalf("reference = %#v, want nil", reference)
 	}
@@ -126,7 +165,11 @@ func TestOpenCloseWindowProcessLinuxReportsUnavailablePIDFD(t *testing.T) {
 func TestOpenCloseWindowProcessLinuxDoesNotTreatPreBindExitAsSuccess(t *testing.T) {
 	runtime := &fakeLinuxPIDFDRuntime{openErr: unix.ESRCH}
 
-	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	reference, err := openCloseWindowProcessLinux(
+		42,
+		linuxTestProcessIdentity(),
+		runtime.dependencies(),
+	)
 	if reference != nil {
 		t.Fatalf("reference = %#v, want nil", reference)
 	}
@@ -135,10 +178,46 @@ func TestOpenCloseWindowProcessLinuxDoesNotTreatPreBindExitAsSuccess(t *testing.
 	}
 }
 
+func TestOpenCloseWindowProcessLinuxRejectsIdentityChangeAfterPIDFDOpen(t *testing.T) {
+	runtime := &fakeLinuxPIDFDRuntime{
+		openFD: 9,
+		identity: closeWindowProcessFingerprint{
+			primary:   1,
+			secondary: 3,
+		},
+	}
+
+	reference, err := openCloseWindowProcessLinux(
+		42,
+		linuxTestProcessIdentity(),
+		runtime.dependencies(),
+	)
+	if err == nil {
+		t.Fatal("openCloseWindowProcessLinux() accepted changed process identity")
+	}
+	if reference != nil {
+		t.Fatalf("reference = %#v, want nil", reference)
+	}
+	if runtime.closeCalls != 1 || runtime.closedFD != 9 {
+		t.Fatalf(
+			"rejected pidfd cleanup = calls %d, fd %d; want calls 1, fd 9",
+			runtime.closeCalls,
+			runtime.closedFD,
+		)
+	}
+	if len(runtime.signals) != 0 {
+		t.Fatalf("signals after identity change = %v, want none", runtime.signals)
+	}
+}
+
 func TestCloseWindowProcessLinuxReportsAndDoesNotRepeatCloseFailure(t *testing.T) {
 	closeErr := errors.New("close failed")
 	runtime := &fakeLinuxPIDFDRuntime{openFD: 9, closeErr: closeErr}
-	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	reference, err := openCloseWindowProcessLinux(
+		42,
+		linuxTestProcessIdentity(),
+		runtime.dependencies(),
+	)
 	if err != nil {
 		t.Fatalf("openCloseWindowProcessLinux() error = %v", err)
 	}
@@ -157,7 +236,11 @@ func TestCloseWindowProcessLinuxReportsAndDoesNotRepeatCloseFailure(t *testing.T
 
 func TestCloseWindowProcessLinuxClosesFileDescriptorZero(t *testing.T) {
 	runtime := &fakeLinuxPIDFDRuntime{openFD: 0}
-	reference, err := openCloseWindowProcessLinux(42, runtime.dependencies())
+	reference, err := openCloseWindowProcessLinux(
+		42,
+		linuxTestProcessIdentity(),
+		runtime.dependencies(),
+	)
 	if err != nil {
 		t.Fatalf("openCloseWindowProcessLinux() error = %v", err)
 	}

--- a/process_runtime_linux_nocgo_test.go
+++ b/process_runtime_linux_nocgo_test.go
@@ -1,0 +1,127 @@
+//go:build linux && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+type fakeLinuxPIDFDRuntime struct {
+	openFD      int
+	openErr     error
+	identity    int64
+	identityErr error
+	sendErr     error
+	closeErr    error
+	closedFD    int
+	signals     []unix.Signal
+}
+
+func (runtime *fakeLinuxPIDFDRuntime) dependencies() linuxPIDFDRuntime {
+	return linuxPIDFDRuntime{
+		openPIDFD: func(int, int) (int, error) {
+			return runtime.openFD, runtime.openErr
+		},
+		closeFD: func(fd int) error {
+			runtime.closedFD = fd
+			return runtime.closeErr
+		},
+		sendSignal: func(
+			_ int,
+			signal unix.Signal,
+			_ *unix.Siginfo,
+			_ int,
+		) error {
+			runtime.signals = append(runtime.signals, signal)
+			return runtime.sendErr
+		},
+		processIdentity: func(int) (int64, error) {
+			return runtime.identity, runtime.identityErr
+		},
+	}
+}
+
+func TestCloseWindowProcessKillLinuxUsesBoundPIDFD(t *testing.T) {
+	runtime := &fakeLinuxPIDFDRuntime{openFD: 9, identity: 100}
+
+	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
+	if err != nil {
+		t.Fatalf("closeWindowProcessKillLinux() error = %v", err)
+	}
+	if got, want := runtime.signals, []unix.Signal{unix.SIGKILL}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("pidfd signals = %v, want %v", got, want)
+	}
+	if runtime.closedFD != 9 {
+		t.Fatalf("closed fd = %d, want 9", runtime.closedFD)
+	}
+}
+
+func TestCloseWindowProcessKillLinuxRejectsReusedPID(t *testing.T) {
+	runtime := &fakeLinuxPIDFDRuntime{openFD: 9, identity: 200}
+
+	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
+	if err != nil {
+		t.Fatalf("closeWindowProcessKillLinux() error = %v", err)
+	}
+	if len(runtime.signals) != 0 {
+		t.Fatalf("signals for reused PID = %v, want none", runtime.signals)
+	}
+}
+
+func TestCloseWindowProcessKillLinuxHandlesExitDuringIdentityProbe(t *testing.T) {
+	runtime := &fakeLinuxPIDFDRuntime{
+		openFD:      9,
+		identityErr: errors.New("process exited"),
+		sendErr:     unix.ESRCH,
+	}
+
+	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
+	if err != nil {
+		t.Fatalf("closeWindowProcessKillLinux() error = %v", err)
+	}
+	if got, want := runtime.signals, []unix.Signal{linuxPIDFDProcessExistenceSignal}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("pidfd signals = %v, want %v", got, want)
+	}
+}
+
+func TestCloseWindowProcessKillLinuxReportsUnavailablePIDFD(t *testing.T) {
+	runtime := &fakeLinuxPIDFDRuntime{openErr: unix.ENOSYS}
+
+	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
+	if !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("error = %v, want ErrNotSupported", err)
+	}
+	if runtime.closedFD != 0 {
+		t.Fatalf("closed fd = %d after failed open", runtime.closedFD)
+	}
+}
+
+func TestCloseWindowProcessKillLinuxHandlesExitBeforePIDFDOpen(t *testing.T) {
+	runtime := &fakeLinuxPIDFDRuntime{openErr: unix.ESRCH}
+
+	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
+	if err != nil {
+		t.Fatalf("closeWindowProcessKillLinux() error = %v", err)
+	}
+	if runtime.closedFD != 0 {
+		t.Fatalf("closed fd = %d after failed open", runtime.closedFD)
+	}
+}
+
+func TestCloseWindowProcessKillLinuxReportsCloseFailure(t *testing.T) {
+	closeErr := errors.New("close failed")
+	runtime := &fakeLinuxPIDFDRuntime{
+		openFD:   9,
+		identity: 100,
+		closeErr: closeErr,
+	}
+
+	err := closeWindowProcessKillLinux(42, 100, runtime.dependencies())
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("error = %v, want close error", err)
+	}
+}

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -958,4 +958,3 @@ func GetPid() int {
 func MinWindow(target int, args ...interface{}) { _ = MinWindowE(target, args...) }
 func MaxWindow(target int, args ...interface{}) { _ = MaxWindowE(target, args...) }
 func CloseWindow(args ...int)                   { _ = CloseWindowE(args...) }
-func CloseWindowKill(...int) error              { return ErrNotSupported }

--- a/window_backend_darwin_nocgo.go
+++ b/window_backend_darwin_nocgo.go
@@ -24,6 +24,7 @@ func platformPureGoWindowCapability() FeatureCapability {
 		Backend: featureBackendPureGoMacOSWindow,
 		Notes: "active/PID/CGWindowID resolution, title, AX frame bounds, " +
 			"activation, minimize/restore, minimized state, and close are supported; " +
+			"CloseWindowKill can request graceful close but has no safe force-kill fallback; " +
 			"client bounds equal the AX frame; maximize and topmost are explicitly unsupported; " +
 			"CGWindowID-to-Accessibility mapping requires the runtime-resolved macOS bridge",
 	}

--- a/window_backend_linux_x11_nocgo.go
+++ b/window_backend_linux_x11_nocgo.go
@@ -36,7 +36,7 @@ func platformPureGoWindowCapability() FeatureCapability {
 		Available: true,
 		Backend:   featureBackendPureGoX11,
 		Reason:    "Pure-Go X11 window introspection and EWMH control are selected",
-		Notes:     "runtime X server access is validated per operation; mutations require a consistent EWMH manager that advertises the operation",
+		Notes:     "runtime X server access is validated per operation; mutations require a consistent EWMH manager that advertises the operation; CloseWindowKill force fallback requires Linux pidfd support",
 	}
 }
 

--- a/window_close_kill_nocgo.go
+++ b/window_close_kill_nocgo.go
@@ -16,11 +16,15 @@ const (
 )
 
 type closeWindowKillRuntime struct {
-	now             func() time.Time
-	sleep           func(time.Duration)
-	pidExists       func(int) (bool, error)
-	processIdentity func(int) (int64, error)
-	kill            func(int, int64) error
+	now         func() time.Time
+	sleep       func(time.Duration)
+	openProcess func(int) (closeWindowProcess, error)
+}
+
+type closeWindowProcess interface {
+	Running() (bool, error)
+	Kill() error
+	Close() error
 }
 
 // CloseWindowKill closes the target window and ensures the owning process
@@ -43,11 +47,9 @@ func CloseWindowKill(args ...int) error {
 
 func platformCloseWindowKillRuntime() closeWindowKillRuntime {
 	return closeWindowKillRuntime{
-		now:             time.Now,
-		sleep:           time.Sleep,
-		pidExists:       closeWindowProcessExists,
-		processIdentity: closeWindowProcessIdentity,
-		kill:            closeWindowProcessKill,
+		now:         time.Now,
+		sleep:       time.Sleep,
+		openProcess: openCloseWindowProcess,
 	}
 }
 
@@ -56,7 +58,7 @@ func closeWindowKillWith(
 	args []int,
 	treatAsHandle bool,
 	runtime closeWindowKillRuntime,
-) error {
+) (resultErr error) {
 	if err := runtime.validate(); err != nil {
 		return err
 	}
@@ -64,22 +66,37 @@ func closeWindowKillWith(
 	if err != nil {
 		return err
 	}
-	identity, err := runtime.processIdentity(pid)
+	process, err := runtime.openProcess(pid)
 	if err != nil {
-		return fmt.Errorf("capture window process %d identity: %w", pid, err)
+		return fmt.Errorf("bind window process %d before close: %w", pid, err)
 	}
-	if identity <= 0 {
+	if process == nil {
+		return fmt.Errorf("%w: process binder returned nil for pid %d", windowbackend.ErrOperation, pid)
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, process.Close())
+	}()
+
+	// Re-read ownership after acquiring the stable process reference. If the
+	// original owner exited during acquisition, do not close the stale window
+	// or bind a destructive fallback to a replacement that reused its PID.
+	currentPID, err := backend.PID(handle)
+	if err != nil {
+		return err
+	}
+	if currentPID != pid {
 		return fmt.Errorf(
-			"%w: window process %d returned invalid identity %d",
-			windowbackend.ErrOperation,
+			"%w: window handle %#x owner changed from pid %d to %d",
+			windowbackend.ErrWindowNotFound,
+			uintptr(handle),
 			pid,
-			identity,
+			currentPID,
 		)
 	}
 	if err := backend.Close(handle); err != nil {
 		return err
 	}
-	return waitForWindowProcessExit(pid, identity, runtime)
+	return waitForWindowProcessExit(pid, process, runtime)
 }
 
 func resolveCloseWindowKillTarget(
@@ -116,27 +133,22 @@ func resolveCloseWindowKillTarget(
 
 func waitForWindowProcessExit(
 	pid int,
-	identity int64,
+	process closeWindowProcess,
 	runtime closeWindowKillRuntime,
 ) error {
 	if err := runtime.validate(); err != nil {
 		return err
 	}
-	if identity <= 0 {
-		return fmt.Errorf(
-			"%w: invalid process identity %d for pid %d",
-			windowbackend.ErrOperation,
-			identity,
-			pid,
-		)
+	if process == nil {
+		return fmt.Errorf("%w: nil process reference for pid %d", windowbackend.ErrOperation, pid)
 	}
 	deadline := runtime.now().Add(closeWindowKillGracePeriod)
 	for runtime.now().Before(deadline) {
-		matches, err := windowProcessMatches(pid, identity, runtime)
+		running, err := process.Running()
 		if err != nil {
-			return err
+			return fmt.Errorf("check window process %d after graceful close: %w", pid, err)
 		}
-		if !matches {
+		if !running {
 			return nil
 		}
 
@@ -144,53 +156,21 @@ func waitForWindowProcessExit(
 		delay := min(closeWindowKillPollInterval, remaining)
 		runtime.sleep(delay)
 	}
-	matches, err := windowProcessMatches(pid, identity, runtime)
+	running, err := process.Running()
 	if err != nil {
-		return err
+		return fmt.Errorf("check window process %d at grace deadline: %w", pid, err)
 	}
-	if !matches {
+	if !running {
 		return nil
 	}
-	if err := runtime.kill(pid, identity); err != nil {
+	if err := process.Kill(); err != nil {
 		return fmt.Errorf("force-kill window process %d: %w", pid, err)
 	}
 	return nil
 }
 
-func windowProcessMatches(
-	pid int,
-	identity int64,
-	runtime closeWindowKillRuntime,
-) (bool, error) {
-	exists, err := runtime.pidExists(pid)
-	if err != nil {
-		return false, fmt.Errorf("check window process %d after graceful close: %w", pid, err)
-	}
-	if !exists {
-		return false, nil
-	}
-	currentIdentity, err := runtime.processIdentity(pid)
-	if err != nil {
-		stillExists, probeErr := runtime.pidExists(pid)
-		if probeErr != nil {
-			return false, fmt.Errorf(
-				"verify window process %d identity after probe failure: %w",
-				pid,
-				errors.Join(err, probeErr),
-			)
-		}
-		if !stillExists {
-			return false, nil
-		}
-		return false, fmt.Errorf("verify window process %d identity: %w", pid, err)
-	}
-	return currentIdentity == identity, nil
-}
-
 func (runtime closeWindowKillRuntime) validate() error {
-	if runtime.now == nil || runtime.sleep == nil ||
-		runtime.pidExists == nil || runtime.processIdentity == nil ||
-		runtime.kill == nil {
+	if runtime.now == nil || runtime.sleep == nil || runtime.openProcess == nil {
 		return fmt.Errorf(
 			"%w: incomplete CloseWindowKill runtime",
 			windowbackend.ErrOperation,

--- a/window_close_kill_nocgo.go
+++ b/window_close_kill_nocgo.go
@@ -1,0 +1,184 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+const (
+	closeWindowKillGracePeriod  = 1500 * time.Millisecond
+	closeWindowKillPollInterval = 100 * time.Millisecond
+)
+
+type closeWindowKillRuntime struct {
+	now             func() time.Time
+	sleep           func(time.Duration)
+	pidExists       func(int) (bool, error)
+	processIdentity func(int) (int64, error)
+	kill            func(int) error
+}
+
+// CloseWindowKill closes the target window and ensures the owning process
+// terminates. A PID is the default target; a second argument or NotPid treats
+// the first argument as a native handle. If no target is supplied, the active
+// window is used. The process is force-killed only after a successful graceful
+// close and a bounded grace period.
+func CloseWindowKill(args ...int) error {
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return err
+	}
+	return closeWindowKillWith(
+		backend,
+		args,
+		currentTreatAsHandle(),
+		platformCloseWindowKillRuntime(),
+	)
+}
+
+func platformCloseWindowKillRuntime() closeWindowKillRuntime {
+	return closeWindowKillRuntime{
+		now:             time.Now,
+		sleep:           time.Sleep,
+		pidExists:       PidExists,
+		processIdentity: closeWindowProcessIdentity,
+		kill:            Kill,
+	}
+}
+
+func closeWindowKillWith(
+	backend windowbackend.Backend,
+	args []int,
+	treatAsHandle bool,
+	runtime closeWindowKillRuntime,
+) error {
+	if err := runtime.validate(); err != nil {
+		return err
+	}
+	handle, pid, err := resolveCloseWindowKillTarget(backend, args, treatAsHandle)
+	if err != nil {
+		return err
+	}
+	identity, err := runtime.processIdentity(pid)
+	if err != nil {
+		return fmt.Errorf("capture window process %d identity: %w", pid, err)
+	}
+	if identity <= 0 {
+		return fmt.Errorf(
+			"%w: window process %d returned invalid identity %d",
+			windowbackend.ErrOperation,
+			pid,
+			identity,
+		)
+	}
+	if err := backend.Close(handle); err != nil {
+		return err
+	}
+	return waitForWindowProcessExit(pid, identity, runtime)
+}
+
+func resolveCloseWindowKillTarget(
+	backend windowbackend.Backend,
+	args []int,
+	treatAsHandle bool,
+) (windowbackend.Handle, int, error) {
+	var (
+		handle windowbackend.Handle
+		err    error
+	)
+	if len(args) == 0 {
+		handle, err = backend.Active()
+	} else {
+		handle, err = backend.Resolve(args[0], len(args) > 1 || treatAsHandle)
+	}
+	if err != nil {
+		return 0, 0, err
+	}
+	pid, err := backend.PID(handle)
+	if err != nil {
+		return 0, 0, err
+	}
+	if pid <= 0 {
+		return 0, 0, fmt.Errorf(
+			"%w: window handle %#x returned invalid pid %d",
+			windowbackend.ErrWindowNotFound,
+			uintptr(handle),
+			pid,
+		)
+	}
+	return handle, pid, nil
+}
+
+func waitForWindowProcessExit(
+	pid int,
+	identity int64,
+	runtime closeWindowKillRuntime,
+) error {
+	if err := runtime.validate(); err != nil {
+		return err
+	}
+	if identity <= 0 {
+		return fmt.Errorf(
+			"%w: invalid process identity %d for pid %d",
+			windowbackend.ErrOperation,
+			identity,
+			pid,
+		)
+	}
+	deadline := runtime.now().Add(closeWindowKillGracePeriod)
+	for {
+		exists, err := runtime.pidExists(pid)
+		if err != nil {
+			return fmt.Errorf("check window process %d after graceful close: %w", pid, err)
+		}
+		if !exists {
+			return nil
+		}
+		currentIdentity, err := runtime.processIdentity(pid)
+		if err != nil {
+			stillExists, probeErr := runtime.pidExists(pid)
+			if probeErr != nil {
+				return fmt.Errorf(
+					"verify window process %d identity after probe failure: %w",
+					pid,
+					errors.Join(err, probeErr),
+				)
+			}
+			if !stillExists {
+				return nil
+			}
+			return fmt.Errorf("verify window process %d identity: %w", pid, err)
+		}
+		if currentIdentity != identity {
+			return nil
+		}
+
+		remaining := deadline.Sub(runtime.now())
+		if remaining <= 0 {
+			break
+		}
+		delay := min(closeWindowKillPollInterval, remaining)
+		runtime.sleep(delay)
+	}
+	if err := runtime.kill(pid); err != nil {
+		return fmt.Errorf("force-kill window process %d: %w", pid, err)
+	}
+	return nil
+}
+
+func (runtime closeWindowKillRuntime) validate() error {
+	if runtime.now == nil || runtime.sleep == nil ||
+		runtime.pidExists == nil || runtime.processIdentity == nil ||
+		runtime.kill == nil {
+		return fmt.Errorf(
+			"%w: incomplete CloseWindowKill runtime",
+			windowbackend.ErrOperation,
+		)
+	}
+	return nil
+}

--- a/window_close_kill_nocgo.go
+++ b/window_close_kill_nocgo.go
@@ -20,7 +20,7 @@ type closeWindowKillRuntime struct {
 	sleep           func(time.Duration)
 	pidExists       func(int) (bool, error)
 	processIdentity func(int) (int64, error)
-	kill            func(int) error
+	kill            func(int, int64) error
 }
 
 // CloseWindowKill closes the target window and ensures the owning process
@@ -45,9 +45,9 @@ func platformCloseWindowKillRuntime() closeWindowKillRuntime {
 	return closeWindowKillRuntime{
 		now:             time.Now,
 		sleep:           time.Sleep,
-		pidExists:       PidExists,
+		pidExists:       closeWindowProcessExists,
 		processIdentity: closeWindowProcessIdentity,
-		kill:            Kill,
+		kill:            closeWindowProcessKill,
 	}
 }
 
@@ -131,44 +131,60 @@ func waitForWindowProcessExit(
 		)
 	}
 	deadline := runtime.now().Add(closeWindowKillGracePeriod)
-	for {
-		exists, err := runtime.pidExists(pid)
+	for runtime.now().Before(deadline) {
+		matches, err := windowProcessMatches(pid, identity, runtime)
 		if err != nil {
-			return fmt.Errorf("check window process %d after graceful close: %w", pid, err)
+			return err
 		}
-		if !exists {
-			return nil
-		}
-		currentIdentity, err := runtime.processIdentity(pid)
-		if err != nil {
-			stillExists, probeErr := runtime.pidExists(pid)
-			if probeErr != nil {
-				return fmt.Errorf(
-					"verify window process %d identity after probe failure: %w",
-					pid,
-					errors.Join(err, probeErr),
-				)
-			}
-			if !stillExists {
-				return nil
-			}
-			return fmt.Errorf("verify window process %d identity: %w", pid, err)
-		}
-		if currentIdentity != identity {
+		if !matches {
 			return nil
 		}
 
 		remaining := deadline.Sub(runtime.now())
-		if remaining <= 0 {
-			break
-		}
 		delay := min(closeWindowKillPollInterval, remaining)
 		runtime.sleep(delay)
 	}
-	if err := runtime.kill(pid); err != nil {
+	matches, err := windowProcessMatches(pid, identity, runtime)
+	if err != nil {
+		return err
+	}
+	if !matches {
+		return nil
+	}
+	if err := runtime.kill(pid, identity); err != nil {
 		return fmt.Errorf("force-kill window process %d: %w", pid, err)
 	}
 	return nil
+}
+
+func windowProcessMatches(
+	pid int,
+	identity int64,
+	runtime closeWindowKillRuntime,
+) (bool, error) {
+	exists, err := runtime.pidExists(pid)
+	if err != nil {
+		return false, fmt.Errorf("check window process %d after graceful close: %w", pid, err)
+	}
+	if !exists {
+		return false, nil
+	}
+	currentIdentity, err := runtime.processIdentity(pid)
+	if err != nil {
+		stillExists, probeErr := runtime.pidExists(pid)
+		if probeErr != nil {
+			return false, fmt.Errorf(
+				"verify window process %d identity after probe failure: %w",
+				pid,
+				errors.Join(err, probeErr),
+			)
+		}
+		if !stillExists {
+			return false, nil
+		}
+		return false, fmt.Errorf("verify window process %d identity: %w", pid, err)
+	}
+	return currentIdentity == identity, nil
 }
 
 func (runtime closeWindowKillRuntime) validate() error {

--- a/window_close_kill_nocgo.go
+++ b/window_close_kill_nocgo.go
@@ -16,9 +16,19 @@ const (
 )
 
 type closeWindowKillRuntime struct {
-	now         func() time.Time
-	sleep       func(time.Duration)
-	openProcess func(int) (closeWindowProcess, error)
+	now             func() time.Time
+	sleep           func(time.Duration)
+	processIdentity func(int) (closeWindowProcessFingerprint, error)
+	openProcess     func(int, closeWindowProcessFingerprint) (closeWindowProcess, error)
+}
+
+type closeWindowProcessFingerprint struct {
+	primary   uint64
+	secondary uint64
+}
+
+func (identity closeWindowProcessFingerprint) valid() bool {
+	return identity.primary != 0 || identity.secondary != 0
 }
 
 type closeWindowProcess interface {
@@ -47,9 +57,10 @@ func CloseWindowKill(args ...int) error {
 
 func platformCloseWindowKillRuntime() closeWindowKillRuntime {
 	return closeWindowKillRuntime{
-		now:         time.Now,
-		sleep:       time.Sleep,
-		openProcess: openCloseWindowProcess,
+		now:             time.Now,
+		sleep:           time.Sleep,
+		processIdentity: captureCloseWindowProcessIdentity,
+		openProcess:     openCloseWindowProcess,
 	}
 }
 
@@ -66,7 +77,14 @@ func closeWindowKillWith(
 	if err != nil {
 		return err
 	}
-	process, err := runtime.openProcess(pid)
+	identity, err := runtime.processIdentity(pid)
+	if err != nil {
+		return fmt.Errorf("capture window process %d identity before binding: %w", pid, err)
+	}
+	if !identity.valid() {
+		return fmt.Errorf("%w: invalid process identity for pid %d", windowbackend.ErrOperation, pid)
+	}
+	process, err := runtime.openProcess(pid, identity)
 	if err != nil {
 		return fmt.Errorf("bind window process %d before close: %w", pid, err)
 	}
@@ -170,7 +188,8 @@ func waitForWindowProcessExit(
 }
 
 func (runtime closeWindowKillRuntime) validate() error {
-	if runtime.now == nil || runtime.sleep == nil || runtime.openProcess == nil {
+	if runtime.now == nil || runtime.sleep == nil ||
+		runtime.processIdentity == nil || runtime.openProcess == nil {
 		return fmt.Errorf(
 			"%w: incomplete CloseWindowKill runtime",
 			windowbackend.ErrOperation,

--- a/window_close_kill_nocgo_test.go
+++ b/window_close_kill_nocgo_test.go
@@ -1,0 +1,443 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/marang/robotgo/internal/windowbackend"
+)
+
+type closeKillWindowBackend struct {
+	activeHandle  windowbackend.Handle
+	resolved      windowbackend.Handle
+	pid           int
+	activeErr     error
+	resolveErr    error
+	pidErr        error
+	closeErr      error
+	resolveTarget int
+	resolveHandle bool
+	calls         []string
+}
+
+func (backend *closeKillWindowBackend) Active() (windowbackend.Handle, error) {
+	backend.calls = append(backend.calls, "active")
+	return backend.activeHandle, backend.activeErr
+}
+
+func (backend *closeKillWindowBackend) Resolve(
+	target int,
+	isHandle bool,
+) (windowbackend.Handle, error) {
+	backend.calls = append(backend.calls, "resolve")
+	backend.resolveTarget = target
+	backend.resolveHandle = isHandle
+	return backend.resolved, backend.resolveErr
+}
+
+func (backend *closeKillWindowBackend) Select(int, bool) error { return nil }
+
+func (backend *closeKillWindowBackend) Selected() windowbackend.Handle { return 0 }
+
+func (backend *closeKillWindowBackend) PID(handle windowbackend.Handle) (int, error) {
+	backend.calls = append(backend.calls, fmt.Sprintf("pid:%d", handle))
+	return backend.pid, backend.pidErr
+}
+
+func (backend *closeKillWindowBackend) Title(windowbackend.Handle) (string, error) {
+	return "", nil
+}
+
+func (backend *closeKillWindowBackend) Bounds(
+	windowbackend.Handle,
+	bool,
+) (windowbackend.Rect, error) {
+	return windowbackend.Rect{}, nil
+}
+
+func (backend *closeKillWindowBackend) Activate(windowbackend.Handle) error { return nil }
+
+func (backend *closeKillWindowBackend) SetState(
+	windowbackend.Handle,
+	windowbackend.State,
+	bool,
+) error {
+	return nil
+}
+
+func (backend *closeKillWindowBackend) State(
+	windowbackend.Handle,
+	windowbackend.State,
+) (bool, error) {
+	return false, nil
+}
+
+func (backend *closeKillWindowBackend) TopMost(windowbackend.Handle) (bool, error) {
+	return false, nil
+}
+
+func (backend *closeKillWindowBackend) SetTopMost(windowbackend.Handle, bool) error {
+	return nil
+}
+
+func (backend *closeKillWindowBackend) Close(handle windowbackend.Handle) error {
+	backend.calls = append(backend.calls, fmt.Sprintf("close:%d", handle))
+	return backend.closeErr
+}
+
+type fakeCloseKillRuntime struct {
+	now           time.Time
+	exists        []bool
+	existsErr     error
+	existsCalls   int
+	identity      int64
+	identities    []int64
+	identityErr   error
+	identityErrs  []error
+	identityCalls int
+	sleepTotal    time.Duration
+	killedPID     int
+	killErr       error
+	unexpectedOp  bool
+}
+
+func (runtime *fakeCloseKillRuntime) dependencies() closeWindowKillRuntime {
+	if runtime.identity == 0 {
+		runtime.identity = 100
+	}
+	return closeWindowKillRuntime{
+		now: func() time.Time {
+			return runtime.now
+		},
+		sleep: func(delay time.Duration) {
+			runtime.sleepTotal += delay
+			runtime.now = runtime.now.Add(delay)
+		},
+		pidExists: func(int) (bool, error) {
+			runtime.existsCalls++
+			if runtime.existsErr != nil {
+				return false, runtime.existsErr
+			}
+			if len(runtime.exists) == 0 {
+				runtime.unexpectedOp = true
+				return false, errors.New("unexpected process probe")
+			}
+			exists := runtime.exists[0]
+			if len(runtime.exists) > 1 {
+				runtime.exists = runtime.exists[1:]
+			}
+			return exists, nil
+		},
+		processIdentity: func(int) (int64, error) {
+			runtime.identityCalls++
+			if len(runtime.identityErrs) > 0 {
+				identityErr := runtime.identityErrs[0]
+				runtime.identityErrs = runtime.identityErrs[1:]
+				if identityErr != nil {
+					return 0, identityErr
+				}
+			}
+			if runtime.identityErr != nil {
+				return 0, runtime.identityErr
+			}
+			if len(runtime.identities) == 0 {
+				return runtime.identity, nil
+			}
+			identity := runtime.identities[0]
+			if len(runtime.identities) > 1 {
+				runtime.identities = runtime.identities[1:]
+			}
+			return identity, nil
+		},
+		kill: func(pid int) error {
+			runtime.killedPID = pid
+			return runtime.killErr
+		},
+	}
+}
+
+func TestCloseWindowKillWithPIDAllowsGracefulExit(t *testing.T) {
+	backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+	runtime := &fakeCloseKillRuntime{exists: []bool{true, false}}
+
+	err := closeWindowKillWith(
+		backend,
+		[]int{42},
+		false,
+		runtime.dependencies(),
+	)
+	if err != nil {
+		t.Fatalf("closeWindowKillWith() error = %v", err)
+	}
+	if backend.resolveTarget != 42 || backend.resolveHandle {
+		t.Fatalf(
+			"Resolve() = (%d, %v), want PID target",
+			backend.resolveTarget,
+			backend.resolveHandle,
+		)
+	}
+	if got, want := backend.calls, []string{"resolve", "pid:70", "close:70"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("backend calls = %v, want %v", got, want)
+	}
+	if runtime.killedPID != 0 {
+		t.Fatalf("killed PID = %d, want no force-kill", runtime.killedPID)
+	}
+	if runtime.sleepTotal != closeWindowKillPollInterval {
+		t.Fatalf("sleep total = %v, want %v", runtime.sleepTotal, closeWindowKillPollInterval)
+	}
+}
+
+func TestCloseWindowKillWithHandleForceKillsAfterGracePeriod(t *testing.T) {
+	backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+	runtime := &fakeCloseKillRuntime{exists: []bool{true}}
+
+	err := closeWindowKillWith(
+		backend,
+		[]int{70, 1},
+		false,
+		runtime.dependencies(),
+	)
+	if err != nil {
+		t.Fatalf("closeWindowKillWith() error = %v", err)
+	}
+	if !backend.resolveHandle {
+		t.Fatal("Resolve() treated explicit handle as PID")
+	}
+	if runtime.sleepTotal != closeWindowKillGracePeriod {
+		t.Fatalf("sleep total = %v, want %v", runtime.sleepTotal, closeWindowKillGracePeriod)
+	}
+	if runtime.killedPID != 42 {
+		t.Fatalf("killed PID = %d, want 42", runtime.killedPID)
+	}
+	if runtime.unexpectedOp {
+		t.Fatal("process polling consumed an unexpected scripted result")
+	}
+}
+
+func TestCloseWindowKillWithUsesActiveWindowWithoutTarget(t *testing.T) {
+	backend := &closeKillWindowBackend{activeHandle: 70, pid: 42}
+	runtime := &fakeCloseKillRuntime{exists: []bool{false}}
+
+	err := closeWindowKillWith(backend, nil, false, runtime.dependencies())
+	if err != nil {
+		t.Fatalf("closeWindowKillWith() error = %v", err)
+	}
+	if got, want := backend.calls, []string{"active", "pid:70", "close:70"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("backend calls = %v, want %v", got, want)
+	}
+}
+
+func TestCloseWindowKillWithHonorsConfiguredHandleMode(t *testing.T) {
+	backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+	runtime := &fakeCloseKillRuntime{exists: []bool{false}}
+
+	err := closeWindowKillWith(
+		backend,
+		[]int{70},
+		true,
+		runtime.dependencies(),
+	)
+	if err != nil {
+		t.Fatalf("closeWindowKillWith() error = %v", err)
+	}
+	if !backend.resolveHandle {
+		t.Fatal("Resolve() ignored configured handle mode")
+	}
+}
+
+func TestCloseWindowKillWithFailsClosed(t *testing.T) {
+	t.Run("identity failure before close", func(t *testing.T) {
+		identityErr := errors.New("identity failed")
+		backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+		runtime := &fakeCloseKillRuntime{
+			exists:      []bool{true},
+			identityErr: identityErr,
+		}
+
+		err := closeWindowKillWith(
+			backend,
+			[]int{42},
+			false,
+			runtime.dependencies(),
+		)
+		if !errors.Is(err, identityErr) {
+			t.Fatalf("error = %v, want identity error", err)
+		}
+		if got, want := backend.calls, []string{"resolve", "pid:70"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("backend calls = %v, want %v", got, want)
+		}
+		if runtime.existsCalls != 0 || runtime.killedPID != 0 {
+			t.Fatalf(
+				"process operations = probes %d, kill %d; want none",
+				runtime.existsCalls,
+				runtime.killedPID,
+			)
+		}
+	})
+
+	t.Run("close failure", func(t *testing.T) {
+		closeErr := errors.New("close failed")
+		backend := &closeKillWindowBackend{
+			resolved: 70,
+			pid:      42,
+			closeErr: closeErr,
+		}
+		runtime := &fakeCloseKillRuntime{exists: []bool{true}}
+
+		err := closeWindowKillWith(
+			backend,
+			[]int{42},
+			false,
+			runtime.dependencies(),
+		)
+		if !errors.Is(err, closeErr) {
+			t.Fatalf("error = %v, want close error", err)
+		}
+		if runtime.existsCalls != 0 || runtime.killedPID != 0 {
+			t.Fatalf(
+				"process operations = probes %d, kill %d; want none",
+				runtime.existsCalls,
+				runtime.killedPID,
+			)
+		}
+	})
+
+	t.Run("process probe failure", func(t *testing.T) {
+		probeErr := errors.New("probe failed")
+		backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+		runtime := &fakeCloseKillRuntime{
+			exists:    []bool{true},
+			existsErr: probeErr,
+		}
+
+		err := closeWindowKillWith(
+			backend,
+			[]int{42},
+			false,
+			runtime.dependencies(),
+		)
+		if !errors.Is(err, probeErr) {
+			t.Fatalf("error = %v, want process probe error", err)
+		}
+		if runtime.killedPID != 0 {
+			t.Fatalf("killed PID = %d after failed probe", runtime.killedPID)
+		}
+	})
+
+	t.Run("identity failure after close", func(t *testing.T) {
+		identityErr := errors.New("identity failed after close")
+		backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+		runtime := &fakeCloseKillRuntime{
+			exists:       []bool{true},
+			identityErrs: []error{nil, identityErr},
+		}
+
+		err := closeWindowKillWith(
+			backend,
+			[]int{42},
+			false,
+			runtime.dependencies(),
+		)
+		if !errors.Is(err, identityErr) {
+			t.Fatalf("error = %v, want identity error", err)
+		}
+		if runtime.killedPID != 0 {
+			t.Fatalf("killed PID = %d after failed identity check", runtime.killedPID)
+		}
+	})
+
+	t.Run("invalid resolved pid", func(t *testing.T) {
+		backend := &closeKillWindowBackend{resolved: 70}
+		runtime := &fakeCloseKillRuntime{exists: []bool{true}}
+
+		err := closeWindowKillWith(
+			backend,
+			[]int{42},
+			false,
+			runtime.dependencies(),
+		)
+		if !errors.Is(err, windowbackend.ErrWindowNotFound) {
+			t.Fatalf("error = %v, want invalid-window process error", err)
+		}
+		if got, want := backend.calls, []string{"resolve", "pid:70"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("backend calls = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestCloseWindowKillDoesNotKillReusedPID(t *testing.T) {
+	backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+	runtime := &fakeCloseKillRuntime{
+		exists:     []bool{true},
+		identities: []int64{100, 200},
+	}
+
+	err := closeWindowKillWith(
+		backend,
+		[]int{42},
+		false,
+		runtime.dependencies(),
+	)
+	if err != nil {
+		t.Fatalf("closeWindowKillWith() error = %v", err)
+	}
+	if runtime.killedPID != 0 {
+		t.Fatalf("reused PID was force-killed: %d", runtime.killedPID)
+	}
+	if runtime.sleepTotal != 0 {
+		t.Fatalf("slept %v after PID identity changed", runtime.sleepTotal)
+	}
+}
+
+func TestCloseWindowKillHandlesExitBetweenExistenceAndIdentityProbe(t *testing.T) {
+	backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+	processExitedErr := errors.New("process exited during identity probe")
+	runtime := &fakeCloseKillRuntime{
+		exists:       []bool{true, false},
+		identityErrs: []error{nil, processExitedErr},
+	}
+
+	err := closeWindowKillWith(
+		backend,
+		[]int{42},
+		false,
+		runtime.dependencies(),
+	)
+	if err != nil {
+		t.Fatalf("closeWindowKillWith() error = %v", err)
+	}
+	if runtime.killedPID != 0 {
+		t.Fatalf("exited process was force-killed: %d", runtime.killedPID)
+	}
+	if runtime.sleepTotal != 0 {
+		t.Fatalf("slept %v after process exit", runtime.sleepTotal)
+	}
+}
+
+func TestWaitForWindowProcessExitReportsKillFailure(t *testing.T) {
+	killErr := errors.New("kill failed")
+	runtime := &fakeCloseKillRuntime{
+		exists:  []bool{true},
+		killErr: killErr,
+	}
+
+	err := waitForWindowProcessExit(42, 100, runtime.dependencies())
+	if !errors.Is(err, killErr) {
+		t.Fatalf("error = %v, want kill error", err)
+	}
+	if runtime.killedPID != 42 {
+		t.Fatalf("killed PID = %d, want 42", runtime.killedPID)
+	}
+}
+
+func TestWaitForWindowProcessExitRejectsIncompleteRuntime(t *testing.T) {
+	err := waitForWindowProcessExit(42, 100, closeWindowKillRuntime{})
+	if !errors.Is(err, windowbackend.ErrOperation) {
+		t.Fatalf("error = %v, want window operation error", err)
+	}
+}

--- a/window_close_kill_nocgo_test.go
+++ b/window_close_kill_nocgo_test.go
@@ -16,6 +16,7 @@ type closeKillWindowBackend struct {
 	activeHandle  windowbackend.Handle
 	resolved      windowbackend.Handle
 	pid           int
+	pids          []int
 	activeErr     error
 	resolveErr    error
 	pidErr        error
@@ -46,6 +47,11 @@ func (backend *closeKillWindowBackend) Selected() windowbackend.Handle { return 
 
 func (backend *closeKillWindowBackend) PID(handle windowbackend.Handle) (int, error) {
 	backend.calls = append(backend.calls, fmt.Sprintf("pid:%d", handle))
+	if len(backend.pids) > 0 {
+		pid := backend.pids[0]
+		backend.pids = backend.pids[1:]
+		return pid, backend.pidErr
+	}
 	return backend.pid, backend.pidErr
 }
 
@@ -104,6 +110,8 @@ type fakeCloseKillRuntime struct {
 	killedPID      int
 	killedIdentity int64
 	killErr        error
+	closeErr       error
+	closeCalls     int
 	unexpectedOp   bool
 }
 
@@ -119,48 +127,96 @@ func (runtime *fakeCloseKillRuntime) dependencies() closeWindowKillRuntime {
 			runtime.sleepTotal += delay
 			runtime.now = runtime.now.Add(delay)
 		},
-		pidExists: func(int) (bool, error) {
-			runtime.existsCalls++
-			if runtime.existsErr != nil {
-				return false, runtime.existsErr
+		openProcess: func(pid int) (closeWindowProcess, error) {
+			identity, err := runtime.nextIdentity()
+			if err != nil {
+				return nil, err
 			}
-			if len(runtime.exists) == 0 {
-				runtime.unexpectedOp = true
-				return false, errors.New("unexpected process probe")
-			}
-			exists := runtime.exists[0]
-			if len(runtime.exists) > 1 {
-				runtime.exists = runtime.exists[1:]
-			}
-			return exists, nil
-		},
-		processIdentity: func(int) (int64, error) {
-			runtime.identityCalls++
-			if len(runtime.identityErrs) > 0 {
-				identityErr := runtime.identityErrs[0]
-				runtime.identityErrs = runtime.identityErrs[1:]
-				if identityErr != nil {
-					return 0, identityErr
-				}
-			}
-			if runtime.identityErr != nil {
-				return 0, runtime.identityErr
-			}
-			if len(runtime.identities) == 0 {
-				return runtime.identity, nil
-			}
-			identity := runtime.identities[0]
-			if len(runtime.identities) > 1 {
-				runtime.identities = runtime.identities[1:]
-			}
-			return identity, nil
-		},
-		kill: func(pid int, identity int64) error {
-			runtime.killedPID = pid
-			runtime.killedIdentity = identity
-			return runtime.killErr
+			return &fakeCloseWindowProcess{
+				pid:      pid,
+				identity: identity,
+				runtime:  runtime,
+			}, nil
 		},
 	}
+}
+
+type fakeCloseWindowProcess struct {
+	pid      int
+	identity int64
+	runtime  *fakeCloseKillRuntime
+}
+
+func (process *fakeCloseWindowProcess) Running() (bool, error) {
+	runtime := process.runtime
+	exists, err := runtime.nextExists()
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	identity, err := runtime.nextIdentity()
+	if err != nil {
+		stillExists, probeErr := runtime.nextExists()
+		if probeErr != nil {
+			return false, errors.Join(err, probeErr)
+		}
+		if !stillExists {
+			return false, nil
+		}
+		return false, err
+	}
+	return identity == process.identity, nil
+}
+
+func (process *fakeCloseWindowProcess) Kill() error {
+	process.runtime.killedPID = process.pid
+	process.runtime.killedIdentity = process.identity
+	return process.runtime.killErr
+}
+
+func (process *fakeCloseWindowProcess) Close() error {
+	process.runtime.closeCalls++
+	return process.runtime.closeErr
+}
+
+func (runtime *fakeCloseKillRuntime) nextIdentity() (int64, error) {
+	runtime.identityCalls++
+	if len(runtime.identityErrs) > 0 {
+		identityErr := runtime.identityErrs[0]
+		runtime.identityErrs = runtime.identityErrs[1:]
+		if identityErr != nil {
+			return 0, identityErr
+		}
+	}
+	if runtime.identityErr != nil {
+		return 0, runtime.identityErr
+	}
+	if len(runtime.identities) == 0 {
+		return runtime.identity, nil
+	}
+	identity := runtime.identities[0]
+	if len(runtime.identities) > 1 {
+		runtime.identities = runtime.identities[1:]
+	}
+	return identity, nil
+}
+
+func (runtime *fakeCloseKillRuntime) nextExists() (bool, error) {
+	runtime.existsCalls++
+	if runtime.existsErr != nil {
+		return false, runtime.existsErr
+	}
+	if len(runtime.exists) == 0 {
+		runtime.unexpectedOp = true
+		return false, errors.New("unexpected process probe")
+	}
+	exists := runtime.exists[0]
+	if len(runtime.exists) > 1 {
+		runtime.exists = runtime.exists[1:]
+	}
+	return exists, nil
 }
 
 func TestCloseWindowKillWithPIDAllowsGracefulExit(t *testing.T) {
@@ -183,7 +239,7 @@ func TestCloseWindowKillWithPIDAllowsGracefulExit(t *testing.T) {
 			backend.resolveHandle,
 		)
 	}
-	if got, want := backend.calls, []string{"resolve", "pid:70", "close:70"}; !reflect.DeepEqual(got, want) {
+	if got, want := backend.calls, []string{"resolve", "pid:70", "pid:70", "close:70"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("backend calls = %v, want %v", got, want)
 	}
 	if runtime.killedPID != 0 {
@@ -222,6 +278,9 @@ func TestCloseWindowKillWithHandleForceKillsAfterGracePeriod(t *testing.T) {
 	if runtime.unexpectedOp {
 		t.Fatal("process polling consumed an unexpected scripted result")
 	}
+	if runtime.closeCalls != 1 {
+		t.Fatalf("stable process reference closes = %d, want 1", runtime.closeCalls)
+	}
 }
 
 func TestCloseWindowKillWithUsesActiveWindowWithoutTarget(t *testing.T) {
@@ -232,7 +291,7 @@ func TestCloseWindowKillWithUsesActiveWindowWithoutTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("closeWindowKillWith() error = %v", err)
 	}
-	if got, want := backend.calls, []string{"active", "pid:70", "close:70"}; !reflect.DeepEqual(got, want) {
+	if got, want := backend.calls, []string{"active", "pid:70", "pid:70", "close:70"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("backend calls = %v, want %v", got, want)
 	}
 }
@@ -310,6 +369,9 @@ func TestCloseWindowKillWithFailsClosed(t *testing.T) {
 				runtime.killedPID,
 			)
 		}
+		if runtime.closeCalls != 1 {
+			t.Fatalf("stable process reference closes = %d, want 1", runtime.closeCalls)
+		}
 	})
 
 	t.Run("process probe failure", func(t *testing.T) {
@@ -356,6 +418,28 @@ func TestCloseWindowKillWithFailsClosed(t *testing.T) {
 		}
 	})
 
+	t.Run("stable process reference close failure", func(t *testing.T) {
+		closeErr := errors.New("stable process close failed")
+		backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+		runtime := &fakeCloseKillRuntime{
+			exists:   []bool{false},
+			closeErr: closeErr,
+		}
+
+		err := closeWindowKillWith(
+			backend,
+			[]int{42},
+			false,
+			runtime.dependencies(),
+		)
+		if !errors.Is(err, closeErr) {
+			t.Fatalf("error = %v, want process-reference close error", err)
+		}
+		if runtime.closeCalls != 1 {
+			t.Fatalf("stable process reference closes = %d, want 1", runtime.closeCalls)
+		}
+	})
+
 	t.Run("invalid resolved pid", func(t *testing.T) {
 		backend := &closeKillWindowBackend{resolved: 70}
 		runtime := &fakeCloseKillRuntime{exists: []bool{true}}
@@ -396,6 +480,33 @@ func TestCloseWindowKillDoesNotKillReusedPID(t *testing.T) {
 	}
 	if runtime.sleepTotal != 0 {
 		t.Fatalf("slept %v after PID identity changed", runtime.sleepTotal)
+	}
+}
+
+func TestCloseWindowKillRejectsOwnerChangeAfterProcessBinding(t *testing.T) {
+	backend := &closeKillWindowBackend{
+		resolved: 70,
+		pids:     []int{42, 43},
+	}
+	runtime := &fakeCloseKillRuntime{exists: []bool{true}}
+
+	err := closeWindowKillWith(
+		backend,
+		[]int{42},
+		false,
+		runtime.dependencies(),
+	)
+	if !errors.Is(err, windowbackend.ErrWindowNotFound) {
+		t.Fatalf("error = %v, want changed-owner window error", err)
+	}
+	if got, want := backend.calls, []string{"resolve", "pid:70", "pid:70"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("backend calls = %v, want %v", got, want)
+	}
+	if runtime.killedPID != 0 {
+		t.Fatalf("replacement process was force-killed: %d", runtime.killedPID)
+	}
+	if runtime.closeCalls != 1 {
+		t.Fatalf("stable process reference closes = %d, want 1", runtime.closeCalls)
 	}
 }
 
@@ -459,7 +570,12 @@ func TestWaitForWindowProcessExitReportsKillFailure(t *testing.T) {
 		killErr: killErr,
 	}
 
-	err := waitForWindowProcessExit(42, 100, runtime.dependencies())
+	dependencies := runtime.dependencies()
+	process, openErr := dependencies.openProcess(42)
+	if openErr != nil {
+		t.Fatalf("open fake process: %v", openErr)
+	}
+	err := waitForWindowProcessExit(42, process, dependencies)
 	if !errors.Is(err, killErr) {
 		t.Fatalf("error = %v, want kill error", err)
 	}
@@ -469,7 +585,7 @@ func TestWaitForWindowProcessExitReportsKillFailure(t *testing.T) {
 }
 
 func TestWaitForWindowProcessExitRejectsIncompleteRuntime(t *testing.T) {
-	err := waitForWindowProcessExit(42, 100, closeWindowKillRuntime{})
+	err := waitForWindowProcessExit(42, nil, closeWindowKillRuntime{})
 	if !errors.Is(err, windowbackend.ErrOperation) {
 		t.Fatalf("error = %v, want window operation error", err)
 	}

--- a/window_close_kill_nocgo_test.go
+++ b/window_close_kill_nocgo_test.go
@@ -91,19 +91,20 @@ func (backend *closeKillWindowBackend) Close(handle windowbackend.Handle) error 
 }
 
 type fakeCloseKillRuntime struct {
-	now           time.Time
-	exists        []bool
-	existsErr     error
-	existsCalls   int
-	identity      int64
-	identities    []int64
-	identityErr   error
-	identityErrs  []error
-	identityCalls int
-	sleepTotal    time.Duration
-	killedPID     int
-	killErr       error
-	unexpectedOp  bool
+	now            time.Time
+	exists         []bool
+	existsErr      error
+	existsCalls    int
+	identity       int64
+	identities     []int64
+	identityErr    error
+	identityErrs   []error
+	identityCalls  int
+	sleepTotal     time.Duration
+	killedPID      int
+	killedIdentity int64
+	killErr        error
+	unexpectedOp   bool
 }
 
 func (runtime *fakeCloseKillRuntime) dependencies() closeWindowKillRuntime {
@@ -154,8 +155,9 @@ func (runtime *fakeCloseKillRuntime) dependencies() closeWindowKillRuntime {
 			}
 			return identity, nil
 		},
-		kill: func(pid int) error {
+		kill: func(pid int, identity int64) error {
 			runtime.killedPID = pid
+			runtime.killedIdentity = identity
 			return runtime.killErr
 		},
 	}
@@ -213,6 +215,9 @@ func TestCloseWindowKillWithHandleForceKillsAfterGracePeriod(t *testing.T) {
 	}
 	if runtime.killedPID != 42 {
 		t.Fatalf("killed PID = %d, want 42", runtime.killedPID)
+	}
+	if runtime.killedIdentity != 100 {
+		t.Fatalf("killed process identity = %d, want 100", runtime.killedIdentity)
 	}
 	if runtime.unexpectedOp {
 		t.Fatal("process polling consumed an unexpected scripted result")
@@ -416,6 +421,34 @@ func TestCloseWindowKillHandlesExitBetweenExistenceAndIdentityProbe(t *testing.T
 	}
 	if runtime.sleepTotal != 0 {
 		t.Fatalf("slept %v after process exit", runtime.sleepTotal)
+	}
+}
+
+func TestCloseWindowKillRevalidatesAfterFinalSleep(t *testing.T) {
+	backend := &closeKillWindowBackend{resolved: 70, pid: 42}
+	exists := make([]bool, 16)
+	for index := 0; index < len(exists)-1; index++ {
+		exists[index] = true
+	}
+	runtime := &fakeCloseKillRuntime{exists: exists}
+
+	err := closeWindowKillWith(
+		backend,
+		[]int{42},
+		false,
+		runtime.dependencies(),
+	)
+	if err != nil {
+		t.Fatalf("closeWindowKillWith() error = %v", err)
+	}
+	if runtime.sleepTotal != closeWindowKillGracePeriod {
+		t.Fatalf("sleep total = %v, want %v", runtime.sleepTotal, closeWindowKillGracePeriod)
+	}
+	if runtime.existsCalls != len(exists) {
+		t.Fatalf("existence probes = %d, want %d", runtime.existsCalls, len(exists))
+	}
+	if runtime.killedPID != 0 {
+		t.Fatalf("process that exited after final sleep was killed: %d", runtime.killedPID)
 	}
 }
 

--- a/window_close_kill_nocgo_test.go
+++ b/window_close_kill_nocgo_test.go
@@ -127,14 +127,27 @@ func (runtime *fakeCloseKillRuntime) dependencies() closeWindowKillRuntime {
 			runtime.sleepTotal += delay
 			runtime.now = runtime.now.Add(delay)
 		},
-		openProcess: func(pid int) (closeWindowProcess, error) {
+		processIdentity: func(int) (closeWindowProcessFingerprint, error) {
+			identity, err := runtime.nextIdentity()
+			if err != nil {
+				return closeWindowProcessFingerprint{}, err
+			}
+			return closeWindowProcessFingerprint{primary: uint64(identity)}, nil
+		},
+		openProcess: func(
+			pid int,
+			expected closeWindowProcessFingerprint,
+		) (closeWindowProcess, error) {
 			identity, err := runtime.nextIdentity()
 			if err != nil {
 				return nil, err
 			}
+			if expected.primary != uint64(identity) {
+				return nil, errors.New("process identity changed during binding")
+			}
 			return &fakeCloseWindowProcess{
 				pid:      pid,
-				identity: identity,
+				identity: int64(expected.primary),
 				runtime:  runtime,
 			}, nil
 		},
@@ -401,7 +414,7 @@ func TestCloseWindowKillWithFailsClosed(t *testing.T) {
 		backend := &closeKillWindowBackend{resolved: 70, pid: 42}
 		runtime := &fakeCloseKillRuntime{
 			exists:       []bool{true},
-			identityErrs: []error{nil, identityErr},
+			identityErrs: []error{nil, nil, identityErr},
 		}
 
 		err := closeWindowKillWith(
@@ -472,14 +485,17 @@ func TestCloseWindowKillDoesNotKillReusedPID(t *testing.T) {
 		false,
 		runtime.dependencies(),
 	)
-	if err != nil {
-		t.Fatalf("closeWindowKillWith() error = %v", err)
+	if err == nil {
+		t.Fatal("closeWindowKillWith() accepted reused PID during process binding")
 	}
 	if runtime.killedPID != 0 {
 		t.Fatalf("reused PID was force-killed: %d", runtime.killedPID)
 	}
 	if runtime.sleepTotal != 0 {
 		t.Fatalf("slept %v after PID identity changed", runtime.sleepTotal)
+	}
+	if got, want := backend.calls, []string{"resolve", "pid:70"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("backend calls = %v, want %v", got, want)
 	}
 }
 
@@ -515,7 +531,7 @@ func TestCloseWindowKillHandlesExitBetweenExistenceAndIdentityProbe(t *testing.T
 	processExitedErr := errors.New("process exited during identity probe")
 	runtime := &fakeCloseKillRuntime{
 		exists:       []bool{true, false},
-		identityErrs: []error{nil, processExitedErr},
+		identityErrs: []error{nil, nil, processExitedErr},
 	}
 
 	err := closeWindowKillWith(
@@ -571,7 +587,11 @@ func TestWaitForWindowProcessExitReportsKillFailure(t *testing.T) {
 	}
 
 	dependencies := runtime.dependencies()
-	process, openErr := dependencies.openProcess(42)
+	identity, identityErr := dependencies.processIdentity(42)
+	if identityErr != nil {
+		t.Fatalf("capture fake process identity: %v", identityErr)
+	}
+	process, openErr := dependencies.openProcess(42, identity)
 	if openErr != nil {
 		t.Fatalf("open fake process: %v", openErr)
 	}


### PR DESCRIPTION
## Goal

Close the remaining `CloseWindowKill` parity gap where a destructive fallback can be bound to a stable OS process object, while preserving explicit unsupported behavior where that guarantee is unavailable.

## Changes

- resolve active/PID/native-handle targets through the selected Pure-Go window backend
- capture the original process identity before binding, then reject any identity change while opening the stable reference
- on Windows, verify creation time on the retained process handle; on Linux, verify the exact procfs process instance around `pidfd_open`
- revalidate window ownership before requesting graceful close
- retain the same verified Windows handle or Linux `pidfd` through the bounded 1.5-second grace period and optional force-kill
- support the full Windows `uint32` PID range and report `ErrNotSupported` when Linux lacks pidfd support
- keep macOS graceful close, but return explicit `ErrNotSupported` if force termination would require an unsafe PID-only race
- add hermetic tests for graceful exit, guarded force-kill, identity/owner changes, deadline races, fd-zero cleanup, and fail-closed paths
- document platform behavior and roadmap status

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run`
- `CGO_ENABLED=0 golangci-lint run`
- Non-CGO root test cross-compiles for Darwin amd64/arm64 and Windows amd64

No test creates screenshots, persistent artifacts, or terminates a real process; destructive operations use injected fakes.