### PR TITLE
fix(ci): preserve sanitizer failure diagnostics (LAB-4)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,35 +79,7 @@ jobs:
       - name: Run default native suite with AddressSanitizer and LeakSanitizer
         run: go test -asan -count=1 ./...
       - name: Run hermetic Wayland ownership paths with sanitizers
-        run: |
-          set -euo pipefail
-          expected="$(printf '%s\n' \
-            TestScreencopyDmabufFailureDoesNotCloseStdin \
-            TestScreencopyTimeoutIsBounded \
-            TestScreencopyWlShm | LC_ALL=C sort)"
-          listed="$(go test -asan -tags 'wayland test' ./screen \
-            -list '^TestScreencopy(WlShm|TimeoutIsBounded|DmabufFailureDoesNotCloseStdin)$')"
-          printf '%s\n' "$listed"
-          actual="$(printf '%s\n' "$listed" | \
-            awk '/^TestScreencopy/ { print }' | LC_ALL=C sort)"
-          if [ "$actual" != "$expected" ]; then
-            echo "sanitizer test manifest mismatch" >&2
-            printf 'expected:\n%s\nactual:\n%s\n' \
-              "$expected" "${actual:-<empty>}" >&2
-            exit 1
-          fi
-          output="$(go test -asan -tags 'wayland test' ./screen \
-            -run '^TestScreencopy(WlShm|TimeoutIsBounded|DmabufFailureDoesNotCloseStdin)$' \
-            -count=1 -timeout=60s -v)"
-          printf '%s\n' "$output"
-          while IFS= read -r test_name; do
-            if ! grep -Eq "^--- PASS: ${test_name} \\(.*\\)$" <<<"$output"; then
-              echo "sanitizer test did not pass: ${test_name}" >&2
-              exit 1
-            fi
-          done <<EOF
-          $expected
-          EOF
+        run: scripts/run-wayland-sanitizer-tests.sh
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/TEST.md
+++ b/TEST.md
@@ -51,15 +51,16 @@ ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 \
   go test -asan -count=1 ./...
 
 ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 \
