### PR TITLE
fix: isolate Wayland capture and bounds from X11

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -293,6 +293,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential pkg-config libx11-dev libxtst-dev \
+            libwayland-dev libxkbcommon-dev wayland-protocols \
+            libgbm-dev libdrm-dev \
             xvfb xauth x11-xkb-utils libxkbcommon-tools
       - name: Run native and Pure-Go X11 contract and benchmark smoke
         env:
@@ -331,6 +333,34 @@ jobs:
               printf "%s\n" "$output"
               if ! printf "%s\n" "$output" | grep -Eq "^--- PASS: ${test_name} \\(.*\\)$"; then
                 echo "missing-XTEST test did not pass" >&2
+                exit 1
+              fi
+            '
+      - name: Preserve X11 capture in Wayland-enabled builds
+        env:
+          CGO_ENABLED: "1"
+        run: |
+          xvfb-run -a \
+            -s '-screen 0 640x480x24 -nolisten tcp -noreset' \
+            sh -eu -c '
+              unset WAYLAND_DISPLAY XDG_SESSION_TYPE
+              test_name=TestWaylandBuildPreservesX11Capture
+              listed="$(go test -tags "wayland x11integration" \
+                -list "^${test_name}$" .)"
+              printf "%s\n" "$listed"
+              if ! printf "%s\n" "$listed" | grep -Fxq "$test_name"; then
+                echo "Wayland-enabled X11 capture test is absent" >&2
+                exit 1
+              fi
+              if ! output="$(go test -tags "wayland x11integration" \
+                -run "^${test_name}$" -count=1 -timeout=30s -v .)"; then
+                printf "%s\n" "$output"
+                exit 1
+              fi
+              printf "%s\n" "$output"
+              if ! printf "%s\n" "$output" | \
+                grep -Eq "^--- PASS: ${test_name} \\(.*\\)$"; then
+                echo "Wayland-enabled X11 capture test did not pass" >&2
                 exit 1
               fi
             '

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ group.
 | Linux/X11 | CGO-enabled default build | X11/XTest input, capture, window, and process paths |
 | Linux/X11 | `CGO_ENABLED=0` | Pure-Go X11 capture/bounds, XTEST input, and window title/PID/handle/geometry/state/control through X11/EWMH; horizontal scroll and window mutations without a consistent EWMH window manager are explicitly unsupported |
 | Linux/Wayland | `-tags wayland` for native protocols; add `pipewire` for persistent ScreenCast frames | Native wlroots capture/input where compositor protocols exist, one-shot Screenshot fallback, reusable ScreenCast/PipeWire capture, explicit RemoteDesktop portal sessions, capability-aware window support |
-| Other supported platforms without CGO | `CGO_ENABLED=0` | Linux/Wayland uses the Screenshot portal; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input; remaining unavailable operations return `ErrNotSupported` |
+| Other supported platforms without CGO | `CGO_ENABLED=0` | Linux/Wayland uses the Screenshot portal without implicit Xwayland capture; non-prompting bounds remain explicitly unsupported; explicit RemoteDesktop sessions provide limited Pure-Go Wayland input |
 
 Wayland compositors intentionally restrict global automation. GNOME and KDE can
 use consent-aware Screenshot and RemoteDesktop portal paths. The explicit
@@ -344,6 +344,8 @@ empty. `DetectDisplayServer` remains an environment-only observation; runtime
 backend information and capabilities report the explicitly selected X11
 target. A Wayland environment remains authoritative, so RobotGo does not route
 a Wayland-primary operation through X11 merely because Xwayland is present.
+CGO binaries compiled with `-tags wayland` retain the XGB/Xinerama `Capture`,
+`CaptureImg`, and bounds compatibility paths when run in a real X11 session.
 
 Linux/X11 also supports capture, bounds, and input without a C compiler or X11
 development headers:
@@ -667,6 +669,15 @@ after opening, including decode-error paths, so sensitive desktop images are
 not left behind. On macOS, capture returns `ErrPermissionDenied` with
 remediation when Screen Recording access is absent; capability inspection
 never requests that permission implicitly.
+
+Display geometry has error-returning variants: `GetDisplayBoundsE`,
+`GetScreenSizeE`, `GetScreenRectE`, and `DisplaysNumE`.
+Use them when backend availability matters. In a Pure-Go Wayland build these
+return `ErrNotSupported` rather than querying an Xwayland `DISPLAY` or opening a
+consent dialog. Their legacy counterparts retain zero-value compatibility.
+CGO-enabled Linux keeps the legacy `Capture` helper and bounds on the selected
+session path (native protocol or its documented Wayland fallback), so a
+Wayland-primary path never falls through to X11.
 
 Use `CaptureImg()` with no arguments for a full-screen capture. Region capture
 requires at least `x, y, width, height`; partial argument lists, non-positive

--- a/TEST.md
+++ b/TEST.md
@@ -432,6 +432,8 @@ Purpose:
   `CGO_ENABLED=0`: capture pixels/bounds/backend identity, pointer movement and
   observation, buttons/scroll, canonical modifier order, ASCII text delivery,
   and unchanged keyboard/modifier maps
+- A Wayland-enabled CGO build running against Xvfb, proving that the build tag
+  does not remove `Capture` or `CaptureImg` from a real X11 runtime
 - Native regression coverage proving unsupported Unicode, unmapped modified
   keys, and a later unmapped text character fail before any key event and never
   change the server-global keyboard map
@@ -505,6 +507,19 @@ ROBOTGO_EXPECT_X11_NO_XTEST=1 \
     unset WAYLAND_DISPLAY XDG_SESSION_TYPE
     go test -tags x11integration \
       -run "^TestX11MissingXTestReadinessContract$" \
+      -count=1 -timeout=30s -v .
+  '
+```
+
+Wayland-enabled build on an X11 runtime:
+
+```bash
+CGO_ENABLED=1 \
+  xvfb-run -a -s "-screen 0 640x480x24 -nolisten tcp -noreset" \
+  sh -eu -c '
+    unset WAYLAND_DISPLAY XDG_SESSION_TYPE
+    go test -tags "wayland x11integration" \
+      -run "^TestWaylandBuildPreservesX11Capture$" \
       -count=1 -timeout=30s -v .
   '
 ```
@@ -591,6 +606,14 @@ go test -tags "portal" ./screen/portal -v
 go test -tags "pipewire" ./screen/portal -v
 go test -tags "wayland test" ./screen -run 'TestScreencopy(BitmapStringHelper|WlShm|PortalFallback)' -v
 go test -tags "wayland integration" . ./mouse ./window -v
+```
+
+The non-CGO Wayland bounds-isolation regression is hermetic and deliberately
+sets both `WAYLAND_DISPLAY` and `DISPLAY` to prove the X11 backend is never
+contacted:
+
+```bash
+CGO_ENABLED=0 go test -run '^TestPureGoWaylandBounds|^TestPureGoCaptureAliasUsesWaylandPortal' .
 ```
 
 Run tag-gated suites as needed for the area you changed. Native or Pure-Go X11

--- a/docs/compatibility/runtime-v1.md
+++ b/docs/compatibility/runtime-v1.md
@@ -1,7 +1,7 @@
 # Runtime Compatibility Matrix v1
 
 Matrix version: **1**
