### PR TITLE
fix: harden alert backend contracts (LAB-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,11 @@ func main() {
 Legacy APIs remain available for source compatibility. Their signatures may be
 unable to report all backend failures, so new reliability-sensitive code should
 use variants such as `MoveE`, `MoveRelativeE`, `ClickE`, `ScrollE`, `LocationE`,
-`TypeStrE`, `UnicodeTypeE`, and the error-returning window APIs.
+`TypeStrE`, `UnicodeTypeE`, `AlertE`, and the error-returning window APIs.
+On Linux, `AlertE` tries `zenity`, `kdialog`, and `xmessage` before using
+`notify-send` for an OK-only informational alert. A cancel-capable alert never
+silently degrades to a non-interactive notification; missing or failed backends
+are returned explicitly. Legacy `Alert` keeps its bool-only signature.
 `KeyTap` and `KeyToggle` model keys rather than portable text entry. A selected
 backend may support a single non-ASCII rune directly (the RemoteDesktop portal
 and Pure-Go X11 do), while another native keymap can return `ErrNotSupported`.

--- a/TEST.md
+++ b/TEST.md
@@ -88,6 +88,12 @@ Unix clipboard read/write cancellation tests likewise wait for a fake command's
 readiness before canceling, cover already-canceled contexts separately, and use
 only fixed fixture text without reading or changing the developer's clipboard.
 
+Linux alert tests replace every external dialog backend through a private test
+`PATH`. They verify fallback order, user rejection, missing/failed backends, and
+the non-interactive notification boundary without displaying real UI.
+The shared native-result tests also keep macOS and Windows backend failures
+distinct from a user rejecting the dialog.
+
 The default CGO macOS and Windows pointer checks preserve and verify restoration
 of the original pointer location. They use bounded observation polling instead
 of fixed post-event sleeps and do not retry an injected event to manufacture a

--- a/alert_result.go
+++ b/alert_result.go
@@ -1,0 +1,20 @@
+package robotgo
+
+import "fmt"
+
+const (
+	nativeAlertAccepted = 0
+	nativeAlertRejected = 1
+	nativeAlertFailed   = -1
+)
+
+func nativeAlertResult(status int) (bool, error) {
+	switch status {
+	case nativeAlertAccepted:
+		return true, nil
+	case nativeAlertRejected:
+		return false, nil
+	default:
+		return false, fmt.Errorf("native alert backend failed with status %d", status)
+	}
+}

--- a/alert_result_test.go
+++ b/alert_result_test.go
@@ -1,0 +1,29 @@
+package robotgo
+
+import "testing"
+
+func TestNativeAlertResult(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		wantAccepted bool
+		wantError    bool
+	}{
+		{name: "accepted", status: nativeAlertAccepted, wantAccepted: true},
+		{name: "rejected", status: nativeAlertRejected},
+		{name: "failed", status: nativeAlertFailed, wantError: true},
+		{name: "unknown", status: 42, wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			accepted, err := nativeAlertResult(test.status)
+			if accepted != test.wantAccepted || (err != nil) != test.wantError {
+				t.Fatalf(
+					"nativeAlertResult(%d) = accepted %t, error %v; want accepted %t, error %t",
+					test.status, accepted, err, test.wantAccepted, test.wantError,
+				)
+			}
+		})
+	}
+}

