### PR TITLE
fix: bound portal screenshot decoding (LAB-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,8 +679,11 @@ Pure-Go CoreGraphics, Windows, or X11 screenshot backend where available.
 Wayland sessions use this fork's hardened screenshot portal and preserve
 `ROBOTGO_DISABLE_PORTAL`; unsupported targets return `ErrNotSupported`
 explicitly. Portal-provided temporary screenshot files are unlinked immediately
-after opening, including decode-error paths, so sensitive desktop images are
-not left behind. On macOS, capture returns `ErrPermissionDenied` with
+after an identity-verified open, including decode-error and cancellation paths,
+so sensitive desktop images are not left behind. Decoding follows the capture
+context and rejects symlinks, changed file identities, encoded or estimated
+decoded PNG data above 512 MiB, and dimensions above 32,768 pixels per axis.
+On macOS, capture returns `ErrPermissionDenied` with
 remediation when Screen Recording access is absent; capability inspection
 never requests that permission implicitly.
 

--- a/TEST.md
+++ b/TEST.md
@@ -77,7 +77,10 @@ Default Linux screen tests use hermetic portal fixtures rather than persisting
 the developer's real desktop. Portal regression tests require temporary
 screenshot files to be absent after successful decoding and after decode
 failures. The production portal reader unlinks the sensitive file immediately
-after opening it.
+after an identity-verified open. Hermetic tests also cover cancellation,
+symlink and replacement rejection, sparse oversized files, and PNG headers that
+would otherwise request excessive decoder allocation; they never capture the
+developer's desktop.
 
 The command-backed OCR cancellation test waits for its fake backend to publish
 the private image path before canceling. It then requires bounded command

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -92,7 +92,9 @@ capabilities and the capture debug trace.
 
 Current status: the one-shot native and screenshot-portal paths are hardened,
 including timeout, portal request-race, crop, DMA-BUF failure, and FD ownership
-regressions. An opt-in `pipewire` build now opens one ScreenCast consent session,
+regressions. Portal artifacts are unlinked after an identity-verified open and
+decoded with cancellation, encoded-size, dimension, and allocation bounds. An
+opt-in `pipewire` build now opens one ScreenCast consent session,
 owns its PipeWire remote and stream deterministically, returns repeated raw
 frames, converts supported RGB/BGR formats to RGBA, maps logical regions at
 fractional scale, applies all eight SPA video transforms and crop metadata,

--- a/screen/portal/screenshot_portal.go
+++ b/screen/portal/screenshot_portal.go
@@ -4,10 +4,12 @@ package portal
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"image"
 	"image/png"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -25,7 +27,14 @@ const (
 	portalResponse    = portalRequestIF + ".Response"
 	portalScreenshot  = "org.freedesktop.portal.Screenshot.Screenshot"
 	portalTimeout     = 10 * time.Second
+
+	portalScreenshotMaxEncodedBytes = int64(512 << 20)
+	portalScreenshotMaxDecodedBytes = int64(512 << 20)
+	portalScreenshotMaxDimension    = int64(32_768)
+	portalPNGHeaderSize             = 29
 )
+
+const portalPNGSignature = "\x89PNG\r\n\x1a\n"
 
 var portalTokenCounter atomic.Uint64
 
@@ -204,7 +213,7 @@ func captureRegionImage(ctx context.Context, portal screenshotPortal, x, y, w, h
 			if err != nil {
 				return nil, err
 			}
-			img, err := decodeFileURI(uri)
+			img, err := decodeFileURI(ctx, uri)
 			if err != nil {
 				return nil, err
 			}
@@ -257,64 +266,229 @@ func responseURI(sig *dbus.Signal) (string, error) {
 	return uri, nil
 }
 
-func decodeFileURI(rawURI string) (image.Image, error) {
+func decodeFileURI(ctx context.Context, rawURI string) (img image.Image, retErr error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	path, err := portalScreenshotPath(rawURI)
+	if err != nil {
+		return nil, err
+	}
+	f, info, err := openAndUnlinkPortalScreenshot(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("portal: close screenshot: %w", closeErr))
+		}
+	}()
+
+	return decodePortalScreenshot(ctx, f, info.Size())
+}
+
+func portalScreenshotPath(rawURI string) (string, error) {
 	u, err := url.Parse(rawURI)
 	if err != nil {
-		return nil, fmt.Errorf("portal: parse screenshot uri: %w", err)
+		return "", fmt.Errorf("portal: parse screenshot uri: %w", err)
 	}
 	if u.Scheme != "file" || (u.Host != "" && u.Host != "localhost") {
-		return nil, fmt.Errorf("portal: unsupported screenshot uri %q", rawURI)
+		return "", fmt.Errorf("portal: unsupported screenshot uri %q", rawURI)
 	}
 	path, err := url.PathUnescape(u.EscapedPath())
 	if err != nil {
-		return nil, fmt.Errorf("portal: decode screenshot path: %w", err)
+		return "", fmt.Errorf("portal: decode screenshot path: %w", err)
 	}
 	path = filepath.FromSlash(path)
 	if path == "" {
-		return nil, errors.New("portal: empty screenshot path")
+		return "", errors.New("portal: empty screenshot path")
 	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("portal: screenshot path is not absolute: %q", path)
+	}
+	return path, nil
+}
 
-	info, err := os.Lstat(path)
+func openAndUnlinkPortalScreenshot(path string) (f *os.File, openedInfo os.FileInfo, retErr error) {
+	expectedInfo, err := os.Lstat(path)
 	if err != nil {
-		return nil, fmt.Errorf("portal: inspect screenshot: %w", err)
+		return nil, nil, fmt.Errorf("portal: inspect screenshot: %w", err)
 	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("portal: screenshot is not a regular file: %q", path)
+	if !expectedInfo.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("portal: screenshot is not a regular file: %q", path)
 	}
-	f, err := os.Open(path)
+	f, err = os.Open(path)
 	if err != nil {
 		openErr := fmt.Errorf("portal: open screenshot: %w", err)
-		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			return nil, errors.Join(
+		if removeErr := removeVerifiedPortalScreenshot(path, expectedInfo); removeErr != nil {
+			return nil, nil, errors.Join(
 				openErr,
 				fmt.Errorf("portal: remove sensitive screenshot after open failure: %w", removeErr),
 			)
 		}
-		return nil, openErr
+		return nil, nil, openErr
+	}
+	cleanupAttempted := false
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if closeErr := f.Close(); closeErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("portal: close screenshot after setup failure: %w", closeErr))
+		}
+		if cleanupAttempted {
+			return
+		}
+		if cleanupErr := removeVerifiedPortalScreenshot(path, expectedInfo); cleanupErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("portal: remove sensitive screenshot: %w", cleanupErr))
+		}
+	}()
+
+	openedInfo, err = f.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("portal: inspect opened screenshot: %w", err)
+	}
+	if err := verifyPortalScreenshotIdentity(expectedInfo, openedInfo); err != nil {
+		return nil, nil, err
 	}
 	// The portal artifact contains the user's desktop. Unlink it immediately
 	// after opening so it cannot remain on disk if decoding or later processing
 	// fails. Linux keeps the opened contents available through f until close.
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		closeErr := f.Close()
-		removeErr := fmt.Errorf("portal: remove sensitive screenshot: %w", err)
-		if closeErr != nil {
-			return nil, errors.Join(
-				removeErr,
-				fmt.Errorf("portal: close screenshot after cleanup failure: %w", closeErr),
-			)
-		}
-		return nil, removeErr
+	cleanupAttempted = true
+	if removeErr := removeVerifiedPortalScreenshot(path, openedInfo); removeErr != nil {
+		return nil, nil, fmt.Errorf("portal: remove sensitive screenshot: %w", removeErr)
 	}