-Published: **2026-07-17**
+Published: **2026-07-18**
 
 This matrix separates implemented behavior from blocking runtime evidence.
 `supported` means the applicable build and behavioral contract is blocking in
@@ -16,7 +16,7 @@ available. A pending row is not a passing row.
 | Linux/X11 | Native CGO | supported | Default Linux tests, race/vet/lint, ASan/LeakSanitizer ownership gate, Xvfb/XTEST public contract, XTEST-disabled negative contract |
 | Linux/X11 | Pure Go | supported | Non-CGO Linux tests plus non-skipping Xvfb/XTEST input, capture, bounds, cleanup, and crash-guardian contracts |
 | Linux/Wayland/wlroots | Native CGO, `wayland` | supported for advertised protocols | Weston integration plus hermetic screencopy, virtual input, bounds, scale, transform, fallback, and manifest-checked ASan/LeakSanitizer ownership tests; compositor-specific protocols remain capability-gated |
-| Linux/Wayland | Pure Go | supported for portal APIs | Non-CGO portal capture/input contracts; user consent and portal backend availability remain runtime requirements |
+| Linux/Wayland | Pure Go | supported for portal APIs | Non-CGO portal capture/input contracts; shared capture helpers refuse implicit Xwayland, while non-prompting display bounds return explicit unsupported errors; user consent and portal backend availability remain runtime requirements |
 | GNOME/Wayland | CGO and Pure Go portal paths | implemented / evidence pending | Protected GNOME runner required for RemoteDesktop and persistent ScreenCast evidence |
 | KDE Plasma/Wayland | CGO and Pure Go portal paths | implemented / evidence pending | Protected KDE runner required for RemoteDesktop and persistent ScreenCast evidence |
 | macOS | Native CGO | supported | Hosted macOS build/test; Screen Recording and Accessibility are runtime permissions |

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -227,6 +227,10 @@ Hermetic tests never terminate a real process.
 The current upstream public-helper surface is also source-compatible without
 adopting upstream's breaking `Click` signature change. The versioned upstream
 audit records which changes are adopted, superseded, or rejected and why.
+Shared Linux capture and bounds helpers now respect the selected display
+server: CGO builds stay within the selected Wayland/X11 session path, Pure-Go
+Wayland capture uses the hardened portal, and non-prompting Pure-Go Wayland
+bounds return explicit errors instead of falling through to Xwayland.
 
 The Linux/X11 evaluation slice of Phase 3 is complete. Native CGO and Pure-Go
 X11 binaries pass one black-box public-API contract for capture, pointer,

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -44,6 +44,10 @@ Current implementation baseline:
 - Non-CGO `CaptureImg`/`CaptureScreen`, their Go-bitmap/string variants, and
   pixel-color queries use the hardened screenshot portal on Wayland and the
   Pure-Go screenshot backend on X11/Windows; unsupported targets fail explicitly.
+- Shared `Capture` and display-bounds helpers no longer route Wayland-primary
+  sessions through X11. Error-returning bounds and display-count variants make
+  Pure-Go Wayland's unavailable non-prompting geometry explicit while legacy
+  APIs retain zero-value compatibility.
 - Capability introspection probes the live screencopy protocol, desktop portal
   D-Bus owner, virtual pointer and virtual keyboard instead of inferring support
   solely from session environment variables.

