### PR TITLE
fix: stabilize CGO pointer tests and exact smooth endpoints (LAB-5)

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -82,7 +82,8 @@ after opening it.
 The default CGO macOS and Windows pointer checks preserve and verify restoration
 of the original pointer location. They use bounded observation polling instead
 of fixed post-event sleeps and do not retry an injected event to manufacture a
-passing result.
+passing result. Absolute, relative, and smooth moves must all reach their exact
+requested endpoint.
 
 The real scale probe can be reproduced on a macOS GUI runner without granting
 Screen Recording or Accessibility access:

--- a/TEST.md
+++ b/TEST.md
@@ -79,6 +79,11 @@ screenshot files to be absent after successful decoding and after decode
 failures. The production portal reader unlinks the sensitive file immediately
 after opening it.
 
+The default CGO macOS and Windows pointer checks preserve and verify restoration
+of the original pointer location. They use bounded observation polling instead
+of fixed post-event sleeps and do not retry an injected event to manufacture a
+passing result.
+
 The real scale probe can be reproduced on a macOS GUI runner without granting
 Screen Recording or Accessibility access:
 

--- a/mouse/mouse_c.h
+++ b/mouse/mouse_c.h
@@ -836,5 +836,10 @@ bool smoothlyMoveMouse(MMPointInt32 endPoint, double lowSpeed, double highSpeed)
 		// microsleep(DEADBEEF_UNIFORM(1.0, 3.0));
 	}
 
+	/* The smoothing loop intentionally stops near the destination. Finish at
+	 * the exact public-API endpoint without duplicating an exact final event. */
+	if (pos.x != endPoint.x || pos.y != endPoint.y) {
+		moveMouse(endPoint);
+	}
 	return true;
 }

--- a/pointer_wait_test.go
+++ b/pointer_wait_test.go
@@ -1,0 +1,141 @@
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+var errPointerPositionTimeout = errors.New("pointer position observation timed out")
+
+type pointerPosition struct {
+	x int
+	y int
+}
+
+type pointerPositionWaiter struct {
+	observe func() (int, int, error)
+	now     func() time.Time
+	sleep   func(time.Duration)
+}
+
+func (waiter pointerPositionWaiter) wait(
+	want pointerPosition,
+	timeout time.Duration,
+	pollInterval time.Duration,
+) error {
+	deadline := waiter.now().Add(timeout)
+	last := pointerPosition{}
+	for {
+		x, y, err := waiter.observe()
+		if err != nil {
+			return fmt.Errorf("observe pointer position: %w", err)
+		}
+		last = pointerPosition{x: x, y: y}
+		if last == want {
+			return nil
+		}
+		if !waiter.now().Before(deadline) {
+			return fmt.Errorf(
+				"%w after %s: want (%d,%d), last observed (%d,%d)",
+				errPointerPositionTimeout,
+				timeout,
+				want.x,
+				want.y,
+				last.x,
+				last.y,
+			)
+		}
+		waiter.sleep(pollInterval)
+	}
+}
+
+func TestPointerPositionWaiterDelayedObservation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(0, 0)
+	observations := []pointerPosition{
+		{x: 10, y: 20},
+		{x: 30, y: 40},
+	}
+	observeCount := 0
+	sleepCount := 0
+	waiter := pointerPositionWaiter{
+		observe: func() (int, int, error) {
+			position := observations[observeCount]
+			observeCount++
+			return position.x, position.y, nil
+		},
+		now: func() time.Time {
+			return now
+		},
+		sleep: func(duration time.Duration) {
+			sleepCount++
+			now = now.Add(duration)
+		},
+	}
+
+	err := waiter.wait(pointerPosition{x: 30, y: 40}, time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("wait for delayed pointer position: %v", err)
+	}
+	if observeCount != 2 {
+		t.Errorf("observation count = %d, want 2", observeCount)
+	}
+	if sleepCount != 1 {
+		t.Errorf("sleep count = %d, want 1", sleepCount)
+	}
+}
+
+func TestPointerPositionWaiterTimeoutIncludesLastPosition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(0, 0)
+	waiter := pointerPositionWaiter{
+		observe: func() (int, int, error) {
+			return 7, 9, nil
+		},
+		now: func() time.Time {
+			return now
+		},
+		sleep: func(duration time.Duration) {
+			now = now.Add(duration)
+		},
+	}
+
+	err := waiter.wait(pointerPosition{x: 11, y: 13}, 20*time.Millisecond, 10*time.Millisecond)
+	if !errors.Is(err, errPointerPositionTimeout) {
+		t.Fatalf("wait error = %v, want %v", err, errPointerPositionTimeout)
+	}
+	for _, detail := range []string{"want (11,13)", "last observed (7,9)"} {
+		if !strings.Contains(err.Error(), detail) {
+			t.Errorf("wait error %q does not contain %q", err, detail)
+		}
+	}
+}
+
+func TestPointerPositionWaiterObserverFailure(t *testing.T) {
+	t.Parallel()
+
+	observeErr := errors.New("location unavailable")
+	sleepCalled := false
+	waiter := pointerPositionWaiter{
+		observe: func() (int, int, error) {
+			return 0, 0, observeErr
+		},
+		now: time.Now,
+		sleep: func(time.Duration) {
+			sleepCalled = true
+		},
+	}
+
+	err := waiter.wait(pointerPosition{}, time.Second, 10*time.Millisecond)
+	if !errors.Is(err, observeErr) {
+		t.Fatalf("wait error = %v, want %v", err, observeErr)
+	}
+	if sleepCalled {
+		t.Fatal("waiter slept after observer failure")
+	}
+}

