### PR TITLE
docs: add agentic planning and Linear workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,12 @@
 
 Use the following documents as the primary entry points:
 
-- [Workflow conventions](workflow_conventions.md) for branches, pull requests,
-  CI, reviewer feedback, merges, and cleanup.
+- [Workflow conventions](workflow_conventions.md) for Linear planning, branches,
+  pull requests, CI, reviewer feedback, merges, and cleanup.
 - [Test guide](../TEST.md) for validation commands and runtime prerequisites.
 - [Product roadmap](plan/product-roadmap.md) for delivery phases.
+- [Agentic desktop automation plan](plan/agentic-desktop-automation.md) for the
+  session, policy, observe-act-verify, and adapter architecture.
 - [Wayland status](wayland-tasks.md) for backend support and open Wayland work.
 - [Upstream compatibility audit](compatibility/upstream-master.md) for
   selectively adopted and intentionally rejected upstream changes.

--- a/docs/plan/agentic-desktop-automation.md
+++ b/docs/plan/agentic-desktop-automation.md
@@ -6,7 +6,7 @@ Linear coordination:
 
 - Team: `Lab` (`LAB`)
 - Team ID: `38f32d3c-b65c-409e-86eb-2996abd84d3e`
-- Project: [`P001 | RobotGo Agentic Desktop Automation`](https://linear.app/riotbox/project/p001-or-robotgo-agentic-desktop-automation-342ce54e76e6)
+- Project: [`RobotGo | P001 | Agentic Desktop Automation`](https://linear.app/riotbox/project/robotgo-or-p001-or-agentic-desktop-automation-342ce54e76e6)
 - Project ID: `b24081a5-dcab-44f7-803a-948bc563a03f`
 - Plan: [`RobotGo Agentic Desktop Automation — Architecture and Delivery Plan`](https://linear.app/riotbox/document/robotgo-agentic-desktop-automation-architecture-and-delivery-plan-f145b8426b88)
 - Plan document ID: `41fa02c3-706f-444a-acd0-ab1373165ee9`

--- a/docs/plan/agentic-desktop-automation.md
+++ b/docs/plan/agentic-desktop-automation.md
@@ -6,7 +6,9 @@ Linear coordination:
 
 - Team: `Lab` (`LAB`)
 - Team ID: `38f32d3c-b65c-409e-86eb-2996abd84d3e`
-- Issue label: `RobotGo`
+- Issue label group: `Codebase`
+- Issue label group ID: `32c01842-01b5-431f-9bf5-b2abf041f559`
+- Issue label: `Codebase` → `RobotGo`
 - Issue label ID: `5641e353-f8d9-4508-8f54-3edc087e7ef9`
 - Project: [`RobotGo | P001 | Agentic Desktop Automation`](https://linear.app/riotbox/project/robotgo-or-p001-or-agentic-desktop-automation-342ce54e76e6)
 - Project ID: `b24081a5-dcab-44f7-803a-948bc563a03f`
@@ -28,9 +30,9 @@ The agent-facing layer should let a caller:
 6. retain a redacted audit and replay trail
 
 The initial project is an architecture and delivery container. When executable
-issues are created, assign both this project and the `RobotGo` codebase label.
-Do not create a large speculative issue backlog before the first executable
-slice and its boundaries are accepted.
+issues are created, assign both this project and the `Codebase` → `RobotGo`
+label. Do not create a large speculative issue backlog before the first
+executable slice and its boundaries are accepted.
 
 ## 2. Architectural direction
 

--- a/docs/plan/agentic-desktop-automation.md
+++ b/docs/plan/agentic-desktop-automation.md
@@ -1,0 +1,173 @@
+# Agentic Desktop Automation Plan
+
+Status: Draft
+
+Linear coordination:
+
+- Team: `Lab` (`LAB`)
+- Team ID: `38f32d3c-b65c-409e-86eb-2996abd84d3e`
+- Project: [`P001 | RobotGo Agentic Desktop Automation`](https://linear.app/riotbox/project/p001-or-robotgo-agentic-desktop-automation-342ce54e76e6)
+- Project ID: `b24081a5-dcab-44f7-803a-948bc563a03f`
+- Plan: [`RobotGo Agentic Desktop Automation — Architecture and Delivery Plan`](https://linear.app/riotbox/document/robotgo-agentic-desktop-automation-architecture-and-delivery-plan-f145b8426b88)
+- Plan document ID: `41fa02c3-706f-444a-acd0-ab1373165ee9`
+
+## 1. Outcome
+
+Make RobotGo a safe, observable desktop-automation runtime for agents without
+weakening its existing cross-platform Go API or its explicit backend contracts.
+
+The agent-facing layer should let a caller:
+
+1. discover exactly which operations are available
+2. observe the desktop in a bounded and privacy-aware form
+3. propose and authorize typed actions
+4. execute actions with deadlines and deterministic cleanup
+5. verify the resulting desktop state
+6. retain a redacted audit and replay trail
+
+The initial project is an architecture and delivery container. Do not create a
+large speculative issue backlog before the first executable slice and its
+boundaries are accepted.
+
+## 2. Architectural direction
+
+Keep the existing `robotgo` package as the compatibility and low-level backend
+surface. Add a session-oriented agent layer above it:
+
+```text
+LLM or workflow
+      |
+MCP, JSON-RPC, or Go adapter
+      |
+Agent session
+  - operation capability catalog
+  - policy and approval
+  - observe -> act -> verify
+  - audit and replay
+      |
+RobotGo platform backends
+```
+
+The protocol adapter must remain thin. Session, policy, validation, execution,
+and verification behavior belong in reusable Go packages rather than an MCP or
+CLI entry point.
+
+## 3. Planned capability slices
+
+### 3.1 Session ownership
+
+Introduce an explicit session that owns configuration, active capture/input
+leases, deadlines, cleanup, policy, and audit state. Existing package-level
+functions remain source-compatible and may delegate to a default session.
+
+The design must prevent two concurrent agent sessions from silently replacing
+each other's ScreenCast or RemoteDesktop state. Until backend state is fully
+instance-owned, the agent layer must expose and enforce any process-wide
+exclusivity honestly.
+
+### 3.2 Operation-level capability catalog
+
+Extend feature-level diagnostics with a versioned operation catalog. Report
+availability per operation, including:
+
+- backend and fallback
+- input constraints
+- consent and permission requirements
+- risk class and confirmation requirement
+- timeout/cancellation support
+- unsupported reason and remediation
+
+Initial operation families are desktop observation, screen capture, pointer,
+keyboard, clipboard, window, and process operations.
+
+### 3.3 Typed actions and structured results
+
+The agent surface must not expose legacy variadic or `interface{}` argument
+shapes. It uses strict, JSON-serializable action and target types with complete
+preflight validation.
+
+Results include an action ID, status, selected backend, duration, observation
+lineage, and structured error data. Errors distinguish at least unsupported,
+permission/consent, invalid input, stale target, policy denial, timeout,
+retryable failure, and unknown outcome.
+
+### 3.4 Observe, act, and verify
+
+Mutating actions can bind to an observation and declare preconditions, such as
+the expected active window or unchanged target region. Verification uses
+bounded conditions rather than fixed sleeps where possible.
+
+Useful conditions include window title/state, process state, pixel or region
+change, OCR text, and later accessibility element state.
+
+### 3.5 Semantic grounding
+
+Add a normalized UI-element model with role, name, value, state, bounds, and
+source. Prefer native accessibility data where a platform exposes it and use
+structured OCR or visual matching as an explicit fallback.
+
+Wayland limitations and portal consent remain visible. The agent layer must
+never imply universal foreign-window or accessibility support.
+
+### 3.6 Policy, approval, and privacy
+
+Classify actions as read-only, sensitive read, reversible mutation, or
+destructive. A policy can constrain:
+
+- allowed operations
+- target processes and windows
+- displays and screen regions
+- clipboard access
+- process execution and termination
+- action count, text length, rate, and total duration
+
+Screenshots, clipboard contents, typed secrets, restore tokens, and equivalent
+sensitive data are excluded from logs by default. Portal consent dialogs remain
+explicit user-authorized actions.
+
+### 3.7 Adapter and evaluation
+
+After the Go session contract is proven, add a thin MCP adapter with a small
+orthogonal tool set:
+
+- capabilities
+- observe
+- find
+- act
+- wait
+- close session
+
+Add redacted record/replay, a fake driver, and hermetic evaluation tasks before
+claiming reliable autonomous behavior.
+
+## 4. First executable slice
+
+The first implementation slice should prove the architecture with:
+
+1. session creation and deterministic close
+2. versioned operation catalog
+3. policy evaluation and dry-run
+4. desktop observation with runtime diagnostics and optional capture
+5. typed move, click, and text actions
+6. action result and structured error schema
+7. unit tests, a runnable example, and one applicable real-runtime integration
+   path
+
+An MCP server is not required for this first slice. It should consume the
+accepted Go contract rather than define it.
+
+## 5. Exit criteria
+
+The project is ready to transition from architecture to broader implementation
+when:
+
+- session ownership and process-global limitations are explicit and tested
+- operation availability can be consumed without parsing prose
+- every exposed mutation passes policy and preflight before desktop input
+- cancellation releases RobotGo-owned input and session resources
+- observation lineage can detect a stale or changed target
+- sensitive payloads are absent from default diagnostics and traces
+- the first slice works through the Go API and has a stable adapter boundary
+
+Platform support remains governed by `AGENTS.md`, `TEST.md`, and the existing
+Wayland-first fallback policy.

--- a/docs/plan/agentic-desktop-automation.md
+++ b/docs/plan/agentic-desktop-automation.md
@@ -6,6 +6,8 @@ Linear coordination:
 
 - Team: `Lab` (`LAB`)
 - Team ID: `38f32d3c-b65c-409e-86eb-2996abd84d3e`
+- Issue label: `RobotGo`
+- Issue label ID: `5641e353-f8d9-4508-8f54-3edc087e7ef9`
 - Project: [`RobotGo | P001 | Agentic Desktop Automation`](https://linear.app/riotbox/project/robotgo-or-p001-or-agentic-desktop-automation-342ce54e76e6)
 - Project ID: `b24081a5-dcab-44f7-803a-948bc563a03f`
 - Plan: [`RobotGo Agentic Desktop Automation — Architecture and Delivery Plan`](https://linear.app/riotbox/document/robotgo-agentic-desktop-automation-architecture-and-delivery-plan-f145b8426b88)
@@ -25,9 +27,10 @@ The agent-facing layer should let a caller:
 5. verify the resulting desktop state
 6. retain a redacted audit and replay trail
 
-The initial project is an architecture and delivery container. Do not create a
-large speculative issue backlog before the first executable slice and its
-boundaries are accepted.
+The initial project is an architecture and delivery container. When executable
+issues are created, assign both this project and the `RobotGo` codebase label.
+Do not create a large speculative issue backlog before the first executable
+slice and its boundaries are accepted.
 
 ## 2. Architectural direction
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -401,6 +401,9 @@ demonstrate the difference, not merely expose more functions. The standard is:
 - `docs/wayland-tasks.md` is the operational backlog and current support matrix.
 - `docs/plan/wayland-prio-plan.md` contains the detailed Wayland architecture
   and milestone history.
+- `docs/plan/agentic-desktop-automation.md` defines the planned agent-session,
+  policy, observe-act-verify, and adapter architecture. It does not supersede
+  the current reliability delivery order until an executable slice is accepted.
 - This document defines product direction and delivery order.
 - A roadmap item is complete only when implementation, tests, examples where
   applicable, compatibility documentation, and required CI gates are complete.

--- a/docs/workflow_conventions.md
+++ b/docs/workflow_conventions.md
@@ -1,55 +1,164 @@
 # RobotGo Workflow Conventions
 
-Version: 1.0  
+Version: 1.2
 Status: Active  
 Audience: contributors, reviewers, and coding agents
 
 ## 1. Purpose and ownership
 
-This document is the canonical operational workflow for RobotGo branches,
-pull requests, CI, reviews, merges, and branch cleanup.
+This document is the canonical operational workflow for RobotGo planning,
+branches, pull requests, CI, reviews, merges, and branch cleanup.
 
 Documentation ownership is split as follows:
 
 - `AGENTS.md` defines non-negotiable engineering and safety rules.
-- `docs/workflow_conventions.md` defines the operational Git and GitHub loop.
+- `docs/workflow_conventions.md` defines Linear coordination and the operational
+  Git and GitHub loop.
 - `TEST.md` defines validation commands and runtime prerequisites.
 - `docs/plan/product-roadmap.md` and `docs/wayland-tasks.md` define product
   direction and delivery status.
 
-Repository state, tests, Git history, and GitHub are the durable record. Do not
-leave important workflow state only in chat or local memory.
+Linear is the durable planning and coordination record. Repository
+documentation is the durable technical and behavioral record. Tests, Git
+history, pull requests, and CI are the implementation and validation record.
+Do not leave important state only in chat or local memory.
 
-## 2. Default workflow
+## 2. Linear planning and project structure
+
+RobotGo work is coordinated in the shared `Lab` Linear team under key `LAB`.
+Because this team also owns non-RobotGo work, every RobotGo issue must belong to
+the relevant RobotGo project; team membership alone is not sufficient routing.
+Current team and project identifiers are recorded in the relevant repository
+plan rather than in runtime configuration.
+
+Use Linear at three levels:
+
+1. A project owns one bounded product or architecture outcome and its delivery
+   plan.
+2. Project milestones describe meaningful exit boundaries when the project is
+   large enough to need them.
+3. Issues describe executable, reviewable slices only after their scope and
+   acceptance evidence are understood.
+
+Do not create a large speculative issue backlog merely to mirror a draft plan.
+It is valid to start with only a team, one project, and one project plan. Split
+issues from that plan when a slice is ready to implement.
+
+A project plan should state:
+
+- intended outcome and why it matters
+- architectural direction and compatibility boundaries
+- explicit non-goals
+- ordered delivery slices
+- safety, privacy, and platform risks
+- validation strategy and exit criteria
+
+Source-of-truth boundaries:
+
+- Linear owns project status, sequencing, ownership, coordination decisions,
+  and actionable follow-ups.
+- Repository plans and architecture documents own lasting technical decisions,
+  public contracts, backend policy, and test strategy.
+- GitHub pull requests and CI own implementation diff, review discussion, and
+  merge evidence.
+
+Keep the records linked and synchronized:
+
+- Link the repository plan from its Linear project and the Linear project from
+  the repository plan.
+- Link an implementation issue in its branch or pull request and link the pull
+  request back to the issue.
+- Reflect lasting architectural or behavioral decisions in repository
+  documentation; do not leave them only in a Linear comment.
+- Update the issue and project after merge, including deferred evidence or
+  concrete follow-ups.
+- Do not store Linear tokens, screenshots, clipboard contents, restore tokens,
+  credentials, or other sensitive desktop artifacts in the repository or
+  Linear.
+
+### 2.1 Plan anchoring
+
+When a project plan becomes an accepted direction:
+
+- keep its technical detail under `docs/plan/`
+- link it from `docs/README.md`
+- connect it to `docs/plan/product-roadmap.md`
+- update `AGENTS.md`, `TEST.md`, or backend documentation only when the plan
+  changes their lasting contracts
+
+Do not duplicate the complete plan across these files. Linear holds the
+coordination copy; the repository plan is the durable technical source.
+
+## 3. Default workflow
 
 Normal implementation work follows this loop:
 
-`sync main -> feature branch -> implementation and tests -> local review -> commit and push -> draft PR -> CI -> ready for review -> reviewer feedback -> merge -> sync main -> branch cleanup`
+`Linear issue -> In Progress -> current main -> isolated branch/worktree -> implementation and tests -> local review -> commit and push -> draft PR -> In Review -> CI and reviewer feedback -> merge -> Done/project update -> sync main -> branch cleanup`
 
-1. Start from a clean, current local `main`.
-2. Create a narrowly named feature, fix, docs, test, or chore branch.
-3. Implement one coherent slice and update its tests and lasting documentation.
-4. Run the default and area-specific validation required by `AGENTS.md` and
+1. Create or select exactly one Linear issue for an executable implementation
+   or documentation slice and assign it to the correct RobotGo project.
+2. Move the issue to `In Progress` before creating or reusing its branch.
+3. Start from a clean, current local `main`.
+4. Create a narrowly named feature, fix, docs, test, or chore branch containing
+   the `LAB-*` issue key.
+5. Implement one coherent slice and update its tests and lasting documentation.
+6. Run the default and area-specific validation required by `AGENTS.md` and
    `TEST.md`.
-5. Review the complete branch diff, including generated files, build tags,
+7. Review the complete branch diff, including generated files, build tags,
    platform boundaries, resource ownership, and sensitive-data cleanup.
-6. Commit with an English Conventional Commit message and push the branch.
-7. Open a draft PR against `main` with behavior, risk, fallback, and validation
-   evidence.
-8. Inspect every CI job. Fix failures owned by the branch and push the fixes.
-9. Once the branch is locally complete and CI is healthy, mark the PR ready for
-   review. A draft PR is not evidence that configured reviewers have reviewed
-   it.
-10. Inspect all review surfaces, address actionable findings, and repeat CI and
+8. Commit with an English Conventional Commit message and push the branch.
+9. Open a draft PR against `main` with behavior, risk, fallback, validation
+   evidence, and the Linear issue link when applicable.
+10. Move the issue to `In Review` and add a short update covering the change,
+    verification, and bounded follow-up work.
+11. Inspect every CI job. Fix failures owned by the branch and push the fixes.
+12. Once the branch is locally complete and CI is healthy, mark the PR ready for
+    review. A draft PR is not evidence that configured reviewers have reviewed
+    it.
+13. Inspect all review surfaces, address actionable findings, and repeat CI and
     review inspection after every review-driven push.
-11. Merge only when the gate in section 5 is satisfied.
-12. Sync local `main`, verify the merge, and remove the completed feature branch
+14. Merge only when the gate in section 6 is satisfied.
+15. Move the issue to `Done` and update the project with the delivered outcome,
+    merge evidence, and remaining follow-ups.
+16. Sync local `main`, verify the merge, and remove the completed feature branch
     when it is no longer needed.
+
+The only issue-first exception is initial team/project creation and draft plan
+shaping before an executable slice exists. This exception must not carry product
+implementation. Once a slice is ready to change repository behavior, use an
+issue before its implementation branch.
 
 Do not push normal implementation work directly to `main`. Do not mix the next
 unrelated product slice into a PR that is already at the review boundary.
 
-## 3. Pull request content
+### 3.1 Parallel agents and worktrees
+
+When another agent or release branch is active, each agent must use its own Git
+worktree and feature branch. Do not edit through a shared dirty worktree.
+
+Before committing or opening a PR:
+
+1. verify the branch started from the intended current `main`
+2. inspect other active worktrees and likely overlapping files
+3. refresh against current `main` when it advanced
+4. re-review conflicts instead of overwriting another agent's changes
+
+Keep parallel PRs separate until their scopes and conflict order are understood.
+Never place tokens or other credentials in worktree configuration committed to
+the repository.
+
+### 3.2 Branch naming
+
+Preferred patterns are:
+
+- `feature/lab-123-short-slice`
+- `fix/lab-123-short-slice`
+- `docs/lab-123-short-slice`
+
+Keep one branch aligned with one main issue. Project-bootstrap planning branches
+without an issue key are permitted only under the exception above.
+
+## 4. Pull request content
 
 A PR description must state:
 
@@ -60,15 +169,16 @@ A PR description must state:
 - resource, privacy, and compatibility risks
 - local validation performed
 - intentionally omitted runtime evidence or follow-up work
+- the associated Linear issue when one exists
 
 Use English for branch names, commits, PR titles, and PR descriptions. Keep the
 description current when later commits materially change the result or risk.
 
-## 4. CI and review polling
+## 5. CI and review polling
 
 CI status and review status are separate. Both must be inspected explicitly.
 
-### 4.1 CI
+### 5.1 CI
 
 - Verify authenticated GitHub access before relying on automation.
 - Inspect check summaries first; fetch full logs only for failed, cancelled, or
@@ -78,7 +188,7 @@ CI status and review status are separate. Both must be inspected explicitly.
 - A local green test run does not replace GitHub Actions, and GitHub Actions do
   not replace relevant local or real-runtime evidence.
 
-### 4.2 GitHub reviews
+### 5.2 GitHub reviews
 
 For every open PR, inspect all of the following:
 
@@ -124,7 +234,7 @@ After a review-driven push:
 
 Never report a PR as fully reviewed merely because its CI is green.
 
-## 5. Merge gate
+## 6. Merge gate
 
 A PR is ready to merge only when all applicable conditions are true:
 
@@ -145,7 +255,7 @@ A PR is ready to merge only when all applicable conditions are true:
 After merge, verify GitHub reports the PR as merged and local `main` contains the
 merge before deleting branches.
 
-## 6. Sensitive test and development data
+## 7. Sensitive test and development data
 
 The cleanup contract in `AGENTS.md` applies throughout this workflow:
 
@@ -161,7 +271,33 @@ The cleanup contract in `AGENTS.md` applies throughout this workflow:
 When a real desktop integration test is necessary, make that opt-in and document
 its privacy impact and cleanup behavior in `TEST.md`.
 
-## 7. Practical closeout checklist
+## 8. Linear updates, backlog, and retention
+
+Use two update levels:
+
+- Issue updates record transitions to `In Review`, material changes in
+  recommendation, and the merged outcome.
+- Project updates record meaningful slices entering review or merging and
+  cross-ticket changes to architecture, roadmap, or working mode.
+
+Once implementation starts, keep an honest small horizon:
+
+- one main issue in `In Progress`
+- issues in `In Review` only while their PRs are genuinely open
+- one to five near-next backlog issues when those slices are already clear
+
+Do not fully decompose distant phases. Projects answer which product/outcome the
+work belongs to; labels answer the slice type.
+
+Linear is the active execution surface, not the only long-term archive. Because
+the workspace uses the free tier, completed issues may be removed after their
+useful context is preserved under
+`docs/archive/linear_issues/LAB-123.md`. Do not delete an issue until its PR is
+merged, it is `Done`, and the archive entry exists. Archive only durable context
+such as purpose, shipped outcome, verification, PR, merge commit, and bounded
+follow-ups; never archive sensitive desktop data or credentials.
+
+## 9. Practical closeout checklist
 
 Before declaring a PR complete:
 
@@ -176,4 +312,6 @@ Before declaring a PR complete:
 - [ ] All actionable findings were fixed or explicitly tracked.
 - [ ] Relevant checks were rerun after the last fix.
 - [ ] No sensitive test or development artifacts remain.
+- [ ] The Linear issue and project reflect the merged result and follow-ups.
+- [ ] Useful issue context was archived before any free-tier cleanup.
 - [ ] Merge state and local `main` were verified after merge.

--- a/docs/workflow_conventions.md
+++ b/docs/workflow_conventions.md
@@ -27,9 +27,10 @@ Do not leave important state only in chat or local memory.
 
 RobotGo work is coordinated in the shared `Lab` Linear team under key `LAB`.
 Because this team also owns non-RobotGo work, every RobotGo issue must belong to
-the relevant RobotGo project; team membership alone is not sufficient routing.
-Current team and project identifiers are recorded in the relevant repository
-plan rather than in runtime configuration.
+the relevant RobotGo project and carry the `RobotGo` codebase label; team
+membership alone is not sufficient routing. Current team, label, and project
+identifiers are recorded in the relevant repository plan rather than in
+runtime configuration.
 
 Name RobotGo projects `RobotGo | PNNN | Outcome` so projects group by codebase
 inside the shared team before their sequence and purpose are considered.
@@ -100,7 +101,8 @@ Normal implementation work follows this loop:
 `Linear issue -> In Progress -> current main -> isolated branch/worktree -> implementation and tests -> local review -> commit and push -> draft PR -> In Review -> CI and reviewer feedback -> merge -> Done/project update -> sync main -> branch cleanup`
 
 1. Create or select exactly one Linear issue for an executable implementation
-   or documentation slice and assign it to the correct RobotGo project.
+   or documentation slice, assign it to the correct RobotGo project, and apply
+   the `RobotGo` codebase label.
 2. Move the issue to `In Progress` before creating or reusing its branch.
 3. Start from a clean, current local `main`.
 4. Create a narrowly named feature, fix, docs, test, or chore branch containing

--- a/docs/workflow_conventions.md
+++ b/docs/workflow_conventions.md
@@ -86,8 +86,9 @@ When a project plan becomes an accepted direction:
 - update `AGENTS.md`, `TEST.md`, or backend documentation only when the plan
   changes their lasting contracts
 
-Do not duplicate the complete plan across these files. Linear holds the
-coordination copy; the repository plan is the durable technical source.
+Do not duplicate the complete plan across multiple repository files. Linear may
+carry a coordination copy, while the repository plan remains the durable
+technical source; keep their scope and status links synchronized.
 
 ## 3. Default workflow
 

--- a/docs/workflow_conventions.md
+++ b/docs/workflow_conventions.md
@@ -31,6 +31,9 @@ the relevant RobotGo project; team membership alone is not sufficient routing.
 Current team and project identifiers are recorded in the relevant repository
 plan rather than in runtime configuration.
 
+Name RobotGo projects `RobotGo | PNNN | Outcome` so projects group by codebase
+inside the shared team before their sequence and purpose are considered.
+
 Use Linear at three levels:
 
 1. A project owns one bounded product or architecture outcome and its delivery

--- a/docs/workflow_conventions.md
+++ b/docs/workflow_conventions.md
@@ -100,7 +100,7 @@ technical source; keep their scope and status links synchronized.
 
 Normal implementation work follows this loop:
 
-`Linear issue -> In Progress -> current main -> isolated branch/worktree -> implementation and tests -> local review -> commit and push -> draft PR -> In Review -> CI and reviewer feedback -> merge -> Done/project update -> sync main -> branch cleanup`
+`Linear issue -> In Progress -> current main -> isolated branch/worktree -> implementation and tests -> local review -> commit and push -> draft PR -> CI -> ready PR and In Review -> reviewer feedback -> merge -> Done/project update -> sync main -> branch cleanup`
 
 1. Create or select exactly one Linear issue for an executable implementation
    or documentation slice, assign it to the correct RobotGo project, and apply
@@ -117,12 +117,12 @@ Normal implementation work follows this loop:
 8. Commit with an English Conventional Commit message and push the branch.
 9. Open a draft PR against `main` with behavior, risk, fallback, validation
    evidence, and the Linear issue link when applicable.
-10. Move the issue to `In Review` and add a short update covering the change,
-    verification, and bounded follow-up work.
-11. Inspect every CI job. Fix failures owned by the branch and push the fixes.
-12. Once the branch is locally complete and CI is healthy, mark the PR ready for
+10. Inspect every CI job. Fix failures owned by the branch and push the fixes.
+11. Once the branch is locally complete and CI is healthy, mark the PR ready for
     review. A draft PR is not evidence that configured reviewers have reviewed
     it.
+12. Move the issue to `In Review` and add a short update covering the change,
+    verification, and bounded follow-up work.
 13. Inspect all review surfaces, address actionable findings, and repeat CI and
     review inspection after every review-driven push.
 14. Merge only when the gate in section 6 is satisfied.

--- a/docs/workflow_conventions.md
+++ b/docs/workflow_conventions.md
@@ -27,13 +27,15 @@ Do not leave important state only in chat or local memory.
 
 RobotGo work is coordinated in the shared `Lab` Linear team under key `LAB`.
 Because this team also owns non-RobotGo work, every RobotGo issue must belong to
-the relevant RobotGo project and carry the `RobotGo` codebase label; team
-membership alone is not sufficient routing. Current team, label, and project
-identifiers are recorded in the relevant repository plan rather than in
-runtime configuration.
+the relevant RobotGo project and carry `Codebase` → `RobotGo`; team membership
+alone is not sufficient routing. Current team, label-group, label, and project
+identifiers are recorded in the relevant repository plan rather than in runtime
+configuration.
 
 Name RobotGo projects `RobotGo | PNNN | Outcome` so projects group by codebase
 inside the shared team before their sequence and purpose are considered.
+Use the mutually exclusive `Codebase` label group for issue routing so a ticket
+cannot silently claim multiple codebases.
 
 Use Linear at three levels:
 
@@ -102,7 +104,7 @@ Normal implementation work follows this loop:
 
 1. Create or select exactly one Linear issue for an executable implementation
    or documentation slice, assign it to the correct RobotGo project, and apply
-   the `RobotGo` codebase label.
+   `Codebase` → `RobotGo`.
 2. Move the issue to `In Progress` before creating or reusing its branch.
 3. Start from a clean, current local `main`.
 4. Create a narrowly named feature, fix, docs, test, or chore branch containing


### PR DESCRIPTION
## Why This Matters

RobotGo now has a dedicated planning home for becoming a safe, observable desktop-automation runtime for agents. The repository also needs a durable operating contract that keeps Linear planning, technical documentation, GitHub evidence, and parallel-agent work synchronized without mixing credentials or unrelated work.

Linear coordination:

- Team: `Lab` (`LAB`)
- Codebase issue label: `Codebase` → `RobotGo`
- Project: [RobotGo | P001 | Agentic Desktop Automation](https://linear.app/riotbox/project/robotgo-or-p001-or-agentic-desktop-automation-342ce54e76e6)
- Plan document: [RobotGo Agentic Desktop Automation — Architecture and Delivery Plan](https://linear.app/riotbox/document/robotgo-agentic-desktop-automation-architecture-and-delivery-plan-f145b8426b88)

This is the documented project-bootstrap exception before executable implementation issues are created. It contains no RobotGo behavior change.

## Summary

- add the repository-owned agentic desktop automation architecture and delivery plan
- record non-sensitive Linear team, issue-label group, issue-label, project, and plan identifiers and links
- define the `Lab` project-routing, `Codebase` → `RobotGo` issue-label, and `RobotGo | PNNN | Outcome` project-naming rules
- adopt a Linear-first issue → worktree/branch → draft PR/CI → ready PR/In Review → review → merge → closeout loop for executable slices
- define isolated-worktree rules for parallel agents and release work
- add plan anchoring, issue/project updates, a small backlog horizon, and free-tier archive-before-delete retention
- link the new plan from the docs index and product-roadmap governance

## Compatibility, Privacy, and Platform Check

- public APIs and runtime behavior: unchanged
- platform/backend selection: unchanged
- fallback and unsupported contracts: unchanged
- credentials/tokens: not stored
- sensitive desktop artifacts: not stored
- retired team/product names: absent from the changed files and Linear plan

## Verification

- `git diff --check origin/main...HEAD`
- inspected the complete four-file branch diff
- rebased conflict-free onto current `main` commit `ea5b523` after PR #92
- verified PR #92's release-evidence roadmap updates remain intact
- verified the main worktree remains separate and clean
- scanned changed files for credential patterns and retired team names
- all applicable GitHub and CircleCI checks passed on `8856865`
- addressed the Codex P2 workflow-ordering finding and received a clean Codex re-review on `8856865`

Go tests were not run separately before push because this is a documentation-only planning/workflow change; the repository CI matrix passed on the final PR head.