--- a/examples/display_bounds/main.go
+++ b/examples/display_bounds/main.go
@@ -7,8 +7,16 @@ import (
 )
 
 func main() {
-	desktop := robotgo.GetScreenRect()
-	width, height := robotgo.GetScreenSize()
+	desktop, err := robotgo.GetScreenRectE()
+	if err != nil {
+		fmt.Println("desktop bounds unavailable:", err)
+		return
+	}
+	width, height, err := robotgo.GetScreenSizeE()
+	if err != nil {
+		fmt.Println("screen size unavailable:", err)
+		return
+	}
 	fmt.Printf(
 		"desktop: origin=(%d,%d) size=%dx%d (GetScreenSize=%dx%d)\n",
 		desktop.X,
@@ -19,19 +27,25 @@ func main() {
 		height,
 	)
 
-	count := robotgo.DisplaysNum()
-	mainID := robotgo.GetMainId()
-	fmt.Printf("outputs: %d, primary index: %d\n", count, mainID)
+	count, err := robotgo.DisplaysNumE()
+	if err != nil {
+		fmt.Println("display enumeration unavailable:", err)
+		return
+	}
+	fmt.Printf("outputs: %d, platform main ID: %d\n", count, robotgo.GetMainId())
 	for displayID := 0; displayID < count; displayID++ {
-		rect := robotgo.GetScreenRect(displayID)
+		x, y, width, height, err := robotgo.GetDisplayBoundsE(displayID)
+		if err != nil {
+			fmt.Printf("output[%d] unavailable: %v\n", displayID, err)
+			continue
+		}
 		fmt.Printf(
-			"output[%d]: origin=(%d,%d) size=%dx%d primary=%t\n",
+			"output[%d]: origin=(%d,%d) size=%dx%d\n",
 			displayID,
-			rect.X,
-			rect.Y,
-			rect.W,
-			rect.H,
-			displayID == mainID,
+			x,
+			y,
+			width,
+			height,
 		)
 	}
 }

--- a/robotgo.go
+++ b/robotgo.go
@@ -431,10 +431,20 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		c.Events = c.Hook
 
 	case DisplayServerX11:
-		displayErr, inputErr := nativeX11CapabilityErrors()
+		displayErr, inputErr := runtimeX11CapabilityErrors()
+		nativeBackendReason := "native X11 backend is not compiled for this build"
+		if displayErr != nil {
+			nativeBackendReason = displayErr.Error()
+		}
 		if capabilityProbeSucceeded(displayErr) {
-			c.Capture = FeatureCapability{Available: true, Backend: "x11", Reason: "X11 display connection is available", Notes: "native X11 capture path"}
-			c.Bounds = FeatureCapability{Available: true, Backend: "x11", Reason: "X11 display connection is available", Notes: "native X11 bounds path"}
+			captureNotes := "native X11 capture path"
+			boundsNotes := "native X11 bounds path"
+			if !nativeX11BackendCompiled() {
+				captureNotes = "XGB/Xinerama compatibility capture path"
+				boundsNotes = "XGB/Xinerama compatibility bounds path"
+			}
+			c.Capture = FeatureCapability{Available: true, Backend: "x11", Reason: "X11 display connection is available", Notes: captureNotes}
+			c.Bounds = FeatureCapability{Available: true, Backend: "x11", Reason: "X11 display connection is available", Notes: boundsNotes}
 		} else {
 			c.Capture = FeatureCapability{Available: false, Backend: "x11", Reason: displayErr.Error(), Notes: "check DISPLAY and X11 server access"}
 			c.Bounds = c.Capture
@@ -449,12 +459,12 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		if capabilityProbeSucceeded(displayErr) && nativeX11BackendCompiled() {
 			c.Window = FeatureCapability{Available: true, Backend: "x11", Reason: "X11 display connection is available", Notes: "native X11 activation, title, and close path"}
 		} else {
-			c.Window = FeatureCapability{Available: false, Backend: "x11", Reason: displayErr.Error(), Notes: "build the native X11 backend and verify the configured X11 display"}
+			c.Window = FeatureCapability{Available: false, Backend: "x11", Reason: nativeBackendReason, Notes: "build the native X11 backend and verify the configured X11 display"}
 		}
 		if capabilityProbeSucceeded(displayErr) && nativeX11BackendCompiled() {
 			c.Hook = FeatureCapability{Available: true, Backend: "x11", Reason: "X11 display connection is available", Notes: "native X11 hook/event path"}
 		} else {
-			c.Hook = FeatureCapability{Available: false, Backend: "x11", Reason: displayErr.Error(), Notes: "build the native X11 backend and verify the configured X11 display"}
+			c.Hook = FeatureCapability{Available: false, Backend: "x11", Reason: nativeBackendReason, Notes: "build the native X11 backend and verify the configured X11 display"}
 		}
 		c.Events = c.Hook
 
@@ -1466,6 +1476,9 @@ func CaptureGo(args ...int) (Bitmap, error) {
 
 // CaptureImg capture the screen and return image.Image, error
 func CaptureImg(args ...int) (image.Image, error) {
+	if img, handled, err := platformCaptureImgFallback(args...); handled {
+		return img, err
+	}
 	bit, err := CaptureScreen(args...)
 	if err != nil {
 		return nil, err

--- a/robotgo_nocgo_capture_test.go
+++ b/robotgo_nocgo_capture_test.go
@@ -388,6 +388,103 @@ func TestPureGoCaptureImgUsesHardenedWaylandPortal(t *testing.T) {
 	}
 }
 
+func TestPureGoCaptureAliasUsesWaylandPortalWithoutX11Bounds(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv(envWaylandDisplay, "wayland-test")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	t.Setenv(envDisablePortal, "")
+
+	legacyCalls := 0
+	pureGoCaptureImage = func(...int) (image.Image, error) {
+		legacyCalls++
+		return nil, errors.New("legacy screenshot backend must not be called")
+	}
+	portalCalls := 0
+	pureGoPortalCaptureImage = func(_ context.Context, x, y, width, height int) (image.Image, error) {
+		portalCalls++
+		if x != 0 || y != 0 || width != 0 || height != 0 {
+			t.Fatalf("portal full-screen rectangle = %d,%d %dx%d", x, y, width, height)
+		}
+		return image.NewRGBA(image.Rect(0, 0, 4, 3)), nil
+	}
+
+	img, err := Capture()
+	if err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	if img.Bounds() != image.Rect(0, 0, 4, 3) {
+		t.Fatalf("Capture() bounds = %v, want 4x3", img.Bounds())
+	}
+	if legacyCalls != 0 || portalCalls != 1 {
+		t.Fatalf(
+			"capture calls = legacy:%d portal:%d, want legacy:0 portal:1",
+			legacyCalls,
+			portalCalls,
+		)
+	}
+}
+
+func TestPureGoCaptureAliasHonorsScreenCastOverride(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv(envWaylandDisplay, "wayland-test")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	t.Setenv(envWaylandBackend, waylandBackendScreenCast)
+	pureGoPortalCaptureImage = func(context.Context, int, int, int, int) (image.Image, error) {
+		t.Fatal("portal capture called for an unsupported ScreenCast override")
+		return nil, nil
+	}
+
+	if _, err := Capture(); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("Capture() error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestPureGoCaptureAliasRejectsXDGWaylandConflict(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv(envWaylandDisplay, "")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	pureGoCaptureImage = func(...int) (image.Image, error) {
+		t.Fatal("legacy X11 screenshot backend called for an XDG Wayland session")
+		return nil, nil
+	}
+	pureGoPortalCaptureImage = func(context.Context, int, int, int, int) (image.Image, error) {
+		t.Fatal("portal capture opened implicitly for an XDG Wayland conflict")
+		return nil, nil
+	}
+
+	if _, err := Capture(0, 0, 1, 1); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("Capture() error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestPureGoCaptureAliasForcedPortalBypassesXDGWaylandConflict(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv(envWaylandDisplay, "")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	t.Setenv(envForcePortal, "1")
+	t.Setenv(envDisablePortal, "")
+	pureGoCaptureImage = func(...int) (image.Image, error) {
+		t.Fatal("legacy X11 screenshot backend called for forced portal capture")
+		return nil, nil
+	}
+	portalCalls := 0
+	pureGoPortalCaptureImage = func(context.Context, int, int, int, int) (image.Image, error) {
+		portalCalls++
+		return image.NewRGBA(image.Rect(0, 0, 2, 2)), nil
+	}
+
+	if _, err := Capture(0, 0, 2, 2); err != nil {
+		t.Fatalf("Capture() forced portal error = %v", err)
+	}
+	if portalCalls != 1 {
+		t.Fatalf("portal capture calls = %d, want 1", portalCalls)
+	}
+}
+
 func TestPureGoCaptureImgReportsExplicitUnsupported(t *testing.T) {
 	preservePureGoCaptureFakes(t)
 	t.Setenv("WAYLAND_DISPLAY", "")

--- a/robotgo_wayland_cap_test.go
+++ b/robotgo_wayland_cap_test.go
@@ -290,6 +290,20 @@ func TestWaylandScreenFallbackWithoutX11(t *testing.T) {
 	if rect.X != 10 || rect.Y != 20 || rect.W != 800 || rect.H != 600 {
 		t.Fatalf("unexpected screen rect from fallback: %+v", rect)
 	}
+	rectE, err := GetScreenRectE()
+	if err != nil {
+		t.Fatalf("GetScreenRectE fallback error: %v", err)
+	}
+	if rectE != rect {
+		t.Fatalf("GetScreenRectE fallback = %+v, want %+v", rectE, rect)
+	}
+	widthE, heightE, err := GetScreenSizeE()
+	if err != nil {
+		t.Fatalf("GetScreenSizeE fallback error: %v", err)
+	}
+	if widthE != 800 || heightE != 600 {
+		t.Fatalf("GetScreenSizeE fallback = %dx%d, want 800x600", widthE, heightE)
+	}
 }
 
 func TestGetLinuxCapabilitiesWaylandFallback(t *testing.T) {

--- a/screen.go
+++ b/screen.go
@@ -15,10 +15,30 @@ import (
 	"image"
 )
 
-// GetDisplayBounds gets the display screen bounds
+// GetDisplayBounds gets the display screen bounds. Use GetDisplayBoundsE when
+// backend failures must be distinguished from an empty legacy result.
 func GetDisplayBounds(i int) (x, y, w, h int) {
-	bs := platformDisplayBounds(i)
-	return bs.Min.X, bs.Min.Y, bs.Dx(), bs.Dy()
+	x, y, w, h, _ = GetDisplayBoundsE(i)
+	return x, y, w, h
+}
+
+// GetDisplayBoundsE gets the display screen bounds and reports invalid display
+// indices, unavailable backends, and empty backend results explicitly.
+func GetDisplayBoundsE(i int) (x, y, w, h int, err error) {
+	if i < 0 {
+		return 0, 0, 0, 0, invalidDisplayIndexError(i)
+	}
+	if err := pureGoWaylandBoundsError(); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	bounds, err := platformDisplayBoundsE(i)
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	if err := validateDisplayRectangle(bounds); err != nil {
+		return 0, 0, 0, 0, err
+	}
+	return bounds.Min.X, bounds.Min.Y, bounds.Dx(), bounds.Dy(), nil
 }
 
 // GetDisplayRect gets the display rect

--- a/screen_backend_darwin_nocgo.go
+++ b/screen_backend_darwin_nocgo.go
@@ -174,17 +174,17 @@ func platformDisplayCount() int {
 	return count
 }
 
-func platformDisplayBounds(displayIndex int) image.Rectangle {
+func platformDisplayBoundsE(displayIndex int) (image.Rectangle, error) {
 	api, err := openDarwinGraphics()
 	if err != nil {
-		return image.Rectangle{}
+		return image.Rectangle{}, err
 	}
 	defer func() { _ = api.close() }()
 	bounds, err := darwinDisplayBounds(api, displayIndex)
 	if err != nil {
-		return image.Rectangle{}
+		return image.Rectangle{}, err
 	}
-	return bounds
+	return bounds, nil
 }
 
 func platformCapture(x, y, width, height int) (*image.RGBA, error) {

--- a/screen_backend_linux_cgo.go
+++ b/screen_backend_linux_cgo.go
@@ -1,0 +1,170 @@
+//go:build cgo && linux
+
+package robotgo
+
+import (
+	"fmt"
+	"image"
+	"os"
+	"strings"
+
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xinerama"
+	"github.com/vcaesar/screenshot"
+)
+
+const (
+	envLinuxSessionType     = "XDG_SESSION_TYPE"
+	linuxSessionTypeWayland = "wayland"
+)
+
+func platformDisplayBoundsE(displayIndex int) (image.Rectangle, error) {
+	server := selectedDisplayServer()
+	if server == DisplayServerX11 {
+		if err := linuxX11SessionConflictError("display bounds"); err != nil {
+			return image.Rectangle{}, err
+		}
+	}
+	waylandBounds := func(index int) (image.Rectangle, error) {
+		rect := GetScreenRect(index)
+		return image.Rect(rect.X, rect.Y, rect.X+rect.W, rect.Y+rect.H), nil
+	}
+	return dispatchLinuxDisplayBounds(
+		server,
+		displayIndex,
+		waylandBounds,
+		x11DisplayBounds,
+	)
+}
+
+func x11DisplayBounds(displayIndex int) (image.Rectangle, error) {
+	if displayIndex < 0 {
+		return image.Rectangle{}, invalidDisplayIndexError(displayIndex)
+	}
+	unlock := lockNativeX11Display()
+	display := getXDisplayNameLocked()
+	unlock()
+
+	conn, err := xgb.NewConnDisplay(display)
+	if err != nil {
+		return image.Rectangle{}, fmt.Errorf("robotgo: connect to X11 display for bounds: %w", err)
+	}
+	defer conn.Close()
+	if err := xinerama.Init(conn); err != nil {
+		return image.Rectangle{}, fmt.Errorf("robotgo: initialize Xinerama for bounds: %w", err)
+	}
+	reply, err := xinerama.QueryScreens(conn).Reply()
+	if err != nil {
+		return image.Rectangle{}, fmt.Errorf("robotgo: query Xinerama screens: %w", err)
+	}
+	count := int(reply.Number)
+	if count != len(reply.ScreenInfo) {
+		return image.Rectangle{}, fmt.Errorf(
+			"robotgo: malformed Xinerama reply: count=%d records=%d",
+			count,
+			len(reply.ScreenInfo),
+		)
+	}
+	if displayIndex >= count {
+		return image.Rectangle{}, fmt.Errorf(
+			"robotgo: display index %d is outside active Xinerama count %d",
+			displayIndex,
+			count,
+		)
+	}
+	primary := reply.ScreenInfo[0]
+	screen := reply.ScreenInfo[displayIndex]
+	x := int(screen.XOrg) - int(primary.XOrg)
+	y := int(screen.YOrg) - int(primary.YOrg)
+	width := int(screen.Width)
+	height := int(screen.Height)
+	return image.Rect(x, y, x+width, y+height), nil
+}
+
+func platformCapture(x, y, width, height int) (*image.RGBA, error) {
+	nativeCapture := func(x, y, width, height int) (*image.RGBA, error) {
+		captured, err := CaptureImg(x, y, width, height)
+		if err != nil {
+			return nil, err
+		}
+		rgba, ok := captured.(*image.RGBA)
+		if !ok {
+			return nil, fmt.Errorf(
+				"robotgo: native Linux capture returned %T instead of *image.RGBA",
+				captured,
+			)
+		}
+		return rgba, nil
+	}
+	x11Capture := nativeCapture
+	if !nativeX11BackendCompiled() && !linuxCaptureUsesPortalBackend() {
+		// A Wayland-enabled CGO binary may still run in a real X11 session.
+		// Its C build intentionally omits the native X11 capture backend, so
+		// preserve the portable XGB/Xinerama path used by Capture before the
+		// Linux session dispatcher was introduced.
+		x11Capture = func(x, y, width, height int) (*image.RGBA, error) {
+			if err := linuxX11SessionConflictError("capture"); err != nil {
+				return nil, err
+			}
+			img, err := screenshot.Capture(x, y, width, height)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"robotgo: capture X11 from a Wayland-enabled build: %w",
+					err,
+				)
+			}
+			setLastBackend(BackendX11)
+			return img, nil
+		}
+	}
+	return dispatchLinuxCapture(
+		selectedDisplayServer(),
+		x,
+		y,
+		width,
+		height,
+		nativeCapture,
+		x11Capture,
+	)
+}
+
+func linuxCaptureUsesPortalBackend() bool {
+	backend := strings.ToLower(strings.TrimSpace(os.Getenv(envWaylandBackend)))
+	return os.Getenv(envForcePortal) != "" ||
+		backend == waylandBackendPortalName ||
+		backend == waylandBackendScreenCast
+}
+
+func linuxX11SessionConflictError(feature string) error {
+	if !strings.EqualFold(
+		strings.TrimSpace(os.Getenv(envLinuxSessionType)),
+		linuxSessionTypeWayland,
+	) {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: the X11 backend is selected but %s selects Wayland; refusing implicit Xwayland %s",
+		ErrNotSupported,
+		envLinuxSessionType,
+		feature,
+	)
+}
+
+func platformCaptureImgFallback(args ...int) (image.Image, bool, error) {
+	if nativeX11BackendCompiled() ||
+		selectedDisplayServer() != DisplayServerX11 ||
+		linuxCaptureUsesPortalBackend() {
+		return nil, false, nil
+	}
+	if err := validateCaptureArguments(args); err != nil {
+		return nil, true, err
+	}
+	if len(args) > 5 {
+		return nil, true, fmt.Errorf(
+			"%w: process-targeted X11 capture is unavailable in a Wayland-enabled build",
+			ErrNotSupported,
+		)
+	}
+	img, err := Capture(args...)
+	return img, true, err
+}

--- a/screen_backend_linux_dispatch.go
+++ b/screen_backend_linux_dispatch.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+package robotgo
+
+import (
+	"fmt"
+	"image"
+)
+
+type linuxDisplayBoundsBackend func(int) (image.Rectangle, error)
+type linuxCaptureBackend func(int, int, int, int) (*image.RGBA, error)
+
+func dispatchLinuxDisplayBounds(
+	server DisplayServer,
+	displayIndex int,
+	wayland linuxDisplayBoundsBackend,
+	x11 linuxDisplayBoundsBackend,
+) (image.Rectangle, error) {
+	var backend linuxDisplayBoundsBackend
+	switch server {
+	case DisplayServerWayland:
+		backend = wayland
+	case DisplayServerX11:
+		backend = x11
+	default:
+		return image.Rectangle{}, fmt.Errorf(
+			"%w: no supported Linux display server selected",
+			ErrNotSupported,
+		)
+	}
+	if backend == nil {
+		return image.Rectangle{}, fmt.Errorf(
+			"%w: display bounds are unavailable for %s",
+			ErrNotSupported,
+			server,
+		)
+	}
+	bounds, err := backend(displayIndex)
+	if err != nil {
+		return image.Rectangle{}, err
+	}
+	if err := validateDisplayRectangle(bounds); err != nil {
+		return image.Rectangle{}, fmt.Errorf("%s display %d: %w", server, displayIndex, err)
+	}
+	return bounds, nil
+}
+
+func dispatchLinuxCapture(
+	server DisplayServer,
+	x, y, width, height int,
+	wayland linuxCaptureBackend,
+	x11 linuxCaptureBackend,
+) (*image.RGBA, error) {
+	var backend linuxCaptureBackend
+	switch server {
+	case DisplayServerWayland:
+		backend = wayland
+	case DisplayServerX11:
+		backend = x11
+	default:
+		return nil, fmt.Errorf(
+			"%w: no supported Linux display server selected",
+			ErrNotSupported,
+		)
+	}
+	if backend == nil {
+		return nil, fmt.Errorf(
+			"%w: capture is unavailable for %s",
+			ErrNotSupported,
+			server,
+		)
+	}
+	img, err := backend(x, y, width, height)
+	if err != nil {
+		return nil, err
+	}
+	if img == nil || img.Bounds().Empty() {
+		return nil, fmt.Errorf("%s capture returned an empty image", server)
+	}
+	return img, nil
+}

--- a/screen_backend_linux_dispatch_test.go
+++ b/screen_backend_linux_dispatch_test.go
@@ -1,0 +1,163 @@
+//go:build linux
+
+package robotgo
+
+import (
+	"errors"
+	"image"
+	"testing"
+)
+
+func TestDispatchLinuxDisplayBoundsSelectsSessionBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		server     DisplayServer
+		wantBounds image.Rectangle
+		wantCalls  [2]int
+	}{
+		{
+			name:       "Wayland",
+			server:     DisplayServerWayland,
+			wantBounds: image.Rect(-100, 20, 1820, 1100),
+			wantCalls:  [2]int{1, 0},
+		},
+		{
+			name:       "X11",
+			server:     DisplayServerX11,
+			wantBounds: image.Rect(0, 0, 1280, 720),
+			wantCalls:  [2]int{0, 1},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls [2]int
+			bounds, err := dispatchLinuxDisplayBounds(
+				test.server,
+				2,
+				func(index int) (image.Rectangle, error) {
+					calls[0]++
+					if index != 2 {
+						t.Fatalf("Wayland display index = %d, want 2", index)
+					}
+					return image.Rect(-100, 20, 1820, 1100), nil
+				},
+				func(index int) (image.Rectangle, error) {
+					calls[1]++
+					if index != 2 {
+						t.Fatalf("X11 display index = %d, want 2", index)
+					}
+					return image.Rect(0, 0, 1280, 720), nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("dispatchLinuxDisplayBounds() error = %v", err)
+			}
+			if bounds != test.wantBounds {
+				t.Fatalf(
+					"dispatchLinuxDisplayBounds() = %v, want %v",
+					bounds,
+					test.wantBounds,
+				)
+			}
+			if calls != test.wantCalls {
+				t.Fatalf("backend calls = %v, want %v", calls, test.wantCalls)
+			}
+		})
+	}
+}
+
+func TestDispatchLinuxDisplayBoundsRejectsUnavailableBackend(t *testing.T) {
+	t.Parallel()
+
+	_, err := dispatchLinuxDisplayBounds(
+		DisplayServerWayland,
+		0,
+		nil,
+		func(int) (image.Rectangle, error) {
+			t.Fatal("X11 bounds backend called in Wayland session")
+			return image.Rectangle{}, nil
+		},
+	)
+	if !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("dispatchLinuxDisplayBounds() error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestDispatchLinuxCaptureSelectsSessionBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		server    DisplayServer
+		wantPixel byte
+		wantCalls [2]int
+	}{
+		{name: "Wayland", server: DisplayServerWayland, wantPixel: 10, wantCalls: [2]int{1, 0}},
+		{name: "X11", server: DisplayServerX11, wantPixel: 20, wantCalls: [2]int{0, 1}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls [2]int
+			capture := func(callIndex int, pixel byte) linuxCaptureBackend {
+				return func(x, y, width, height int) (*image.RGBA, error) {
+					calls[callIndex]++
+					if x != -4 || y != 7 || width != 2 || height != 3 {
+						t.Fatalf("capture rectangle = %d,%d %dx%d", x, y, width, height)
+					}
+					img := image.NewRGBA(image.Rect(0, 0, width, height))
+					img.Pix[0] = pixel
+					return img, nil
+				}
+			}
+			img, err := dispatchLinuxCapture(
+				test.server,
+				-4,
+				7,
+				2,
+				3,
+				capture(0, 10),
+				capture(1, 20),
+			)
+			if err != nil {
+				t.Fatalf("dispatchLinuxCapture() error = %v", err)
+			}
+			if img.Pix[0] != test.wantPixel {
+				t.Fatalf("selected backend pixel = %d, want %d", img.Pix[0], test.wantPixel)
+			}
+			if calls != test.wantCalls {
+				t.Fatalf("backend calls = %v, want %v", calls, test.wantCalls)
+			}
+		})
+	}
+}
+
+func TestDispatchLinuxCaptureRejectsUnknownSession(t *testing.T) {
+	t.Parallel()
+
+	_, err := dispatchLinuxCapture(
+		DisplayServerUnknown,
+		0,
+		0,
+		1,
+		1,
+		func(int, int, int, int) (*image.RGBA, error) {
+			t.Fatal("Wayland capture backend called without a selected session")
+			return nil, nil
+		},
+		func(int, int, int, int) (*image.RGBA, error) {
+			t.Fatal("X11 capture backend called without a selected session")
+			return nil, nil
+		},
+	)
+	if !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("dispatchLinuxCapture() error = %v, want ErrNotSupported", err)
+	}
+}

--- a/screen_backend_linux_nocgo.go
+++ b/screen_backend_linux_nocgo.go
@@ -1,0 +1,99 @@
+//go:build !cgo && linux
+
+package robotgo
+
+import (
+	"fmt"
+	"image"
+	"image/draw"
+
+	"github.com/vcaesar/screenshot"
+)
+
+func platformDisplayCount() int {
+	if selectedDisplayServer() != DisplayServerX11 || pureGoX11EnvironmentConflict() {
+		return 0
+	}
+	return screenshot.NumActiveDisplays()
+}
+
+func platformDisplayBoundsE(displayIndex int) (image.Rectangle, error) {
+	if err := pureGoWaylandBoundsError(); err != nil {
+		return image.Rectangle{}, err
+	}
+	return dispatchLinuxDisplayBounds(
+		selectedDisplayServer(),
+		displayIndex,
+		nil,
+		func(index int) (image.Rectangle, error) {
+			return screenshot.GetDisplayBounds(index), nil
+		},
+	)
+}
+
+func platformCapture(x, y, width, height int) (*image.RGBA, error) {
+	server := selectedDisplayServer()
+	backendOverride := pureGoWaylandBackendOverride()
+	if backendOverride == waylandBackendScreenCast {
+		return nil, fmt.Errorf(
+			"%w: persistent ScreenCast capture requires a CGO PipeWire backend",
+			ErrNotSupported,
+		)
+	}
+	if pureGoPortalForced(backendOverride) || server == DisplayServerWayland {
+		if server == DisplayServerWayland &&
+			backendOverride != "" &&
+			backendOverride != "auto" &&
+			backendOverride != waylandBackendPortalName {
+			captureDebugf(
+				"Pure-Go build cannot use requested %s backend; falling back to screenshot portal",
+				backendOverride,
+			)
+		}
+		selection := "Wayland compatibility"
+		if pureGoPortalForced(backendOverride) {
+			selection = "forced compatibility"
+		}
+		img, err := capturePureGoPortal([]int{x, y, width, height}, selection)
+		if err != nil {
+			return nil, err
+		}
+		return zeroOriginRGBA(img)
+	}
+	if server == DisplayServerX11 && pureGoX11EnvironmentConflict() {
+		return nil, fmt.Errorf(
+			"%w: the X11 backend is selected but %s selects Wayland; refusing implicit Xwayland capture",
+			ErrNotSupported,
+			envXDGSessionType,
+		)
+	}
+	img, err := dispatchLinuxCapture(
+		server,
+		x,
+		y,
+		width,
+		height,
+		nil,
+		screenshot.Capture,
+	)
+	if err != nil {
+		return nil, err
+	}
+	setPureGoCaptureBackend(BackendX11)
+	captureDebugf("Pure-Go capture compatibility helper used %s backend", BackendX11)
+	return img, nil
+}
+
+func zeroOriginRGBA(img image.Image) (*image.RGBA, error) {
+	normalized, err := zeroOriginCaptureImage(img)
+	if err != nil {
+		return nil, err
+	}
+	if rgba, ok := normalized.(*image.RGBA); ok {
+		return rgba, nil
+	}
+	bounds := normalized.Bounds()
+	rgba := image.NewRGBA(image.Rect(0, 0, bounds.Dx(), bounds.Dy()))
+	draw.Draw(rgba, rgba.Bounds(), normalized, bounds.Min, draw.Src)
+	return rgba, nil
+}

--- a/screen_backend_linux_wayland_test.go
+++ b/screen_backend_linux_wayland_test.go
@@ -1,0 +1,38 @@
+//go:build cgo && linux && wayland
+
+package robotgo
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestWaylandBuildX11CaptureRejectsWaylandSessionConflict(t *testing.T) {
+	t.Setenv(envWaylandDisplay, "")
+	t.Setenv(envDisplay, "xwayland-test.invalid:1")
+	t.Setenv(envLinuxSessionType, linuxSessionTypeWayland)
+
+	if _, err := platformCapture(0, 0, 1, 1); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("platformCapture error = %v, want ErrNotSupported", err)
+	}
+	if _, err := platformDisplayBoundsE(0); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("platformDisplayBoundsE error = %v, want ErrNotSupported", err)
+	}
+	capabilities := GetRuntimeCapabilities()
+	if capabilities.Capture.Available {
+		t.Fatalf("capture capability = %+v, want unavailable", capabilities.Capture)
+	}
+	if capabilities.Bounds.Available {
+		t.Fatalf("bounds capability = %+v, want unavailable", capabilities.Bounds)
+	}
+}
+
+func TestWaylandBuildX11CaptureImgRejectsProcessTarget(t *testing.T) {
+	t.Setenv(envWaylandDisplay, "")
+	t.Setenv(envDisplay, "x11-test.invalid:1")
+	t.Setenv(envLinuxSessionType, "")
+
+	if _, err := CaptureImg(0, 0, 1, 1, 0, 1); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("CaptureImg error = %v, want ErrNotSupported", err)
+	}
+}

