### PR TITLE
feat: add upstream helper API parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,7 @@ Real Wayland input results are tracked in the
 - [Key names and conversion](docs/keys.md)
 - [Testing guide](TEST.md)
 - [Release evidence format and verification](docs/compatibility/release-evidence-v1.md)
+- [Upstream compatibility audit](docs/compatibility/upstream-master.md)
 - [X11 native-vs-Pure-Go evidence](docs/performance/x11-native-vs-purego.md)
 - [Current Wayland support and backlog](docs/wayland-tasks.md)
 - [Product roadmap](docs/plan/product-roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ Use the following documents as the primary entry points:
 - [Test guide](../TEST.md) for validation commands and runtime prerequisites.
 - [Product roadmap](plan/product-roadmap.md) for delivery phases.
 - [Wayland status](wayland-tasks.md) for backend support and open Wayland work.
+- [Upstream compatibility audit](compatibility/upstream-master.md) for
+  selectively adopted and intentionally rejected upstream changes.
 
 API details are available through examples and Go documentation. Lasting
 backend behavior and support contracts are documented in this directory.

--- a/docs/compatibility/upstream-master.md
+++ b/docs/compatibility/upstream-master.md
@@ -1,0 +1,23 @@
+# Upstream Compatibility Audit
+
+RobotGo tracks useful changes from
+[`go-vgo/robotgo`](https://github.com/go-vgo/robotgo) without treating upstream
+`master` as an automatically trusted source. Each port must preserve this
+fork's explicit error, lifecycle, platform-boundary, and test contracts.
+
+Last audited upstream revision:
+`766c6abccc400cc9a2aa96481c2493355b93fe29` (2026-07-08).
+
+| Upstream area | Fork status | Decision |
+|---|---|---|
+| Public helper names (`CmdV`, `Paste`, `Type`, `TypeDelay`, `ClickV1`, `MultiClick`, `Capture1`, `SaveCaptureGo`) | Compatible | Added as portable aliases or checked helpers without changing established signatures |
+| Process termination validation | Superseded | The fork rejects unsafe PIDs and binds forced window termination to a verified stable process handle or `pidfd` |
+| Keyboard release ordering and macOS click/movement fixes | Superseded | Equivalent or stronger ownership, rollback, ordering, and bounded-movement contracts are already tested |
+| Pure-Go X11 main display ID | Intentionally different | The fork keeps display ID 0 as primary because its public capture IDs address Xinerama outputs; upstream indexes X protocol screens instead |
+| Experimental Pure-Go Wayland screencopy | Not ported | The upstream path has unbounded waits, incomplete output scale/transform semantics, unsafe size arithmetic, and weaker connection/resource lifecycle behavior |
+
+Pure-Go Wayland protocol work remains eligible only as a hardened backend:
+bounded cancellation, checked buffer arithmetic, deterministic cleanup,
+logical multi-output geometry, transforms, explicit unsupported errors, and
+hermetic plus real-compositor evidence are required before it can replace or
+precede the current portal path.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -29,7 +29,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
   Weston integration, race, vet, and native sanitizer/leak variants.
 
-## Execution Status (2026-07-17)
+## Execution Status (2026-07-18)
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
@@ -223,6 +223,10 @@ probe failures abort without a destructive fallback. macOS captures process
 identity for the graceful wait and returns explicit unsupported if graceful
 close is insufficient because it has no equivalent stable process handle.
 Hermetic tests never terminate a real process.
+
+The current upstream public-helper surface is also source-compatible without
+adopting upstream's breaking `Click` signature change. The versioned upstream
+audit records which changes are adopted, superseded, or rejected and why.
 
 The Linux/X11 evaluation slice of Phase 3 is complete. Native CGO and Pure-Go
 X11 binaries pass one black-box public-API contract for capture, pointer,

--- a/upstream_compat.go
+++ b/upstream_compat.go
@@ -1,0 +1,70 @@
+package robotgo
+
+import (
+	"fmt"
+	"image"
+)
+
+// CmdV presses the platform paste shortcut.
+func CmdV() error {
+	return cmdVWith(CmdCtrl(), KeyTap)
+}
+
+func cmdVWith(modifier string, tap func(string, ...interface{}) error) error {
+	return tap("v", modifier)
+}
+
+// Paste writes text to the clipboard and presses the platform paste shortcut.
+func Paste(text string) error {
+	return PasteStr(text)
+}
+
+// Type sends UTF-8 text. It is an upstream-compatible alias for TypeStr.
+func Type(text string, args ...int) {
+	TypeStr(text, args...)
+}
+
+// TypeDelay sends UTF-8 text and waits for delay milliseconds afterwards.
+func TypeDelay(text string, delay int) {
+	TypeStrDelay(text, delay)
+}
+
+// ClickV1 clicks a mouse button. It preserves the upstream compatibility name
+// while the established RobotGo Click API remains source-compatible.
+func ClickV1(args ...interface{}) {
+	Click(args...)
+}
+
+// MultiClick performs count single clicks and stops at the first backend
+// error. The optional compatibility argument is accepted for source parity
+// with upstream; RobotGo uses the same checked path on every platform.
+func MultiClick(button string, count int, compatibility ...bool) error {
+	return multiClickWith(button, count, compatibility, ClickE)
+}
+
+func multiClickWith(
+	button string,
+	count int,
+	compatibility []bool,
+	click func(...interface{}) error,
+) error {
+	_ = compatibility
+	for index := 0; index < count; index++ {
+		if err := click(button, false); err != nil {
+			return fmt.Errorf("robotgo: multi-click %d/%d: %w", index+1, count, err)
+		}
+	}
+	return nil
+}
+
+// Capture1 captures a screen region. It preserves the compatibility name used
+// by upstream's platform adapters; new code should use Capture.
+func Capture1(args ...int) (*image.RGBA, error) {
+	return Capture(args...)
+}
+
+// SaveCaptureGo captures and saves an image. It is an upstream-compatible
+// alias for SaveCapture.
+func SaveCaptureGo(path string, args ...int) error {
+	return SaveCapture(path, args...)
+}

--- a/upstream_compat_test.go
+++ b/upstream_compat_test.go
@@ -1,0 +1,109 @@
+package robotgo
+
+import (
+	"errors"
+	"image"
+	"reflect"
+	"testing"
+)
+
+var (
+	_ func() error                      = CmdV
+	_ func(string) error                = Paste
+	_ func(string, ...int)              = Type
+	_ func(string, int)                 = TypeDelay
+	_ func(...interface{})              = ClickV1
+	_ func(string, int, ...bool) error  = MultiClick
+	_ func(...int) (*image.RGBA, error) = Capture1
+	_ func(string, ...int) error        = SaveCaptureGo
+)
+
+func TestCmdVWith(t *testing.T) {
+	t.Parallel()
+
+	var key string
+	var modifiers []interface{}
+	err := cmdVWith("control", func(gotKey string, gotModifiers ...interface{}) error {
+		key = gotKey
+		modifiers = gotModifiers
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("cmdVWith() error = %v", err)
+	}
+	if key != "v" {
+		t.Fatalf("cmdVWith() key = %q, want %q", key, "v")
+	}
+	if want := []interface{}{"control"}; !reflect.DeepEqual(modifiers, want) {
+		t.Fatalf("cmdVWith() modifiers = %#v, want %#v", modifiers, want)
+	}
+}
+
+func TestCmdVWithPreservesBackendError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("tap failed")
+	err := cmdVWith("command", func(string, ...interface{}) error {
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("cmdVWith() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestMultiClickWith(t *testing.T) {
+	t.Parallel()
+
+	var calls [][]interface{}
+	err := multiClickWith("right", 3, nil, func(args ...interface{}) error {
+		calls = append(calls, append([]interface{}(nil), args...))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("multiClickWith() error = %v", err)
+	}
+	want := [][]interface{}{
+		{"right", false},
+		{"right", false},
+		{"right", false},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("multiClickWith() calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestMultiClickWithNonPositiveCountDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	err := multiClickWith("left", -1, []bool{true}, func(...interface{}) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("multiClickWith() error = %v", err)
+	}
+	if called {
+		t.Fatal("multiClickWith() called backend for a non-positive count")
+	}
+}
+
+func TestMultiClickWithStopsAtFirstError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("click failed")
+	calls := 0
+	err := multiClickWith("left", 4, nil, func(...interface{}) error {
+		calls++
+		if calls == 2 {
+			return wantErr
+		}
+		return nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("multiClickWith() error = %v, want wrapped %v", err, wantErr)
+	}
+	if calls != 2 {
+		t.Fatalf("multiClickWith() calls = %d, want 2", calls)
+	}
+}


### PR DESCRIPTION
## Goal

Keep the fork source-compatible with useful public helpers added on current upstream master without weakening established RobotGo signatures or backend error contracts.

## Changes

- add portable CmdV, Paste, Type, TypeDelay, ClickV1, MultiClick, Capture1, and SaveCaptureGo compatibility APIs
- route MultiClick through the checked ClickE path and stop on the first backend error
- add hermetic helper tests that never inject real input or capture the desktop
- publish a revision-pinned upstream compatibility audit, including intentionally rejected experimental Pure-Go Wayland behavior
- update the product roadmap and documentation index

## Validation

- go test ./...
- CGO_ENABLED=0 go test ./...
- go test -race ./...
- go vet ./...
- CGO_ENABLED=0 go vet ./...
- golangci-lint run
- CGO_ENABLED=0 golangci-lint run
- non-CGO Windows amd64 crossbuild
- non-CGO macOS amd64 and arm64 crossbuilds

## Risk

Low. Existing signatures and behavior are unchanged. New stateful helpers delegate to existing checked APIs; tests use injected fakes only and leave no files or desktop data behind.