### PR TITLE
fix: reject unsafe process kill identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ and inspect `GetRuntimeCapabilities` when an operation is required for a
 workflow. `GetRuntimeDiagnostics` provides the stable machine-readable report;
 `GetLinuxCapabilities` remains the compact Linux-specific view.
 
+`Kill` accepts only a positive process identifier that fits the platform PID
+range. Invalid values return `ErrInvalidPID` before any operating-system signal
+or termination call; in particular, `Kill(0)` can never target a Unix process
+group.
+
 ## Support overview
 
 | Platform/session | Build | Current behavior |

--- a/TEST.md
+++ b/TEST.md
@@ -31,6 +31,10 @@ Inspect a live host without opening a consent dialog with:
 go run ./examples/runtime_diagnostics
 ```
 
+Process-termination validation is tested only through an injected fake killer:
+the suite proves that zero, negative, and platform-overflow PIDs are rejected
+without sending a real signal or terminating a process.
+
 Both build variants are blocking linter targets as well:
 
 ```bash

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -343,8 +343,10 @@ the test-log SHA-256 for native/Pure-Go Linux, macOS, and Windows cells. It also
 requires and records the complete protected CircleCI/lint/vet/race/sanitizer/
 platform/Wayland/X11 check set for the exact commit. A published release
 receives the verified bundle and checksum; manual runs remain read-only
-artifacts. Dedicated GNOME/KDE/wlroots jobs and the first published release
-asset remain open.
+artifacts. Process termination rejects non-positive and platform-overflow PIDs
+before invoking the operating system, preventing Unix process-group signaling
+through `Kill(0)` or a narrowed negative PID. Dedicated GNOME/KDE/wlroots jobs
+and the first published release asset remain open.
 
 Releases require:
 

--- a/process_kill_pid_unix.go
+++ b/process_kill_pid_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package robotgo
+
+import "math"
+
+// Unix pid_t is signed. Passing a value that narrows to a negative pid can
+// target a process group instead of one process.
+const maxProcessIDForKill = uint64(math.MaxInt32)

--- a/process_kill_pid_unix_test.go
+++ b/process_kill_pid_unix_test.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package robotgo
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestValidateProcessIDForKillUsesSignedUnixRange(t *testing.T) {
+	if err := validateProcessIDForKill(math.MaxInt32); err != nil {
+		t.Fatalf("validateProcessIDForKill(MaxInt32): %v", err)
+	}
+	if strconv.IntSize == 64 {
+		err := validateProcessIDForKill(int(math.MaxInt32) + 1)
+		if !errors.Is(err, ErrInvalidPID) {
+			t.Fatalf("validateProcessIDForKill(MaxInt32 + 1) = %v, want ErrInvalidPID", err)
+		}
+	}
+}

--- a/process_kill_pid_windows.go
+++ b/process_kill_pid_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package robotgo
+
+import "math"
+
+// Windows process identifiers use the complete uint32 range.
+const maxProcessIDForKill = uint64(math.MaxUint32)

--- a/process_kill_pid_windows_test.go
+++ b/process_kill_pid_windows_test.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package robotgo
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestValidateProcessIDForKillUsesUint32WindowsRange(t *testing.T) {
+	if strconv.IntSize != 64 {
+		t.Skip("full uint32 PID range requires a 64-bit Go int")
+	}
+	if err := validateProcessIDForKill(int(math.MaxUint32)); err != nil {
+		t.Fatalf("validateProcessIDForKill(MaxUint32): %v", err)
+	}
+	err := validateProcessIDForKill(int(math.MaxUint32) + 1)
+	if !errors.Is(err, ErrInvalidPID) {
+		t.Fatalf("validateProcessIDForKill(MaxUint32 + 1) = %v, want ErrInvalidPID", err)
+	}
+}

--- a/process_kill_test.go
+++ b/process_kill_test.go
@@ -1,0 +1,47 @@
+package robotgo
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestKillProcessWithRejectsUnsafePIDWithoutCallingKiller(t *testing.T) {
+	tests := []struct {
+		name string
+		pid  int
+	}{
+		{name: "zero", pid: 0},
+		{name: "negative", pid: -1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			err := killProcessWith(test.pid, func(int) error {
+				called = true
+				return nil
+			})
+			if !errors.Is(err, ErrInvalidPID) {
+				t.Fatalf("killProcessWith(%d) error = %v, want ErrInvalidPID", test.pid, err)
+			}
+			if called {
+				t.Fatalf("killProcessWith(%d) called destructive backend", test.pid)
+			}
+		})
+	}
+}
+
+func TestKillProcessWithForwardsSafePIDAndError(t *testing.T) {
+	killErr := errors.New("injected kill failure")
+	calledPID := 0
+
+	err := killProcessWith(42, func(pid int) error {
+		calledPID = pid
+		return killErr
+	})
+	if !errors.Is(err, killErr) {
+		t.Fatalf("killProcessWith(42) error = %v, want injected failure", err)
+	}
+	if calledPID != 42 {
+		t.Fatalf("destructive backend pid = %d, want 42", calledPID)
+	}
+}

--- a/ps.go
+++ b/ps.go
@@ -11,7 +11,16 @@
 
 package robotgo
 
-import ps "github.com/vcaesar/gops"
+import (
+	"errors"
+	"fmt"
+
+	ps "github.com/vcaesar/gops"
+)
+
+// ErrInvalidPID reports a process identifier that cannot safely identify one
+// process on the current platform.
+var ErrInvalidPID = errors.New("invalid process id")
 
 // Nps process struct
 type Nps struct {
@@ -74,5 +83,19 @@ func Run(path string) ([]byte, error) {
 
 // Kill kill the process by PID
 func Kill(pid int) error {
-	return ps.Kill(pid)
+	return killProcessWith(pid, ps.Kill)
+}
+
+func killProcessWith(pid int, kill func(int) error) error {
+	if err := validateProcessIDForKill(pid); err != nil {
+		return err
+	}
+	return kill(pid)
+}
+
+func validateProcessIDForKill(pid int) error {
+	if pid <= 0 || uint64(pid) > maxProcessIDForKill {
+		return fmt.Errorf("%w: %d", ErrInvalidPID, pid)
+	}
+	return nil
 }


### PR DESCRIPTION
## Goal

Prevent `Kill` from forwarding a PID that can target a Unix process group or wrap to another platform process identifier.

## Changes

- add exported `ErrInvalidPID` for stable caller-side detection
- reject zero, negative, and platform-overflow PIDs before invoking the destructive backend
- preserve the signed Unix `pid_t` range and full Windows `uint32` PID range
- test validation exclusively through an injected fake killer; no test sends a real signal or terminates a process
- document the public safety contract and roadmap status

## Upstream parity

This selectively ports the valid-PID safety fix identified during the July 2026 `upstream/master` audit. Key constants and cleanup behavior are already equal or stronger in this fork, and the fork already uses a newer `golang.org/x/image` release.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run`
- `CGO_ENABLED=0 golangci-lint run`
- Non-CGO root test cross-compiles for Windows amd64 and Darwin amd64

No test creates files, captures desktop data, sends a signal, or terminates a real process.