--- a/screen_backend_screenshot.go
+++ b/screen_backend_screenshot.go
@@ -1,15 +1,23 @@
-//go:build cgo || !darwin
+//go:build (cgo && !linux) || (!cgo && !darwin && !linux)
 
 package robotgo
 
 import (
+	"fmt"
 	"image"
 
 	"github.com/vcaesar/screenshot"
 )
 
-func platformDisplayBounds(displayIndex int) image.Rectangle {
-	return screenshot.GetDisplayBounds(displayIndex)
+func platformDisplayBoundsE(displayIndex int) (image.Rectangle, error) {
+	bounds := screenshot.GetDisplayBounds(displayIndex)
+	if bounds.Empty() {
+		return image.Rectangle{}, fmt.Errorf(
+			"robotgo: display %d bounds are unavailable",
+			displayIndex,
+		)
+	}
+	return bounds, nil
 }
 
 func platformCapture(x, y, width, height int) (*image.RGBA, error) {

--- a/screen_backend_screenshot_nocgo.go
+++ b/screen_backend_screenshot_nocgo.go
@@ -1,4 +1,4 @@
-//go:build !cgo && !darwin
+//go:build !cgo && !darwin && !linux
 
 package robotgo
 

--- a/screen_bounds_error.go
+++ b/screen_bounds_error.go
@@ -1,0 +1,68 @@
+package robotgo
+
+import (
+	"fmt"
+	"image"
+)
+
+func invalidDisplayIndexError(displayIndex int) error {
+	return fmt.Errorf("robotgo: display index must be non-negative, got %d", displayIndex)
+}
+
+func validateDisplayRectangle(bounds image.Rectangle) error {
+	if bounds.Empty() {
+		return fmt.Errorf("robotgo: display bounds are unavailable or empty")
+	}
+	return nil
+}
+
+// GetScreenSizeE returns the selected screen size and reports unavailable or
+// empty backend results explicitly.
+func GetScreenSizeE() (width, height int, err error) {
+	if err := pureGoWaylandBoundsError(); err != nil {
+		return 0, 0, err
+	}
+	width, height = GetScreenSize()
+	if width <= 0 || height <= 0 {
+		return 0, 0, fmt.Errorf("robotgo: screen size is unavailable or empty")
+	}
+	return width, height, nil
+}
+
+// GetScreenRectE returns a screen rectangle and reports unavailable or empty
+// backend results explicitly.
+func GetScreenRectE(displayID ...int) (Rect, error) {
+	if len(displayID) > 1 {
+		return Rect{}, fmt.Errorf(
+			"robotgo: screen rectangle accepts at most one display index, got %d",
+			len(displayID),
+		)
+	}
+	if len(displayID) == 1 && displayID[0] < -1 {
+		return Rect{}, fmt.Errorf(
+			"robotgo: screen display identifier must be -1 or non-negative, got %d",
+			displayID[0],
+		)
+	}
+	if err := pureGoWaylandBoundsError(); err != nil {
+		return Rect{}, err
+	}
+	rect := GetScreenRect(displayID...)
+	if rect.W <= 0 || rect.H <= 0 {
+		return Rect{}, fmt.Errorf("robotgo: screen rectangle is unavailable or empty")
+	}
+	return rect, nil
+}
+
+// DisplaysNumE returns the active display count and reports an unavailable
+// display-enumeration backend explicitly.
+func DisplaysNumE() (int, error) {
+	if err := pureGoWaylandBoundsError(); err != nil {
+		return 0, err
+	}
+	count := DisplaysNum()
+	if count <= 0 {
+		return 0, fmt.Errorf("robotgo: active display count is unavailable")
+	}
+	return count, nil
+}

--- a/screen_bounds_error_test.go
+++ b/screen_bounds_error_test.go
@@ -1,0 +1,38 @@
+package robotgo
+
+import (
+	"image"
+	"testing"
+)
+
+var (
+	_ func(int) (int, int, int, int, error) = GetDisplayBoundsE
+	_ func() (int, int, error)              = GetScreenSizeE
+	_ func(...int) (Rect, error)            = GetScreenRectE
+	_ func() (int, error)                   = DisplaysNumE
+)
+
+func TestDisplayBoundsErrorAPIsValidateArgumentsBeforeBackend(t *testing.T) {
+	t.Parallel()
+
+	if _, _, _, _, err := GetDisplayBoundsE(-1); err == nil {
+		t.Fatal("GetDisplayBoundsE(-1) unexpectedly succeeded")
+	}
+	if _, err := GetScreenRectE(-2); err == nil {
+		t.Fatal("GetScreenRectE(-2) unexpectedly succeeded")
+	}
+	if _, err := GetScreenRectE(0, 1); err == nil {
+		t.Fatal("GetScreenRectE(0, 1) unexpectedly succeeded")
+	}
+}
+
+func TestValidateDisplayRectangle(t *testing.T) {
+	t.Parallel()
+
+	if err := validateDisplayRectangle(image.Rectangle{}); err == nil {
+		t.Fatal("validateDisplayRectangle() accepted empty bounds")
+	}
+	if err := validateDisplayRectangle(image.Rect(-10, 20, 90, 220)); err != nil {
+		t.Fatalf("validateDisplayRectangle() error = %v", err)
+	}
+}

--- a/screen_bounds_linux_nocgo_test.go
+++ b/screen_bounds_linux_nocgo_test.go
@@ -1,0 +1,57 @@
+//go:build linux && !cgo
+
+package robotgo
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPureGoWaylandBoundsNeverUseX11(t *testing.T) {
+	t.Setenv(envWaylandDisplay, "wayland-test")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	assertPureGoWaylandBoundsUnsupported(t)
+}
+
+func TestPureGoWaylandSessionConflictBoundsNeverUseX11(t *testing.T) {
+	t.Setenv(envWaylandDisplay, "")
+	t.Setenv(envDisplay, ":99")
+	t.Setenv(envXDGSessionType, sessionTypeWayland)
+	assertPureGoWaylandBoundsUnsupported(t)
+}
+
+func assertPureGoWaylandBoundsUnsupported(t *testing.T) {
+	t.Helper()
+	if _, _, _, _, err := GetDisplayBoundsE(0); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("GetDisplayBoundsE() error = %v, want ErrNotSupported", err)
+	}
+	if _, _, err := GetScreenSizeE(); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("GetScreenSizeE() error = %v, want ErrNotSupported", err)
+	}
+	if _, err := GetScreenRectE(); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("GetScreenRectE() error = %v, want ErrNotSupported", err)
+	}
+	if _, err := DisplaysNumE(); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("DisplaysNumE() error = %v, want ErrNotSupported", err)
+	}
+	x, y, width, height := GetDisplayBounds(0)
+	if x != 0 || y != 0 || width != 0 || height != 0 {
+		t.Fatalf(
+			"legacy GetDisplayBounds() = %d,%d %dx%d, want an empty result",
+			x,
+			y,
+			width,
+			height,
+		)
+	}
+	if width, height := GetScreenSize(); width != 0 || height != 0 {
+		t.Fatalf("legacy GetScreenSize() = %dx%d, want an empty result", width, height)
+	}
+	if rect := GetScreenRect(); rect != (Rect{}) {
+		t.Fatalf("legacy GetScreenRect() = %+v, want an empty result", rect)
+	}
+	if count := DisplaysNum(); count != 0 {
+		t.Fatalf("legacy DisplaysNum() = %d, want 0", count)
+	}
+}

