### PR TITLE
test: add blocking Wayland multi-output runtime evidence

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -405,7 +405,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config weston \
+            build-essential pkg-config weston xvfb xauth \
             libx11-dev libxtst-dev libxkbcommon-dev \
             libwayland-dev wayland-protocols \
             libgbm-dev libdrm-dev libpipewire-0.3-dev
@@ -483,6 +483,37 @@ jobs:
           go test -tags "wayland integration" . ./mouse ./window -v
       - name: Run Pure-Go Wayland output integration
         run: |
-          CGO_ENABLED=0 go test -tags "waylandoutputintegration" . \
-            -run '^TestPureGoWaylandOutputEnumerationWeston$' \
-            -count=1 -timeout=30s -v
+          set -euo pipefail
+          expected="$(printf '%s\n' \
+            TestPureGoWaylandMultiOutputEnumerationWeston \
+            TestPureGoWaylandOutputEnumerationWeston | LC_ALL=C sort)"
+          listed="$(CGO_ENABLED=0 go test -tags "waylandoutputintegration" . \
+            -list '^TestPureGoWayland.*EnumerationWeston$')"
+          printf '%s\n' "$listed"
+          actual="$(printf '%s\n' "$listed" | \
+            awk '/^TestPureGoWayland/ { print }' | LC_ALL=C sort)"
+          if [ "$actual" != "$expected" ]; then
+            echo "Pure-Go Wayland output integration manifest mismatch" >&2
+            printf 'expected:\n%s\nactual:\n%s\n' \
+              "$expected" "${actual:-<empty>}" >&2
+            exit 1
+          fi
+          if ! output="$(ROBOTGO_REQUIRE_WAYLAND_OUTPUT_INTEGRATION=1 \
+              xvfb-run -a -s '-screen 0 1920x1080x24 -nolisten tcp -noreset' \
+              env CGO_ENABLED=0 \
+              go test -tags "waylandoutputintegration" . \
+                -run '^TestPureGoWayland.*EnumerationWeston$' \
+                -count=1 -timeout=30s -v 2>&1)"; then
+            printf '%s\n' "$output"
+            exit 1
+          fi
+          printf '%s\n' "$output"
+          while IFS= read -r test_name; do
+            if ! printf '%s\n' "$output" | \
+              grep -Eq "^--- PASS: ${test_name} \\(.*\\)$"; then
+              echo "Pure-Go Wayland output integration did not pass: ${test_name}" >&2
+              exit 1
+            fi
+          done <<EOF
+          $expected
+          EOF

--- a/TEST.md
+++ b/TEST.md
@@ -608,6 +608,13 @@ go test -tags "wayland test" ./screen -run 'TestScreencopy(BitmapStringHelper|Wl
 go test -tags "wayland integration" . ./mouse ./window -v
 CGO_ENABLED=0 go test -tags "waylandoutputintegration" . \
   -run '^TestPureGoWaylandOutputEnumerationWeston$' -count=1 -timeout=30s -v
+
+ROBOTGO_REQUIRE_WAYLAND_OUTPUT_INTEGRATION=1 \
+  xvfb-run -a -s '-screen 0 1920x1080x24 -nolisten tcp -noreset' \
+  env CGO_ENABLED=0 \
+  go test -tags "waylandoutputintegration" . \
+    -run '^TestPureGoWayland.*EnumerationWeston$' \
+    -count=1 -timeout=30s -v
 ```
 
 The non-CGO Wayland output suite is hermetic and deliberately sets both
@@ -621,11 +628,16 @@ CGO_ENABLED=0 go test ./internal/waylandoutput -count=1 -v
 CGO_ENABLED=0 go test -run '^TestPureGoWaylandBounds|^TestPureGoCaptureAliasUsesWaylandPortal' .
 ```
 