--- a/robotgo_test.go
+++ b/robotgo_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/vcaesar/tt"
 )
@@ -50,31 +51,27 @@ func TestSize(t *testing.T) {
 }
 
 func TestMoveMouse(t *testing.T) {
-	Move(20, 20)
-	MilliSleep(50)
-	x, y := Location()
+	preservePointerLocation(t)
 
-	tt.Equal(t, 20, x)
-	tt.Equal(t, 20, y)
+	if err := MoveE(20, 20); err != nil {
+		t.Fatalf("MoveE: %v", err)
+	}
+	requirePointerPosition(t, pointerPosition{x: 20, y: 20})
 }
 
 func TestMoveMouseSmooth(t *testing.T) {
-	b := MoveSmooth(100, 100)
-	MilliSleep(50)
-	x, y := Location()
+	preservePointerLocation(t)
 
+	b := MoveSmooth(100, 100)
 	tt.True(t, b)
-	tt.Equal(t, 100, x)
-	tt.Equal(t, 100, y)
+	requirePointerPosition(t, pointerPosition{x: 100, y: 100})
 }
 
 func TestDragMouse(t *testing.T) {
-	DragSmooth(500, 500)
-	MilliSleep(50)
-	x, y := Location()
+	preservePointerLocation(t)
 
-	tt.Equal(t, 500, x)
-	tt.Equal(t, 500, y)
+	DragSmooth(500, 500)
+	requirePointerPosition(t, pointerPosition{x: 500, y: 500})
 }
 
 func TestScrollMouse(t *testing.T) {
@@ -89,27 +86,76 @@ func TestScrollMouse(t *testing.T) {
 }
 
 func TestMoveRelative(t *testing.T) {
-	Move(200, 200)
-	MilliSleep(50)
+	preservePointerLocation(t)
 
-	MoveRelative(10, -10)
-	MilliSleep(50)
+	if err := MoveE(200, 200); err != nil {
+		t.Fatalf("establish pointer position: %v", err)
+	}
+	requirePointerPosition(t, pointerPosition{x: 200, y: 200})
 
-	x, y := Location()
-	tt.Equal(t, 210, x)
-	tt.Equal(t, 190, y)
+	if err := MoveRelativeE(10, -10); err != nil {
+		t.Fatalf("MoveRelativeE: %v", err)
+	}
+
+	requirePointerPosition(t, pointerPosition{x: 210, y: 190})
 }
 
 func TestMoveSmoothRelative(t *testing.T) {
-	Move(200, 200)
-	MilliSleep(50)
+	preservePointerLocation(t)
+
+	if err := MoveE(200, 200); err != nil {
+		t.Fatalf("establish pointer position: %v", err)
+	}
+	requirePointerPosition(t, pointerPosition{x: 200, y: 200})
 
 	MoveSmoothRelative(10, -10)
-	MilliSleep(50)
+	requirePointerPosition(t, pointerPosition{x: 210, y: 190})
+}
 
-	x, y := Location()
-	tt.Equal(t, 210, x)
-	tt.Equal(t, 190, y)
+const (
+	pointerObservationTimeout  = 2 * time.Second
+	pointerObservationInterval = 10 * time.Millisecond
+)
+
+var livePointerPositionWaiter = pointerPositionWaiter{
+	observe: LocationE,
+	now:     time.Now,
+	sleep:   time.Sleep,
+}
+
+func preservePointerLocation(t *testing.T) {
+	t.Helper()
+
+	x, y, err := LocationE()
+	if err != nil {
+		t.Fatalf("record original pointer position: %v", err)
+	}
+	original := pointerPosition{x: x, y: y}
+	t.Cleanup(func() {
+		if err := MoveE(original.x, original.y); err != nil {
+			t.Errorf("restore original pointer position: %v", err)
+			return
+		}
+		if err := livePointerPositionWaiter.wait(
+			original,
+			pointerObservationTimeout,
+			pointerObservationInterval,
+		); err != nil {
+			t.Errorf("verify original pointer position restoration: %v", err)
+		}
+	})
+}
+
+func requirePointerPosition(t *testing.T, want pointerPosition) {
+	t.Helper()
+
+	if err := livePointerPositionWaiter.wait(
+		want,
+		pointerObservationTimeout,
+		pointerObservationInterval,
+	); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestMouseToggle(t *testing.T) {


### PR DESCRIPTION
## Goal

Make real macOS/Windows CGO pointer evidence deterministic and cleanup-safe, and make native smooth movement finish at the exact endpoint promised by the API.

Linear: [LAB-5](https://linear.app/riotbox/issue/LAB-5/stabilize-cgo-pointer-tests-and-exact-smooth-endpoints)

## Root causes

1. Pointer tests used one fixed 50 ms sleep before a single location assertion. One macOS runner observed the pre-relative position `(200,200)` instead of `(210,190)`, while the parallel job and unchanged retry passed.
2. On the first PR head, both Windows CGO jobs showed that the native smoothing loop could stabilize next to its target: `(101,100)` for `MoveSmooth(100,100)` and `(500,499)` for `DragSmooth(500,500)`. The loop intentionally stops near the destination but issued no final exact move.
3. The movement tests left the pointer at test coordinates instead of restoring the original state.

## Changes

- replace fixed post-event sleeps with bounded observable polling of `LocationE`
- observe setup positions before issuing relative movements
- record, restore, and verify the original position through `t.Cleanup`
- keep every injected operation single-shot; polling never retries input
- retain exact assertions for absolute, relative, smooth, and cleanup positions
- finish the native C smoothing path with one exact endpoint move only when the loop stopped nearby
- add hermetic fake-clock tests for delayed observation, timeout diagnostics, and observer failure
- document the runtime observation, exact endpoint, and cleanup contract in `TEST.md`

## User/developer impact

`MoveSmooth`, `MoveSmoothRelative`, and smooth drag now reliably finish at the requested coordinate instead of potentially returning one or more pixels away. Test runs restore the developer/runner pointer after each movement test, including assertion failures.

No public signature, permission, speed-selection, or smoothing-trajectory changes.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=1 golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0 golangci-lint run --timeout=5m ./...`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 go test -asan -count=1 ./...`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 scripts/run-wayland-sanitizer-tests.sh`

## Review focus

- cleanup registration precedes every real pointer mutation
- timeout polling observes only and never reinjects
- the native final event is emitted only when the smooth loop did not already reach the exact endpoint
- all target and restoration assertions remain exact; no tolerance hides backend drift

## Risk

Low and tightly scoped. The only production change is a final exact move after native smoothing stops near its target. The macOS and Windows CGO matrices provide real-runtime evidence for both the endpoint and cleanup contracts.