--- a/screen_bounds_policy_cgo.go
+++ b/screen_bounds_policy_cgo.go
@@ -1,0 +1,7 @@
+//go:build cgo
+
+package robotgo
+
+func pureGoWaylandBoundsError() error {
+	return nil
+}

--- a/screen_bounds_policy_nocgo.go
+++ b/screen_bounds_policy_nocgo.go
@@ -1,0 +1,28 @@
+//go:build !cgo
+
+package robotgo
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func pureGoWaylandBoundsError() error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+	if selectedDisplayServer() == DisplayServerWayland {
+		return fmt.Errorf(
+			"%w: Pure-Go Wayland display bounds require a non-prompting native protocol backend",
+			ErrNotSupported,
+		)
+	}
+	if pureGoX11EnvironmentConflict() {
+		return fmt.Errorf(
+			"%w: %s selects Wayland; refusing X11 display bounds",
+			ErrNotSupported,
+			envXDGSessionType,
+		)
+	}
+	return nil
+}

--- a/screen_capture_img_fallback_other.go
+++ b/screen_capture_img_fallback_other.go
@@ -1,0 +1,9 @@
+//go:build cgo && !linux
+
+package robotgo
+
+import "image"
+
+func platformCaptureImgFallback(...int) (image.Image, bool, error) {
+	return nil, false, nil
+}

