### PR TITLE
test: synchronize Unix clipboard cancellation (LAB-7)

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -84,6 +84,10 @@ the private image path before canceling. It then requires bounded command
 termination and verifies that the temporary OCR image no longer exists; fixed
 startup sleeps or OCR-operation retries are not used.
 
+Unix clipboard read/write cancellation tests likewise wait for a fake command's
+readiness before canceling, cover already-canceled contexts separately, and use
+only fixed fixture text without reading or changing the developer's clipboard.
+
 The default CGO macOS and Windows pointer checks preserve and verify restoration
 of the original pointer location. They use bounded observation polling instead
 of fixed post-event sleeps and do not retry an injected event to manufacture a

--- a/clipboard/clipboard_unix_test.go
+++ b/clipboard/clipboard_unix_test.go
@@ -12,6 +12,109 @@ import (
 	"time"
 )
 
+const clipboardTestSynchronizationTimeout = 2 * time.Second
+
+type clipboardContextTestCall struct {
+	name string
+	run  func(context.Context) error
+}
+
+func clipboardContextTestCalls() []clipboardContextTestCall {
+	return []clipboardContextTestCall{
+		{
+			name: "read",
+			run: func(ctx context.Context) error {
+				_, err := ReadAllContext(ctx)
+				return err
+			},
+		},
+		{
+			name: "write",
+			run: func(ctx context.Context) error {
+				return WriteAllContext(ctx, "robotgo clipboard cancellation fixture")
+			},
+		},
+	}
+}
+
+func installClipboardTestCommand(t *testing.T, script string) string {
+	t.Helper()
+
+	directory := t.TempDir()
+	command := filepath.Join(directory, xclip)
+	if err := os.WriteFile(command, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", directory)
+	previousTool := selectedTool
+	selectedTool = unixClipboardXclip
+	t.Cleanup(func() { selectedTool = previousTool })
+	return directory
+}
+
+func startCancelableClipboardTestCall(
+	t *testing.T,
+	call func(context.Context) error,
+) (context.CancelFunc, <-chan error) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		result <- call(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		timer := time.NewTimer(clipboardTestSynchronizationTimeout)
+		defer timer.Stop()
+		select {
+		case <-done:
+		case <-timer.C:
+			t.Error("canceled clipboard call did not stop during test cleanup")
+		}
+	})
+	return cancel, result
+}
+
+func requireClipboardTestPath(t *testing.T, path string) {
+	t.Helper()
+
+	timer := time.NewTimer(clipboardTestSynchronizationTimeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("observe clipboard test path %q: %v", path, err)
+		}
+
+		select {
+		case <-timer.C:
+			t.Fatalf("timed out waiting for clipboard test path %q", path)
+		case <-ticker.C:
+		}
+	}
+}
+
+func requireCanceledClipboardTestCall(t *testing.T, result <-chan error) {
+	t.Helper()
+
+	timer := time.NewTimer(clipboardTestSynchronizationTimeout)
+	defer timer.Stop()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("clipboard call error = %v, want cancellation", err)
+		}
+	case <-timer.C:
+		t.Fatal("clipboard call did not return after cancellation")
+	}
+}
+
 func TestUnixClipboardCommandSelectionsAreStateless(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -39,26 +142,39 @@ func TestUnixClipboardCommandSelectionsAreStateless(t *testing.T) {
 	}
 }
 
-func TestClipboardContextCancelsCommand(t *testing.T) {
-	directory := t.TempDir()
-	command := filepath.Join(directory, xclip)
-	if err := os.WriteFile(command, []byte("#!/bin/sh\nexec /bin/sleep 30\n"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", directory)
-	previousTool := selectedTool
-	selectedTool = unixClipboardXclip
-	t.Cleanup(func() { selectedTool = previousTool })
+func TestClipboardContextCancelsRunningCommand(t *testing.T) {
+	for _, test := range clipboardContextTestCalls() {
+		t.Run(test.name, func(t *testing.T) {
+			script := "#!/bin/sh\nprintf ready > \"$ROBOTGO_CLIPBOARD_TEST_READY\"\nexec /bin/sleep 30\n"
+			directory := installClipboardTestCommand(t, script)
+			ready := filepath.Join(directory, "ready")
+			t.Setenv("ROBOTGO_CLIPBOARD_TEST_READY", ready)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-	started := time.Now()
-	_, err := ReadAllContext(ctx)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("ReadAllContext error = %v, want deadline", err)
+			cancel, result := startCancelableClipboardTestCall(t, test.run)
+			requireClipboardTestPath(t, ready)
+			cancel()
+			requireCanceledClipboardTestCall(t, result)
+		})
 	}
-	if elapsed := time.Since(started); elapsed > time.Second {
-		t.Fatalf("canceled clipboard command took %v", elapsed)
+}
+
+func TestClipboardContextDoesNotStartCommandWhenAlreadyCanceled(t *testing.T) {
+	for _, test := range clipboardContextTestCalls() {
+		t.Run(test.name, func(t *testing.T) {
+			script := "#!/bin/sh\nprintf invoked > \"$ROBOTGO_CLIPBOARD_TEST_INVOKED\"\n"
+			directory := installClipboardTestCommand(t, script)
+			invoked := filepath.Join(directory, "invoked")
+			t.Setenv("ROBOTGO_CLIPBOARD_TEST_INVOKED", invoked)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			if err := test.run(ctx); !errors.Is(err, context.Canceled) {
+				t.Fatalf("clipboard call error = %v, want cancellation", err)
+			}
+			if _, err := os.Stat(invoked); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("already-canceled clipboard call invoked backend or stat failed: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Goal

Remove the fixed-deadline scheduler race from Unix clipboard command cancellation tests and prove both active and pre-start cancellation for read and write operations.

Linear: [LAB-7](https://linear.app/riotbox/issue/LAB-7/synchronize-unix-clipboard-command-cancellation-tests)

## Root cause

`TestClipboardContextCancelsCommand` used a fixed 20 ms deadline around a fake `xclip` process but never confirmed that the command had started. Under load it could therefore pass without exercising active cancellation or fail for timing reasons, matching the scheduler pattern proven by LAB-6.

## Changes

- cover `ReadAllContext` and `WriteAllContext` through the same test contract
- publish a bounded readiness marker before active cancellation
- require `context.Canceled` and bounded return after one cancellation
- separately verify that already-canceled contexts never invoke the backend
- cancel and join test calls before environment and `t.TempDir()` cleanup
- restore the package-global selected clipboard tool per subtest
- use only fixed synthetic write data; the real clipboard is never read or changed
- document the synchronization and privacy contract in `TEST.md`

## Risk

Test and documentation only; no production API or clipboard behavior changes. The main risks are leaked test processes or shared-state contamination, mitigated by bounded LIFO cleanup and non-parallel subtests.

## Local validation

- focused default suite, 100 repetitions
- focused Pure-Go suite, 100 repetitions
- focused race suite, 100 repetitions
- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=1 golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0 golangci-lint run --timeout=5m ./...`

## Review focus

- fake command readiness is published before active cancellation
- pre-start cases cannot execute the fake backend
- global `selectedTool`, environment, goroutine/process, and temporary-directory cleanup order is deterministic