-  go test -asan -tags "wayland test" ./screen \
-  -run '^TestScreencopy(WlShm|TimeoutIsBounded|DmabufFailureDoesNotCloseStdin)$' \
-  -count=1 -timeout=60s -v
+  scripts/run-wayland-sanitizer-tests.sh
 ```
 
 The tagged tests use hermetic Wayland protocol servers and must all pass; CI
 checks their manifest so a missing or renamed ownership test cannot silently
 reduce coverage. The gate covers allocation/free, timeout cleanup, and file
 descriptor ownership without requiring a graphical session or render node.
+The runner prints both listing and execution diagnostics before returning the
+original failing command's status, so transient sanitizer failures retain their
+actionable output.
 
 The non-CGO suite runs on Linux, macOS, and Windows in CI. It also verifies
 runtime build/feature introspection, pixel-color parity, and hermetic Pure-Go

--- a/scripts/run-wayland-sanitizer-tests.sh
+++ b/scripts/run-wayland-sanitizer-tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly go_bin="${ROBOTGO_GO_BIN:-go}"
+readonly test_pattern='^TestScreencopy(WlShm|TimeoutIsBounded|DmabufFailureDoesNotCloseStdin)$'
+
+expected="$(printf '%s\n' \
+  TestScreencopyDmabufFailureDoesNotCloseStdin \
+  TestScreencopyTimeoutIsBounded \
+  TestScreencopyWlShm | LC_ALL=C sort)"
+readonly expected
+
+set +e
+listed="$("$go_bin" test -asan -tags 'wayland test' ./screen \
+  -list "$test_pattern" 2>&1)"
+list_status=$?
+set -e
+printf '%s\n' "$listed"
+if ((list_status != 0)); then
+  exit "$list_status"
+fi
+
+actual="$(printf '%s\n' "$listed" | \
+  awk '/^TestScreencopy/ { print }' | LC_ALL=C sort)"
+readonly actual
+if [[ "$actual" != "$expected" ]]; then
+  printf 'sanitizer test manifest mismatch\nexpected:\n%s\nactual:\n%s\n' \
+    "$expected" "${actual:-<empty>}" >&2
+  exit 1
+fi
+
+set +e
+output="$("$go_bin" test -asan -tags 'wayland test' ./screen \
+  -run "$test_pattern" -count=1 -timeout=60s -v 2>&1)"
+test_status=$?
+set -e
+printf '%s\n' "$output"
+if ((test_status != 0)); then
+  exit "$test_status"
+fi
+
+while IFS= read -r test_name; do
+  if ! grep -Eq "^--- PASS: ${test_name} \\(.*\\)$" <<<"$output"; then
+    printf 'sanitizer test did not pass: %s\n' "$test_name" >&2
+    exit 1
+  fi
+done <<<"$expected"

--- a/scripts/run_wayland_sanitizer_tests_linux_test.go
+++ b/scripts/run_wayland_sanitizer_tests_linux_test.go
@@ -1,0 +1,172 @@
+package scripts
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	sanitizerExpectedList = "TestScreencopyDmabufFailureDoesNotCloseStdin\n" +
+		"TestScreencopyTimeoutIsBounded\n" +
+		"TestScreencopyWlShm\n" +
+		"ok\tgithub.com/marang/robotgo/screen\t0.001s"
+	sanitizerPassingOutput = "=== RUN   TestScreencopyDmabufFailureDoesNotCloseStdin\n" +
+		"--- PASS: TestScreencopyDmabufFailureDoesNotCloseStdin (0.00s)\n" +
+		"=== RUN   TestScreencopyTimeoutIsBounded\n" +
+		"--- PASS: TestScreencopyTimeoutIsBounded (0.01s)\n" +
+		"=== RUN   TestScreencopyWlShm\n" +
+		"--- PASS: TestScreencopyWlShm (0.00s)\n" +
+		"PASS\nok\tgithub.com/marang/robotgo/screen\t0.012s"
+)
+
+func TestWaylandSanitizerRunner(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		listOutput      string
+		listError       string
+		listStatus      string
+		runOutput       string
+		runError        string
+		runStatus       string
+		wantStatus      int
+		wantOutputParts []string
+	}{
+		{
+			name:       "success emits listing and execution output",
+			listOutput: sanitizerExpectedList,
+			runOutput:  sanitizerPassingOutput,
+			wantOutputParts: []string{
+				"TestScreencopyDmabufFailureDoesNotCloseStdin",
+				"=== RUN   TestScreencopyWlShm",
+				"PASS",
+			},
+		},
+		{
+			name:       "manifest mismatch is blocking",
+			listOutput: "TestScreencopyWlShm\nok\tgithub.com/marang/robotgo/screen\t0.001s",
+			wantStatus: 1,
+			wantOutputParts: []string{
+				"TestScreencopyWlShm",
+				"sanitizer test manifest mismatch",
+				"TestScreencopyTimeoutIsBounded",
+			},
+		},
+		{
+			name:       "listing failure preserves diagnostics and status",
+			listOutput: "listing stdout marker",
+			listError:  "listing stderr marker",
+			listStatus: "17",
+			wantStatus: 17,
+			wantOutputParts: []string{
+				"listing stdout marker",
+				"listing stderr marker",
+			},
+		},
+		{
+			name:       "execution failure preserves diagnostics and status",
+			listOutput: sanitizerExpectedList,
+			runOutput:  "execution stdout marker",
+			runError:   "execution stderr marker",
+			runStatus:  "23",
+			wantStatus: 23,
+			wantOutputParts: []string{
+				"execution stdout marker",
+				"execution stderr marker",
+			},
+		},
+		{
+			name:       "missing pass marker is blocking",
+			listOutput: sanitizerExpectedList,
+			runOutput: strings.ReplaceAll(
+				sanitizerPassingOutput,
+				"--- PASS: TestScreencopyTimeoutIsBounded (0.01s)\n",
+				"",
+			),
+			wantStatus: 1,
+			wantOutputParts: []string{
+				"PASS",
+				"sanitizer test did not pass: TestScreencopyTimeoutIsBounded",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeGo := writeFakeGo(t)
+			command := exec.Command("bash", "run-wayland-sanitizer-tests.sh")
+			command.Env = append(os.Environ(),
+				"ROBOTGO_GO_BIN="+fakeGo,
+				"FAKE_LIST_OUTPUT="+test.listOutput,
+				"FAKE_LIST_ERROR="+test.listError,
+				"FAKE_LIST_STATUS="+test.listStatus,
+				"FAKE_RUN_OUTPUT="+test.runOutput,
+				"FAKE_RUN_ERROR="+test.runError,
+				"FAKE_RUN_STATUS="+test.runStatus,
+			)
+			output, err := command.CombinedOutput()
+			if got := commandExitStatus(t, err); got != test.wantStatus {
+				t.Fatalf("runner exit status = %d, want %d; error: %v\noutput:\n%s",
+					got, test.wantStatus, err, output)
+			}
+			for _, part := range test.wantOutputParts {
+				if !strings.Contains(string(output), part) {
+					t.Errorf("runner output does not contain %q:\n%s", part, output)
+				}
+			}
+		})
+	}
+}
+
+func writeFakeGo(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "fake-go")
+	const source = `#!/usr/bin/env bash
+set -euo pipefail
+
+mode=run
+for argument in "$@"; do
+  if [[ "$argument" == "-list" ]]; then
+    mode=list
+    break
+  fi
+done
+
+if [[ "$mode" == "list" ]]; then
+  printf '%s\n' "${FAKE_LIST_OUTPUT:-}"
+  printf '%s\n' "${FAKE_LIST_ERROR:-}" >&2
+  exit "${FAKE_LIST_STATUS:-0}"
+fi
+
+printf '%s\n' "${FAKE_RUN_OUTPUT:-}"
+printf '%s\n' "${FAKE_RUN_ERROR:-}" >&2
+exit "${FAKE_RUN_STATUS:-0}"
+`
+	if err := os.WriteFile(path, []byte(source), 0o700); err != nil {
+		t.Fatalf("write fake go executable: %v", err)
+	}
+	return path
+}
+
+func commandExitStatus(t *testing.T, err error) int {
+	t.Helper()
+
+	if err == nil {
+		return 0
+	}
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		return exitError.ExitCode()
+	}
+	t.Fatalf("command did not return an exit status: %v", err)
+	return -1
+}


### PR DESCRIPTION
## Goal

Make the hermetic Wayland sanitizer gate retain actionable diagnostics when either test discovery or execution fails.

Linear: [LAB-4](https://linear.app/riotbox/issue/LAB-4/preserve-hermetic-sanitizer-failure-diagnostics)

## Root cause

The workflow captured `go test` output inside a command substitution while `set -e` was active. A non-zero test status terminated the shell before the captured output could be printed, leaving transient sanitizer failures without their useful stdout/stderr.

## Changes

- move the exact Wayland ownership manifest and sanitizer execution into a reusable script
- always print combined listing/execution diagnostics before returning the original failing exit status
- keep exact manifest and explicit per-test PASS-marker checks blocking
- add hermetic tests for success, manifest drift, listing failure, execution failure, and missing PASS markers
- document the reproducible runner in `TEST.md`

## User/developer impact

No production behavior or public API changes. CI failures now retain the diagnostics needed to distinguish sanitizer defects, harness failures, and manifest drift.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go vet ./...`
- `go test -race ./scripts`
- `CGO_ENABLED=1 golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0 golangci-lint run --timeout=5m ./...`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 go test -asan -count=1 ./...`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 scripts/run-wayland-sanitizer-tests.sh`

## Risk

Low and CI-only. The sanitizer test set and production capture code are unchanged; the principal risk is shell portability, bounded to Bash on the existing Ubuntu runner and covered by hermetic process/exit-code tests.