--- a/x11_capture_wayland_build_integration_test.go
+++ b/x11_capture_wayland_build_integration_test.go
@@ -1,0 +1,48 @@
+//go:build linux && cgo && wayland && x11integration
+
+package robotgo_test
+
+import (
+	"testing"
+
+	"github.com/marang/robotgo"
+)
+
+// TestWaylandBuildPreservesX11Capture proves that enabling the Wayland CGO
+// backend at build time does not remove X11 capture from an X11 runtime.
+func TestWaylandBuildPreservesX11Capture(t *testing.T) {
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("XDG_SESSION_TYPE", "")
+
+	capabilities := robotgo.GetRuntimeCapabilities()
+	if !capabilities.Capture.Available || capabilities.Capture.Backend != "x11" {
+		t.Fatalf("capture capability = %+v, want available X11", capabilities.Capture)
+	}
+	if !capabilities.Bounds.Available || capabilities.Bounds.Backend != "x11" {
+		t.Fatalf("bounds capability = %+v, want available X11", capabilities.Bounds)
+	}
+
+	const width, height = 8, 8
+	img, err := robotgo.Capture(0, 0, width, height)
+	if err != nil {
+		t.Fatalf("Capture from X11 runtime: %v", err)
+	}
+	if got := img.Bounds(); got.Min.X != 0 || got.Min.Y != 0 ||
+		got.Dx() != width || got.Dy() != height {
+		t.Fatalf("Capture bounds = %v, want %dx%d at zero origin", got, width, height)
+	}
+	if got := robotgo.LastBackend(); got != robotgo.BackendX11 {
+		t.Fatalf("LastBackend = %q, want %q", got, robotgo.BackendX11)
+	}
+
+	capturedImage, err := robotgo.CaptureImg(0, 0, width, height)
+	if err != nil {
+		t.Fatalf("CaptureImg from X11 runtime: %v", err)
+	}
+	if got := capturedImage.Bounds(); got.Dx() != width || got.Dy() != height {
+		t.Fatalf("CaptureImg bounds = %v, want %dx%d", got, width, height)
+	}
+	if got := robotgo.LastBackend(); got != robotgo.BackendX11 {
+		t.Fatalf("CaptureImg LastBackend = %q, want %q", got, robotgo.BackendX11)
+	}
+}

