### PR TITLE
fix: bound external command cleanup (LAB-9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ On Linux, `AlertE` tries `zenity`, `kdialog`, and `xmessage` before using
 `notify-send` for an OK-only informational alert. A cancel-capable alert never
 silently degrades to a non-interactive notification; missing or failed backends
 are returned explicitly. Legacy `Alert` keeps its bool-only signature.
+Context-backed OCR, clipboard, Wayland probe, and compositor command paths also
+bound inherited process I/O cleanup. On Unix, cancellation terminates the
+one-shot backend's process group so a descendant cannot keep an API call stuck
+indefinitely past its documented timeout.
 `KeyTap` and `KeyToggle` model keys rather than portable text entry. A selected
 backend may support a single non-ASCII rune directly (the RemoteDesktop portal
 and Pure-Go X11 do), while another native keymap can return `ErrNotSupported`.

--- a/TEST.md
+++ b/TEST.md
@@ -88,6 +88,12 @@ Unix clipboard read/write cancellation tests likewise wait for a fake command's
 readiness before canceling, cover already-canceled contexts separately, and use
 only fixed fixture text without reading or changing the developer's clipboard.
 
+Shared external-command lifecycle tests launch only private `t.TempDir()`
+backends. They verify that descendants holding inherited stdin/stdout cannot
+extend a call beyond the named cleanup delay and that the isolated Unix process
+group is gone afterward; they do not access real OCR, clipboard, compositor, or
+desktop data.
+
 Linux alert tests replace every external dialog backend through a private test
 `PATH`. They verify fallback order, user rejection, missing/failed backends, and
 the non-interactive notification boundary without displaying real UI.

--- a/clipboard/clipboard_darwin.go
+++ b/clipboard/clipboard_darwin.go
@@ -10,8 +10,9 @@ package clipboard
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
+
+	commandpkg "github.com/marang/robotgo/internal/command"
 )
 
 var (
@@ -29,8 +30,7 @@ func readAllContext(ctx context.Context, selection Selection) (string, error) {
 	if selection != SelectionClipboard {
 		return "", fmt.Errorf("clipboard: primary selection is unsupported on macOS")
 	}
-	pasteCmd := exec.CommandContext(ctx, pasteCmdArgs)
-	out, err := pasteCmd.Output()
+	out, err := commandpkg.Output(ctx, pasteCmdArgs)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", ctxErr
@@ -50,9 +50,7 @@ func writeAllContext(ctx context.Context, text string, selection Selection) erro
 	if selection != SelectionClipboard {
 		return fmt.Errorf("clipboard: primary selection is unsupported on macOS")
 	}
-	copyCmd := exec.CommandContext(ctx, copyCmdArgs)
-	copyCmd.Stdin = strings.NewReader(text)
-	if err := copyCmd.Run(); err != nil {
+	if err := commandpkg.Run(ctx, strings.NewReader(text), copyCmdArgs); err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}

--- a/clipboard/clipboard_unix.go
+++ b/clipboard/clipboard_unix.go
@@ -12,6 +12,8 @@ import (
 	"errors"
 	"os/exec"
 	"strings"
+
+	commandpkg "github.com/marang/robotgo/internal/command"
 )
 
 const (
@@ -87,7 +89,7 @@ func readAllContext(ctx context.Context, selection Selection) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	out, err := exec.CommandContext(ctx, name, args...).Output()
+	out, err := commandpkg.Output(ctx, name, args...)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", ctxErr
@@ -112,9 +114,7 @@ func writeAllContext(ctx context.Context, text string, selection Selection) erro
 	if err != nil {
 		return err
 	}
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Stdin = strings.NewReader(text)
-	if err := cmd.Run(); err != nil {
+	if err := commandpkg.Run(ctx, strings.NewReader(text), name, args...); err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,0 +1,57 @@
+// Package command provides the bounded lifecycle used by RobotGo's one-shot
+// external command backends.
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// CleanupDelay bounds the time spent waiting for inherited command I/O to
+// close after the direct process exits or its context is canceled.
+const CleanupDelay = 250 * time.Millisecond
+
+// Output runs a one-shot command and returns its standard output. It returns
+// exec.ErrWaitDelay when inherited I/O remains open past CleanupDelay.
+func Output(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := newContextCommand(ctx, name, args...)
+	output, err := cmd.Output()
+	return output, finish(cmd, err)
+}
+
+// Run runs a one-shot command with the supplied standard input. It returns
+// exec.ErrWaitDelay when inherited I/O remains open past CleanupDelay.
+func Run(ctx context.Context, stdin io.Reader, name string, args ...string) error {
+	cmd := newContextCommand(ctx, name, args...)
+	cmd.Stdin = stdin
+	return finish(cmd, cmd.Run())
+}
+
+func newContextCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = CleanupDelay
+	configureProcessTree(cmd)
+	return cmd
+}
+
+func finish(cmd *exec.Cmd, commandErr error) error {
+	if commandErr == nil {
+		return nil
+	}
+	cleanupErr := terminateProcessTree(cmd)
+	if cleanupErr == nil || errors.Is(cleanupErr, os.ErrProcessDone) {
+		return commandErr
+	}
+	return errors.Join(
+		commandErr,
+		fmt.Errorf("terminate external command process tree: %w", cleanupErr),
+	)
+}

--- a/internal/command/command_unix_test.go
+++ b/internal/command/command_unix_test.go
@@ -5,9 +5,11 @@ package command
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -73,8 +75,8 @@ func requireTestProcessGone(t *testing.T, process int) {
 	t.Helper()
 	deadline := time.Now().Add(commandTestTimeout)
 	for {
-		err := syscall.Kill(process, 0)
-		if errors.Is(err, syscall.ESRCH) {
+		terminated, err := testProcessTerminated(process)
+		if terminated {
 			return
 		}
 		if err != nil {
@@ -84,6 +86,67 @@ func requireTestProcessGone(t *testing.T, process int) {
 			t.Fatalf("external command child %d survived cleanup", process)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func testProcessTerminated(process int) (bool, error) {
+	err := syscall.Kill(process, 0)
+	if errors.Is(err, syscall.ESRCH) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if runtime.GOOS != "linux" {
+		return false, nil
+	}
+
+	// A container's PID 1 may not reap orphaned descendants. Linux still lets
+	// kill(pid, 0) find such a zombie even though it can no longer execute or
+	// retain inherited I/O, so inspect the kernel state before waiting again.
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(process) + "/stat")
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ESRCH) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return linuxTestProcessTerminated(process, data)
+}
+
+func linuxTestProcessTerminated(process int, data []byte) (bool, error) {
+	closingParen := strings.LastIndexByte(string(data), ')')
+	if closingParen < 0 || closingParen+2 >= len(data) {
+		return false, fmt.Errorf("parse /proc status for process %d", process)
+	}
+	state := data[closingParen+2]
+	return state == 'Z' || state == 'X', nil
+}
+
+func TestLinuxTestProcessTerminated(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		stat string
+		want bool
+		err  bool
+	}{
+		{name: "running", stat: "42 (backend worker) S 1", want: false},
+		{name: "zombie", stat: "42 (backend worker) Z 1", want: true},
+		{name: "dead", stat: "42 (backend worker) X 1", want: true},
+		{name: "closing parenthesis in name", stat: "42 (backend) worker) Z 1", want: true},
+		{name: "malformed", stat: "42 backend Z 1", err: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := linuxTestProcessTerminated(42, []byte(tc.stat))
+			if (err != nil) != tc.err {
+				t.Fatalf("error = %v, want error %t", err, tc.err)
+			}
+			if got != tc.want {
+				t.Fatalf("terminated = %t, want %t", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/command/command_unix_test.go
+++ b/internal/command/command_unix_test.go
@@ -17,6 +17,11 @@ import (
 
 const commandTestTimeout = 2 * time.Second
 
+type testProcesses struct {
+	processGroup int
+	child        int
+}
+
 func writeTestCommand(t *testing.T, script string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "backend")
@@ -26,57 +31,69 @@ func writeTestCommand(t *testing.T, script string) string {
 	return path
 }
 
-func readTestProcessGroup(t *testing.T, path string) int {
+func parseTestProcesses(t *testing.T, data []byte) testProcesses {
+	t.Helper()
+	fields := strings.Fields(string(data))
+	if len(fields) != 2 {
+		t.Fatalf("process record = %q, want process group and child PID", data)
+	}
+	processGroup, err := strconv.Atoi(fields[0])
+	if err != nil {
+		t.Fatalf("parse process group %q: %v", data, err)
+	}
+	child, err := strconv.Atoi(fields[1])
+	if err != nil {
+		t.Fatalf("parse child PID %q: %v", data, err)
+	}
+	return testProcesses{processGroup: processGroup, child: child}
+}
+
+func readTestProcesses(t *testing.T, path string) testProcesses {
 	t.Helper()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	processGroup, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		t.Fatalf("parse process group %q: %v", data, err)
-	}
-	return processGroup
+	return parseTestProcesses(t, data)
 }
 
-func cleanupTestProcessGroup(t *testing.T, processGroup *int) {
+func cleanupTestProcesses(t *testing.T, processes *testProcesses) {
 	t.Helper()
 	t.Cleanup(func() {
-		if *processGroup > 0 {
-			_ = syscall.Kill(-*processGroup, syscall.SIGKILL)
+		if processes.processGroup > 0 {
+			_ = syscall.Kill(-processes.processGroup, syscall.SIGKILL)
+		}
+		if processes.child > 0 {
+			_ = syscall.Kill(processes.child, syscall.SIGKILL)
 		}
 	})
 }
 
-func requireTestProcessGroupGone(t *testing.T, processGroup int) {
+func requireTestProcessGone(t *testing.T, process int) {
 	t.Helper()
 	deadline := time.Now().Add(commandTestTimeout)
 	for {
-		err := syscall.Kill(-processGroup, 0)
+		err := syscall.Kill(process, 0)
 		if errors.Is(err, syscall.ESRCH) {
 			return
 		}
 		if err != nil {
-			t.Fatalf("probe process group %d: %v", processGroup, err)
+			t.Fatalf("probe process %d: %v", process, err)
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("external command process group %d survived cleanup", processGroup)
+			t.Fatalf("external command child %d survived cleanup", process)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 }
 
-func waitForTestProcessGroup(t *testing.T, path string) int {
+func waitForTestProcesses(t *testing.T, path string) testProcesses {
 	t.Helper()
 	deadline := time.Now().Add(commandTestTimeout)
 	for {
 		data, err := os.ReadFile(path)
 		if err == nil {
-			processGroup, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
-			if parseErr != nil {
-				t.Fatalf("parse process group %q: %v", data, parseErr)
-			}
-			return processGroup
+			return parseTestProcesses(t, data)
 		}
 		if !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("read process group: %v", err)
@@ -92,12 +109,13 @@ func TestOutputBoundsInheritedStandardOutput(t *testing.T) {
 	pidPath := filepath.Join(t.TempDir(), "process-group")
 	t.Setenv("ROBOTGO_COMMAND_TEST_PGID", pidPath)
 	backend := writeTestCommand(t, `#!/bin/sh
-/bin/sleep 2 &
-printf '%s' "$$" > "$ROBOTGO_COMMAND_TEST_PGID"
+/bin/sleep 5 &
+child=$!
+printf '%s %s' "$$" "$child" > "$ROBOTGO_COMMAND_TEST_PGID"
 printf ready
 `)
-	processGroup := 0
-	cleanupTestProcessGroup(t, &processGroup)
+	processes := testProcesses{}
+	cleanupTestProcesses(t, &processes)
 
 	started := time.Now()
 	output, err := Output(context.Background(), backend)
@@ -111,8 +129,8 @@ printf ready
 	if elapsed >= commandTestTimeout {
 		t.Fatalf("Output waited %s for inherited stdout", elapsed)
 	}
-	processGroup = readTestProcessGroup(t, pidPath)
-	requireTestProcessGroupGone(t, processGroup)
+	processes = readTestProcesses(t, pidPath)
+	requireTestProcessGone(t, processes.child)
 }
 
 func TestRunBoundsInheritedStandardInput(t *testing.T) {
@@ -120,11 +138,12 @@ func TestRunBoundsInheritedStandardInput(t *testing.T) {
 	t.Setenv("ROBOTGO_COMMAND_TEST_PGID", pidPath)
 	backend := writeTestCommand(t, `#!/bin/sh
 exec 3<&0
-/bin/sleep 2 <&3 &
-printf '%s' "$$" > "$ROBOTGO_COMMAND_TEST_PGID"
+/bin/sleep 5 <&3 &
+child=$!
+printf '%s %s' "$$" "$child" > "$ROBOTGO_COMMAND_TEST_PGID"
 `)
-	processGroup := 0
-	cleanupTestProcessGroup(t, &processGroup)
+	processes := testProcesses{}
+	cleanupTestProcesses(t, &processes)
 
 	input := strings.NewReader(strings.Repeat("x", 8<<20))
 	started := time.Now()
@@ -136,20 +155,21 @@ printf '%s' "$$" > "$ROBOTGO_COMMAND_TEST_PGID"
 	if elapsed >= commandTestTimeout {
 		t.Fatalf("Run waited %s for inherited stdin", elapsed)
 	}
-	processGroup = readTestProcessGroup(t, pidPath)
-	requireTestProcessGroupGone(t, processGroup)
+	processes = readTestProcesses(t, pidPath)
+	requireTestProcessGone(t, processes.child)
 }
 
 func TestOutputCancellationTerminatesProcessGroup(t *testing.T) {
 	pidPath := filepath.Join(t.TempDir(), "process-group")
 	t.Setenv("ROBOTGO_COMMAND_TEST_PGID", pidPath)
 	backend := writeTestCommand(t, `#!/bin/sh
-/bin/sleep 2 &
-printf '%s' "$$" > "$ROBOTGO_COMMAND_TEST_PGID"
+/bin/sleep 5 &
+child=$!
+printf '%s %s' "$$" "$child" > "$ROBOTGO_COMMAND_TEST_PGID"
 wait
 `)
-	processGroup := 0
-	cleanupTestProcessGroup(t, &processGroup)
+	processes := testProcesses{}
+	cleanupTestProcesses(t, &processes)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -158,7 +178,7 @@ wait
 		_, err := Output(ctx, backend)
 		result <- err
 	}()
-	processGroup = waitForTestProcessGroup(t, pidPath)
+	processes = waitForTestProcesses(t, pidPath)
 	cancel()
 
 	select {
@@ -169,5 +189,5 @@ wait
 	case <-time.After(commandTestTimeout):
 		t.Fatal("canceled Output did not return within cleanup bound")
 	}
-	requireTestProcessGroupGone(t, processGroup)
+	requireTestProcessGone(t, processes.child)
 }

--- a/internal/command/command_unix_test.go
+++ b/internal/command/command_unix_test.go
@@ -1,0 +1,173 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package command
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const commandTestTimeout = 2 * time.Second
+
+func writeTestCommand(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "backend")
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readTestProcessGroup(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	processGroup, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parse process group %q: %v", data, err)
+	}
+	return processGroup
+}
+
+func cleanupTestProcessGroup(t *testing.T, processGroup *int) {
+	t.Helper()
+	t.Cleanup(func() {
+		if *processGroup > 0 {
+			_ = syscall.Kill(-*processGroup, syscall.SIGKILL)
+		}
+	})
+}
+
+func requireTestProcessGroupGone(t *testing.T, processGroup int) {
+	t.Helper()
+	deadline := time.Now().Add(commandTestTimeout)
+	for {
+		err := syscall.Kill(-processGroup, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("probe process group %d: %v", processGroup, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("external command process group %d survived cleanup", processGroup)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForTestProcessGroup(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(commandTestTimeout)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			processGroup, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr != nil {
+				t.Fatalf("parse process group %q: %v", data, parseErr)
+			}
+			return processGroup
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read process group: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for external command process group")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestOutputBoundsInheritedStandardOutput(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "process-group")
+	t.Setenv("ROBOTGO_COMMAND_TEST_PGID", pidPath)
+	backend := writeTestCommand(t, `#!/bin/sh
+/bin/sleep 2 &
+printf '%s' "$$" > "$ROBOTGO_COMMAND_TEST_PGID"
+printf ready
+`)
+	processGroup := 0
+	cleanupTestProcessGroup(t, &processGroup)
+
+	started := time.Now()
+	output, err := Output(context.Background(), backend)
+	elapsed := time.Since(started)
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("Output error = %v, want exec.ErrWaitDelay", err)
+	}
+	if string(output) != "ready" {
+		t.Fatalf("Output = %q, want ready", output)
+	}
+	if elapsed >= commandTestTimeout {
+		t.Fatalf("Output waited %s for inherited stdout", elapsed)
+	}
+	processGroup = readTestProcessGroup(t, pidPath)
+	requireTestProcessGroupGone(t, processGroup)
+}
+
+func TestRunBoundsInheritedStandardInput(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "process-group")
+	t.Setenv("ROBOTGO_COMMAND_TEST_PGID", pidPath)
+	backend := writeTestCommand(t, `#!/bin/sh
+exec 3<&0
+/bin/sleep 2 <&3 &
+printf '%s' "$$" > "$ROBOTGO_COMMAND_TEST_PGID"
+`)
+	processGroup := 0
+	cleanupTestProcessGroup(t, &processGroup)
+
+	input := strings.NewReader(strings.Repeat("x", 8<<20))
+	started := time.Now()
+	err := Run(context.Background(), input, backend)
+	elapsed := time.Since(started)
+	if !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("Run error = %v, want exec.ErrWaitDelay", err)
+	}
+	if elapsed >= commandTestTimeout {
+		t.Fatalf("Run waited %s for inherited stdin", elapsed)
+	}
+	processGroup = readTestProcessGroup(t, pidPath)
+	requireTestProcessGroupGone(t, processGroup)
+}
+
+func TestOutputCancellationTerminatesProcessGroup(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "process-group")
+	t.Setenv("ROBOTGO_COMMAND_TEST_PGID", pidPath)
+	backend := writeTestCommand(t, `#!/bin/sh
+/bin/sleep 2 &
+printf '%s' "$$" > "$ROBOTGO_COMMAND_TEST_PGID"
+wait
+`)
+	processGroup := 0
+	cleanupTestProcessGroup(t, &processGroup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := Output(ctx, backend)
+		result <- err
+	}()
+	processGroup = waitForTestProcessGroup(t, pidPath)
+	cancel()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("canceled Output returned nil error")
+		}
+	case <-time.After(commandTestTimeout):
+		t.Fatal("canceled Output did not return within cleanup bound")
+	}
+	requireTestProcessGroupGone(t, processGroup)
+}

--- a/internal/command/process_other.go
+++ b/internal/command/process_other.go
@@ -1,0 +1,17 @@
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package command
+
+import (
+	"os"
+	"os/exec"
+)
+
+func configureProcessTree(*exec.Cmd) {}
+
+func terminateProcessTree(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	return cmd.Process.Kill()
+}

--- a/internal/command/process_unix.go
+++ b/internal/command/process_unix.go
@@ -1,0 +1,30 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package command
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureProcessTree(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return terminateProcessTree(cmd)
+	}
+}
+
+func terminateProcessTree(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
+}

--- a/robotgo.go
+++ b/robotgo.go
@@ -71,6 +71,7 @@ import (
 	"unsafe"
 
 	inputportal "github.com/marang/robotgo/input/portal"
+	commandpkg "github.com/marang/robotgo/internal/command"
 	portalpkg "github.com/marang/robotgo/screen/portal"
 	"github.com/vcaesar/tt"
 )
@@ -645,7 +646,7 @@ func waylandScreenBoundsFallback() (Rect, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(ctx, path).Output()
+	out, err := commandpkg.Output(ctx, path)
 	if err != nil {
 		waylandBoundsMu.Lock()
 		waylandBoundsProbed = true

--- a/robotgo_ocr_cli.go
+++ b/robotgo_ocr_cli.go
@@ -4,8 +4,9 @@ package robotgo
 
 import (
 	"context"
-	"os/exec"
 	"time"
+
+	commandpkg "github.com/marang/robotgo/internal/command"
 )
 
 const defaultOCRTimeout = 2 * time.Minute
@@ -33,7 +34,7 @@ func GetTextContext(ctx context.Context, imgPath string, args ...string) (string
 		}
 	}
 
-	body, err := exec.CommandContext(ctx, "tesseract", imgPath, "stdout", "-l", lang).Output()
+	body, err := commandpkg.Output(ctx, "tesseract", imgPath, "stdout", "-l", lang)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", ctxErr

--- a/window_backend.go
+++ b/window_backend.go
@@ -7,10 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os/exec"
 	"runtime"
 	"strings"
 	"time"
+
+	commandpkg "github.com/marang/robotgo/internal/command"
 )
 
 const (
@@ -61,7 +62,7 @@ var (
 	errWindowOperationFailed     = errors.New("window operation failed for compositor backend")
 	errHyprlandStatusUnavailable = errors.New("hyprland status request unavailable")
 	runWindowCommand             = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-		return exec.CommandContext(ctx, name, args...).Output()
+		return commandpkg.Output(ctx, name, args...)
 	}
 )
 


### PR DESCRIPTION
## Outcome

Add one shared bounded lifecycle for RobotGo's context-backed external commands so inherited I/O descriptors and backend descendants cannot keep automation calls blocked indefinitely.

## Why

`exec.CommandContext` leaves `Cmd.WaitDelay` unset. Go therefore allows `Output`/ `Run` to wait for inherited pipes held by orphaned subprocesses after the direct command exits.

A hermetic reproduction used a 100 ms context and a successful direct parent whose background child held stdout. The call returned only after 2 seconds with `nil`, while the context had already expired.

Linear: https://linear.app/riotbox/issue/LAB-9/bound-external-command-io-and-descendant-cleanup

## Behavior and platform impact

- Introduces `internal/command` with a named 250 ms I/O cleanup delay.
- Routes Wayland bounds probes, compositor commands, CLI OCR, Unix clipboard, and macOS clipboard through that lifecycle.
- Unix one-shot commands run in isolated process groups.
- Context cancellation and failed/expired I/O cleanup terminate the owned process group.
- A successful parent that leaves inherited stdout open now returns `exec.ErrWaitDelay` instead of delayed false success.
- Write commands are likewise bounded when a descendant holds stdin.
- Windows and other platforms retain direct-process cancellation plus bounded Go I/O cleanup.
- Modal alerts and the separately managed X11 guardian remain intentionally unchanged.
- Command arguments remain direct; no shell evaluation is introduced in production.

## Resource, privacy, and compatibility

Public signatures and normal successful behavior are unchanged. Errors remain compatible with `errors.Is`/`errors.As`. The regression suite uses only scripts in `t.TempDir()`, fixed synthetic input, explicit cleanup fallbacks, and descendant disappearance checks. It does not read or change the real clipboard, OCR input, compositor, screen, or desktop.

## Validation

Passed locally:

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go test -tags ocr ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- both CGO and non-CGO `golangci-lint` gates
- Linux, Windows, and all supported Unix cross-compilation for `internal/command`
- macOS and Windows full non-CGO cross-compilation
- `go test -race ./internal/command -count=20`
- repeated OCR, clipboard, and window contract tests
- ASan/LeakSanitizer default suite
- hermetic Wayland sanitizer suite

The optional local `go test -tags ocr ./...` CGO build is omitted because this host lacks the external Leptonica development header `leptonica/allheaders.h`. The changed CLI OCR implementation is covered by default, non-CGO, tagged non-CGO, race, and CI builds.