### PR TITLE
feat: add policy-gated agent session core (LAB-11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,9 @@ move/click/text requests, and sanitized structured results. Its catalog reports
 that the underlying input backend remains process-global and that cancellation
 is currently guaranteed before dispatch, not during a synchronous OS input
 call. Direct callers of legacy RobotGo APIs remain outside this exclusivity.
+For pointer moves, `AllowedDisplayIDs` fails closed: the selected display must
+be allowed and the global target coordinates must fall within its live bounds.
+If display geometry cannot be resolved, no input is injected.
 
 The example is validation-only by default and never injects input unless
 `-act` is supplied explicitly:

--- a/README.md
+++ b/README.md
@@ -490,6 +490,9 @@ falls back to the aggregate desktop. Native
 the core-output fallback applies integer scale and all eight transforms. The
 Pure-Go query is read-only, bounded, closes its Unix connection after every
 atomic snapshot, and never opens a portal consent dialog.
+Native `zwlr_virtual_pointer_v1` absolute moves use the same aggregate logical
+origin, so displays positioned left of or above the primary output do not wrap
+negative global coordinates into the protocol's unsigned absolute frame.
 
 Capture selection is:
 

--- a/README.md
+++ b/README.md
@@ -739,6 +739,24 @@ go run ./examples/runtime_diagnostics
 go run -tags wayland ./examples/linux_capabilities
 ```
 
+### Policy-gated agent sessions
+
+The `agent` package adds a strict Go boundary for automation agents without
+changing the legacy package-level API. One process-exclusive session exposes a
+versioned operation catalog, policy and confirmation gates, dry-run, typed
+move/click/text requests, and sanitized structured results. Its catalog reports
+that the underlying input backend remains process-global and that cancellation
+is currently guaranteed before dispatch, not during a synchronous OS input
+call. Direct callers of legacy RobotGo APIs remain outside this exclusivity.
+
+The example is validation-only by default and never injects input unless
+`-act` is supplied explicitly:
+
+```bash
+go run ./examples/agent_session -operation move -x 100 -y 100 -display 0
+go run ./examples/agent_session -act -operation move -x 100 -y 100 -display 0
+```
+
 ## Examples
 
 The checked-in examples use this fork's module path and track the current API:
@@ -748,6 +766,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Screen capture and pixels](examples/screen/main.go)
 - [Full-screen capture with backend reporting](examples/screen_full/main.go)
 - [Cross-platform aggregate and per-output bounds](examples/display_bounds/main.go)
+- [Policy-gated agent session](examples/agent_session/main.go)
 - [Linux capabilities](examples/linux_capabilities/main.go)
 - [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
 - [Versioned runtime diagnostics](examples/runtime_diagnostics/main.go)

--- a/TEST.md
+++ b/TEST.md
@@ -308,7 +308,8 @@ Purpose:
 - Hermetic native absolute-pointer mapping for negative aggregate origins and
   exclusive desktop edges
 - Bounded Wayland input flush retries for transient `EAGAIN`, interrupted
-  waits, queued backpressure, and permanent transport failures
+  waits, explicit still-queued delivery errors, and permanent transport
+  failures
 - DRM helper tests
 
 Typical command:

--- a/TEST.md
+++ b/TEST.md
@@ -305,6 +305,8 @@ Purpose:
   overflow boundaries, and all eight output transforms
 - Hermetic aggregate/per-output bounds for negative origins, fractional
   `xdg-output` geometry, stable display indices, scale, and all transforms
+- Hermetic native absolute-pointer mapping for negative aggregate origins and
+  exclusive desktop edges
 - DRM helper tests
 
 Typical command:

--- a/TEST.md
+++ b/TEST.md
@@ -97,6 +97,29 @@ extend a call beyond the named cleanup delay and that the isolated Unix process
 group is gone afterward; they do not access real OCR, clipboard, compositor, or
 desktop data.
 
+Agent-session unit tests use an in-memory input driver and never contact or
+mutate the desktop. They cover process-exclusive lifecycle, concurrent close,
+strict request validation, policy/confirmation/display/text/action limits,
+dry-run, quota handling, sanitized results, backend errors, and the documented
+preflight-only cancellation boundary:
+
+```bash
+go test -race ./agent
+CGO_ENABLED=0 go test ./agent
+```
+
+The opt-in runtime path performs one real pointer move to explicit coordinates:
+
+```bash
+ROBOTGO_AGENT_INPUT_E2E=1 \
+ROBOTGO_AGENT_INPUT_X=100 ROBOTGO_AGENT_INPUT_Y=100 \
+ROBOTGO_AGENT_INPUT_DISPLAY=0 \
+go test -tags integration ./agent -run TestAgentSessionMoveRuntime -v
+```
+
+Run it only in a graphical session where global pointer movement is intended.
+It creates no screenshot, clipboard, OCR, or other persistent artifact.
+
 Linux alert tests replace every external dialog backend through a private test
 `PATH`. They verify fallback order, user rejection, missing/failed backends, and
 the non-interactive notification boundary without displaying real UI.

--- a/TEST.md
+++ b/TEST.md
@@ -367,6 +367,8 @@ Purpose:
 - Shared RemoteDesktop/ScreenCast negotiation, stream metadata, absolute
   pointer coordinates, optional touch, and restore-token handling
 - High-level CGO and non-CGO fallback dispatch after explicit consent
+- Native-to-portal absolute fallback preserves caller global coordinates even
+  when legacy native scaling is enabled
 - CGO/non-CGO parity for mouse delays and explicit consent-timeout diagnostics
 
 Command:

--- a/TEST.md
+++ b/TEST.md
@@ -100,7 +100,8 @@ desktop data.
 Agent-session unit tests use an in-memory input driver and never contact or
 mutate the desktop. They cover process-exclusive lifecycle, concurrent close,
 strict request validation, policy/confirmation/display/text/action limits,
-dry-run, quota handling, sanitized results, backend errors, and the documented
+live display-bound enforcement, dry-run, quota handling, sanitized results,
+backend errors, and the documented
 preflight-only cancellation boundary:
 
 ```bash

--- a/TEST.md
+++ b/TEST.md
@@ -307,6 +307,8 @@ Purpose:
   `xdg-output` geometry, stable display indices, scale, and all transforms
 - Hermetic native absolute-pointer mapping for negative aggregate origins and
   exclusive desktop edges
+- Bounded Wayland input flush retries for transient `EAGAIN`, interrupted
+  waits, queued backpressure, and permanent transport failures
 - DRM helper tests
 
 Typical command:

--- a/agent/catalog.go
+++ b/agent/catalog.go
@@ -1,0 +1,38 @@
+package agent
+
+import robotgo "github.com/marang/robotgo"
+
+func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCatalog {
+	return OperationCatalog{
+		SchemaVersion: CatalogSchemaVersion,
+		Operations: []OperationCapability{
+			operationCapability(OperationMove, policy, capabilities.Mouse),
+			operationCapability(OperationClick, policy, capabilities.Mouse),
+			operationCapability(OperationTypeText, policy, capabilities.Keyboard),
+		},
+	}
+}
+
+func operationCapability(operation Operation, policy Policy, feature robotgo.FeatureCapability) OperationCapability {
+	_, confirmationRequired := policy.requireConfirmation[operation]
+	_, policyAllowed := policy.allowOperation[operation]
+	remediation := feature.Notes
+	if remediation == "" {
+		remediation = feature.Reason
+	}
+	return OperationCapability{
+		Operation: operation, Available: feature.Available, PolicyAllowed: policyAllowed, Backend: feature.Backend,
+		Fallback: feature.Fallback, Risk: RiskReversibleMutation,
+		ConfirmationRequired: confirmationRequired,
+		Cancellation:         CancellationPreflightOnly,
+		ProcessGlobalBackend: true, ExclusiveAgentSession: true,
+		Reason: feature.Reason, Remediation: remediation,
+	}
+}
+
+func cloneCatalog(source OperationCatalog) OperationCatalog {
+	return OperationCatalog{
+		SchemaVersion: source.SchemaVersion,
+		Operations:    append([]OperationCapability(nil), source.Operations...),
+	}
+}

--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package agent_test
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/marang/robotgo/agent"
+)
+
+func TestAgentSessionMoveRuntime(t *testing.T) {
+	if os.Getenv("ROBOTGO_AGENT_INPUT_E2E") != "1" {
+		t.Skip("set ROBOTGO_AGENT_INPUT_E2E=1 to permit real pointer movement")
+	}
+	x := requiredCoordinate(t, "ROBOTGO_AGENT_INPUT_X")
+	y := requiredCoordinate(t, "ROBOTGO_AGENT_INPUT_Y")
+	displayID := requiredCoordinate(t, "ROBOTGO_AGENT_INPUT_DISPLAY")
+	session, err := agent.NewSession(agent.Config{Policy: agent.Policy{
+		AllowedOperations: []agent.Operation{agent.OperationMove},
+		AllowedDisplayIDs: []int{displayID},
+		MaxActions:        1,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	request := agent.ActionRequest{
+		Operation: agent.OperationMove,
+		Move:      &agent.MoveAction{X: x, Y: y, DisplayID: displayID},
+	}
+	if _, err := session.DryRun(context.Background(), request); err != nil {
+		t.Fatalf("dry-run preflight: %v", err)
+	}
+	if _, err := session.Execute(context.Background(), request); err != nil {
+		t.Fatalf("runtime move: %v", err)
+	}
+}
+
+func requiredCoordinate(t *testing.T, name string) int {
+	t.Helper()
+	value, err := strconv.Atoi(os.Getenv(name))
+	if err != nil || value < 0 {
+		t.Fatalf("%s must be a non-negative integer", name)
+	}
+	return value
+}

--- a/agent/policy.go
+++ b/agent/policy.go
@@ -1,0 +1,64 @@
+package agent
+
+import "fmt"
+
+// Policy constrains every mutation performed by a Session. Empty allow lists
+// deny access; callers must opt in explicitly.
+type Policy struct {
+	AllowedOperations   []Operation `json:"allowed_operations"`
+	ConfirmOperations   []Operation `json:"confirm_operations,omitempty"`
+	AllowedDisplayIDs   []int       `json:"allowed_display_ids,omitempty"`
+	MaxActions          uint64      `json:"max_actions"`
+	MaxTextRunes        int         `json:"max_text_runes"`
+	AllowDoubleClick    bool        `json:"allow_double_click,omitempty"`
+	allowOperation      map[Operation]struct{}
+	requireConfirmation map[Operation]struct{}
+	allowDisplay        map[int]struct{}
+}
+
+func preparePolicy(input Policy) (Policy, error) {
+	if input.MaxActions == 0 {
+		return Policy{}, fmt.Errorf("agent: max actions must be positive")
+	}
+	if input.MaxTextRunes < 0 {
+		return Policy{}, fmt.Errorf("agent: max text runes must be non-negative")
+	}
+	prepared := Policy{
+		AllowedOperations: append([]Operation(nil), input.AllowedOperations...),
+		ConfirmOperations: append([]Operation(nil), input.ConfirmOperations...),
+		AllowedDisplayIDs: append([]int(nil), input.AllowedDisplayIDs...),
+		MaxActions:        input.MaxActions, MaxTextRunes: input.MaxTextRunes,
+		AllowDoubleClick:    input.AllowDoubleClick,
+		allowOperation:      make(map[Operation]struct{}),
+		requireConfirmation: make(map[Operation]struct{}),
+		allowDisplay:        make(map[int]struct{}),
+	}
+	for _, operation := range prepared.AllowedOperations {
+		if !knownOperation(operation) {
+			return Policy{}, fmt.Errorf("agent: unknown allowed operation %q", operation)
+		}
+		prepared.allowOperation[operation] = struct{}{}
+	}
+	for _, operation := range prepared.ConfirmOperations {
+		if _, allowed := prepared.allowOperation[operation]; !allowed {
+			return Policy{}, fmt.Errorf("agent: confirmation operation %q is not allowed", operation)
+		}
+		prepared.requireConfirmation[operation] = struct{}{}
+	}
+	for _, displayID := range prepared.AllowedDisplayIDs {
+		if displayID < 0 {
+			return Policy{}, fmt.Errorf("agent: allowed display IDs must be non-negative")
+		}
+		prepared.allowDisplay[displayID] = struct{}{}
+	}
+	return prepared, nil
+}
+
+func knownOperation(operation Operation) bool {
+	switch operation {
+	case OperationMove, OperationClick, OperationTypeText:
+		return true
+	default:
+		return false
+	}
+}

--- a/agent/session.go
+++ b/agent/session.go
@@ -1,0 +1,272 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+type inputDriver interface {
+	Move(x, y, displayID int) error
+	Click(button MouseButton, double bool) error
+	TypeText(text string) error
+}
+
+type robotGoDriver struct{}
+
+func (robotGoDriver) Move(x, y, displayID int) error { return robotgo.MoveE(x, y, displayID) }
+func (robotGoDriver) Click(button MouseButton, double bool) error {
+	return robotgo.ClickE(string(button), double)
+}
+func (robotGoDriver) TypeText(text string) error { return robotgo.TypeStrE(text) }
+
+// Config defines immutable session policy.
+type Config struct {
+	Policy Policy `json:"policy"`
+}
+
+// Session serializes policy-gated desktop mutations. The underlying RobotGo
+// input backends remain process-global, so only one agent Session may exist.
+type Session struct {
+	policy  Policy
+	driver  inputDriver
+	catalog OperationCatalog
+	ctx     context.Context
+	cancel  context.CancelFunc
+
+	actionGate chan struct{}
+	used       uint64
+	closeOnce  sync.Once
+}
+
+var (
+	ownerMu      sync.Mutex
+	activeOwner  *Session
+	actionSerial atomic.Uint64
+)
+
+// NewSession creates the single active agent session for this process. Runtime
+// capability discovery is bounded and never opens a consent dialog.
+func NewSession(config Config) (*Session, error) {
+	policy, err := preparePolicy(config.Policy)
+	if err != nil {
+		return nil, err
+	}
+	capabilities := robotgo.GetRuntimeCapabilities()
+	return newSession(policy, robotGoDriver{}, capabilities)
+}
+
+func newSession(policy Policy, driver inputDriver, capabilities robotgo.RuntimeCapabilities) (*Session, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		policy: policy, driver: driver, catalog: buildCatalog(policy, capabilities),
+		ctx: ctx, cancel: cancel, actionGate: make(chan struct{}, 1),
+	}
+	s.actionGate <- struct{}{}
+	ownerMu.Lock()
+	defer ownerMu.Unlock()
+	if activeOwner != nil {
+		cancel()
+		return nil, &ActionError{Code: ErrorSessionBusy, Message: "another agent session is already active", cause: ErrSessionBusy}
+	}
+	activeOwner = s
+	return s, nil
+}
+
+// Catalog returns a defensive copy of the session's immutable catalog.
+func (s *Session) Catalog() OperationCatalog {
+	return cloneCatalog(s.catalog)
+}
+
+// Close prevents future actions, waits for an active synchronous mutation, and
+// releases the process-wide agent-session claim. It is safe to call repeatedly.
+func (s *Session) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.closeOnce.Do(func() {
+		s.cancel()
+		<-s.actionGate
+		s.actionGate <- struct{}{}
+		ownerMu.Lock()
+		if activeOwner == s {
+			activeOwner = nil
+		}
+		ownerMu.Unlock()
+	})
+	return nil
+}
+
+// DryRun performs the same shape, policy, quota, capability, and cancellation
+// preflight as Execute without injecting input or consuming action quota.
+func (s *Session) DryRun(ctx context.Context, request ActionRequest) (ActionResult, error) {
+	return s.run(ctx, request, true)
+}
+
+// Execute validates and serially performs one typed desktop mutation.
+func (s *Session) Execute(ctx context.Context, request ActionRequest) (ActionResult, error) {
+	return s.run(ctx, request, false)
+}
+
+func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (ActionResult, error) {
+	started := time.Now()
+	id := fmt.Sprintf("action-%d", actionSerial.Add(1))
+	resultOperation := request.Operation
+	if !knownOperation(resultOperation) {
+		resultOperation = ""
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return contextFailure(ctx, id, resultOperation, started)
+	case <-s.ctx.Done():
+		return actionFailure(id, resultOperation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+	case <-s.actionGate:
+	}
+	defer func() { s.actionGate <- struct{}{} }()
+	if err := ctx.Err(); err != nil {
+		return contextFailure(ctx, id, resultOperation, started)
+	}
+	select {
+	case <-s.ctx.Done():
+		return actionFailure(id, resultOperation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+	default:
+	}
+	capability, ok := s.capability(request.Operation)
+	if !ok {
+		return invalidAction(id, resultOperation, started, "unknown operation")
+	}
+	if err := validateRequest(request); err != nil {
+		return invalidAction(id, request.Operation, started, "%v", err)
+	}
+	if err := s.authorize(request); err != nil {
+		return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy denied the action", err)
+	}
+	if !capability.Available {
+		return actionFailure(id, request.Operation, started, ErrorUnsupported, "operation is unavailable on the selected backend", robotgo.ErrNotSupported)
+	}
+	if s.used >= s.policy.MaxActions {
+		return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy action limit reached", ErrPolicyDenied)
+	}
+	if dryRun {
+		return ActionResult{
+			ActionID: id, Operation: request.Operation, Status: ActionPlanned,
+			Backend: capability.Backend, DurationMillis: time.Since(started).Milliseconds(),
+		}, nil
+	}
+	s.used++
+	if err := s.execute(request); err != nil {
+		code, message := classifyBackendError(err)
+		result, actionErr := actionFailure(id, request.Operation, started, code, message, err)
+		result.Backend = capability.Backend
+		return result, actionErr
+	}
+	return ActionResult{
+		ActionID: id, Operation: request.Operation, Status: ActionSucceeded,
+		Backend: capability.Backend, DurationMillis: time.Since(started).Milliseconds(),
+	}, nil
+}
+
+func (s *Session) capability(operation Operation) (OperationCapability, bool) {
+	for _, capability := range s.catalog.Operations {
+		if capability.Operation == operation {
+			return capability, true
+		}
+	}
+	return OperationCapability{}, false
+}
+
+func (s *Session) authorize(request ActionRequest) error {
+	if _, allowed := s.policy.allowOperation[request.Operation]; !allowed {
+		return ErrPolicyDenied
+	}
+	if _, required := s.policy.requireConfirmation[request.Operation]; required && !request.Confirmed {
+		return ErrPolicyDenied
+	}
+	if request.Move != nil {
+		if _, allowed := s.policy.allowDisplay[request.Move.DisplayID]; !allowed {
+			return ErrPolicyDenied
+		}
+	}
+	if request.Click != nil && request.Click.Double && !s.policy.AllowDoubleClick {
+		return ErrPolicyDenied
+	}
+	if request.TypeText != nil && utf8.RuneCountInString(request.TypeText.Text) > s.policy.MaxTextRunes {
+		return ErrPolicyDenied
+	}
+	return nil
+}
+
+func validateRequest(request ActionRequest) error {
+	payloads := 0
+	if request.Move != nil {
+		payloads++
+	}
+	if request.Click != nil {
+		payloads++
+	}
+	if request.TypeText != nil {
+		payloads++
+	}
+	if payloads != 1 {
+		return errors.New("exactly one action payload is required")
+	}
+	switch request.Operation {
+	case OperationMove:
+		if request.Move == nil || request.Move.DisplayID < 0 {
+			return errors.New("move requires a non-negative display ID")
+		}
+	case OperationClick:
+		if request.Click == nil {
+			return errors.New("click payload does not match operation")
+		}
+		switch request.Click.Button {
+		case MouseButtonLeft, MouseButtonMiddle, MouseButtonRight:
+		default:
+			return errors.New("unsupported mouse button")
+		}
+	case OperationTypeText:
+		if request.TypeText == nil || request.TypeText.Text == "" || !utf8.ValidString(request.TypeText.Text) {
+			return errors.New("type-text requires non-empty valid UTF-8")
+		}
+	default:
+		return errors.New("unknown operation")
+	}
+	return nil
+}
+
+func (s *Session) execute(request ActionRequest) error {
+	switch request.Operation {
+	case OperationMove:
+		return s.driver.Move(request.Move.X, request.Move.Y, request.Move.DisplayID)
+	case OperationClick:
+		return s.driver.Click(request.Click.Button, request.Click.Double)
+	case OperationTypeText:
+		return s.driver.TypeText(request.TypeText.Text)
+	default:
+		return fmt.Errorf("%w: unknown operation", robotgo.ErrNotSupported)
+	}
+}
+
+func classifyBackendError(err error) (ErrorCode, string) {
+	switch {
+	case errors.Is(err, robotgo.ErrNotSupported):
+		return ErrorUnsupported, "operation is unsupported by the selected backend"
+	case errors.Is(err, robotgo.ErrPermissionDenied):
+		return ErrorPermissionDenied, "desktop permission denied"
+	case errors.Is(err, context.DeadlineExceeded):
+		return ErrorTimedOut, "backend action deadline exceeded"
+	case errors.Is(err, context.Canceled):
+		return ErrorCanceled, "backend action canceled"
+	default:
+		return ErrorBackendFailure, "desktop backend action failed"
+	}
+}

--- a/agent/session.go
+++ b/agent/session.go
@@ -13,6 +13,7 @@ import (
 )
 
 type inputDriver interface {
+	DisplayBounds(displayID int) (displayBounds, error)
 	Move(x, y, displayID int) error
 	Click(button MouseButton, double bool) error
 	TypeText(text string) error
@@ -20,6 +21,10 @@ type inputDriver interface {
 
 type robotGoDriver struct{}
 
+func (robotGoDriver) DisplayBounds(displayID int) (displayBounds, error) {
+	x, y, width, height, err := robotgo.GetDisplayBoundsE(displayID)
+	return displayBounds{x: x, y: y, width: width, height: height}, err
+}
 func (robotGoDriver) Move(x, y, displayID int) error { return robotgo.MoveE(x, y, displayID) }
 func (robotGoDriver) Click(button MouseButton, double bool) error {
 	return robotgo.ClickE(string(button), double)
@@ -156,6 +161,25 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 	if s.used >= s.policy.MaxActions {
 		return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy action limit reached", ErrPolicyDenied)
 	}
+	if request.Move != nil {
+		if err := s.validateMoveTarget(*request.Move); err != nil {
+			if errors.Is(err, ErrPolicyDenied) {
+				return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy denied the action", err)
+			}
+			code, message := classifyBackendError(err)
+			result, actionErr := actionFailure(id, request.Operation, started, code, message, err)
+			result.Backend = capability.Backend
+			return result, actionErr
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return contextFailure(ctx, id, request.Operation, started)
+	}
+	select {
+	case <-s.ctx.Done():
+		return actionFailure(id, request.Operation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+	default:
+	}
 	if dryRun {
 		return ActionResult{
 			ActionID: id, Operation: request.Operation, Status: ActionPlanned,
@@ -173,6 +197,32 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 		ActionID: id, Operation: request.Operation, Status: ActionSucceeded,
 		Backend: capability.Backend, DurationMillis: time.Since(started).Milliseconds(),
 	}, nil
+}
+
+type displayBounds struct {
+	x      int
+	y      int
+	width  int
+	height int
+}
+
+func (b displayBounds) contains(x, y int) bool {
+	return containsAxis(x, b.x, b.width) && containsAxis(y, b.y, b.height)
+}
+
+func containsAxis(value, minimum, size int) bool {
+	return size > 0 && value >= minimum && uint(value)-uint(minimum) < uint(size)
+}
+
+func (s *Session) validateMoveTarget(move MoveAction) error {
+	bounds, err := s.driver.DisplayBounds(move.DisplayID)
+	if err != nil {
+		return err
+	}
+	if !bounds.contains(move.X, move.Y) {
+		return ErrPolicyDenied
+	}
+	return nil
 }
 
 func (s *Session) capability(operation Operation) (OperationCapability, bool) {
@@ -267,6 +317,6 @@ func classifyBackendError(err error) (ErrorCode, string) {
 	case errors.Is(err, context.Canceled):
 		return ErrorCanceled, "backend action canceled"
 	default:
-		return ErrorBackendFailure, "desktop backend action failed"
+		return ErrorBackendFailure, "desktop backend operation failed"
 	}
 }

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -1,0 +1,285 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+type driverCall struct {
+	operation Operation
+	text      string
+}
+
+type fakeDriver struct {
+	mu      sync.Mutex
+	calls   []driverCall
+	err     error
+	started chan struct{}
+	release chan struct{}
+}
+
+func (d *fakeDriver) record(call driverCall) error {
+	if d.started != nil {
+		select {
+		case d.started <- struct{}{}:
+		default:
+		}
+	}
+	if d.release != nil {
+		<-d.release
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.calls = append(d.calls, call)
+	return d.err
+}
+
+func (d *fakeDriver) Move(_, _, _ int) error {
+	return d.record(driverCall{operation: OperationMove})
+}
+
+func (d *fakeDriver) Click(_ MouseButton, _ bool) error {
+	return d.record(driverCall{operation: OperationClick})
+}
+
+func (d *fakeDriver) TypeText(text string) error {
+	return d.record(driverCall{operation: OperationTypeText, text: text})
+}
+
+func (d *fakeDriver) callCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.calls)
+}
+
+func availableCapabilities() robotgo.RuntimeCapabilities {
+	return robotgo.RuntimeCapabilities{
+		Mouse:    robotgo.FeatureCapability{Available: true, Backend: "fake-mouse"},
+		Keyboard: robotgo.FeatureCapability{Available: true, Backend: "fake-keyboard"},
+	}
+}
+
+func testPolicy() Policy {
+	return Policy{
+		AllowedOperations: []Operation{OperationMove, OperationClick, OperationTypeText},
+		AllowedDisplayIDs: []int{0, 2}, MaxActions: 3, MaxTextRunes: 8,
+		AllowDoubleClick: true,
+	}
+}
+
+func newTestSession(t *testing.T, input Policy, driver inputDriver) *Session {
+	t.Helper()
+	policy, err := preparePolicy(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := newSession(policy, driver, availableCapabilities())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func TestCatalogIsStableAndDefensive(t *testing.T) {
+	session := newTestSession(t, testPolicy(), &fakeDriver{})
+	catalog := session.Catalog()
+	if catalog.SchemaVersion != CatalogSchemaVersion {
+		t.Fatalf("schema = %q", catalog.SchemaVersion)
+	}
+	want := []Operation{OperationMove, OperationClick, OperationTypeText}
+	for index, operation := range want {
+		got := catalog.Operations[index]
+		if got.Operation != operation || !got.Available || !got.ProcessGlobalBackend || !got.ExclusiveAgentSession {
+			t.Fatalf("operation[%d] = %+v", index, got)
+		}
+		if got.Cancellation != CancellationPreflightOnly {
+			t.Fatalf("cancellation = %q", got.Cancellation)
+		}
+	}
+	catalog.Operations[0].Backend = "mutated"
+	if got := session.Catalog().Operations[0].Backend; got != "fake-mouse" {
+		t.Fatalf("catalog mutation leaked into session: %q", got)
+	}
+}
+
+func TestDryRunDoesNotInjectOrConsumeQuota(t *testing.T) {
+	driver := &fakeDriver{}
+	policy := testPolicy()
+	policy.MaxActions = 1
+	session := newTestSession(t, policy, driver)
+	request := ActionRequest{
+		Operation: OperationMove,
+		Move:      &MoveAction{X: -10, Y: 20, DisplayID: 2},
+	}
+	result, err := session.DryRun(context.Background(), request)
+	if err != nil || result.Status != ActionPlanned {
+		t.Fatalf("DryRun = %+v, %v", result, err)
+	}
+	if driver.callCount() != 0 {
+		t.Fatal("dry-run injected input")
+	}
+	if result, err = session.Execute(context.Background(), request); err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if driver.callCount() != 1 {
+		t.Fatalf("driver calls = %d", driver.callCount())
+	}
+	result, err = session.Execute(context.Background(), request)
+	if err == nil || result.Error == nil || result.Error.Code != ErrorPolicyDenied {
+		t.Fatalf("quota result = %+v, %v", result, err)
+	}
+	result, err = session.DryRun(context.Background(), request)
+	if err == nil || result.Error == nil || result.Error.Code != ErrorPolicyDenied {
+		t.Fatalf("dry-run quota result = %+v, %v", result, err)
+	}
+}
+
+func TestValidationAndPolicyRunBeforeDriver(t *testing.T) {
+	driver := &fakeDriver{}
+	policy := testPolicy()
+	policy.ConfirmOperations = []Operation{OperationClick}
+	policy.AllowDoubleClick = false
+	session := newTestSession(t, policy, driver)
+	tests := []ActionRequest{
+		{Operation: OperationMove, Move: &MoveAction{DisplayID: 9}},
+		{Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft}},
+		{Operation: OperationClick, Confirmed: true, Click: &ClickAction{Button: MouseButtonLeft, Double: true}},
+		{Operation: OperationTypeText, TypeText: &TypeTextAction{Text: "too-long!"}},
+		{Operation: OperationTypeText, Move: &MoveAction{DisplayID: 0}, TypeText: &TypeTextAction{Text: "x"}},
+	}
+	for _, request := range tests {
+		if _, err := session.Execute(context.Background(), request); err == nil {
+			t.Fatalf("request %+v unexpectedly succeeded", request)
+		}
+	}
+	if driver.callCount() != 0 {
+		t.Fatalf("rejected requests reached driver %d times", driver.callCount())
+	}
+}
+
+func TestTypedTextIsAbsentFromResultAndSerializedError(t *testing.T) {
+	const secret = "s3cr3t"
+	driver := &fakeDriver{err: errors.New("backend detail")}
+	session := newTestSession(t, testPolicy(), driver)
+	result, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationTypeText,
+		TypeText:  &TypeTextAction{Text: secret},
+	})
+	if err == nil || result.Error == nil || result.Error.Code != ErrorBackendFailure {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	data, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	if strings.Contains(string(data), secret) || strings.Contains(string(data), "backend detail") {
+		t.Fatalf("serialized result leaked payload or backend detail: %s", data)
+	}
+	if !errors.Is(err, driver.err) {
+		t.Fatalf("returned error lost backend cause: %v", err)
+	}
+}
+
+func TestContextIsPreflightOnlyOnceDriverStarts(t *testing.T) {
+	driver := &fakeDriver{started: make(chan struct{}, 1), release: make(chan struct{})}
+	session := newTestSession(t, testPolicy(), driver)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan ActionResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := session.Execute(ctx, ActionRequest{
+			Operation: OperationClick,
+			Click:     &ClickAction{Button: MouseButtonLeft},
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	<-driver.started
+	cancel()
+	close(driver.release)
+	if result, err := <-resultCh, <-errCh; err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("completed backend action mislabeled: %+v, %v", result, err)
+	}
+}
+
+func TestQueuedActionCancellationDoesNotWaitForDriver(t *testing.T) {
+	driver := &fakeDriver{started: make(chan struct{}, 1), release: make(chan struct{})}
+	session := newTestSession(t, testPolicy(), driver)
+	firstDone := make(chan struct{})
+	go func() {
+		_, _ = session.Execute(context.Background(), ActionRequest{
+			Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		})
+		close(firstDone)
+	}()
+	<-driver.started
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+	result, err := session.Execute(ctx, ActionRequest{
+		Operation: OperationMove, Move: &MoveAction{DisplayID: 0},
+	})
+	if !errors.Is(err, context.Canceled) || result.Error == nil || result.Error.Code != ErrorCanceled {
+		t.Fatalf("queued cancellation = %+v, %v", result, err)
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("queued cancellation took %v", elapsed)
+	}
+	close(driver.release)
+	<-firstDone
+}
+
+func TestExclusiveSessionAndConcurrentClose(t *testing.T) {
+	driver := &fakeDriver{started: make(chan struct{}, 1), release: make(chan struct{})}
+	session := newTestSession(t, testPolicy(), driver)
+	policy, err := preparePolicy(testPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newSession(policy, &fakeDriver{}, availableCapabilities()); !errors.Is(err, ErrSessionBusy) {
+		t.Fatalf("second session error = %v", err)
+	}
+	executeDone := make(chan struct{})
+	go func() {
+		_, _ = session.Execute(context.Background(), ActionRequest{
+			Operation: OperationMove,
+			Move:      &MoveAction{DisplayID: 0},
+		})
+		close(executeDone)
+	}()
+	<-driver.started
+	closeDone := make(chan struct{})
+	go func() {
+		_ = session.Close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned before the active driver call completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(driver.release)
+	<-executeDone
+	<-closeDone
+	if _, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationMove, Move: &MoveAction{DisplayID: 0},
+	}); !errors.Is(err, ErrSessionClosed) {
+		t.Fatalf("post-close action error = %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("idempotent Close = %v", err)
+	}
+	replacement, err := newSession(policy, &fakeDriver{}, availableCapabilities())
+	if err != nil {
+		t.Fatalf("replacement session = %v", err)
+	}
+	_ = replacement.Close()
+}

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -18,11 +18,43 @@ type driverCall struct {
 }
 
 type fakeDriver struct {
-	mu      sync.Mutex
-	calls   []driverCall
-	err     error
-	started chan struct{}
-	release chan struct{}
+	mu        sync.Mutex
+	calls     []driverCall
+	err       error
+	bounds    map[int]displayBounds
+	boundsErr error
+	boundsHit chan struct{}
+	boundsGo  chan struct{}
+	started   chan struct{}
+	release   chan struct{}
+}
+
+func (d *fakeDriver) DisplayBounds(displayID int) (displayBounds, error) {
+	if d.boundsHit != nil {
+		select {
+		case d.boundsHit <- struct{}{}:
+		default:
+		}
+	}
+	if d.boundsGo != nil {
+		<-d.boundsGo
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.boundsErr != nil {
+		return displayBounds{}, d.boundsErr
+	}
+	if bounds, ok := d.bounds[displayID]; ok {
+		return bounds, nil
+	}
+	switch displayID {
+	case 0:
+		return displayBounds{x: 0, y: 0, width: 100, height: 100}, nil
+	case 2:
+		return displayBounds{x: -100, y: 0, width: 100, height: 100}, nil
+	default:
+		return displayBounds{}, errors.New("display bounds unavailable")
+	}
 }
 
 func (d *fakeDriver) record(call driverCall) error {
@@ -162,6 +194,94 @@ func TestValidationAndPolicyRunBeforeDriver(t *testing.T) {
 	}
 	if driver.callCount() != 0 {
 		t.Fatalf("rejected requests reached driver %d times", driver.callCount())
+	}
+}
+
+func TestMoveCoordinatesMustBeWithinAllowedDisplay(t *testing.T) {
+	driver := &fakeDriver{}
+	session := newTestSession(t, testPolicy(), driver)
+
+	for _, request := range []ActionRequest{
+		{
+			Operation: OperationMove,
+			Move:      &MoveAction{X: -10, Y: 20, DisplayID: 0},
+		},
+		{
+			Operation: OperationMove,
+			Move:      &MoveAction{X: 100, Y: 20, DisplayID: 0},
+		},
+	} {
+		result, err := session.DryRun(context.Background(), request)
+		if !errors.Is(err, ErrPolicyDenied) || result.Error == nil || result.Error.Code != ErrorPolicyDenied {
+			t.Fatalf("out-of-display move = %+v, %v", result, err)
+		}
+	}
+	if driver.callCount() != 0 {
+		t.Fatalf("out-of-display moves reached driver %d times", driver.callCount())
+	}
+
+	result, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationMove,
+		Move:      &MoveAction{X: -10, Y: 20, DisplayID: 2},
+	})
+	if err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("in-display move = %+v, %v", result, err)
+	}
+	if driver.callCount() != 1 {
+		t.Fatalf("driver calls = %d", driver.callCount())
+	}
+}
+
+func TestDisplayBoundsFailureDoesNotReachInput(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code ErrorCode
+	}{
+		{name: "unsupported", err: robotgo.ErrNotSupported, code: ErrorUnsupported},
+		{name: "backend", err: errors.New("bounds failed"), code: ErrorBackendFailure},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			driver := &fakeDriver{boundsErr: tc.err}
+			session := newTestSession(t, testPolicy(), driver)
+			result, err := session.Execute(context.Background(), ActionRequest{
+				Operation: OperationMove,
+				Move:      &MoveAction{X: 10, Y: 20, DisplayID: 0},
+			})
+			if !errors.Is(err, tc.err) || result.Error == nil || result.Error.Code != tc.code {
+				t.Fatalf("bounds failure = %+v, %v", result, err)
+			}
+			if driver.callCount() != 0 {
+				t.Fatalf("failed bounds lookup reached driver %d times", driver.callCount())
+			}
+		})
+	}
+}
+
+func TestMoveCancellationDuringBoundsPreflightDoesNotReachInput(t *testing.T) {
+	driver := &fakeDriver{boundsHit: make(chan struct{}, 1), boundsGo: make(chan struct{})}
+	session := newTestSession(t, testPolicy(), driver)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan ActionResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := session.Execute(ctx, ActionRequest{
+			Operation: OperationMove,
+			Move:      &MoveAction{X: 10, Y: 20, DisplayID: 0},
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	<-driver.boundsHit
+	cancel()
+	close(driver.boundsGo)
+	result, err := <-resultCh, <-errCh
+	if !errors.Is(err, context.Canceled) || result.Error == nil || result.Error.Code != ErrorCanceled {
+		t.Fatalf("bounds preflight cancellation = %+v, %v", result, err)
+	}
+	if driver.callCount() != 0 {
+		t.Fatalf("canceled bounds preflight reached input %d times", driver.callCount())
 	}
 }
 

--- a/agent/types.go
+++ b/agent/types.go
@@ -62,7 +62,8 @@ const (
 	MouseButtonRight  MouseButton = "right"
 )
 
-// MoveAction moves the pointer on one explicit display.
+// MoveAction moves the pointer to global coordinates that must fall within the
+// live bounds of the explicitly selected display.
 type MoveAction struct {
 	X         int `json:"x"`
 	Y         int `json:"y"`

--- a/agent/types.go
+++ b/agent/types.go
@@ -1,0 +1,163 @@
+// Package agent provides a typed, policy-gated session layer above RobotGo's
+// low-level compatibility API. It deliberately contains no protocol adapter.
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// CatalogSchemaVersion identifies the operation catalog JSON contract.
+const CatalogSchemaVersion = "1"
+
+// Operation identifies one strict agent operation.
+type Operation string
+
+const (
+	OperationMove     Operation = "pointer.move"
+	OperationClick    Operation = "pointer.click"
+	OperationTypeText Operation = "keyboard.type-text"
+)
+
+// RiskClass describes the policy impact of an operation.
+type RiskClass string
+
+const RiskReversibleMutation RiskClass = "reversible-mutation"
+
+// CancellationSupport describes where cancellation is enforceable.
+type CancellationSupport string
+
+const CancellationPreflightOnly CancellationSupport = "preflight-only"
+
+// OperationCapability is one stable entry in an operation catalog.
+type OperationCapability struct {
+	Operation             Operation           `json:"operation"`
+	Available             bool                `json:"available"`
+	PolicyAllowed         bool                `json:"policy_allowed"`
+	Backend               string              `json:"backend,omitempty"`
+	Fallback              bool                `json:"fallback"`
+	Risk                  RiskClass           `json:"risk"`
+	ConfirmationRequired  bool                `json:"confirmation_required"`
+	Cancellation          CancellationSupport `json:"cancellation"`
+	ProcessGlobalBackend  bool                `json:"process_global_backend"`
+	ExclusiveAgentSession bool                `json:"exclusive_agent_session"`
+	Reason                string              `json:"reason,omitempty"`
+	Remediation           string              `json:"remediation,omitempty"`
+}
+
+// OperationCatalog is an immutable snapshot of operation availability.
+type OperationCatalog struct {
+	SchemaVersion string                `json:"schema_version"`
+	Operations    []OperationCapability `json:"operations"`
+}
+
+// MouseButton is a validated pointer button name.
+type MouseButton string
+
+const (
+	MouseButtonLeft   MouseButton = "left"
+	MouseButtonMiddle MouseButton = "center"
+	MouseButtonRight  MouseButton = "right"
+)
+
+// MoveAction moves the pointer on one explicit display.
+type MoveAction struct {
+	X         int `json:"x"`
+	Y         int `json:"y"`
+	DisplayID int `json:"display_id"`
+}
+
+// ClickAction clicks one validated pointer button.
+type ClickAction struct {
+	Button MouseButton `json:"button"`
+	Double bool        `json:"double,omitempty"`
+}
+
+// TypeTextAction types UTF-8 text. The text is never copied into results.
+type TypeTextAction struct {
+	Text string `json:"text"`
+}
+
+// ActionRequest is a strict JSON-serializable action union. Exactly one action
+// payload must be present and must match Operation.
+type ActionRequest struct {
+	Operation Operation       `json:"operation"`
+	Confirmed bool            `json:"confirmed,omitempty"`
+	Move      *MoveAction     `json:"move,omitempty"`
+	Click     *ClickAction    `json:"click,omitempty"`
+	TypeText  *TypeTextAction `json:"type_text,omitempty"`
+}
+
+// ActionStatus identifies the outcome of an action request.
+type ActionStatus string
+
+const (
+	ActionPlanned   ActionStatus = "planned"
+	ActionSucceeded ActionStatus = "succeeded"
+	ActionFailed    ActionStatus = "failed"
+)
+
+// ErrorCode is a stable machine-readable action failure category.
+type ErrorCode string
+
+const (
+	ErrorInvalidInput     ErrorCode = "invalid-input"
+	ErrorPolicyDenied     ErrorCode = "policy-denied"
+	ErrorUnsupported      ErrorCode = "unsupported"
+	ErrorPermissionDenied ErrorCode = "permission-denied"
+	ErrorSessionClosed    ErrorCode = "session-closed"
+	ErrorSessionBusy      ErrorCode = "session-busy"
+	ErrorCanceled         ErrorCode = "canceled"
+	ErrorTimedOut         ErrorCode = "timed-out"
+	ErrorBackendFailure   ErrorCode = "backend-failure"
+)
+
+// ActionError is safe to serialize: Message never contains action payloads.
+type ActionError struct {
+	Code      ErrorCode `json:"code"`
+	Operation Operation `json:"operation,omitempty"`
+	Message   string    `json:"message"`
+	cause     error
+}
+
+func (e *ActionError) Error() string { return e.Message }
+func (e *ActionError) Unwrap() error { return e.cause }
+
+// ActionResult reports one planned or attempted action without retaining its
+// input payload.
+type ActionResult struct {
+	ActionID       string       `json:"action_id"`
+	Operation      Operation    `json:"operation"`
+	Status         ActionStatus `json:"status"`
+	Backend        string       `json:"backend,omitempty"`
+	DurationMillis int64        `json:"duration_ms"`
+	Error          *ActionError `json:"error,omitempty"`
+}
+
+var (
+	ErrSessionBusy   = errors.New("another agent session is already active")
+	ErrSessionClosed = errors.New("agent session is closed")
+	ErrPolicyDenied  = errors.New("agent policy denied the action")
+)
+
+func actionFailure(id string, operation Operation, started time.Time, code ErrorCode, message string, cause error) (ActionResult, error) {
+	actionErr := &ActionError{Code: code, Operation: operation, Message: message, cause: cause}
+	return ActionResult{
+		ActionID: id, Operation: operation, Status: ActionFailed,
+		DurationMillis: time.Since(started).Milliseconds(), Error: actionErr,
+	}, actionErr
+}
+
+func contextFailure(ctx context.Context, id string, operation Operation, started time.Time) (ActionResult, error) {
+	err := ctx.Err()
+	if errors.Is(err, context.DeadlineExceeded) {
+		return actionFailure(id, operation, started, ErrorTimedOut, "action deadline exceeded", err)
+	}
+	return actionFailure(id, operation, started, ErrorCanceled, "action canceled", err)
+}
+
+func invalidAction(id string, operation Operation, started time.Time, format string, args ...any) (ActionResult, error) {
+	return actionFailure(id, operation, started, ErrorInvalidInput, fmt.Sprintf(format, args...), nil)
+}

--- a/docs/plan/agentic-desktop-automation.md
+++ b/docs/plan/agentic-desktop-automation.md
@@ -145,18 +145,35 @@ orthogonal tool set:
 Add redacted record/replay, a fake driver, and hermetic evaluation tasks before
 claiming reliable autonomous behavior.
 
-## 4. First executable slice
+## 4. First executable slices
 
-The first implementation slice should prove the architecture with:
+Deliver the first architecture proof through two reviewable boundaries rather
+than coupling desktop observation and mutation in one initial change.
 
-1. session creation and deterministic close
-2. versioned operation catalog
-3. policy evaluation and dry-run
-4. desktop observation with runtime diagnostics and optional capture
-5. typed move, click, and text actions
-6. action result and structured error schema
-7. unit tests, a runnable example, and one applicable real-runtime integration
-   path
+### 4.1 Typed session and action core
+
+The first foundation slice provides:
+
+1. deterministic, process-exclusive agent session creation and close
+2. versioned operation catalog for typed move, click, and text actions
+3. explicit process-global backend and preflight-only cancellation contracts
+4. policy evaluation, confirmation, action/text/display limits, and dry-run
+5. structured action results and sanitized errors
+6. unit tests, a dry-run-first example, and an opt-in pointer integration path
+
+It intentionally does not capture or retain screenshots, clipboard contents,
+OCR text, or typed text in results. Direct callers of the legacy package-level
+RobotGo APIs remain outside agent-session exclusivity and are reported as a
+process-global limitation.
+
+### 4.2 Observation and verification proof
+
+The following slice completes the initial architecture proof with:
+
+1. bounded desktop observation using runtime diagnostics and optional capture
+2. observation lineage and stale-target preconditions
+3. bounded post-action verification
+4. privacy-safe audit/replay seams
 
 An MCP server is not required for this first slice. It should consume the
 accepted Go contract rather than define it.

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -65,6 +65,9 @@ Current implementation baseline:
   Deterministic output indices are shared with screencopy, Wayland display
   count/main-index queries avoid X11, and the `wayland-info` fallback accepts
   output records without numeric identifiers.
+- Native absolute virtual-pointer moves translate the aggregate logical origin
+  into the protocol's unsigned coordinate frame and fail closed outside the
+  current aggregate, including layouts left of or above the primary output.
 - Pure-Go aggregate/per-output bounds use the same primary-first geometry
   ordering, prefer fractional `xdg-output` logical geometry, apply integer scale
   and all transforms in the core fallback, clamp advertised protocol versions,

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -68,6 +68,8 @@ Current implementation baseline:
 - Native absolute virtual-pointer moves translate the aggregate logical origin
   into the protocol's unsigned coordinate frame and fail closed outside the
   current aggregate, including layouts left of or above the primary output.
+  Bounded writable retries treat `EAGAIN` as queued backpressure and reserve
+  backend teardown for permanent Wayland transport failures.
 - Pure-Go aggregate/per-output bounds use the same primary-first geometry
   ordering, prefer fractional `xdg-output` logical geometry, apply integer scale
   and all transforms in the core fallback, clamp advertised protocol versions,

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -120,7 +120,9 @@ Current implementation baseline:
   session for stream-aware absolute pointer and touchscreen input. Stream
     geometry, mapping ID, PipeWire serial, persistence token availability, and
     permission status (including timeout versus cancellation) are observable
-    without exposing token contents. Portal mouse delays have CGO/non-CGO parity.
+    without exposing token contents. Absolute fallback retains the caller's
+    global coordinates rather than reusing native scaled coordinates. Portal
+    mouse delays have CGO/non-CGO parity.
 - Runtime integration tests cover backend capability selection for
   `sway`/`hyprland`/`wlroots-generic` with explicit skip behavior when runtime
   preconditions are not present.

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -68,8 +68,9 @@ Current implementation baseline:
 - Native absolute virtual-pointer moves translate the aggregate logical origin
   into the protocol's unsigned coordinate frame and fail closed outside the
   current aggregate, including layouts left of or above the primary output.
-  Bounded writable retries treat `EAGAIN` as queued backpressure and reserve
-  backend teardown for permanent Wayland transport failures.
+  Bounded writable retries treat `EAGAIN` as transient backpressure. Requests
+  still queued after that budget report an explicit delivery error, while
+  backend teardown remains reserved for permanent Wayland transport failures.
 - Pure-Go aggregate/per-output bounds use the same primary-first geometry
   ordering, prefer fractional `xdg-output` logical geometry, apply integer scale
   and all transforms in the core fallback, clamp advertised protocol versions,

--- a/examples/agent_session/main.go
+++ b/examples/agent_session/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/marang/robotgo/agent"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	act := flag.Bool("act", false, "perform the action; default is validation-only dry-run")
+	operation := flag.String("operation", "move", "move, click, or type")
+	x := flag.Int("x", 0, "move destination x")
+	y := flag.Int("y", 0, "move destination y")
+	displayID := flag.Int("display", 0, "explicit display ID")
+	text := flag.String("text", "RobotGo agent session", "text used only with -operation type")
+	flag.Parse()
+
+	session, err := agent.NewSession(agent.Config{Policy: agent.Policy{
+		AllowedOperations: []agent.Operation{
+			agent.OperationMove, agent.OperationClick, agent.OperationTypeText,
+		},
+		ConfirmOperations: []agent.Operation{
+			agent.OperationMove, agent.OperationClick, agent.OperationTypeText,
+		},
+		AllowedDisplayIDs: []int{*displayID},
+		MaxActions:        1, MaxTextRunes: 256,
+	}})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = session.Close() }()
+
+	request, err := requestFor(*operation, *x, *y, *displayID, *text)
+	if err != nil {
+		return err
+	}
+	var result agent.ActionResult
+	if *act {
+		request.Confirmed = true
+		result, err = session.Execute(context.Background(), request)
+	} else {
+		// DryRun applies the same validation, policy, quota, and capability
+		// preflight but never injects desktop input.
+		request.Confirmed = true
+		result, err = session.DryRun(context.Background(), request)
+	}
+	output := struct {
+		Catalog agent.OperationCatalog `json:"catalog"`
+		Result  agent.ActionResult     `json:"result"`
+	}{Catalog: session.Catalog(), Result: result}
+	if encodeErr := json.NewEncoder(os.Stdout).Encode(output); encodeErr != nil {
+		return encodeErr
+	}
+	return err
+}
+
+func requestFor(operation string, x, y, displayID int, text string) (agent.ActionRequest, error) {
+	switch operation {
+	case "move":
+		return agent.ActionRequest{Operation: agent.OperationMove, Move: &agent.MoveAction{X: x, Y: y, DisplayID: displayID}}, nil
+	case "click":
+		return agent.ActionRequest{Operation: agent.OperationClick, Click: &agent.ClickAction{Button: agent.MouseButtonLeft}}, nil
+	case "type":
+		return agent.ActionRequest{Operation: agent.OperationTypeText, TypeText: &agent.TypeTextAction{Text: text}}, nil
+	default:
+		return agent.ActionRequest{}, fmt.Errorf("unknown operation %q", operation)
+	}
+}

--- a/mouse/mouse_c.h
+++ b/mouse/mouse_c.h
@@ -151,6 +151,7 @@ enum RobotGoMouseStatus {
         #include <wayland-client.h>
         #include <linux/input-event-codes.h>
         #include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
+	#include "wayland_absolute.h"
         #include "../window/get_bounds_wayland.h"
 
 	        static struct wl_display *rg_wl_display = NULL;
@@ -158,6 +159,8 @@ enum RobotGoMouseStatus {
         static struct wl_seat *rg_wl_seat = NULL;
         static struct zwlr_virtual_pointer_manager_v1 *rg_wl_vptr_mgr = NULL;
         static struct zwlr_virtual_pointer_v1 *rg_wl_vptr = NULL;
+	static int rg_wl_x = 0;
+	static int rg_wl_y = 0;
         static int rg_wl_width = 0;
         static int rg_wl_height = 0;
         static int rg_wl_inited = 0;
@@ -228,6 +231,24 @@ enum RobotGoMouseStatus {
                 NULL
 	        };
 
+	        static int rg_refresh_wayland_bounds(void) {
+	                int x = 0;
+	                int y = 0;
+	                int width = 0;
+	                int height = 0;
+	                if (get_screen_rect_wayland(
+	                        rg_wl_display, -1, &x, &y,
+	                        &width, &height) != 0 ||
+	                    width <= 0 || height <= 0) {
+	                        return 0;
+	                }
+	                rg_wl_x = x;
+	                rg_wl_y = y;
+	                rg_wl_width = width;
+	                rg_wl_height = height;
+	                return 1;
+	        }
+
 	        static void rg_cleanup_wayland(void) {
 	                if (rg_wl_vptr) {
 	                        zwlr_virtual_pointer_v1_destroy(rg_wl_vptr);
@@ -249,6 +270,8 @@ enum RobotGoMouseStatus {
 	                        wl_display_disconnect(rg_wl_display);
 	                        rg_wl_display = NULL;
 	                }
+	                rg_wl_x = 0;
+	                rg_wl_y = 0;
 	                rg_wl_width = 0;
 	                rg_wl_height = 0;
 	                rg_wl_inited = 0;
@@ -284,7 +307,10 @@ enum RobotGoMouseStatus {
 	                        rg_cleanup_wayland();
 	                        return 0;
 	                }
-	                get_bounds_wayland(rg_wl_display, &rg_wl_width, &rg_wl_height);
+	                if (!rg_refresh_wayland_bounds()) {
+	                        rg_cleanup_wayland();
+	                        return 0;
+	                }
 	                rg_wl_inited = 1;
 	                return 1;
 	        }
@@ -407,56 +433,97 @@ static int robotgo_x11_release_owned_buttons(void) { return ROBOTGO_MOUSE_OK; }
 	}
 #endif
 
-/* Move the mouse to a specific point. */
-void moveMouse(MMPointInt32 point){
+/* Move the mouse to a specific point and preserve backend failures. */
+static int moveMouseInternal(MMPointInt32 point, bool refresh_bounds){
+	(void)refresh_bounds;
         #if defined(IS_MACOSX)
 		CGEventSourceRef source = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
 		CGEventRef move = CGEventCreateMouseEvent(source, kCGEventMouseMoved, 
 								CGPointFromMMPointInt32(point), kCGMouseButtonLeft);
+		if (move == NULL) {
+			if (source != NULL) { CFRelease(source); }
+			return ROBOTGO_MOUSE_INJECTION_FAILED;
+		}
 
 		calculateDeltas(&move, point);
 
 		CGEventPost(kCGHIDEventTap, move);
 		CFRelease(move);
-		CFRelease(source);
+		if (source != NULL) { CFRelease(source); }
+		return ROBOTGO_MOUSE_OK;
         #elif defined(IS_LINUX)
 #ifdef ROBOTGO_USE_WAYLAND
                 if (robotgo_wayland_mouse_backend_selected()) {
                         if (!rg_init_wayland()) {
 #if !defined(DISPLAY_SERVER_WAYLAND)
                                 Display *display = XGetMainDisplay();
-                                if (display == NULL) { return; }
+				if (display == NULL) { return ROBOTGO_MOUSE_NO_DISPLAY; }
                                 XWarpPointer(display, None, DefaultRootWindow(display), 0, 0, 0, 0, point.x, point.y);
                                 XSync(display, false);
+				return ROBOTGO_MOUSE_OK;
+#else
+				return ROBOTGO_MOUSE_NO_DISPLAY;
 #endif
                         } else {
-                                if (rg_wl_width > 0 && rg_wl_height > 0) {
-                                        uint32_t sx = (uint32_t)((double)point.x * 65535.0 / rg_wl_width);
-                                        uint32_t sy = (uint32_t)((double)point.y * 65535.0 / rg_wl_height);
-                                        zwlr_virtual_pointer_v1_motion_absolute(rg_wl_vptr, 0, sx, sy, 65535, 65535);
-                                        wl_display_flush(rg_wl_display);
-                                        rg_wl_last_x = point.x;
-                                        rg_wl_last_y = point.y;
-                                }
+				if (refresh_bounds && !rg_refresh_wayland_bounds()) {
+					return ROBOTGO_MOUSE_NO_DISPLAY;
+				}
+				uint32_t sx = 0;
+				uint32_t sy = 0;
+				if (robotgo_wayland_map_absolute(
+				        point.x, point.y, rg_wl_x, rg_wl_y,
+				        rg_wl_width, rg_wl_height,
+				        ROBOTGO_WAYLAND_ABSOLUTE_EXTENT,
+				        ROBOTGO_WAYLAND_ABSOLUTE_EXTENT,
+				        &sx, &sy) != 0) {
+					return ROBOTGO_MOUSE_INVALID;
+				}
+				zwlr_virtual_pointer_v1_motion_absolute(
+					rg_wl_vptr, 0, sx, sy,
+					ROBOTGO_WAYLAND_ABSOLUTE_EXTENT,
+					ROBOTGO_WAYLAND_ABSOLUTE_EXTENT);
+				zwlr_virtual_pointer_v1_frame(rg_wl_vptr);
+				if (wl_display_flush(rg_wl_display) < 0) {
+					rg_cleanup_wayland();
+					return ROBOTGO_MOUSE_INJECTION_FAILED;
+				}
+				rg_wl_last_x = point.x;
+				rg_wl_last_y = point.y;
+				return ROBOTGO_MOUSE_OK;
                         }
                 }
 #if !defined(DISPLAY_SERVER_WAYLAND)
                 else {
                         Display *display = XGetMainDisplay();
-                        if (display == NULL) { return; }
+			if (display == NULL) { return ROBOTGO_MOUSE_NO_DISPLAY; }
                         XWarpPointer(display, None, DefaultRootWindow(display), 0, 0, 0, 0, point.x, point.y);
                         XSync(display, false);
+			return ROBOTGO_MOUSE_OK;
                 }
+#else
+		return ROBOTGO_MOUSE_UNSUPPORTED;
 #endif
 #else
                 Display *display = XGetMainDisplay();
-                if (display == NULL) { return; }
+		if (display == NULL) { return ROBOTGO_MOUSE_NO_DISPLAY; }
                 XWarpPointer(display, None, DefaultRootWindow(display), 0, 0, 0, 0, point.x, point.y);
                 XSync(display, false);
+		return ROBOTGO_MOUSE_OK;
 #endif
         #elif defined(IS_WINDOWS)
-                SetCursorPos(point.x, point.y);
+		return SetCursorPos(point.x, point.y)
+			? ROBOTGO_MOUSE_OK : ROBOTGO_MOUSE_INJECTION_FAILED;
         #endif
+	return ROBOTGO_MOUSE_UNSUPPORTED;
+}
+
+int moveMouseChecked(MMPointInt32 point){
+	return moveMouseInternal(point, true);
+}
+
+/* Legacy callers intentionally discard the checked error contract. */
+void moveMouse(MMPointInt32 point){
+	(void)moveMouseInternal(point, false);
 }
 
 void dragMouse(MMPointInt32 point, const MMMouseButton button){

--- a/mouse/mouse_c.h
+++ b/mouse/mouse_c.h
@@ -147,9 +147,12 @@ enum RobotGoMouseStatus {
 
 #ifdef ROBOTGO_USE_WAYLAND
         /* Wayland support */
+	#include <errno.h>
+	#include <poll.h>
         #include <string.h>
         #include <wayland-client.h>
         #include <linux/input-event-codes.h>
+	#include "wayland_flush.h"
         #include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
 	#include "wayland_absolute.h"
         #include "../window/get_bounds_wayland.h"
@@ -313,6 +316,47 @@ enum RobotGoMouseStatus {
 	                }
 	                rg_wl_inited = 1;
 	                return 1;
+	        }
+
+	        static int rg_try_flush_wayland(void *context) {
+	                return wl_display_flush((struct wl_display *)context);
+	        }
+
+	        static int rg_wait_wayland_writable(void *context, int timeout_ms) {
+	                struct pollfd writable = {
+	                        .fd = wl_display_get_fd((struct wl_display *)context),
+	                        .events = POLLOUT,
+	                        .revents = 0
+	                };
+	                int ready = poll(&writable, 1, timeout_ms);
+	                if (ready <= 0) {
+	                        return ready;
+	                }
+	                if (writable.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+	                        errno = EPIPE;
+	                        return -1;
+	                }
+	                return (writable.revents & POLLOUT) ? 1 : 0;
+	        }
+
+	        static int rg_flush_wayland_mouse(void) {
+	                enum {
+	                        RG_WL_MOUSE_FLUSH_POLL_MS = 50,
+	                        RG_WL_MOUSE_FLUSH_ATTEMPTS = 3
+	                };
+	                if (rg_wl_display == NULL) {
+	                        return ROBOTGO_MOUSE_NO_DISPLAY;
+	                }
+	                int result = robotgo_wayland_flush_with_retry(
+	                        rg_wl_display, rg_try_flush_wayland,
+	                        rg_wait_wayland_writable,
+	                        RG_WL_MOUSE_FLUSH_POLL_MS,
+	                        RG_WL_MOUSE_FLUSH_ATTEMPTS);
+	                if (result == ROBOTGO_WAYLAND_FLUSH_FAILED) {
+	                        rg_cleanup_wayland();
+	                        return ROBOTGO_MOUSE_INJECTION_FAILED;
+	                }
+	                return ROBOTGO_MOUSE_OK;
 	        }
 
 	        static int robotgo_wayland_mouse_backend_enabled(void) { return 1; }
@@ -483,9 +527,9 @@ static int moveMouseInternal(MMPointInt32 point, bool refresh_bounds){
 					ROBOTGO_WAYLAND_ABSOLUTE_EXTENT,
 					ROBOTGO_WAYLAND_ABSOLUTE_EXTENT);
 				zwlr_virtual_pointer_v1_frame(rg_wl_vptr);
-				if (wl_display_flush(rg_wl_display) < 0) {
-					rg_cleanup_wayland();
-					return ROBOTGO_MOUSE_INJECTION_FAILED;
+				int flush_status = rg_flush_wayland_mouse();
+				if (flush_status != ROBOTGO_MOUSE_OK) {
+					return flush_status;
 				}
 				rg_wl_last_x = point.x;
 				rg_wl_last_y = point.y;
@@ -593,10 +637,11 @@ void moveMouseRelative(int dx, int dy) {
                         wl_fixed_t fdy = wl_fixed_from_double((double)dy);
                         zwlr_virtual_pointer_v1_motion(rg_wl_vptr, 0, fdx, fdy);
                         zwlr_virtual_pointer_v1_frame(rg_wl_vptr);
-                        wl_display_flush(rg_wl_display);
-                        rg_wl_last_x += dx;
-                        rg_wl_last_y += dy;
-                        return;
+			if (rg_flush_wayland_mouse() == ROBOTGO_MOUSE_OK) {
+				rg_wl_last_x += dx;
+				rg_wl_last_y += dy;
+			}
+			return;
                 }
         }
 #endif
@@ -647,9 +692,9 @@ int toggleMouse(bool down, MMMouseButton button) {
 				}
                                 zwlr_virtual_pointer_v1_button(rg_wl_vptr, 0, code, down ? 1 : 0);
 				zwlr_virtual_pointer_v1_frame(rg_wl_vptr);
-				if (wl_display_flush(rg_wl_display) < 0) {
-					rg_cleanup_wayland();
-					return ROBOTGO_MOUSE_INJECTION_FAILED;
+				int flush_status = rg_flush_wayland_mouse();
+				if (flush_status != ROBOTGO_MOUSE_OK) {
+					return flush_status;
 				}
 				rg_wl_owned_buttons[index] = down;
 				return ROBOTGO_MOUSE_OK;
@@ -773,7 +818,7 @@ void scrollMouseXY(int x, int y) {
 						zwlr_virtual_pointer_v1_frame(rg_wl_vptr);
 					}
 				}
-				wl_display_flush(rg_wl_display);
+				(void)rg_flush_wayland_mouse();
 			}
 #if !defined(DISPLAY_SERVER_WAYLAND)
 			else {

--- a/mouse/mouse_c.h
+++ b/mouse/mouse_c.h
@@ -11,7 +11,8 @@ enum RobotGoMouseStatus {
 	ROBOTGO_MOUSE_UNSUPPORTED = 2,
 	ROBOTGO_MOUSE_INJECTION_FAILED = 3,
 	ROBOTGO_MOUSE_OWNERSHIP_CONFLICT = 4,
-	ROBOTGO_MOUSE_INVALID = 5
+	ROBOTGO_MOUSE_INVALID = 5,
+	ROBOTGO_MOUSE_DELIVERY_PENDING = 6
 };
 #if defined(IS_MACOSX)
 	// #include </System/Library/Frameworks/ApplicationServices.framework/Headers/ApplicationServices.h>
@@ -355,6 +356,9 @@ enum RobotGoMouseStatus {
 	                if (result == ROBOTGO_WAYLAND_FLUSH_FAILED) {
 	                        rg_cleanup_wayland();
 	                        return ROBOTGO_MOUSE_INJECTION_FAILED;
+	                }
+	                if (!robotgo_wayland_flush_is_delivered(result)) {
+	                        return ROBOTGO_MOUSE_DELIVERY_PENDING;
 	                }
 	                return ROBOTGO_MOUSE_OK;
 	        }

--- a/mouse/wayland_absolute.h
+++ b/mouse/wayland_absolute.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+enum { ROBOTGO_WAYLAND_ABSOLUTE_EXTENT = 65535 };
+
+/* Map RobotGo's signed global logical coordinates into the unsigned absolute
+ * frame used by zwlr_virtual_pointer_v1. The aggregate output origin may be
+ * negative when an output is positioned left of or above the primary output. */
+static inline int robotgo_wayland_map_absolute(
+    int32_t global_x, int32_t global_y,
+    int32_t origin_x, int32_t origin_y,
+    int32_t width, int32_t height,
+    uint32_t extent_x, uint32_t extent_y,
+    uint32_t *mapped_x, uint32_t *mapped_y) {
+    if (width <= 0 || height <= 0 || extent_x == 0 || extent_y == 0 ||
+        mapped_x == NULL || mapped_y == NULL) {
+        return -1;
+    }
+
+    int64_t local_x = (int64_t)global_x - (int64_t)origin_x;
+    int64_t local_y = (int64_t)global_y - (int64_t)origin_y;
+    if (local_x < 0 || local_y < 0 || local_x >= width || local_y >= height) {
+        return -1;
+    }
+
+    *mapped_x = (uint32_t)((uint64_t)local_x * extent_x / (uint32_t)width);
+    *mapped_y = (uint32_t)((uint64_t)local_y * extent_y / (uint32_t)height);
+    return 0;
+}

--- a/mouse/wayland_flush.h
+++ b/mouse/wayland_flush.h
@@ -12,6 +12,10 @@ enum RobotGoWaylandFlushResult {
 typedef int (*robotgo_wayland_flush_fn)(void *context);
 typedef int (*robotgo_wayland_wait_writable_fn)(void *context, int timeout_ms);
 
+static inline int robotgo_wayland_flush_is_delivered(int result) {
+    return result == ROBOTGO_WAYLAND_FLUSHED;
+}
+
 /* Retry a nonblocking Wayland flush without treating EAGAIN as disconnect.
  * Exhausting the bounded wait still leaves the request safely queued inside
  * libwayland; only permanent flush/poll errors are reported as failures. */

--- a/mouse/wayland_flush.h
+++ b/mouse/wayland_flush.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <errno.h>
+#include <stddef.h>
+
+enum RobotGoWaylandFlushResult {
+    ROBOTGO_WAYLAND_FLUSHED = 0,
+    ROBOTGO_WAYLAND_FLUSH_QUEUED = 1,
+    ROBOTGO_WAYLAND_FLUSH_FAILED = -1
+};
+
+typedef int (*robotgo_wayland_flush_fn)(void *context);
+typedef int (*robotgo_wayland_wait_writable_fn)(void *context, int timeout_ms);
+
+/* Retry a nonblocking Wayland flush without treating EAGAIN as disconnect.
+ * Exhausting the bounded wait still leaves the request safely queued inside
+ * libwayland; only permanent flush/poll errors are reported as failures. */
+static inline int robotgo_wayland_flush_with_retry(
+    void *context,
+    robotgo_wayland_flush_fn flush,
+    robotgo_wayland_wait_writable_fn wait_writable,
+    int timeout_ms,
+    int attempts) {
+    if (flush == NULL || wait_writable == NULL || timeout_ms < 0 ||
+        attempts < 0) {
+        return ROBOTGO_WAYLAND_FLUSH_FAILED;
+    }
+    if (flush(context) >= 0) {
+        return ROBOTGO_WAYLAND_FLUSHED;
+    }
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+        return ROBOTGO_WAYLAND_FLUSH_FAILED;
+    }
+
+    for (int attempt = 0; attempt < attempts; attempt++) {
+        int ready = wait_writable(context, timeout_ms);
+        if (ready < 0 && errno == EINTR) {
+            continue;
+        }
+        if (ready < 0) {
+            return ROBOTGO_WAYLAND_FLUSH_FAILED;
+        }
+        if (ready == 0) {
+            continue;
+        }
+        if (flush(context) >= 0) {
+            return ROBOTGO_WAYLAND_FLUSHED;
+        }
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            return ROBOTGO_WAYLAND_FLUSH_FAILED;
+        }
+    }
+    return ROBOTGO_WAYLAND_FLUSH_QUEUED;
+}

--- a/remote_desktop_input_cgo_test.go
+++ b/remote_desktop_input_cgo_test.go
@@ -162,6 +162,78 @@ func TestRemoteDesktopFallbackRequiresZeroNativeMutation(t *testing.T) {
 	}
 }
 
+func TestAbsolutePortalFallbackPreservesRequestedCoordinates(t *testing.T) {
+	const requestX, requestY = -1900, 100
+	nativeX, nativeY := requestX, requestY
+	var portalX, portalY int
+
+	usedPortal, err := moveAbsoluteWithFallback(
+		requestX, requestY, []int{1}, DisplayServerWayland,
+		func() (bool, error) {
+			// Model legacy native scaling before a zero-mutation backend error.
+			nativeX, nativeY = requestX/2, requestY/2
+			return true, ErrNotSupported
+		},
+		func(x, y int, displayID []int) (bool, error) {
+			portalX, portalY = x, y
+			if !reflect.DeepEqual(displayID, []int{1}) {
+				t.Fatalf("portal display IDs = %v, want [1]", displayID)
+			}
+			return true, nil
+		},
+	)
+	if err != nil || !usedPortal {
+		t.Fatalf("fallback = (used=%t err=%v), want portal success", usedPortal, err)
+	}
+	if nativeX != -950 || nativeY != 50 {
+		t.Fatalf("native coordinates = (%d,%d), want modeled scale", nativeX, nativeY)
+	}
+	if portalX != requestX || portalY != requestY {
+		t.Fatalf("portal coordinates = (%d,%d), want request (%d,%d)", portalX, portalY, requestX, requestY)
+	}
+}
+
+func TestAbsoluteMoveFallbackDecision(t *testing.T) {
+	nativeFailure := errors.New("native failure")
+	portalFailure := errors.New("portal failure")
+	tests := []struct {
+		name            string
+		ready           bool
+		nativeErr       error
+		portalUsed      bool
+		portalErr       error
+		wantUsedPortal  bool
+		wantErr         error
+		wantPortalCalls int
+	}{
+		{name: "native success", ready: true},
+		{name: "post-mutation native failure", ready: true, nativeErr: nativeFailure, wantErr: nativeFailure},
+		{name: "portal unavailable", nativeErr: nativeFailure, wantErr: nativeFailure, wantPortalCalls: 1},
+		{name: "portal success", nativeErr: nativeFailure, portalUsed: true, wantUsedPortal: true, wantPortalCalls: 1},
+		{name: "portal failure", nativeErr: nativeFailure, portalUsed: true, portalErr: portalFailure, wantUsedPortal: true, wantErr: portalFailure, wantPortalCalls: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			portalCalls := 0
+			usedPortal, err := moveAbsoluteWithFallback(
+				10, 20, nil, DisplayServerWayland,
+				func() (bool, error) { return test.ready, test.nativeErr },
+				func(int, int, []int) (bool, error) {
+					portalCalls++
+					return test.portalUsed, test.portalErr
+				},
+			)
+			if usedPortal != test.wantUsedPortal || !errors.Is(err, test.wantErr) || portalCalls != test.wantPortalCalls {
+				t.Fatalf(
+					"fallback = (used=%t err=%v portalCalls=%d), want (%t,%v,%d)",
+					usedPortal, err, portalCalls,
+					test.wantUsedPortal, test.wantErr, test.wantPortalCalls,
+				)
+			}
+		})
+	}
+}
+
 type blockingHighLevelInputSession struct {
 	*fakeHighLevelPortalSession
 	once    sync.Once

--- a/robotgo.go
+++ b/robotgo.go
@@ -1786,7 +1786,7 @@ func nativeMouseStatusError(status C.int, operation string) error {
 	case C.ROBOTGO_MOUSE_OWNERSHIP_CONFLICT:
 		return fmt.Errorf("%w: %s", ErrInputOwnership, operation)
 	case C.ROBOTGO_MOUSE_INVALID:
-		return fmt.Errorf("robotgo: %s: invalid native mouse button", operation)
+		return fmt.Errorf("robotgo: %s: invalid native mouse input", operation)
 	default:
 		return fmt.Errorf("robotgo: %s: unknown native mouse status %d", operation, int(status))
 	}
@@ -2035,8 +2035,10 @@ func MoveE(x, y int, displayId ...int) error {
 	server := selectedDisplayServer()
 	ready, nativeErr := runNativeMouseOperation(server, func() error {
 		x, y = moveScaleLocked(x, y, displayId...)
-		C.moveMouse(C.MMPointInt32Make(C.int32_t(x), C.int32_t(y)))
-		return nil
+		return nativeMouseStatusError(
+			C.moveMouseChecked(C.MMPointInt32Make(C.int32_t(x), C.int32_t(y))),
+			"move mouse",
+		)
 	})
 	if nativeErr != nil {
 		if shouldTryRemoteDesktopAfterNative(server, ready, nativeErr) {

--- a/robotgo.go
+++ b/robotgo.go
@@ -1787,6 +1787,8 @@ func nativeMouseStatusError(status C.int, operation string) error {
 		return fmt.Errorf("%w: %s", ErrInputOwnership, operation)
 	case C.ROBOTGO_MOUSE_INVALID:
 		return fmt.Errorf("robotgo: %s: invalid native mouse input", operation)
+	case C.ROBOTGO_MOUSE_DELIVERY_PENDING:
+		return fmt.Errorf("robotgo: %s: native mouse input remains queued", operation)
 	default:
 		return fmt.Errorf("robotgo: %s: unknown native mouse status %d", operation, int(status))
 	}

--- a/robotgo.go
+++ b/robotgo.go
@@ -2029,27 +2029,50 @@ func Move(x, y int, displayId ...int) {
 	_ = MoveE(x, y, displayId...)
 }
 
+func moveAbsoluteWithFallback(
+	x, y int,
+	displayID []int,
+	server DisplayServer,
+	native func() (bool, error),
+	portal func(int, int, []int) (bool, error),
+) (usedPortal bool, err error) {
+	ready, nativeErr := native()
+	if nativeErr == nil {
+		return false, nil
+	}
+	if shouldTryRemoteDesktopAfterNative(server, ready, nativeErr) {
+		used, portalErr := portal(x, y, displayID)
+		if used {
+			return true, portalErr
+		}
+	}
+	return false, nativeErr
+}
+
 // MoveE moves the mouse to (x, y) and reports backend availability errors.
 // Prefer it over Move when the caller must know whether injection succeeded.
 func MoveE(x, y int, displayId ...int) error {
 	unlockMouse := lockLinuxMouse()
 	defer unlockMouse()
 	server := selectedDisplayServer()
-	ready, nativeErr := runNativeMouseOperation(server, func() error {
-		x, y = moveScaleLocked(x, y, displayId...)
-		return nativeMouseStatusError(
-			C.moveMouseChecked(C.MMPointInt32Make(C.int32_t(x), C.int32_t(y))),
-			"move mouse",
-		)
-	})
-	if nativeErr != nil {
-		if shouldTryRemoteDesktopAfterNative(server, ready, nativeErr) {
-			used, err := tryRemoteDesktopMoveAbsolute(x, y, displayId)
-			if used {
-				return finishRemoteDesktopMouseEvent(err, 0)
-			}
-		}
-		return nativeErr
+	usedPortal, err := moveAbsoluteWithFallback(
+		x, y, displayId, server,
+		func() (bool, error) {
+			return runNativeMouseOperation(server, func() error {
+				nativeX, nativeY := moveScaleLocked(x, y, displayId...)
+				return nativeMouseStatusError(
+					C.moveMouseChecked(C.MMPointInt32Make(C.int32_t(nativeX), C.int32_t(nativeY))),
+					"move mouse",
+				)
+			})
+		},
+		tryRemoteDesktopMoveAbsolute,
+	)
+	if usedPortal {
+		return finishRemoteDesktopMouseEvent(err, 0)
+	}
+	if err != nil {
+		return err
 	}
 
 	MilliSleep(currentMouseDelay())

--- a/wayland_geometry_test.go
+++ b/wayland_geometry_test.go
@@ -218,24 +218,25 @@ func TestWaylandFlushRetriesTransientBackpressure(t *testing.T) {
 		wantResult    int
 		wantFlushes   int
 		wantWaitCalls int
+		wantDelivered bool
 	}{
-		{name: "immediate success", flushErrnos: []int{0}, attempts: 3, wantResult: 0, wantFlushes: 1},
-		{name: "retry EAGAIN", flushErrnos: []int{int(syscall.EAGAIN), 0}, waitResults: []int{1}, attempts: 3, wantResult: 0, wantFlushes: 2, wantWaitCalls: 1},
+		{name: "immediate success", flushErrnos: []int{0}, attempts: 3, wantResult: 0, wantFlushes: 1, wantDelivered: true},
+		{name: "retry EAGAIN", flushErrnos: []int{int(syscall.EAGAIN), 0}, waitResults: []int{1}, attempts: 3, wantResult: 0, wantFlushes: 2, wantWaitCalls: 1, wantDelivered: true},
 		{name: "bounded queued EAGAIN", flushErrnos: []int{int(syscall.EAGAIN)}, waitResults: []int{0, 0, 0}, attempts: 3, wantResult: 1, wantFlushes: 1, wantWaitCalls: 3},
-		{name: "EINTR then writable", flushErrnos: []int{int(syscall.EAGAIN), 0}, waitResults: []int{-int(syscall.EINTR), 1}, attempts: 3, wantResult: 0, wantFlushes: 2, wantWaitCalls: 2},
+		{name: "EINTR then writable", flushErrnos: []int{int(syscall.EAGAIN), 0}, waitResults: []int{-int(syscall.EINTR), 1}, attempts: 3, wantResult: 0, wantFlushes: 2, wantWaitCalls: 2, wantDelivered: true},
 		{name: "permanent flush failure", flushErrnos: []int{int(syscall.EPIPE)}, attempts: 3, wantResult: -1, wantFlushes: 1},
 		{name: "permanent poll failure", flushErrnos: []int{int(syscall.EAGAIN)}, waitResults: []int{-int(syscall.EPIPE)}, attempts: 3, wantResult: -1, wantFlushes: 1, wantWaitCalls: 1},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, flushCalls, waitCalls := waylandFlushRetryForTest(
+			result, flushCalls, waitCalls, delivered := waylandFlushRetryForTest(
 				test.flushErrnos, test.waitResults, test.attempts,
 			)
-			if result != test.wantResult || flushCalls != test.wantFlushes || waitCalls != test.wantWaitCalls {
+			if result != test.wantResult || flushCalls != test.wantFlushes || waitCalls != test.wantWaitCalls || delivered != test.wantDelivered {
 				t.Fatalf(
-					"flush retry = (result=%d flushes=%d waits=%d), want (%d,%d,%d)",
-					result, flushCalls, waitCalls,
-					test.wantResult, test.wantFlushes, test.wantWaitCalls,
+					"flush retry = (result=%d flushes=%d waits=%d delivered=%t), want (%d,%d,%d,%t)",
+					result, flushCalls, waitCalls, delivered,
+					test.wantResult, test.wantFlushes, test.wantWaitCalls, test.wantDelivered,
 				)
 			}
 		})

--- a/wayland_geometry_test.go
+++ b/wayland_geometry_test.go
@@ -171,6 +171,41 @@ func TestWaylandBoundsPreserveLogicalDesktopGeometry(t *testing.T) {
 	}
 }
 
+func TestWaylandAbsolutePointerMappingPreservesAggregateOrigin(t *testing.T) {
+	bounds := [4]int{-1024, -360, 4224, 1440}
+	tests := []struct {
+		name  string
+		point [2]int
+		ok    bool
+	}{
+		{name: "negative aggregate origin", point: [2]int{-1024, -360}, ok: true},
+		{name: "primary origin", point: [2]int{0, 0}, ok: true},
+		{name: "last aggregate pixel", point: [2]int{3199, 1079}, ok: true},
+		{name: "left of aggregate", point: [2]int{-1025, 0}},
+		{name: "above aggregate", point: [2]int{0, -361}},
+		{name: "right edge is exclusive", point: [2]int{3200, 0}},
+		{name: "bottom edge is exclusive", point: [2]int{0, 1080}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := mapWaylandPointerForTest(test.point, bounds)
+			if ok != test.ok {
+				t.Fatalf("mapping status = %t, want %t (mapped %v)", ok, test.ok, got)
+			}
+			if !ok {
+				return
+			}
+			want := [2]uint32{
+				uint32((int64(test.point[0]-bounds[0]) * 65535) / int64(bounds[2])),
+				uint32((int64(test.point[1]-bounds[1]) * 65535) / int64(bounds[3])),
+			}
+			if got != want {
+				t.Fatalf("mapped point = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func TestWaylandBoundsAcceptLogicalGeometryWithoutCoreMode(t *testing.T) {
 	outputs := []waylandBoundsOutputForTest{{
 		logicalPos:  [2]int{-640, -360},

--- a/wayland_geometry_test.go
+++ b/wayland_geometry_test.go
@@ -2,7 +2,10 @@
 
 package robotgo
 
-import "testing"
+import (
+	"syscall"
+	"testing"
+)
 
 func TestWaylandLogicalCropTransformMatrix(t *testing.T) {
 	tests := []struct {
@@ -201,6 +204,39 @@ func TestWaylandAbsolutePointerMappingPreservesAggregateOrigin(t *testing.T) {
 			}
 			if got != want {
 				t.Fatalf("mapped point = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestWaylandFlushRetriesTransientBackpressure(t *testing.T) {
+	tests := []struct {
+		name          string
+		flushErrnos   []int
+		waitResults   []int
+		attempts      int
+		wantResult    int
+		wantFlushes   int
+		wantWaitCalls int
+	}{
+		{name: "immediate success", flushErrnos: []int{0}, attempts: 3, wantResult: 0, wantFlushes: 1},
+		{name: "retry EAGAIN", flushErrnos: []int{int(syscall.EAGAIN), 0}, waitResults: []int{1}, attempts: 3, wantResult: 0, wantFlushes: 2, wantWaitCalls: 1},
+		{name: "bounded queued EAGAIN", flushErrnos: []int{int(syscall.EAGAIN)}, waitResults: []int{0, 0, 0}, attempts: 3, wantResult: 1, wantFlushes: 1, wantWaitCalls: 3},
+		{name: "EINTR then writable", flushErrnos: []int{int(syscall.EAGAIN), 0}, waitResults: []int{-int(syscall.EINTR), 1}, attempts: 3, wantResult: 0, wantFlushes: 2, wantWaitCalls: 2},
+		{name: "permanent flush failure", flushErrnos: []int{int(syscall.EPIPE)}, attempts: 3, wantResult: -1, wantFlushes: 1},
+		{name: "permanent poll failure", flushErrnos: []int{int(syscall.EAGAIN)}, waitResults: []int{-int(syscall.EPIPE)}, attempts: 3, wantResult: -1, wantFlushes: 1, wantWaitCalls: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, flushCalls, waitCalls := waylandFlushRetryForTest(
+				test.flushErrnos, test.waitResults, test.attempts,
+			)
+			if result != test.wantResult || flushCalls != test.wantFlushes || waitCalls != test.wantWaitCalls {
+				t.Fatalf(
+					"flush retry = (result=%d flushes=%d waits=%d), want (%d,%d,%d)",
+					result, flushCalls, waitCalls,
+					test.wantResult, test.wantFlushes, test.wantWaitCalls,
+				)
 			}
 		})
 	}

--- a/wayland_geometry_testhelper.go
+++ b/wayland_geometry_testhelper.go
@@ -5,6 +5,7 @@ package robotgo
 /*
 #cgo CFLAGS: -DROBOTGO_WAYLAND_TEST
 #include "mouse/wayland_absolute.h"
+#include "mouse/wayland_flush.h"
 void robotgo_wayland_map_logical_rect_for_test(int cap_w, int cap_h,
                                                 int logical_w, int logical_h,
                                                 int transform, int *x, int *y,
@@ -29,6 +30,58 @@ static int robotgo_wayland_map_pointer_for_test(
         ROBOTGO_WAYLAND_ABSOLUTE_EXTENT,
         ROBOTGO_WAYLAND_ABSOLUTE_EXTENT,
         mapped_x, mapped_y);
+}
+
+struct robotgo_wayland_flush_test_state {
+    const int *flush_errnos;
+    int flush_count;
+    int flush_index;
+    const int *wait_results;
+    int wait_count;
+    int wait_index;
+};
+
+static int robotgo_wayland_test_flush(void *context) {
+    struct robotgo_wayland_flush_test_state *state = context;
+    int index = state->flush_index++;
+    int error = index < state->flush_count ? state->flush_errnos[index] : 0;
+    if (error == 0) {
+        return 0;
+    }
+    errno = error;
+    return -1;
+}
+
+static int robotgo_wayland_test_wait(void *context, int timeout_ms) {
+    (void)timeout_ms;
+    struct robotgo_wayland_flush_test_state *state = context;
+    int index = state->wait_index++;
+    int result = index < state->wait_count ? state->wait_results[index] : 0;
+    if (result < 0) {
+        errno = -result;
+        return -1;
+    }
+    return result;
+}
+
+static int robotgo_wayland_flush_retry_for_test(
+    const int *flush_errnos, int flush_count,
+    const int *wait_results, int wait_count,
+    int attempts, int *flush_calls, int *wait_calls) {
+    struct robotgo_wayland_flush_test_state state = {
+        .flush_errnos = flush_errnos,
+        .flush_count = flush_count,
+        .flush_index = 0,
+        .wait_results = wait_results,
+        .wait_count = wait_count,
+        .wait_index = 0
+    };
+    int result = robotgo_wayland_flush_with_retry(
+        &state, robotgo_wayland_test_flush, robotgo_wayland_test_wait,
+        1, attempts);
+    *flush_calls = state.flush_index;
+    *wait_calls = state.wait_index;
+    return result;
 }
 */
 import "C"
@@ -137,4 +190,29 @@ func mapWaylandPointerForTest(point [2]int, bounds [4]int) ([2]uint32, bool) {
 		&x, &y,
 	)
 	return [2]uint32{uint32(x), uint32(y)}, status == 0
+}
+
+func waylandFlushRetryForTest(flushErrnos, waitResults []int, attempts int) (result, flushCalls, waitCalls int) {
+	flushValues := make([]C.int, len(flushErrnos))
+	for index, value := range flushErrnos {
+		flushValues[index] = C.int(value)
+	}
+	waitValues := make([]C.int, len(waitResults))
+	for index, value := range waitResults {
+		waitValues[index] = C.int(value)
+	}
+	var flushPointer, waitPointer *C.int
+	if len(flushValues) > 0 {
+		flushPointer = &flushValues[0]
+	}
+	if len(waitValues) > 0 {
+		waitPointer = &waitValues[0]
+	}
+	var cFlushCalls, cWaitCalls C.int
+	result = int(C.robotgo_wayland_flush_retry_for_test(
+		flushPointer, C.int(len(flushValues)),
+		waitPointer, C.int(len(waitValues)),
+		C.int(attempts), &cFlushCalls, &cWaitCalls,
+	))
+	return result, int(cFlushCalls), int(cWaitCalls)
 }

--- a/wayland_geometry_testhelper.go
+++ b/wayland_geometry_testhelper.go
@@ -4,6 +4,7 @@ package robotgo
 
 /*
 #cgo CFLAGS: -DROBOTGO_WAYLAND_TEST
+#include "mouse/wayland_absolute.h"
 void robotgo_wayland_map_logical_rect_for_test(int cap_w, int cap_h,
                                                 int logical_w, int logical_h,
                                                 int transform, int *x, int *y,
@@ -19,6 +20,16 @@ int robotgo_wayland_resolve_bounds_for_test(const int *values, int count,
 int robotgo_wayland_stable_output_name_for_test(const int *values,
                                                  int output_count,
                                                  int display_id);
+
+static int robotgo_wayland_map_pointer_for_test(
+    int global_x, int global_y, int origin_x, int origin_y,
+    int width, int height, unsigned int *mapped_x, unsigned int *mapped_y) {
+    return robotgo_wayland_map_absolute(
+        global_x, global_y, origin_x, origin_y, width, height,
+        ROBOTGO_WAYLAND_ABSOLUTE_EXTENT,
+        ROBOTGO_WAYLAND_ABSOLUTE_EXTENT,
+        mapped_x, mapped_y);
+}
 */
 import "C"
 
@@ -115,4 +126,15 @@ func stableWaylandOutputNameForTest(outputs [][5]int, displayID int) int {
 		C.int(len(outputs)),
 		C.int(displayID),
 	))
+}
+
+func mapWaylandPointerForTest(point [2]int, bounds [4]int) ([2]uint32, bool) {
+	var x, y C.uint
+	status := C.robotgo_wayland_map_pointer_for_test(
+		C.int(point[0]), C.int(point[1]),
+		C.int(bounds[0]), C.int(bounds[1]),
+		C.int(bounds[2]), C.int(bounds[3]),
+		&x, &y,
+	)
+	return [2]uint32{uint32(x), uint32(y)}, status == 0
 }

--- a/wayland_geometry_testhelper.go
+++ b/wayland_geometry_testhelper.go
@@ -67,7 +67,7 @@ static int robotgo_wayland_test_wait(void *context, int timeout_ms) {
 static int robotgo_wayland_flush_retry_for_test(
     const int *flush_errnos, int flush_count,
     const int *wait_results, int wait_count,
-    int attempts, int *flush_calls, int *wait_calls) {
+    int attempts, int *flush_calls, int *wait_calls, int *delivered) {
     struct robotgo_wayland_flush_test_state state = {
         .flush_errnos = flush_errnos,
         .flush_count = flush_count,
@@ -81,6 +81,7 @@ static int robotgo_wayland_flush_retry_for_test(
         1, attempts);
     *flush_calls = state.flush_index;
     *wait_calls = state.wait_index;
+    *delivered = robotgo_wayland_flush_is_delivered(result);
     return result;
 }
 */
@@ -192,7 +193,7 @@ func mapWaylandPointerForTest(point [2]int, bounds [4]int) ([2]uint32, bool) {
 	return [2]uint32{uint32(x), uint32(y)}, status == 0
 }
 
-func waylandFlushRetryForTest(flushErrnos, waitResults []int, attempts int) (result, flushCalls, waitCalls int) {
+func waylandFlushRetryForTest(flushErrnos, waitResults []int, attempts int) (result, flushCalls, waitCalls int, delivered bool) {
 	flushValues := make([]C.int, len(flushErrnos))
 	for index, value := range flushErrnos {
 		flushValues[index] = C.int(value)
@@ -208,11 +209,11 @@ func waylandFlushRetryForTest(flushErrnos, waitResults []int, attempts int) (res
 	if len(waitValues) > 0 {
 		waitPointer = &waitValues[0]
 	}
-	var cFlushCalls, cWaitCalls C.int
+	var cFlushCalls, cWaitCalls, cDelivered C.int
 	result = int(C.robotgo_wayland_flush_retry_for_test(
 		flushPointer, C.int(len(flushValues)),
 		waitPointer, C.int(len(waitValues)),
-		C.int(attempts), &cFlushCalls, &cWaitCalls,
+		C.int(attempts), &cFlushCalls, &cWaitCalls, &cDelivered,
 	))
-	return result, int(cFlushCalls), int(cWaitCalls)
+	return result, int(cFlushCalls), int(cWaitCalls), cDelivered != 0
 }


### PR DESCRIPTION
## Outcome

Introduces the first executable P001 boundary: a reusable, process-exclusive Go agent session with a versioned operation catalog, strict policy/dry-run, and typed move, click, and text actions.

Linear: https://linear.app/riotbox/issue/LAB-11/establish-typed-policy-gated-agent-session-core

## Architecture

- keeps the root `robotgo` package as the low-level compatibility surface
- adds an `agent` package above it; the root never imports the agent layer
- reports backend availability separately from policy permission
- honestly marks low-level input as process-global and cancellation as preflight-only
- serializes mutations through a cancellation-aware session gate
- permits only one agent session until backend ownership becomes instance-scoped
- sanitizes results and errors so typed text and backend details are not serialized
- leaves direct legacy RobotGo callers explicitly outside agent-session exclusivity

Observation, capture, lineage, verification, audit/replay, and MCP remain deferred to the next bounded slice.

## Behavior

Policies explicitly allow operations and displays, require confirmation where configured, bound mutation count and typed-text length, and optionally permit double-click. Dry-run performs validation, policy, quota, capability, and cancellation preflight without input or quota consumption.

Pointer moves resolve the selected display's live bounds and reject coordinates outside that display before input or quota consumption. Native Wayland absolute moves preserve negative aggregate origins, validate current aggregate geometry, and map signed global coordinates into the protocol frame. Transient Wayland flush backpressure uses bounded writable retries; a request still queued after the budget returns an explicit delivery error without tearing down a healthy connection, while permanent transport failures clean up. A safe Native-to-RemoteDesktop fallback always retains the caller's original global coordinates rather than reusing native-scaled values.

The example is side-effect-free by default; `-act` is required for input. The tagged integration harness requires `ROBOTGO_AGENT_INPUT_E2E=1` and explicit coordinates.

## Privacy and compatibility

No screenshots, clipboard data, OCR input, restore tokens, or typed text are retained. Unit tests use in-memory or hermetic C-backed fixtures only. No exported legacy API changes. Native Wayland pointer correctness and transport handling are strengthened without changing backend selection order.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -tags wayland ./...`
- focused RemoteDesktop fallback decision and unscaled-coordinate tests
- `go test -tags "wayland test" . -run 'TestWayland(AbsolutePointerMapping|FlushRetries|BoundsPreserve)' -count=1 -v`
- `go test -race ./...`
- `go test -race ./agent -count=100`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `go vet -tags wayland ./...`
- both CGO and non-CGO `golangci-lint run`
- strict C header syntax check for the absolute-pointer and flush helpers
- `git diff --check`
- GitHub CI on `b7bf3d7`: 28 successful, 0 failed, 6 intentionally skipped

No real desktop input was executed locally; the opt-in runtime path was compile-checked only.