--- a/x11_display_check_linux_wayland.go
+++ b/x11_display_check_linux_wayland.go
@@ -1,0 +1,45 @@
+//go:build cgo && linux && wayland
+
+package robotgo
+
+import "fmt"
+
+func nativeX11BackendCompiled() bool { return false }
+
+func lockNativeX11Display() func() { return func() {} }
+
+func configuredX11DisplaySelected() bool { return false }
+
+func nativeX11DisplayReadyLocked() error {
+	return fmt.Errorf(
+		"%w: native X11 backend is not compiled in a Wayland-enabled build",
+		ErrNotSupported,
+	)
+}
+
+func nativeX11InputReadyLocked() error {
+	return fmt.Errorf(
+		"%w: native X11 input backend is not compiled in a Wayland-enabled build",
+		ErrNotSupported,
+	)
+}
+
+func nativeX11CapabilityErrors() (displayErr error, inputErr error) {
+	return nativeX11DisplayReadyLocked(), nativeX11InputReadyLocked()
+}
+
+func runtimeX11CapabilityErrors() (displayErr error, inputErr error) {
+	if displayErr = linuxX11SessionConflictError("display capabilities"); displayErr != nil {
+		return displayErr, nativeX11InputReadyLocked()
+	}
+	_, displayErr = x11DisplayBounds(0)
+	return displayErr, nativeX11InputReadyLocked()
+}
+
+func nativeX11ProtocolVersion() (major, minor int, negotiated bool) {
+	return 0, 0, false
+}
+
+func x11MainDisplayAvailableLocked() bool {
+	return false
+}