--- a/examples/window/main.go
+++ b/examples/window/main.go
@@ -19,12 +19,18 @@ import (
 )
 
 func alert() {
-	// show Alert Window
-	abool := robotgo.Alert("hello", "robotgo")
-	if abool {
-		fmt.Println("ok@@@", "ok")
+	accepted, err := robotgo.AlertE("hello", "robotgo")
+	if err != nil {
+		fmt.Println("alert backend:", err)
+	} else {
+		fmt.Println("alert accepted:", accepted)
 	}
-	robotgo.Alert("hello", "robotgo", "Ok", "Cancel")
+	accepted, err = robotgo.AlertE("hello", "robotgo", "Ok", "Cancel")
+	if err != nil {
+		fmt.Println("interactive alert backend:", err)
+	} else {
+		fmt.Println("interactive alert accepted:", accepted)
+	}
 }
 
 func get() {

--- a/robotgo.go
+++ b/robotgo.go
@@ -2511,19 +2511,14 @@ ____    __    ____  __  .__   __.  _______   ______   ____    __    ____
 */
 
 func alertArgs(args ...string) (string, string) {
-	var (
-		defaultBtn = "Ok"
-		cancelBtn  = "Cancel"
-	)
-
-	if len(args) > 0 {
+	defaultBtn := "Ok"
+	cancelBtn := ""
+	if len(args) > 0 && args[0] != "" {
 		defaultBtn = args[0]
 	}
-
 	if len(args) > 1 {
 		cancelBtn = args[1]
 	}
-
 	return defaultBtn, cancelBtn
 }
 

--- a/robotgo_linux_alert.go
+++ b/robotgo_linux_alert.go
@@ -3,97 +3,142 @@
 package robotgo
 
 import (
-    "fmt"
-    "os/exec"
+	"errors"
+	"fmt"
+	"os/exec"
 )
 
-// Alert shows a simple alert dialog with optional custom button labels.
-// On Linux it prefers native Wayland-friendly tools when available.
-// Order of backends: zenity, kdialog, xmessage, notify-send (fire-and-forget).
-// If cancel button is not given, only the default button is displayed.
-//
-// Examples:
-//
-//     robotgo.Alert("hi", "window", "ok", "cancel")
+const (
+	linuxAlertZenity     = "zenity"
+	linuxAlertKDialog    = "kdialog"
+	linuxAlertXMessage   = "xmessage"
+	linuxAlertNotifySend = "notify-send"
+
+	linuxAlertNoCancelExit       = -1
+	linuxAlertDialogCancelExit   = 1
+	linuxAlertXMessageCancelExit = 2
+)
+
+// Alert shows a simple alert dialog and preserves the legacy bool-only API.
+// Use AlertE when backend failures must be distinguished from user rejection.
 func Alert(title, msg string, args ...string) bool {
-    defaultBtn, cancelBtn := alertArgs(args...)
+	accepted, _ := AlertE(title, msg, args...)
+	return accepted
+}
 
-    // Try zenity (GTK; works on Wayland and X11)
-    if hasCmd("zenity") {
-        if cancelBtn == "" {
-            // OK-only
-            cmd := exec.Command("zenity", "--info", "--no-markup",
-                "--title", title, "--text", msg,
-                "--ok-label", defaultBtn,
-            )
-            if err := cmd.Run(); err != nil {
-                return false
-            }
-            return true
-        }
+// AlertE shows a simple alert dialog and reports backend failures explicitly.
+// On Linux it tries zenity, kdialog, xmessage, then notify-send. The final
+// notify-send fallback is valid only for an OK-only informational alert because
+// it cannot report a button choice without optional, backend-dependent actions.
+func AlertE(title, msg string, args ...string) (bool, error) {
+	defaultBtn, cancelBtn := alertArgs(args...)
+	var backendErrors []error
 
-        // Two buttons
-        cmd := exec.Command("zenity", "--question", "--no-markup",
-            "--title", title, "--text", msg,
-            "--ok-label", defaultBtn, "--cancel-label", cancelBtn,
-        )
-        if err := cmd.Run(); err != nil {
-            // zenity returns non-zero when Cancel pressed
-            return false
-        }
-        return true
-    }
+	if hasCmd(linuxAlertZenity) {
+		commandArgs := []string{
+			"--info", "--no-markup",
+			"--title", title, "--text", msg,
+			"--ok-label", defaultBtn,
+		}
+		if cancelBtn != "" {
+			commandArgs = []string{
+				"--question", "--no-markup",
+				"--title", title, "--text", msg,
+				"--ok-label", defaultBtn, "--cancel-label", cancelBtn,
+			}
+		}
+		accepted, err := runLinuxAlertCommand(
+			linuxAlertZenity, commandArgs, linuxAlertDialogCancelExit,
+		)
+		if err == nil {
+			return accepted, nil
+		}
+		backendErrors = append(backendErrors, err)
+	}
 
-    // Try kdialog (Qt; works on Wayland and X11)
-    if hasCmd("kdialog") {
-        if cancelBtn == "" {
-            cmd := exec.Command("kdialog", "--title", title, "--msgbox", msg, "--ok-label", defaultBtn)
-            if err := cmd.Run(); err != nil {
-                return false
-            }
-            return true
-        }
-        cmd := exec.Command("kdialog", "--title", title, "--yesno", msg, "--yes-label", defaultBtn, "--no-label", cancelBtn)
-        if err := cmd.Run(); err != nil {
-            return false
-        }
-        return true
-    }
+	if hasCmd(linuxAlertKDialog) {
+		commandArgs := []string{
+			"--title", title, "--msgbox", msg, "--ok-label", defaultBtn,
+		}
+		if cancelBtn != "" {
+			commandArgs = []string{
+				"--title", title, "--yesno", msg,
+				"--yes-label", defaultBtn, "--no-label", cancelBtn,
+			}
+		}
+		accepted, err := runLinuxAlertCommand(
+			linuxAlertKDialog, commandArgs, linuxAlertDialogCancelExit,
+		)
+		if err == nil {
+			return accepted, nil
+		}
+		backendErrors = append(backendErrors, err)
+	}
 
-    // Fallback to xmessage (X11/XWayland)
-    if hasCmd("xmessage") {
-        buttons := defaultBtn + ":0"
-        if cancelBtn != "" {
-            buttons = buttons + "," + cancelBtn + ":1"
-        }
-        // xmessage prints the index of the selected button to stdout
-        out, err := exec.Command(
-            "xmessage",
-            "-center",
-            "-title", title,
-            "-buttons", buttons,
-            "-default", defaultBtn,
-            "-geometry", "400x200",
-            msg,
-        ).CombinedOutput()
-        if err != nil {
-            return false
-        }
-        return string(out) != "1"
-    }
+	if hasCmd(linuxAlertXMessage) {
+		buttons := defaultBtn + ":0"
+		cancelExit := linuxAlertNoCancelExit
+		if cancelBtn != "" {
+			buttons += fmt.Sprintf(",%s:%d", cancelBtn, linuxAlertXMessageCancelExit)
+			cancelExit = linuxAlertXMessageCancelExit
+		}
+		accepted, err := runLinuxAlertCommand(linuxAlertXMessage, []string{
+			"-center",
+			"-title", title,
+			"-buttons", buttons,
+			"-default", defaultBtn,
+			"-geometry", "400x200",
+			msg,
+		}, cancelExit)
+		if err == nil {
+			return accepted, nil
+		}
+		backendErrors = append(backendErrors, err)
+	}
 
-    // Last-resort: desktop notification without interaction
-    if hasCmd("notify-send") {
-        _ = exec.Command("notify-send", title, msg).Run()
-        return true
-    }
+	if hasCmd(linuxAlertNotifySend) {
+		if cancelBtn != "" {
+			backendErrors = append(backendErrors, fmt.Errorf(
+				"%w: %s cannot report an interactive alert choice",
+				ErrNotSupported, linuxAlertNotifySend,
+			))
+		} else {
+			accepted, err := runLinuxAlertCommand(
+				linuxAlertNotifySend, []string{title, msg}, linuxAlertNoCancelExit,
+			)
+			if err == nil {
+				return accepted, nil
+			}
+			backendErrors = append(backendErrors, err)
+		}
+	}
 
-    // No available backend
-    _ = fmt.Errorf("robotgo.Alert: no dialog backend found (tried zenity, kdialog, xmessage, notify-send)")
-    return false
+	if len(backendErrors) > 0 {
+		return false, errors.Join(backendErrors...)
+	}
+	return false, fmt.Errorf(
+		"%w: no Linux alert backend found (tried %s, %s, %s, %s)",
+		ErrNotSupported,
+		linuxAlertZenity,
+		linuxAlertKDialog,
+		linuxAlertXMessage,
+		linuxAlertNotifySend,
+	)
+}
+
+func runLinuxAlertCommand(name string, args []string, cancelExit int) (bool, error) {
+	err := exec.Command(name, args...).Run()
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if cancelExit >= 0 && errors.As(err, &exitErr) && exitErr.ExitCode() == cancelExit {
+		return false, nil
+	}
+	return false, fmt.Errorf("run Linux alert backend %s: %w", name, err)
 }
 
 func hasCmd(name string) bool {
-    _, err := exec.LookPath(name)
-    return err == nil
+	_, err := exec.LookPath(name)
+	return err == nil
 }

--- a/robotgo_linux_alert_test.go
+++ b/robotgo_linux_alert_test.go
@@ -1,0 +1,160 @@
+//go:build linux
+
+package robotgo
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func linuxAlertTestDirectory(t *testing.T) string {
+	t.Helper()
+	directory := t.TempDir()
+	t.Setenv("PATH", directory)
+	return directory
+}
+
+func writeLinuxAlertTestCommand(t *testing.T, directory, name, script string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(directory, name), []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAlertEFallsBackAfterBackendFailure(t *testing.T) {
+	directory := linuxAlertTestDirectory(t)
+	marker := filepath.Join(directory, "backend-order")
+	t.Setenv("ROBOTGO_ALERT_TEST_MARKER", marker)
+	writeLinuxAlertTestCommand(t, directory, linuxAlertZenity,
+		"#!/bin/sh\nprintf zenity >> \"$ROBOTGO_ALERT_TEST_MARKER\"\nexit 2\n")
+	writeLinuxAlertTestCommand(t, directory, linuxAlertKDialog,
+		"#!/bin/sh\nprintf kdialog >> \"$ROBOTGO_ALERT_TEST_MARKER\"\nexit 0\n")
+
+	accepted, err := AlertE("title", "message", "OK", "Cancel")
+	if err != nil || !accepted {
+		t.Fatalf("AlertE = accepted %t, error %v; want accepted", accepted, err)
+	}
+	order, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(order) != "zenitykdialog" {
+		t.Fatalf("backend order = %q, want zenity then kdialog", order)
+	}
+}
+
+func TestAlertEUserCancelStopsFallback(t *testing.T) {
+	directory := linuxAlertTestDirectory(t)
+	marker := filepath.Join(directory, "backend-order")
+	t.Setenv("ROBOTGO_ALERT_TEST_MARKER", marker)
+	writeLinuxAlertTestCommand(t, directory, linuxAlertZenity,
+		"#!/bin/sh\nprintf zenity >> \"$ROBOTGO_ALERT_TEST_MARKER\"\nexit 1\n")
+	writeLinuxAlertTestCommand(t, directory, linuxAlertKDialog,
+		"#!/bin/sh\nprintf kdialog >> \"$ROBOTGO_ALERT_TEST_MARKER\"\nexit 0\n")
+
+	accepted, err := AlertE("title", "message", "OK", "Cancel")
+	if err != nil || accepted {
+		t.Fatalf("AlertE = accepted %t, error %v; want user cancellation", accepted, err)
+	}
+	order, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(order) != "zenity" {
+		t.Fatalf("backend order after cancellation = %q, want zenity only", order)
+	}
+}
+
+func TestAlertEXMessageUsesDistinctCancelStatus(t *testing.T) {
+	directory := linuxAlertTestDirectory(t)
+	marker := filepath.Join(directory, "xmessage-args")
+	t.Setenv("ROBOTGO_ALERT_TEST_MARKER", marker)
+	writeLinuxAlertTestCommand(t, directory, linuxAlertXMessage,
+		"#!/bin/sh\nprintf '%s' \"$*\" > \"$ROBOTGO_ALERT_TEST_MARKER\"\nexit 2\n")
+
+	accepted, err := AlertE("title", "message", "OK", "Cancel")
+	if err != nil || accepted {
+		t.Fatalf("AlertE = accepted %t, error %v; want xmessage cancellation", accepted, err)
+	}
+	args, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(args), "OK:0,Cancel:2") {
+		t.Fatalf("xmessage arguments = %q, want distinct cancel exit status", args)
+	}
+}
+
+func TestAlertEXMessageErrorIsNotCancellation(t *testing.T) {
+	directory := linuxAlertTestDirectory(t)
+	writeLinuxAlertTestCommand(t, directory, linuxAlertXMessage,
+		"#!/bin/sh\nexit 1\n")
+
+	accepted, err := AlertE("title", "message", "OK", "Cancel")
+	if err == nil || accepted {
+		t.Fatalf("AlertE = accepted %t, error %v; want xmessage backend error", accepted, err)
+	}
+	if !strings.Contains(err.Error(), linuxAlertXMessage) {
+		t.Fatalf("AlertE error = %v, want backend name", err)
+	}
+}
+
+func TestAlertENotifySendSupportsDefaultInformationalAlert(t *testing.T) {
+	directory := linuxAlertTestDirectory(t)
+	marker := filepath.Join(directory, "notified")
+	t.Setenv("ROBOTGO_ALERT_TEST_MARKER", marker)
+	writeLinuxAlertTestCommand(t, directory, linuxAlertNotifySend,
+		"#!/bin/sh\nprintf notified > \"$ROBOTGO_ALERT_TEST_MARKER\"\n")
+
+	accepted, err := AlertE("title", "message")
+	if err != nil || !accepted {
+		t.Fatalf("AlertE = accepted %t, error %v; want informational success", accepted, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("notify-send marker: %v", err)
+	}
+}
+
+func TestAlertENotifySendDoesNotFakeInteractiveChoice(t *testing.T) {
+	directory := linuxAlertTestDirectory(t)
+	marker := filepath.Join(directory, "notified")
+	t.Setenv("ROBOTGO_ALERT_TEST_MARKER", marker)
+	writeLinuxAlertTestCommand(t, directory, linuxAlertNotifySend,
+		"#!/bin/sh\nprintf notified > \"$ROBOTGO_ALERT_TEST_MARKER\"\n")
+
+	accepted, err := AlertE("title", "message", "OK", "Cancel")
+	if !errors.Is(err, ErrNotSupported) || accepted {
+		t.Fatalf("AlertE = accepted %t, error %v; want unsupported interactive notification", accepted, err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("non-interactive notification was invoked or stat failed: %v", err)
+	}
+}
+
+func TestAlertENotifySendFailureIsObservable(t *testing.T) {
+	directory := linuxAlertTestDirectory(t)
+	writeLinuxAlertTestCommand(t, directory, linuxAlertNotifySend,
+		"#!/bin/sh\nexit 3\n")
+
+	accepted, err := AlertE("title", "message")
+	if err == nil || accepted {
+		t.Fatalf("AlertE = accepted %t, error %v; want notify-send backend error", accepted, err)
+	}
+	if !strings.Contains(err.Error(), linuxAlertNotifySend) {
+		t.Fatalf("AlertE error = %v, want backend name", err)
+	}
+}
+
+func TestAlertEMissingBackendIsExplicit(t *testing.T) {
+	linuxAlertTestDirectory(t)
+	accepted, err := AlertE("title", "message")
+	if !errors.Is(err, ErrNotSupported) || accepted {
+		t.Fatalf("AlertE = accepted %t, error %v; want ErrNotSupported", accepted, err)
+	}
+	if Alert("title", "message") {
+		t.Fatal("legacy Alert reported success without a backend")
+	}
+}

--- a/robotgo_mac_win.go
+++ b/robotgo_mac_win.go
@@ -76,27 +76,26 @@ func DisplaysNum() int {
 	return int(C.get_num_displays())
 }
 
-// Alert show a alert window
-// Displays alert with the attributes.
-// If cancel button is not given, only the default button is displayed
-//
-// Examples:
-//
-//	robotgo.Alert("hi", "window", "ok", "cancel")
+// Alert shows an alert window and preserves the legacy bool-only API.
 func Alert(title, msg string, args ...string) bool {
-	var defBtn, cancelBtn *C.char
+	accepted, _ := AlertE(title, msg, args...)
+	return accepted
+}
+
+// AlertE shows an alert window and distinguishes a backend failure from the
+// user rejecting the dialog.
+func AlertE(title, msg string, args ...string) (bool, error) {
+	defaultLabel, cancelLabel := alertArgs(args...)
 	ct := C.CString(title)
 	cm := C.CString(msg)
+	defBtn := C.CString(defaultLabel)
 	defer C.free(unsafe.Pointer(ct))
 	defer C.free(unsafe.Pointer(cm))
-	if len(args) > 0 {
-		defBtn = C.CString(args[0])
-		defer C.free(unsafe.Pointer(defBtn))
-	}
-	if len(args) > 1 {
-		cancelBtn = C.CString(args[1])
+	defer C.free(unsafe.Pointer(defBtn))
+	var cancelBtn *C.char
+	if cancelLabel != "" {
+		cancelBtn = C.CString(cancelLabel)
 		defer C.free(unsafe.Pointer(cancelBtn))
 	}
-	r := C.showAlert(ct, cm, defBtn, cancelBtn)
-	return int(r) == 0
+	return nativeAlertResult(int(C.showAlert(ct, cm, defBtn, cancelBtn)))
 }

--- a/robotgo_nocgo_alert.go
+++ b/robotgo_nocgo_alert.go
@@ -3,4 +3,10 @@
 package robotgo
 
 // Alert reports failure when no native dialog backend is selected.
-func Alert(string, string, ...string) bool { return false }
+func Alert(title, msg string, args ...string) bool {
+	accepted, _ := AlertE(title, msg, args...)
+	return accepted
+}
+
+// AlertE reports that this non-CGO platform has no dialog backend.
+func AlertE(string, string, ...string) (bool, error) { return false, ErrNotSupported }

--- a/window/alert_c.h
+++ b/window/alert_c.h
@@ -3,6 +3,12 @@
 	#include <CoreFoundation/CoreFoundation.h>
 #endif
 
+enum robotgo_alert_status {
+	ROBOTGO_ALERT_FAILED = -1,
+	ROBOTGO_ALERT_ACCEPTED = 0,
+	ROBOTGO_ALERT_REJECTED = 1
+};
+
 #if defined(IS_MACOSX)
 // Use a static inline helper to avoid duplicate symbol definitions when this
 // header is included by multiple translation units.
@@ -30,14 +36,16 @@ static inline int showAlert(const char *title, const char *msg,
 		if (defaultButtonTitle != NULL) CFRelease(defaultButtonTitle);
 		if (cancelButtonTitle != NULL) CFRelease(cancelButtonTitle);
 
-		if (err != 0) { return -1; }
-		return (responseFlags == kCFUserNotificationDefaultResponse) ? 0 : 1;
+		if (err != 0) { return ROBOTGO_ALERT_FAILED; }
+		return (responseFlags == kCFUserNotificationDefaultResponse) ?
+			ROBOTGO_ALERT_ACCEPTED : ROBOTGO_ALERT_REJECTED;
 	#elif defined(IS_LINUX)
-		return 0;
+		return ROBOTGO_ALERT_ACCEPTED;
 	#else
 		/* TODO: Display custom buttons instead of the pre-defined "OK" and "Cancel". */
 		int response = MessageBox(NULL, msg, title,
 								(cancelButton == NULL) ? MB_OK : MB_OKCANCEL );
-		return (response == IDOK) ? 0 : 1;
+		if (response == 0) { return ROBOTGO_ALERT_FAILED; }
+		return (response == IDOK) ? ROBOTGO_ALERT_ACCEPTED : ROBOTGO_ALERT_REJECTED;
 	#endif
 }


### PR DESCRIPTION
## Outcome

Add an error-returning `AlertE` API and make Linux alert fallback behavior honest and deterministic.

## Why

The legacy Linux implementation could report success when `notify-send` failed, treated a non-interactive notification as an interactive button choice, and used xmessage exit status 1 for Cancel even though that status is reserved for errors. CGO and Pure-Go builds also disagreed on the default Cancel button.

## Behavior and platform impact

- Linux tries `zenity`, `kdialog`, `xmessage`, then `notify-send`.
- A real user cancellation returns `(false, nil)` and stops fallback.
- Backend failures are returned by `AlertE`; legacy `Alert` retains its bool-only signature.
- `notify-send` is used only for OK-only informational alerts. Interactive requests never silently degrade to a notification.
- xmessage uses exit status 2 for Cancel, keeping status 1 available for errors.
- macOS and Windows native backend failures are distinct from user rejection.
- Non-CGO platforms without a dialog backend return `ErrNotSupported`.
- The no-argument default is consistently an OK-only alert in CGO and Pure-Go builds.

## Risk and compatibility

The exported legacy signature is unchanged. Existing callers that relied on an implicit default Cancel button now receive the documented OK-only default. Command arguments are passed directly without shell evaluation. Tests use only private `t.TempDir()` backends and never open real UI or persist desktop data.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=1 golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0 golangci-lint run --timeout=5m ./...`
- `GOOS=darwin CGO_ENABLED=0 go test -exec=true ./...`
- `GOOS=windows CGO_ENABLED=0 go test -exec=true ./...`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 go test -asan -count=1 ./...`
- `scripts/run-wayland-sanitizer-tests.sh`
- Focused Alert tests repeated 100 times in CGO, Pure-Go, and race modes

Real macOS/Windows UI interaction is intentionally left to platform CI/runtime testing because no local macOS or Windows desktop is available.

Linear: https://linear.app/riotbox/issue/LAB-8/harden-linux-alert-backend-and-error-contracts