-	img, decodeErr := png.Decode(f)
-	closeErr := f.Close()
-	if decodeErr != nil {
-		return nil, fmt.Errorf("portal: decode screenshot: %w", decodeErr)
+	return f, openedInfo, nil
+}
+
+func decodePortalScreenshot(ctx context.Context, f *os.File, encodedSize int64) (image.Image, error) {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, fmt.Errorf("portal: decode screenshot: %w", ctxErr)
 	}
-	if closeErr != nil {
-		return nil, fmt.Errorf("portal: close screenshot: %w", closeErr)
+	if encodedSize < 0 || encodedSize > portalScreenshotMaxEncodedBytes {
+		return nil, fmt.Errorf(
+			"portal: screenshot file size %d exceeds limit %d",
+			encodedSize, portalScreenshotMaxEncodedBytes,
+		)
+	}
+
+	config, err := png.DecodeConfig(&portalContextReader{
+		ctx:    ctx,
+		reader: io.LimitReader(f, portalScreenshotMaxEncodedBytes),
+	})
+	if err != nil {
+		return nil, portalScreenshotDecodeError(ctx, "inspect", err)
+	}
+	if err := validatePortalScreenshotConfig(f, config); err != nil {
+		return nil, err
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("portal: rewind screenshot: %w", err)
+	}
+	img, err := png.Decode(&portalContextReader{
+		ctx:    ctx,
+		reader: io.LimitReader(f, portalScreenshotMaxEncodedBytes),
+	})
+	if err != nil {
+		return nil, portalScreenshotDecodeError(ctx, "decode", err)
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, fmt.Errorf("portal: decode screenshot: %w", ctxErr)
 	}
 	return img, nil
+}
+
+type portalContextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *portalContextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(p)
+}
+
+func verifyPortalScreenshotIdentity(expected, actual os.FileInfo) error {
+	if expected == nil || actual == nil || !expected.Mode().IsRegular() || !actual.Mode().IsRegular() {
+		return errors.New("portal: screenshot file identity is not regular")
+	}
+	if !os.SameFile(expected, actual) {
+		return errors.New("portal: screenshot file changed before sensitive cleanup")
+	}
+	return nil
+}
+
+func removeVerifiedPortalScreenshot(path string, expected os.FileInfo) error {
+	current, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("re-inspect screenshot before cleanup: %w", err)
+	}
+	if err := verifyPortalScreenshotIdentity(expected, current); err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func validatePortalScreenshotConfig(f *os.File, config image.Config) error {
+	if config.Width <= 0 || config.Height <= 0 {
+		return fmt.Errorf("portal: invalid screenshot dimensions %dx%d", config.Width, config.Height)
+	}
+	width, height := int64(config.Width), int64(config.Height)
+	if width > portalScreenshotMaxDimension || height > portalScreenshotMaxDimension {
+		return fmt.Errorf(
+			"portal: screenshot dimensions %dx%d exceed per-axis limit %d",
+			config.Width, config.Height, portalScreenshotMaxDimension,
+		)
+	}
+
+	header := make([]byte, portalPNGHeaderSize)
+	if _, err := f.ReadAt(header, 0); err != nil {
+		return fmt.Errorf("portal: read screenshot PNG header: %w", err)
+	}
+	if string(header[:len(portalPNGSignature)]) != portalPNGSignature ||
+		string(header[12:16]) != "IHDR" {
+		return errors.New("portal: invalid screenshot PNG header")
+	}
+	headerWidth := int64(binary.BigEndian.Uint32(header[16:20]))
+	headerHeight := int64(binary.BigEndian.Uint32(header[20:24]))
+	if headerWidth != width || headerHeight != height {
+		return errors.New("portal: screenshot PNG header changed during validation")
+	}
+
+	bytesPerPixel := int64(4)
+	if header[24] == 16 {
+		bytesPerPixel = 8
+	} else if header[25] == 3 {
+		bytesPerPixel = 1
+	}
+	allocationFactor := bytesPerPixel
+	if header[28] != 0 {
+		// Adam7 holds the full destination and one partial pass concurrently.
+		allocationFactor *= 2
+	}
+	decodedBytes := width * height * allocationFactor
+	if decodedBytes > portalScreenshotMaxDecodedBytes {
+		return fmt.Errorf(
+			"portal: estimated screenshot decode size %d exceeds limit %d",
+			decodedBytes, portalScreenshotMaxDecodedBytes,
+		)
+	}
+	return nil
+}
+
+func portalScreenshotDecodeError(ctx context.Context, operation string, decodeErr error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("portal: %s screenshot: %w", operation, ctxErr)
+	}
+	return fmt.Errorf("portal: %s screenshot: %w", operation, decodeErr)
 }
 
 func cropImage(img image.Image, x, y, w, h int) (image.Image, error) {

--- a/screen/portal/screenshot_portal_test.go
+++ b/screen/portal/screenshot_portal_test.go
@@ -4,12 +4,15 @@ package portal
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"hash/crc32"
 	"image"
 	"image/color"
 	"image/png"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,6 +77,23 @@ func writeTestPNG(t *testing.T) (string, string) {
 		t.Fatal(err)
 	}
 	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return (&url.URL{Scheme: "file", Path: path}).String(), path
+}
+
+func writeTestPNGHeader(t *testing.T, width, height uint32) (string, string) {
+	t.Helper()
+	path := t.TempDir() + "/portal dimensions.png"
+	header := make([]byte, 0, portalPNGHeaderSize+4)
+	header = append(header, []byte(portalPNGSignature)...)
+	header = binary.BigEndian.AppendUint32(header, 13)
+	header = append(header, []byte("IHDR")...)
+	header = binary.BigEndian.AppendUint32(header, width)
+	header = binary.BigEndian.AppendUint32(header, height)
+	header = append(header, 8, 6, 0, 0, 0)
+	header = binary.BigEndian.AppendUint32(header, crc32.ChecksumIEEE(header[12:]))
+	if err := os.WriteFile(path, header, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return (&url.URL{Scheme: "file", Path: path}).String(), path
@@ -175,7 +195,7 @@ func TestCropImageOnlyTreatsZeroByZeroAsFullScreenshot(t *testing.T) {
 }
 
 func TestDecodeFileURIRejectsNonFileScheme(t *testing.T) {
-	if _, err := decodeFileURI("https://example.com/screenshot.png"); err == nil {
+	if _, err := decodeFileURI(context.Background(), "https://example.com/screenshot.png"); err == nil {
 		t.Fatal("expected unsupported URI error")
 	}
 }
@@ -186,10 +206,121 @@ func TestDecodeFileURIRemovesSensitiveArtifactOnDecodeFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	uri := (&url.URL{Scheme: "file", Path: path}).String()
-	if _, err := decodeFileURI(uri); err == nil {
+	if _, err := decodeFileURI(context.Background(), uri); err == nil {
 		t.Fatal("expected PNG decode error")
 	}
 	assertSensitiveArtifactRemoved(t, path)
+}
+
+func TestDecodeFileURIRemovesSensitiveArtifactWhenContextCanceled(t *testing.T) {
+	uri, path := writeTestPNG(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := decodeFileURI(ctx, uri); !errors.Is(err, context.Canceled) {
+		t.Fatalf("decodeFileURI error = %v, want context.Canceled", err)
+	}
+	assertSensitiveArtifactRemoved(t, path)
+}
+
+func TestDecodeFileURIRejectsOversizedArtifactBeforeDecode(t *testing.T) {
+	uri, path := writeTestPNG(t)
+	if err := os.Truncate(path, portalScreenshotMaxEncodedBytes+1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeFileURI(context.Background(), uri); err == nil ||
+		!strings.Contains(err.Error(), "file size") {
+		t.Fatalf("decodeFileURI error = %v, want file-size limit", err)
+	}
+	assertSensitiveArtifactRemoved(t, path)
+}
+
+func TestDecodeFileURIRejectsAllocationBombHeaderBeforeDecode(t *testing.T) {
+	uri, path := writeTestPNGHeader(t, uint32(portalScreenshotMaxDimension), uint32(portalScreenshotMaxDimension))
+	if _, err := decodeFileURI(context.Background(), uri); err == nil ||
+		!strings.Contains(err.Error(), "estimated screenshot decode size") {
+		t.Fatalf("decodeFileURI error = %v, want decoded-size limit", err)
+	}
+	assertSensitiveArtifactRemoved(t, path)
+}
+
+func TestDecodeFileURIRejectsSymlinkWithoutOpeningTarget(t *testing.T) {
+	_, target := writeTestPNG(t)
+	link := t.TempDir() + "/portal link.png"
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	uri := (&url.URL{Scheme: "file", Path: link}).String()
+	if _, err := decodeFileURI(context.Background(), uri); err == nil ||
+		!strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("decodeFileURI error = %v, want symlink rejection", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("symlink target was changed: %v", err)
+	}
+}
+
+func TestVerifyPortalScreenshotIdentity(t *testing.T) {
+	firstPath := t.TempDir() + "/first"
+	secondPath := t.TempDir() + "/second"
+	if err := os.WriteFile(firstPath, []byte("first"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secondPath, []byte("second"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.Stat(firstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.Stat(secondPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyPortalScreenshotIdentity(first, first); err != nil {
+		t.Fatalf("same file identity rejected: %v", err)
+	}
+	if err := verifyPortalScreenshotIdentity(first, second); err == nil {
+		t.Fatal("different file identities were accepted")
+	}
+}
+
+func TestRemoveVerifiedPortalScreenshotPreservesReplacement(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/portal.png"
+	replacement := dir + "/replacement.png"
+	if err := os.WriteFile(path, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(replacement, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeVerifiedPortalScreenshot(path, expected); err == nil {
+		t.Fatal("replacement identity was removed")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("replacement was not preserved: %v", err)
+	}
+	if string(data) != "replacement" {
+		t.Fatalf("replacement content = %q", data)
+	}
+}
+
+func TestPortalContextReaderStopsBeforeRead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	reader := &portalContextReader{ctx: ctx, reader: strings.NewReader("private pixels")}
+	buffer := make([]byte, 8)
+	if _, err := reader.Read(buffer); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Read error = %v, want context.Canceled", err)
+	}
 }
 
 func assertSensitiveArtifactRemoved(t *testing.T, path string) {


### PR DESCRIPTION
## Outcome

Bounds and cancels decoding of the external screenshot artifact returned by the Linux XDG Screenshot portal, while preserving RobotGo's immediate sensitive-file cleanup contract.

Linear: https://linear.app/riotbox/issue/LAB-10/bound-and-cancel-screenshot-portal-artifact-decoding

## Root cause

The portal request itself had a bounded context, but the returned file URI was decoded with an unbounded `png.Decode`. A portal artifact was only checked for being a regular file; it had no encoded-size, dimension, decoded-allocation, or cancellation boundary. Since PNG dimensions are supplied by the external IHDR header, the standard decoder can allocate its destination before the complete image has been validated.

The portal API contract returns a URI to an accessible screenshot artifact; it does not define image dimensions or a resource budget:
https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Screenshot.html

## Changes

- propagate the active capture context into artifact decoding
- accept only absolute local `file:` URIs and reject symlinks
- verify file identity across inspect/open/cleanup boundaries
- unlink the sensitive screenshot immediately after an identity-verified open
- bound encoded input and estimated decoder allocation to 512 MiB and each axis to 32,768 pixels
- inspect PNG configuration before the full decoder can allocate its destination
- preserve `context.Canceled` and `context.DeadlineExceeded` in returned errors
- document the behavior in README, TEST, and the product roadmap

## Structured boundary review

- **Architecture:** URI validation, artifact ownership, and image decoding are separate helpers rather than one interleaved lifecycle.
- **Resource/privacy:** every owned regular artifact is unlinked before decoding; setup, decode, cancellation, and close errors remain observable.
- **Identity/security:** symlinks and changed inodes are rejected; a replacement path is preserved rather than deleted.
- **Performance:** encoded reads, per-axis dimensions, estimated destination/interlace allocation, and cancellation are bounded.
- **Platform/build tags:** the implementation remains in the existing Linux-only portal file; non-CGO and non-Linux cross-builds remain green.
- **Compatibility:** no exported API changes and no backend/fallback order changes.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go test -race ./screen/portal -count=20`
- `go test -tags portal ./screen/portal -count=1`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=1 golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0 golangci-lint run --timeout=5m ./...`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 go test -asan -count=1 ./...`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:strict_string_checks=1 scripts/run-wayland-sanitizer-tests.sh`
- `GOOS=darwin CGO_ENABLED=0 go test -exec=true ./...`
- `GOOS=windows CGO_ENABLED=0 go test -exec=true ./...`
- `git diff --check`

Tests are hermetic, use synthetic PNGs and `t.TempDir()`, assert cleanup on success/error/cancellation/resource-limit paths, and never capture the developer desktop.

## Runtime evidence

No new live-desktop run is needed for this internal artifact-decoding hardening: public usage and portal negotiation are unchanged. The existing portal capture example remains applicable; adding another example would duplicate it.