--- a/x11_display_check_linux_x11.go
+++ b/x11_display_check_linux_x11.go
@@ -99,6 +99,10 @@ func nativeX11CapabilityErrors() (displayErr error, inputErr error) {
 	return nil, nativeX11InputReadyLocked()
 }
 
+func runtimeX11CapabilityErrors() (displayErr error, inputErr error) {
+	return nativeX11CapabilityErrors()
+}
+
 func nativeX11ProtocolVersion() (major, minor int, negotiated bool) {
 	unlock := lockNativeX11Display()
 	defer unlock()

--- a/x11_display_check_other.go
+++ b/x11_display_check_other.go
@@ -1,6 +1,5 @@
-//go:build cgo && (!linux || wayland)
-// +build cgo
-// +build !linux wayland
+//go:build cgo && !linux
+// +build cgo,!linux
 
 package robotgo
 
@@ -23,6 +22,10 @@ func nativeX11InputReadyLocked() error {
 func nativeX11CapabilityErrors() (displayErr error, inputErr error) {
 	err := nativeX11DisplayReadyLocked()
 	return err, err
+}
+
+func runtimeX11CapabilityErrors() (displayErr error, inputErr error) {
+	return nativeX11CapabilityErrors()
 }
 
 func nativeX11ProtocolVersion() (major, minor int, negotiated bool) {

--- a/x11_input_parity_integration_test.go
+++ b/x11_input_parity_integration_test.go
@@ -84,6 +84,30 @@ func TestX11BackendBehavioralParity(t *testing.T) {
 
 	t.Run("capture", func(t *testing.T) {
 		const width, height = 640, 480
+		x, y, displayWidth, displayHeight, err := robotgo.GetDisplayBoundsE(0)
+		if err != nil {
+			t.Fatalf("GetDisplayBoundsE: %v", err)
+		}
+		if x != 0 || y != 0 || displayWidth != 1280 || displayHeight != 720 {
+			t.Fatalf(
+				"GetDisplayBoundsE = %d,%d %dx%d, want 0,0 1280x720",
+				x,
+				y,
+				displayWidth,
+				displayHeight,
+			)
+		}
+		compatibilityImage, err := robotgo.Capture(0, 0, 2, 2)
+		if err != nil {
+			t.Fatalf("Capture compatibility helper: %v", err)
+		}
+		if got := compatibilityImage.Bounds(); got.Min.X != 0 || got.Min.Y != 0 ||
+			got.Dx() != 2 || got.Dy() != 2 {
+			t.Fatalf("Capture compatibility bounds = %v, want 2x2", got)
+		}
+		if got := robotgo.LastBackend(); got != robotgo.BackendX11 {
+			t.Fatalf("Capture compatibility LastBackend = %q, want %q", got, robotgo.BackendX11)
+		}
 		image, err := robotgo.CaptureImg(0, 0, width, height)
 		if err != nil {
 			t.Fatalf("CaptureImg: %v", err)


### PR DESCRIPTION
## Goal

Ensure every shared Linux capture and bounds helper obeys the selected display-server policy and can never use an implicit X11/Xwayland path from a Wayland-primary session.

## Changes

- route CGO Linux Capture through the existing native session dispatcher
- preserve configured X11 targets and per-monitor Xinerama bounds
- route Pure-Go Wayland Capture through the hardened Screenshot portal
- reject XDG Wayland plus DISPLAY conflicts unless the portal is explicitly forced
- add GetDisplayBoundsE, GetScreenSizeE, GetScreenRectE, and DisplaysNumE
- retain zero-value behavior only in legacy non-error bounds APIs
- update the side-effect-free display-bounds example, roadmap, test guide, and compatibility matrix
- extend the blocking shared X11 contract to cover bounds and the Capture compatibility helper

## Validation

- go test ./...
- CGO_ENABLED=0 go test ./...
- go test -race ./...
- go test -tags wayland ./...
- go test -tags 'wayland integration' . ./mouse ./window
- CGO and non-CGO x11integration compile manifests
- go vet and golangci-lint with CGO enabled and disabled
- non-CGO Windows amd64, macOS amd64/arm64, and Linux arm64 crossbuilds

The local machine does not provide xvfb-run, so the real shared X11 runtime contract is intentionally left to the protected x11-backend-evidence check. No package installation was performed.

## Safety

All new hermetic capture tests use in-memory fake images. They do not capture the real desktop or create files. Crossbuild output used a trap-owned temporary directory and was removed immediately.