-The tagged command above starts a single-output headless Weston instance in a
-test-owned `XDG_RUNTIME_DIR`, exercises the public error-returning bounds APIs,
-terminates and waits for Weston, and lets `t.TempDir` remove the socket and all
-runtime files. It never captures or writes desktop image data. CI runs this as
-a blocking step in `wayland-integration`.
+The first tagged command starts a single-output headless Weston instance. The
+second additionally starts Weston under Xvfb with two virtual outputs, scale
+factor 2, and a 90-degree transform. It verifies exact logical per-output and
+aggregate bounds through the public error-returning APIs. Both instances use a
+test-owned `XDG_RUNTIME_DIR`, terminate and wait for Weston, and let `t.TempDir`
+remove the socket and all runtime files. The Xvfb wrapper removes its temporary
+authorization data. Neither test captures nor writes desktop image data. CI
+requires both tests to pass by setting
+`ROBOTGO_REQUIRE_WAYLAND_OUTPUT_INTEGRATION=1`; missing Weston, Xvfb, outputs,
+or protocol data is a failure rather than a skip.
 
 Run tag-gated suites as needed for the area you changed. Native or Pure-Go X11
 input changes must also run the required `x11integration` comparison command

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -36,7 +36,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet/sanitizer jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE/wlroots evidence |
-| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected real-compositor multi-output Wayland evidence, and assess further backends selectively |
+| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration and Weston multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected GNOME/KDE/wlroots multi-output Wayland evidence, and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, provider-aware Hyprland 0.55+ Lua window dispatch | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline | Dedicated compositor jobs and the first published release evidence asset |
 
@@ -234,7 +234,10 @@ bounds use a bounded native `wl_output`/`xdg-output` client instead of falling
 through to Xwayland. It provides primary-first per-output and aggregate logical
 geometry, fractional `xdg-output` sizes, integer core scale/transforms,
 protocol-version clamping, explicit errors, deterministic socket cleanup,
-hermetic wire tests, and blocking single-output Weston evidence.
+hermetic wire tests, and blocking single- and multi-output Weston evidence. The
+multi-output job runs RobotGo as a Wayland-only client against two virtual
+Weston outputs and verifies exact scale-2, rotated logical geometry without
+capturing pixels.
 
 The Linux/X11 evaluation slice of Phase 3 is complete. Native CGO and Pure-Go
 X11 binaries pass one black-box public-API contract for capture, pointer,
@@ -327,8 +330,9 @@ cross-platform semantics:
   maximize slice only where equally trustworthy state is exposed.
 - Add protected real-desktop capture-helper evidence beyond the delivered
   hermetic native Wayland, portal, and cross-build backend contracts.
-- Collect protected real-compositor multi-output bounds evidence beyond the
-  delivered hermetic geometry matrix and single-output Weston integration.
+- Collect protected GNOME/KDE/wlroots multi-output bounds evidence beyond the
+  delivered hermetic geometry matrix and single-/multi-output Weston
+  integration.
 
 Every addition needs unit tests, an applicable runtime integration test, and a
 runnable example unless the environment makes one technically impossible.

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -69,8 +69,10 @@ Current implementation baseline:
   ordering, prefer fractional `xdg-output` logical geometry, apply integer scale
   and all transforms in the core fallback, clamp advertised protocol versions,
   and close every one-shot Unix connection deterministically. Hermetic wire
-  tests and a blocking single-output Weston integration cover the backend
-  without creating screenshots or persistent artifacts.
+  tests and blocking single-/multi-output Weston integration cover the backend
+  without creating screenshots or persistent artifacts. The multi-output job
+  checks two scale-2, rotated outputs and exact public aggregate geometry while
+  RobotGo remains a Wayland-only client.
 - An explicitly started ScreenCast session provides reusable PipeWire frames
   behind the `pipewire` build tag. It preserves stream geometry/serial metadata,
   supports logical region crop with fractional scaling, converts negotiated raw
@@ -194,8 +196,9 @@ backends.
     across native screencopy and PipeWire mapping.
   - Validate the same scale/transform and region-crop behavior on real wlroots,
     GNOME, and KDE sessions.
-  - Complete real-compositor multi-output selection and bounds evidence using
-    `xdg-output`.
+  - Complete protected GNOME/KDE/wlroots multi-output selection and bounds
+    evidence using `xdg-output`; Weston single-/multi-output evidence is
+    blocking.
 - Portal Path:
   - Expand troubleshooting for xdg-desktop-portal backend selection and consent prompts.
   - Validate the existing high-level RemoteDesktop input fallback on GNOME/KDE.

