### PR TITLE
docs: record v1.0.0-beta.1 release evidence

### DIFF
--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -56,6 +56,17 @@ repository code; it only verifies the already packaged SHA-256 and uploads the
 two assets. Manual runs retain the bundle as a GitHub Actions artifact for 90
 days and do not modify a release.
 
+The first published bundle is attached to
+[`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1):
+
+- [`robotgo-release-evidence-v1.0.0-beta.1-1bab5e173f6b.tar.gz`](https://github.com/marang/robotgo/releases/download/v1.0.0-beta.1/robotgo-release-evidence-v1.0.0-beta.1-1bab5e173f6b.tar.gz)
+- [`robotgo-release-evidence-v1.0.0-beta.1-1bab5e173f6b.tar.gz.sha256`](https://github.com/marang/robotgo/releases/download/v1.0.0-beta.1/robotgo-release-evidence-v1.0.0-beta.1-1bab5e173f6b.tar.gz.sha256)
+
+It records exact source commit
+`1bab5e173f6b96f61d349473b348f839291b9a89`; all six matrix cells and all 15
+protected checks passed. The archive digest is
+`93c45caae406d33fefb0fbbd60ec1cb9d347027b155efcde376c9685161d0207`.
+
 ## Verification
 
 After extracting a bundle at the repository root, verify each matrix cell with:

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -29,7 +29,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
   Weston integration, race, vet, and native sanitizer/leak variants.
 
-## Execution Status (2026-07-18)
+## Execution Status (2026-07-19)
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
@@ -38,7 +38,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE/wlroots evidence |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration and Weston multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected GNOME/KDE/wlroots multi-output Wayland evidence, and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, provider-aware Hyprland 0.55+ Lua window dispatch | Compositor-backed state operations and cross-platform/runtime matrix coverage |
-| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline | Dedicated compositor jobs and the first published release evidence asset |
+| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Dedicated compositor jobs |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
@@ -358,12 +358,14 @@ and descriptor ownership. Release Evidence v1 records exact commit/tree/ref,
 toolchain and runtime identity, sanitized diagnostics, the passed command, and
 the test-log SHA-256 for native/Pure-Go Linux, macOS, and Windows cells. It also
 requires and records the complete protected CircleCI/lint/vet/race/sanitizer/
-platform/Wayland/X11 check set for the exact commit. A published release
-receives the verified bundle and checksum; manual runs remain read-only
+platform/Wayland/X11 check set for the exact commit. The first public
+pre-release, [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1),
+publishes that verified six-cell bundle and checksum for exact commit
+`1bab5e173f6b96f61d349473b348f839291b9a89`; manual runs remain read-only
 artifacts. Process termination rejects non-positive and platform-overflow PIDs
 before invoking the operating system, preventing Unix process-group signaling
 through `Kill(0)` or a narrowed negative PID. Dedicated GNOME/KDE/wlroots jobs
-and the first published release asset remain open.
+remain open.
 
 Releases require:
 


### PR DESCRIPTION
## Result

Record the successfully published `v1.0.0-beta.1` Release Evidence v1 bundle as delivered product evidence.

## Changes

- update the roadmap execution date and Phase 5 delivered/open status
- link the public pre-release and its two exact evidence assets
- record the exact source commit, six successful matrix cells, 15 successful protected checks, and archive SHA-256

## Scope and risk

Documentation only. This PR does not touch `AGENTS.md`, workflow conventions, GitHub Actions, Linear/agent configuration, public APIs, or runtime behavior. The referenced release asset names, commit, and digest were read back from GitHub after publication.

## Validation

- `git diff --check`
- public release and both asset URLs verified through GitHub
- archive SHA-256 independently verified before stream-only inspection
- all six embedded test-log digests independently matched
- every temporary download and isolated Go module cache removed immediately after validation