### PR TITLE
test: synchronize OCR cancellation cleanup (LAB-6)

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -79,6 +79,11 @@ screenshot files to be absent after successful decoding and after decode
 failures. The production portal reader unlinks the sensitive file immediately
 after opening it.
 
+The command-backed OCR cancellation test waits for its fake backend to publish
+the private image path before canceling. It then requires bounded command
+termination and verifies that the temporary OCR image no longer exists; fixed
+startup sleeps or OCR-operation retries are not used.
+
 The default CGO macOS and Windows pointer checks preserve and verify restoration
 of the original pointer location. They use bounded observation polling instead
 of fixed post-event sleeps and do not retry an injected event to manufacture a

--- a/robotgo_ocr_cli_test.go
+++ b/robotgo_ocr_cli_test.go
@@ -5,6 +5,7 @@ package robotgo
 import (
 	"context"
 	"errors"
+	"fmt"
 	"image"
 	"os"
 	"path/filepath"
@@ -13,22 +14,117 @@ import (
 	"time"
 )
 
+const ocrTestSynchronizationTimeout = 2 * time.Second
+
+func startCancelableOCRTestCall(
+	t *testing.T,
+	call func(context.Context) error,
+) (context.CancelFunc, <-chan error) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		result <- call(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		timer := time.NewTimer(ocrTestSynchronizationTimeout)
+		defer timer.Stop()
+		select {
+		case <-done:
+		case <-timer.C:
+			t.Error("canceled OCR call did not stop during test cleanup")
+		}
+	})
+	return cancel, result
+}
+
+func waitForOCRTestPath(ctx context.Context, path string) error {
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("observe OCR test path %q: %w", path, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for OCR test path %q: %w", path, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func requireOCRTestPath(t *testing.T, path string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), ocrTestSynchronizationTimeout)
+	defer cancel()
+	if err := waitForOCRTestPath(ctx, path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requireCanceledOCRTestCall(t *testing.T, result <-chan error) {
+	t.Helper()
+
+	timer := time.NewTimer(ocrTestSynchronizationTimeout)
+	defer timer.Stop()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("OCR call error = %v, want cancellation", err)
+		}
+	case <-timer.C:
+		t.Fatal("OCR call did not return after cancellation")
+	}
+}
+
 func TestGetTextContextCancelsTesseract(t *testing.T) {
 	directory := t.TempDir()
 	tesseract := filepath.Join(directory, "tesseract")
-	if err := os.WriteFile(tesseract, []byte("#!/bin/sh\nexec /bin/sleep 30\n"), 0o700); err != nil {
+	ready := filepath.Join(directory, "ready")
+	script := "#!/bin/sh\nprintf ready > \"$ROBOTGO_OCR_TEST_READY\"\nexec /bin/sleep 30\n"
+	if err := os.WriteFile(tesseract, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", directory)
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	started := time.Now()
-	_, err := GetTextContext(ctx, "ignored.png")
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("GetTextContext error = %v, want deadline", err)
+	t.Setenv("ROBOTGO_OCR_TEST_READY", ready)
+
+	cancel, result := startCancelableOCRTestCall(t, func(ctx context.Context) error {
+		_, err := GetTextContext(ctx, "ignored.png")
+		return err
+	})
+	requireOCRTestPath(t, ready)
+	cancel()
+	requireCanceledOCRTestCall(t, result)
+}
+
+func TestGetTextContextDoesNotStartTesseractWhenAlreadyCanceled(t *testing.T) {
+	directory := t.TempDir()
+	tesseract := filepath.Join(directory, "tesseract")
+	invoked := filepath.Join(directory, "invoked")
+	script := "#!/bin/sh\nprintf invoked > \"$ROBOTGO_OCR_TEST_INVOKED\"\n"
+	if err := os.WriteFile(tesseract, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
 	}
-	if elapsed := time.Since(started); elapsed > time.Second {
-		t.Fatalf("canceled OCR command took %v", elapsed)
+	t.Setenv("PATH", directory)
+	t.Setenv("ROBOTGO_OCR_TEST_INVOKED", invoked)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := GetTextContext(ctx, "ignored.png")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetTextContext error = %v, want cancellation", err)
+	}
+	if _, err := os.Stat(invoked); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("already-canceled OCR call invoked backend or stat failed: %v", err)
 	}
 }
 
@@ -63,23 +159,26 @@ func TestGetTextImgContextRemovesPrivateTemporaryFileAfterCancellation(t *testin
 	directory := t.TempDir()
 	tesseract := filepath.Join(directory, "tesseract")
 	marker := filepath.Join(directory, "image-path")
-	script := "#!/bin/sh\nprintf '%s' \"$1\" > \"$ROBOTGO_OCR_TEST_MARKER\"\nexec /bin/sleep 30\n"
+	ready := filepath.Join(directory, "ready")
+	script := "#!/bin/sh\nprintf '%s' \"$1\" > \"$ROBOTGO_OCR_TEST_MARKER\"\nprintf ready > \"$ROBOTGO_OCR_TEST_READY\"\nexec /bin/sleep 30\n"
 	if err := os.WriteFile(tesseract, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", directory)
 	t.Setenv("ROBOTGO_OCR_TEST_MARKER", marker)
+	t.Setenv("ROBOTGO_OCR_TEST_READY", ready)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	_, err := GetTextImgContext(ctx, image.NewRGBA(image.Rect(0, 0, 1, 1)))
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("GetTextImgContext error = %v, want deadline", err)
-	}
+	cancel, result := startCancelableOCRTestCall(t, func(ctx context.Context) error {
+		_, err := GetTextImgContext(ctx, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+		return err
+	})
+	requireOCRTestPath(t, ready)
 	pathBytes, err := os.ReadFile(marker)
 	if err != nil {
 		t.Fatal(err)
 	}
+	cancel()
+	requireCanceledOCRTestCall(t, result)
 	if _, err := os.Stat(string(pathBytes)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("temporary OCR image still exists after cancellation or stat failed: %v", err)
 	}


### PR DESCRIPTION
## Goal

Remove the scheduler race from command-backed OCR cancellation tests without weakening RobotGo's sensitive temporary-file cleanup contract.

Linear: [LAB-6](https://linear.app/riotbox/issue/LAB-6/synchronize-ocr-cancellation-cleanup-test-with-backend-startup)

## Root cause

The previous cancellation cleanup test used a fixed 20 ms deadline and then immediately read a marker written by the fake Tesseract process. On a loaded macOS runner the context could expire before that process started, so RobotGo still cleaned up its private image but the test failed because the marker had never been created.

## Changes

- synchronize active cancellation with a bounded fake-backend readiness marker
- distinguish already-canceled/pre-start behavior from cancellation of a running Tesseract process
- cancel each OCR operation exactly once and require bounded command termination
- retain the exact assertion that the private OCR image is absent after cancellation
- register cleanup that cancels and joins the test goroutine before `t.TempDir()` removal
- document the no-sleep/no-operation-retry test contract in `TEST.md`

## Risk

Test and documentation only; no production API or OCR behavior changes. The main risk is a test-process leak on failure, mitigated by buffered result delivery plus bounded `t.Cleanup()` cancellation/join.

## Local validation

- focused CGO test set, 100 repetitions
- focused Pure-Go test set, 100 repetitions
- focused race test set, 100 repetitions
- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `CGO_ENABLED=0 go test -tags ocr ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=1 golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0 golangci-lint run --timeout=5m ./...`

## Review focus

- cancellation happens only after confirmed backend startup in active-cancel cases
- all failure paths cancel and join the goroutine before temporary-directory cleanup
- private OCR image deletion is observed only after the OCR call has returned