--- a/wayland_output_weston_integration_test.go
+++ b/wayland_output_weston_integration_test.go
@@ -218,7 +218,7 @@ func startPureGoOutputWeston(
 			t.Fatalf("write Weston configuration: %v", err)
 		}
 		options.arguments = append(
-			[]string{"--config=" + westonConfigName},
+			[]string{"--config=" + configPath},
 			options.arguments...,
 		)
 	}

--- a/wayland_output_weston_integration_test.go
+++ b/wayland_output_weston_integration_test.go
@@ -5,9 +5,11 @@ package robotgo
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,8 +17,29 @@ import (
 	"github.com/marang/robotgo/internal/waylandoutput"
 )
 
+const envRequireWaylandOutputIntegration = "ROBOTGO_REQUIRE_WAYLAND_OUTPUT_INTEGRATION"
+
+const (
+	envXDGConfigHome = "XDG_CONFIG_HOME"
+	westonConfigName = "weston.ini"
+)
+
+type pureGoOutputWestonOptions struct {
+	arguments       []string
+	config          string
+	display         string
+	expectedOutputs int
+}
+
 func TestPureGoWaylandOutputEnumerationWeston(t *testing.T) {
-	snapshot := startPureGoOutputWeston(t)
+	snapshot := startPureGoOutputWeston(t, pureGoOutputWestonOptions{
+		arguments: []string{
+			"--backend=headless",
+			"--width=1024",
+			"--height=768",
+		},
+		expectedOutputs: 1,
+	})
 	if len(snapshot.Outputs) != 1 {
 		t.Fatalf("Weston outputs = %d, want 1", len(snapshot.Outputs))
 	}
@@ -47,32 +70,175 @@ func TestPureGoWaylandOutputEnumerationWeston(t *testing.T) {
 	}
 }
 
