### PR TITLE
chore: prepare v1.0.0-beta.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RobotGo
 
 [![CI: main](https://github.com/marang/robotgo/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/marang/robotgo/actions/workflows/go.yml?query=branch%3Amain)
+[![Release](https://img.shields.io/github/v/release/marang/robotgo?include_prereleases&sort=semver)](https://github.com/marang/robotgo/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/marang/robotgo.svg)](https://pkg.go.dev/github.com/marang/robotgo)
 
 <p align="center">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## RobotGo v1.0.0-beta.1 — 2026-07-19
+
+This is the first published pre-release of the independent
+`github.com/marang/robotgo` module. It establishes the fork's Wayland-first,
+explicit-error, Pure-Go, diagnostics, and release-evidence contracts while
+retaining the existing cross-platform automation API wherever behavior can be
+implemented safely.
+
+See the [complete release notes](releases/v1.0.0-beta.1.md) for highlights,
+installation, compatibility limits, and evidence verification.
+
 <!--### RobotGo-->
 ## RobotGo v0.100.0, MT. Baker; Enhancement bitmap and image, add arm support...
 
@@ -860,4 +871,3 @@ See Commits for more details, after Nov 10.
 - Fix typesetting and MD error
 - Fix fedora dependencies #55
 - Fix doc.md and README.md
-

--- a/docs/releases/v1.0.0-beta.1.md
+++ b/docs/releases/v1.0.0-beta.1.md
@@ -1,0 +1,136 @@
+# RobotGo v1.0.0-beta.1
+
+Published: 2026-07-19
+
+This is the first public pre-release of the independent
+`github.com/marang/robotgo` module. It is not a repackaging of an upstream
+RobotGo tag. The fork preserves upstream attribution and source compatibility
+where practical, but its backend selection, error contracts, Wayland support,
+Pure-Go implementations, diagnostics, and validation have diverged
+substantially.
+
+The release remains a beta because protected real-desktop evidence for current
+GNOME, KDE Plasma, and wlroots environments is not complete. Implemented
+features without that evidence are reported as such rather than being promoted
+to universal support.
+
+## Install
+
+RobotGo requires Go 1.25 or newer.
+
+```bash
+go get github.com/marang/robotgo@v1.0.0-beta.1
+```
+
+Use the fork's module path in application imports:
+
+```go
+import "github.com/marang/robotgo"
+```
+
+Do not substitute `github.com/go-vgo/robotgo`: that is a separate module with
+different behavior and release history.
+
+`Version` and `GetVersion()` now return the canonical string
+`v1.0.0-beta.1`. Code that parsed the historical decorative
+`v1.00.0.1189, MT. Baker!` value must treat the new value as SemVer instead.
+
+## Highlights
+
+### Wayland-first Linux automation
+
+- Native wlroots screencopy with DMA-BUF and `wl_shm` selection, bounded waits,
+  deterministic ownership, and an explicit Screenshot portal fallback.
+- Reusable ScreenCast/PipeWire capture sessions for repeated frames behind the
+  `pipewire` build tag, including logical crop, scale, transform, pixel-format,
+  and restore-token metadata.
+- Consent-aware RemoteDesktop portal input for pointer, keyboard, absolute
+  pointer, and touch operations. Consent is always explicit and never opened by
+  a capability probe.
+- Native virtual keyboard and pointer support where the compositor advertises
+  the required protocols.
+- Bounded native `wl_output`/`xdg-output` logical geometry in Pure-Go builds,
+  with blocking single- and multi-output Weston evidence.
+- Sway, Hyprland, generic wlroots, and Wayland-core window backend resolution.
+  Unsupported compositor operations return explicit errors.
+
+### Useful Pure-Go builds
+
+- macOS CoreGraphics capture/display/scale, Quartz keyboard and pointer input,
+  and Accessibility-backed window inspection/control.
+- Windows capture, foreground-layout-aware `SendInput` keyboard/text,
+  clipboard-assisted paste, pointer control, DPI scale, and Win32 window
+  inspection/control.
+- Linux/X11 capture, XGB/XTEST input, X11/EWMH window inspection/control, and a
+  separate crash guardian for bounded cleanup of RobotGo-owned input state.
+- Wayland Screenshot and RemoteDesktop portal paths plus read-only logical
+  output enumeration without implicit Xwayland.
+- Explicit `ErrNotSupported` or permission errors for unavailable operations;
+  CGO-disabled builds do not return plausible success values for missing
+  backends.
+
+### Observable and safer behavior
+
+- `Version` and `GetVersion()` report the exact release tag consistently in
+  native and Pure-Go builds.
+- `GetRuntimeBackendInfo`, `GetRuntimeCapabilities`,
+  `GetRuntimeDiagnostics`, and `GetLinuxCapabilities` expose selected
+  implementations, protocol versions, fallbacks, permissions, and remediation
+  without consent prompts or sensitive session values.
+- Error-returning variants for required mouse, keyboard, screen, and window
+  operations.
+- Stable process-identity validation before destructive close/kill fallbacks.
+- Deterministic cleanup for portal sessions, PipeWire streams, Wayland/X11
+  objects, file descriptors, buffers, input ownership, and test-created
+  artifacts.
+- Bitmap string helpers, backend-aware capture aliases, window-state error
+  APIs, `FindColorCS`, and audited upstream helper compatibility.
+
+## Validation and release evidence
+
+The release is gated by:
+
+- default tests on Linux, macOS, and Windows;
+- native and Pure-Go builds on all three hosted platforms;
+- lint, vet, race, OCR, sanitizer/leak, Wayland, and X11 evidence jobs;
+- non-skipping Xvfb/XTEST and Weston runtime contracts;
+- a six-cell Release Evidence v1 matrix.
+
+After publication, the release workflow attaches:
+
+```text
+robotgo-release-evidence-v1.0.0-beta.1-<commit>.tar.gz
+robotgo-release-evidence-v1.0.0-beta.1-<commit>.tar.gz.sha256
+```
+
+Verify the archive before extraction:
+
+```bash
+sha256sum -c robotgo-release-evidence-v1.0.0-beta.1-*.tar.gz.sha256
+```
+
+The archive contains the exact source commit/tree/ref, sanitized runtime
+diagnostics, test-log digests, platform/architecture/CGO identity, and the
+successful protected-check manifest. See
+[Release Evidence v1](../compatibility/release-evidence-v1.md) for the schema
+and per-cell verification command.
+
+## Compatibility limits
+
+- GNOME/KDE RemoteDesktop and persistent ScreenCast implementations exist, but
+  protected real-desktop runner evidence is still pending.
+- Wayland global input, capture, and foreign-window control remain subject to
+  compositor policy and portal consent.
+- Persistent ScreenCast capture requires the `pipewire` build tag and PipeWire
+  development/runtime libraries.
+- Pure-Go macOS input/window mutations require Accessibility permission;
+  capture requires Screen Recording permission.
+- Compositor-specific Wayland window operations are supported only when their
+  observable state and mutation contracts are trustworthy.
+- Hook/event functionality on Wayland remains capability-reported rather than
+  implied.
+
+The versioned platform matrix is available in
+[Runtime Compatibility Matrix v1](../compatibility/runtime-v1.md). The active
+implementation backlog remains in [Wayland remaining tasks](../wayland-tasks.md)
+and the [product roadmap](../plan/product-roadmap.md).

--- a/robotgo.go
+++ b/robotgo.go
@@ -76,8 +76,6 @@ import (
 )
 
 const (
-	// Version get the robotgo version
-	Version                  = "v1.00.0.1189, MT. Baker!"
 	envWaylandDisplay        = "WAYLAND_DISPLAY"
 	envDisplay               = "DISPLAY"
 	envCaptureDebug          = "ROBOTGO_CAPTURE_DEBUG"

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -18,8 +18,6 @@ import (
 	"github.com/marang/robotgo/internal/windowbackend"
 )
 
-const Version = "v1.00.0.1189, MT. Baker!"
-
 var (
 	// Deprecated: use SetRuntimeConfig for runtime changes in concurrent programs.
 	MouseSleep = 0

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package robotgo
+
+// Version is the current RobotGo module release.
+const Version = "v1.0.0-beta.1"

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,13 @@
+package robotgo
+
+import "testing"
+
+func TestReleaseVersion(t *testing.T) {
+	const expected = "v1.0.0-beta.1"
+	if Version != expected {
+		t.Fatalf("Version = %q, want %q", Version, expected)
+	}
+	if got := GetVersion(); got != expected {
+		t.Fatalf("GetVersion() = %q, want %q", got, expected)
+	}
+}


### PR DESCRIPTION
## Goal

Prepare the first public pre-release of the independent `github.com/marang/robotgo` module.

The release is intentionally `v1.0.0-beta.1`: the module path does not include `/v2`, so a standards-compliant v2 release would require a separate breaking import-path migration.

## Changes

- define one build-independent canonical `Version` value and keep `GetVersion()` aligned
- replace the historical decorative version string with `v1.0.0-beta.1`
- add a regression test for both public version accessors
- add full release notes with installation, highlights, validation, evidence verification, and compatibility limits
- add the release to the changelog
- add a repository release badge

## User impact and risk

No backend or runtime selection behavior changes in this PR. The intentional public behavior change is that `Version` and `GetVersion()` now return canonical SemVer instead of `v1.00.0.1189, MT. Baker!`; this parsing compatibility point is called out in the release notes.

The release remains beta because protected real-desktop evidence for current GNOME, KDE Plasma, and wlroots environments is not yet complete.

## Validation

- `go test ./... -count=1`
- `CGO_ENABLED=0 go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `go test -tags wayland ./... -count=1`
- `CGO_ENABLED=1 golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0 golangci-lint run --timeout=5m ./...`
- `git diff --check`

A manual Release Evidence v1 dry-run succeeded for exact base commit `996239b4765a13e9f66810a213230872aa5ff653` across all six native/Pure-Go platform cells, protected checks, validation, and packaging: https://github.com/marang/robotgo/actions/runs/29682572394

## Publication

After this PR is reviewed, green, and merged, `v1.0.0-beta.1` will be tagged on the merge commit and published as a GitHub pre-release. The release-event workflow will attach the checksum-protected Release Evidence v1 bundle.