-func startPureGoOutputWeston(t *testing.T) waylandoutput.Snapshot {
+func TestPureGoWaylandMultiOutputEnumerationWeston(t *testing.T) {
+	x11Display := os.Getenv(envDisplay)
+	if x11Display == "" {
+		skipOrFailWaylandOutputIntegration(
+			t,
+			"DISPLAY is unavailable for Weston's multi-output X11 backend",
+		)
+	}
+
+	snapshot := startPureGoOutputWeston(t, pureGoOutputWestonOptions{
+		arguments: []string{
+			"--backend=x11",
+			"--output-count=2",
+			"--width=800",
+			"--height=600",
+			"--renderer=pixman",
+			"--no-input",
+		},
+		config: `[output]
+name=screen0
+mode=800x600
+scale=2
+transform=rotate-90
+
+[output]
+name=screen1
+mode=800x600
+scale=2
+transform=rotate-90
+`,
+		display:         x11Display,
+		expectedOutputs: 2,
+	})
+	want := []waylandoutput.Output{
+		{X: 0, Y: 0, Width: 600, Height: 800, Scale: 2, Transform: 1, Logical: true},
+		{X: 600, Y: 0, Width: 600, Height: 800, Scale: 2, Transform: 1, Logical: true},
+	}
+	assertPureGoWaylandMultiOutputGeometry(t, snapshot, want)
+	assertPureGoWaylandMultiOutputPublicContract(t, want)
+}
+
+func assertPureGoWaylandMultiOutputGeometry(
+	t *testing.T,
+	snapshot waylandoutput.Snapshot,
+	want []waylandoutput.Output,
+) {
+	t.Helper()
+	if len(snapshot.Outputs) != len(want) {
+		t.Fatalf("Weston outputs = %d, want %d", len(snapshot.Outputs), len(want))
+	}
+	for index, expected := range want {
+		got := snapshot.Outputs[index]
+		if got.X != expected.X ||
+			got.Y != expected.Y ||
+			got.Width != expected.Width ||
+			got.Height != expected.Height ||
+			got.Scale != expected.Scale ||
+			got.Transform != expected.Transform ||
+			got.Logical != expected.Logical {
+			t.Fatalf("Weston output %d = %+v, want geometry %+v", index, got, expected)
+		}
+
+		x, y, width, height, err := GetDisplayBoundsE(index)
+		if err != nil {
+			t.Fatalf("GetDisplayBoundsE(%d): %v", index, err)
+		}
+		if x != expected.X || y != expected.Y ||
+			width != expected.Width || height != expected.Height {
+			t.Fatalf(
+				"GetDisplayBoundsE(%d) = %d,%d %dx%d, want %d,%d %dx%d",
+				index,
+				x,
+				y,
+				width,
+				height,
+				expected.X,
+				expected.Y,
+				expected.Width,
+				expected.Height,
+			)
+		}
+	}
+}
+
+func assertPureGoWaylandMultiOutputPublicContract(
+	t *testing.T,
+	want []waylandoutput.Output,
+) {
+	t.Helper()
+	if count, err := DisplaysNumE(); err != nil || count != len(want) {
+		t.Fatalf("DisplaysNumE() = %d, %v, want %d, nil", count, err, len(want))
+	}
+	if _, _, _, _, err := GetDisplayBoundsE(len(want)); err == nil {
+		t.Fatal("GetDisplayBoundsE accepted an inactive output index")
+	}
+	width, height, err := GetScreenSizeE()
+	if err != nil {
+		t.Fatalf("GetScreenSizeE(): %v", err)
+	}
+	if width != want[0].Width || height != want[0].Height {
+		t.Fatalf(
+			"GetScreenSizeE() = %dx%d, want primary %dx%d",
+			width,
+			height,
+			want[0].Width,
+			want[0].Height,
+		)
+	}
+	aggregate, err := GetScreenRectE(-1)
+	if err != nil {
+		t.Fatalf("GetScreenRectE(-1): %v", err)
+	}
+	if aggregate != (Rect{
+		Point: Point{X: 0, Y: 0},
+		Size:  Size{W: 1200, H: 800},
+	}) {
+		t.Fatalf("GetScreenRectE(-1) = %+v, want 0,0 1200x800", aggregate)
+	}
+	capability := pureGoWaylandBoundsCapability()
+	if !capability.Available ||
+		capability.Backend != featureBackendPureGoWaylandOutput ||
+		!strings.HasPrefix(capability.Notes, "outputs=2 ") {
+		t.Fatalf("Pure-Go Wayland multi-output capability = %+v", capability)
+	}
+}
+
+func startPureGoOutputWeston(
+	t *testing.T,
+	options pureGoOutputWestonOptions,
+) waylandoutput.Snapshot {
 	t.Helper()
 	if _, err := exec.LookPath("weston"); err != nil {
-		t.Skipf("weston is unavailable: %v", err)
+		skipOrFailWaylandOutputIntegration(t, "weston is unavailable: "+err.Error())
+	}
+	if options.expectedOutputs <= 0 {
+		t.Fatal("Weston integration requires a positive expected output count")
 	}
 
 	runtimeDir := t.TempDir()
 	if err := os.Chmod(runtimeDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
+	if options.config != "" {
+		configPath := filepath.Join(runtimeDir, westonConfigName)
+		if err := os.WriteFile(configPath, []byte(options.config), 0o600); err != nil {
+			t.Fatalf("write Weston configuration: %v", err)
+		}
+		options.arguments = append(
+			[]string{"--config=" + westonConfigName},
+			options.arguments...,
+		)
+	}
 	socketName := "robotgo-purego-output-test"
 	ctx, cancel := context.WithCancel(context.Background())
+	arguments := append([]string{
+		"--socket=" + socketName,
+		"--idle-time=0",
+		"--shell=kiosk-shell.so",
+	}, options.arguments...)
 	cmd := exec.CommandContext(
 		ctx,
 		"weston",
-		"--backend=headless",
-		"--socket="+socketName,
-		"--width=1024",
-		"--height=768",
-		"--idle-time=0",
+		arguments...,
 	)
-	cmd.Env = append(
+	cmd.Env = pureGoOutputWestonEnvironment(
 		os.Environ(),
-		envXDGRuntimeDir+"="+runtimeDir,
-		"WAYLAND_DISPLAY="+socketName,
-		"DISPLAY=",
+		runtimeDir,
+		socketName,
+		options.display,
 	)
 	var logs bytes.Buffer
 	cmd.Stdout = &logs
@@ -121,10 +287,18 @@ func startPureGoOutputWeston(t *testing.T) waylandoutput.Snapshot {
 			queryCtx, queryCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			snapshot, queryErr := waylandoutput.Enumerate(queryCtx)
 			queryCancel()
-			if queryErr == nil {
+			if queryErr == nil && len(snapshot.Outputs) == options.expectedOutputs {
 				return snapshot
 			}
-			lastErr = queryErr
+			if queryErr != nil {
+				lastErr = queryErr
+			} else {
+				lastErr = fmt.Errorf(
+					"Weston exposed %d outputs, want %d",
+					len(snapshot.Outputs),
+					options.expectedOutputs,
+				)
+			}
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
@@ -134,4 +308,36 @@ func startPureGoOutputWeston(t *testing.T) waylandoutput.Snapshot {
 		logs.String(),
 	)
 	return waylandoutput.Snapshot{}
+}
+
+func pureGoOutputWestonEnvironment(
+	environment []string,
+	runtimeDir, socketName, display string,
+) []string {
+	filtered := make([]string, 0, len(environment)+4)
+	for _, entry := range environment {
+		name, _, found := strings.Cut(entry, "=")
+		if found && (name == envXDGRuntimeDir ||
+			name == envWaylandDisplay ||
+			name == envDisplay ||
+			name == envXDGConfigHome) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return append(
+		filtered,
+		envXDGRuntimeDir+"="+runtimeDir,
+		envWaylandDisplay+"="+socketName,
+		envDisplay+"="+display,
+		envXDGConfigHome+"="+runtimeDir,
+	)
+}
+
+func skipOrFailWaylandOutputIntegration(t *testing.T, reason string) {
+	t.Helper()
+	if os.Getenv(envRequireWaylandOutputIntegration) == "1" {
+		t.Fatal(reason)
+	}
+	t.Skip(reason)
 }


### PR DESCRIPTION
## Goal

Close the next non-infrastructure-blocked Pure-Go Wayland evidence gap by validating real multi-output logical geometry against Weston, while keeping RobotGo in a Wayland-only client session.

## Changes

- add a two-output Weston/X11-under-Xvfb runtime test with scale factor 2 and 90-degree output rotation
- verify exact per-output logical bounds, deterministic ordering, display count, primary size, aggregate bounds, invalid-index errors, and backend capability reporting through public APIs
- harden the Weston harness with expected-output readiness, isolated environment construction, clientless kiosk shell, bounded termination/wait, and required-vs-local-skip behavior
- make CI enforce an exact non-skipping integration-test manifest and print captured logs on failure
- install Xvfb/xauth in the existing blocking Wayland integration job
- update TEST.md and the Wayland/product roadmaps to distinguish delivered Weston evidence from still-open GNOME/KDE/wlroots evidence

## Safety and cleanup

The tests do not capture pixels or write desktop image data. Weston configuration and sockets live in `t.TempDir`; Weston is cancelled, killed on a bounded fallback, and waited before test cleanup. The CI Xvfb wrapper owns and removes its temporary authorization data. A separate Ubuntu 24.04/Weston 13 container validation used a temporary static test binary and `--rm`; all local artifacts were removed after the run.

## Validation

- `go test ./... -count=1`
- `CGO_ENABLED=0 go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `go test -tags wayland ./... -count=1`
- relevant `wayland test` screencopy/root suites
- CGO and non-CGO `golangci-lint`, plus the `waylandoutputintegration` build-tag variant: all 0 issues
- real Ubuntu 24.04 container run with Weston 13 + Xvfb: both single- and multi-output integration tests pass

## Review focus

- Weston/Xvfb process and temporary-file lifecycle
- exact scale/transform logical geometry contract
- CI manifest and no-skip enforcement
- preservation of Wayland-only RobotGo client behavior