### PR TITLE
feat(agent): add bounded observation and verification proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,11 @@ frame, err := robotgo.CaptureScreenCast(ctx) // image.Image
 
 `CaptureScreenCast(ctx, x, y, width, height)` crops in logical compositor
 coordinates and maps fractional stream scaling to physical pixels.
+`CaptureScreenCastDisplay(ctx, displayID, x, y, width, height)` additionally
+requires the active selected stream to be an unambiguous monitor geometry match
+for that display and fails closed before reading a frame otherwise. Agent
+capture uses this display-bound variant so an allow-listed display cannot expose
+pixels from a different monitor, window, or virtual stream.
 `ScreenCastCaptureStreams` exposes selected stream geometry and PipeWire
 metadata; `ScreenCastCaptureRestoreToken` returns the newest single-use restore
 token. Keep restore tokens private and replace the stored token after every

--- a/README.md
+++ b/README.md
@@ -746,21 +746,55 @@ go run -tags wayland ./examples/linux_capabilities
 
 The `agent` package adds a strict Go boundary for automation agents without
 changing the legacy package-level API. One process-exclusive session exposes a
-versioned operation catalog, policy and confirmation gates, dry-run, typed
-move/click/text requests, and sanitized structured results. Its catalog reports
-that the underlying input backend remains process-global and that cancellation
-is currently guaranteed before dispatch, not during a synchronous OS input
-call. Direct callers of legacy RobotGo APIs remain outside this exclusivity.
+versioned operation catalog, policy and confirmation gates, bounded observation,
+dry-run, typed move/click/text requests, stale-target protection, post-action
+verification, and sanitized structured results. Its catalog reports that the
+underlying input backend remains process-global and that cancellation is
+currently guaranteed before dispatch, not during a synchronous OS input call.
+Direct callers of legacy RobotGo APIs remain outside this exclusivity.
 For pointer moves, `AllowedDisplayIDs` fails closed: the selected display must
 be allowed and the global target coordinates must fall within its live bounds.
 If display geometry cannot be resolved, no input is injected.
+
+`Session.Observe` always returns sanitized runtime diagnostics and can optionally
+capture one explicit in-memory region. `MaxObservations`, `MaxCapturePixels`,
+and `AllowedDisplayIDs` bound those reads. Pixels are excluded from JSON and
+audit events; `Observation.Image` returns a defensive copy, while
+`Observation.Close` and `Session.Close` zero RobotGo-owned capture buffers.
+The implementation also enforces hard ceilings of 16,777,216 pixels per frame,
+100 verification attempts, 60 seconds between attempts, and five minutes per
+verification, even when a caller requests larger policy values.
+On Wayland, agent capture uses an already-active ScreenCast stream when
+available. It never opens a portal consent dialog implicitly; callers must
+start consent-aware ScreenCast themselves or explicitly select native-only
+capture with `ROBOTGO_DISABLE_PORTAL=1`.
+
+An action can reference a captured observation through
+`ObservationPrecondition`. RobotGo recaptures the same internally retained
+region immediately before input and rejects a changed target as `stale-target`.
+Optional `capture-changed` or `capture-unchanged` verification then polls within
+the policy's fixed attempt, interval, timeout, pixel, and observation budgets.
+If input completed but proof did not, the result is `unverified` rather than a
+misleading failure that might invite an unsafe retry. `AuditSink` receives only
+payload-free lifecycle metadata; an intent-delivery failure prevents desktop
+I/O, and a completion-delivery failure is returned alongside the actual action
+outcome. Audit sinks are synchronous and must not call back into their invoking
+session. `DryRun` never injects input, but a supplied observation precondition
+still performs a real bounded recapture and consumes observation quota.
 
 The example is validation-only by default and never injects input unless
 `-act` is supplied explicitly:
 
 ```bash
+go run ./examples/agent_session -operation observe
+# Explicit sensitive read; pixels stay in memory and are zeroed on close.
+go run ./examples/agent_session -operation observe -capture \
+  -x 0 -y 0 -width 320 -height 200 -display 0
 go run ./examples/agent_session -operation move -x 100 -y 100 -display 0
 go run ./examples/agent_session -act -operation move -x 100 -y 100 -display 0
+# Explicit sensitive read plus click mutation and bounded changed-region proof.
+go run ./examples/agent_session -act -operation click -verify changed \
+  -x 0 -y 0 -width 320 -height 200 -display 0
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ target. A Wayland environment remains authoritative, so RobotGo does not route
 a Wayland-primary operation through X11 merely because Xwayland is present.
 CGO binaries compiled with `-tags wayland` retain the XGB/Xinerama `Capture`,
 `CaptureImg`, and bounds compatibility paths when run in a real X11 session.
+`CaptureImgNative` provides an explicit portal-free capture boundary: it uses
+the session's native backend and returns an error instead of opening or reusing
+a desktop portal. On Wayland it attempts compositor screencopy only.
 
 Linux/X11 also supports capture, bounds, and input without a C compiler or X11
 development headers:

--- a/TEST.md
+++ b/TEST.md
@@ -101,8 +101,11 @@ Agent-session unit tests use an in-memory input driver and never contact or
 mutate the desktop. They cover process-exclusive lifecycle, concurrent close,
 strict request validation, policy/confirmation/display/text/action limits,
 live display-bound enforcement, dry-run, quota handling, sanitized results,
-backend errors, and the documented
-preflight-only cancellation boundary:
+backend errors, bounded synthetic capture, defensive pixel ownership and
+zeroing, stale-target rejection, changed/unchanged verification, timeout and
+attempt bounds, payload-free audit events, and the documented preflight-only
+cancellation boundary. No agent unit test reads or persists the developer's
+desktop, clipboard, OCR input, or other private data:
 
 ```bash
 go test -race ./agent
@@ -120,6 +123,23 @@ go test -tags integration ./agent -run TestAgentSessionMoveRuntime -v
 
 Run it only in a graphical session where global pointer movement is intended.
 It creates no screenshot, clipboard, OCR, or other persistent artifact.
+
+The separate opt-in capture path reads one explicit real region into memory,
+checks its dimensions, and zeroes both the returned copy and session-owned
+buffer on every test cleanup path. It never writes a screenshot to disk and,
+on Wayland, never opens portal consent implicitly:
+
+```bash
+ROBOTGO_AGENT_CAPTURE_E2E=1 \
+ROBOTGO_AGENT_CAPTURE_X=0 ROBOTGO_AGENT_CAPTURE_Y=0 \
+ROBOTGO_AGENT_CAPTURE_WIDTH=320 ROBOTGO_AGENT_CAPTURE_HEIGHT=200 \
+ROBOTGO_AGENT_CAPTURE_DISPLAY=0 \
+go test -tags integration ./agent -run TestAgentSessionCaptureRuntime -v
+```
+
+Start a consent-aware ScreenCast session before that command when portal
+capture is required, or explicitly set `ROBOTGO_DISABLE_PORTAL=1` to test only
+a native capture path.
 
 Linux alert tests replace every external dialog backend through a private test
 `PATH`. They verify fallback order, user rejection, missing/failed backends, and

--- a/TEST.md
+++ b/TEST.md
@@ -141,6 +141,11 @@ Start a consent-aware ScreenCast session before that command when portal
 capture is required, or explicitly set `ROBOTGO_DISABLE_PORTAL=1` to test only
 a native capture path.
 
+Real post-action changed/unchanged verification is intentionally not automated
+in this integration suite: it would require mutating and repeatedly inspecting
+uncontrolled developer desktop content. Hermetic synthetic-driver tests cover
+the complete stale/pass/fail/timeout/cancel contract instead.
+
 Linux alert tests replace every external dialog backend through a private test
 `PATH`. They verify fallback order, user rejection, missing/failed backends, and
 the non-interactive notification boundary without displaying real UI.

--- a/agent/audit.go
+++ b/agent/audit.go
@@ -1,0 +1,58 @@
+package agent
+
+import (
+	"context"
+	"time"
+)
+
+// AuditSchemaVersion identifies the payload-free audit event contract.
+const AuditSchemaVersion = "1"
+
+// AuditKind identifies a sanitized session lifecycle event.
+type AuditKind string
+
+const (
+	AuditObservationStarted   AuditKind = "observation.started"
+	AuditObservationFinished  AuditKind = "observation.finished"
+	AuditActionStarted        AuditKind = "action.started"
+	AuditActionFinished       AuditKind = "action.finished"
+	AuditVerificationFinished AuditKind = "verification.finished"
+)
+
+// AuditEvent deliberately contains no request payload, coordinates, text,
+// pixels, capture digest, backend error detail, or restore token.
+type AuditEvent struct {
+	SchemaVersion             string             `json:"schema_version"`
+	Sequence                  uint64             `json:"sequence"`
+	Kind                      AuditKind          `json:"kind"`
+	Timestamp                 time.Time          `json:"timestamp"`
+	Operation                 Operation          `json:"operation,omitempty"`
+	ActionID                  string             `json:"action_id,omitempty"`
+	ObservationID             string             `json:"observation_id,omitempty"`
+	PreconditionObservationID string             `json:"precondition_observation_id,omitempty"`
+	PostObservationID         string             `json:"post_observation_id,omitempty"`
+	ActionStatus              ActionStatus       `json:"action_status,omitempty"`
+	VerificationStatus        VerificationStatus `json:"verification_status,omitempty"`
+	VerificationAttempts      uint32             `json:"verification_attempts,omitempty"`
+	ErrorCode                 ErrorCode          `json:"error_code,omitempty"`
+}
+
+// AuditSink receives synchronous, payload-free events. Implementations should
+// honor ctx and return promptly; an intent-event error prevents desktop I/O.
+// A completion-event error is returned alongside the completed result so a
+// caller never needs to guess whether a desktop mutation occurred. A sink must
+// not call back into the Session that invoked it.
+type AuditSink interface {
+	Record(ctx context.Context, event AuditEvent) error
+}
+
+func (s *Session) emitAudit(ctx context.Context, event AuditEvent) error {
+	if s.auditSink == nil {
+		return nil
+	}
+	s.auditSequence++
+	event.SchemaVersion = AuditSchemaVersion
+	event.Sequence = s.auditSequence
+	event.Timestamp = time.Now().UTC()
+	return s.auditSink.Record(ctx, event)
+}

--- a/agent/catalog.go
+++ b/agent/catalog.go
@@ -1,10 +1,6 @@
 package agent
 
-import (
-	"os"
-
-	robotgo "github.com/marang/robotgo"
-)
+import robotgo "github.com/marang/robotgo"
 
 func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCatalog {
 	return OperationCatalog{
@@ -30,9 +26,10 @@ func observationCapability(policy Policy, capabilities robotgo.RuntimeCapabiliti
 	capturePolicyAllowed := policyAllowed && policy.MaxCapturePixels > 0 && len(policy.allowDisplay) > 0
 	if capabilities.Runtime.GOOS == goOSLinux &&
 		capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland &&
-		captureBackend != robotgo.FeatureBackendScreenCast && os.Getenv(disablePortalEnv) == "" {
+		captureBackend != robotgo.FeatureBackendScreenCast &&
+		captureBackend != robotgo.FeatureBackendWaylandScreencopy {
 		captureAvailable = false
-		remediation = "agent capture will not open portal consent implicitly; start ScreenCast explicitly or set " + disablePortalEnv + "=1 for native-only capture"
+		remediation = "agent capture attempts native screencopy first and will not open portal consent implicitly; start ScreenCast explicitly for an authorized fallback"
 	}
 	return OperationCapability{
 		Operation: OperationObserve, Available: true, PolicyAllowed: policyAllowed,

--- a/agent/catalog.go
+++ b/agent/catalog.go
@@ -1,15 +1,51 @@
 package agent
 
-import robotgo "github.com/marang/robotgo"
+import (
+	"os"
+
+	robotgo "github.com/marang/robotgo"
+)
 
 func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCatalog {
 	return OperationCatalog{
 		SchemaVersion: CatalogSchemaVersion,
 		Operations: []OperationCapability{
+			observationCapability(policy, capabilities),
 			operationCapability(OperationMove, policy, capabilities.Mouse),
 			operationCapability(OperationClick, policy, capabilities.Mouse),
 			operationCapability(OperationTypeText, policy, capabilities.Keyboard),
 		},
+	}
+}
+
+func observationCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
+	_, confirmationRequired := policy.requireConfirmation[OperationObserve]
+	_, policyAllowed := policy.allowOperation[OperationObserve]
+	remediation := capabilities.Capture.Notes
+	if remediation == "" {
+		remediation = capabilities.Capture.Reason
+	}
+	captureAvailable := capabilities.Capture.Available
+	captureBackend := capabilities.Capture.Backend
+	capturePolicyAllowed := policyAllowed && policy.MaxCapturePixels > 0 && len(policy.allowDisplay) > 0
+	if capabilities.Runtime.GOOS == goOSLinux &&
+		capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland &&
+		captureBackend != string(robotgo.BackendScreenCast) && os.Getenv(disablePortalEnv) == "" {
+		captureAvailable = false
+		remediation = "agent capture will not open portal consent implicitly; start ScreenCast explicitly or set " + disablePortalEnv + "=1 for native-only capture"
+	}
+	return OperationCapability{
+		Operation: OperationObserve, Available: true, PolicyAllowed: policyAllowed,
+		Backend: runtimeDiagnosticsBackend, Risk: RiskSensitiveRead,
+		ConfirmationRequired: confirmationRequired,
+		Cancellation:         CancellationPreflightOnly,
+		ProcessGlobalBackend: true, ExclusiveAgentSession: true,
+		Reason:      "runtime diagnostics are available without opening desktop consent",
+		Remediation: remediation, OptionalCapture: true,
+		CaptureAvailable:     captureAvailable,
+		CapturePolicyAllowed: capturePolicyAllowed,
+		CaptureFallback:      capabilities.Capture.Fallback,
+		CaptureBackend:       captureBackend,
 	}
 }
 

--- a/agent/catalog.go
+++ b/agent/catalog.go
@@ -30,7 +30,7 @@ func observationCapability(policy Policy, capabilities robotgo.RuntimeCapabiliti
 	capturePolicyAllowed := policyAllowed && policy.MaxCapturePixels > 0 && len(policy.allowDisplay) > 0
 	if capabilities.Runtime.GOOS == goOSLinux &&
 		capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland &&
-		captureBackend != string(robotgo.BackendScreenCast) && os.Getenv(disablePortalEnv) == "" {
+		captureBackend != robotgo.FeatureBackendScreenCast && os.Getenv(disablePortalEnv) == "" {
 		captureAvailable = false
 		remediation = "agent capture will not open portal consent implicitly; start ScreenCast explicitly or set " + disablePortalEnv + "=1 for native-only capture"
 	}

--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -4,6 +4,7 @@ package agent_test
 
 import (
 	"context"
+	"image"
 	"os"
 	"strconv"
 	"testing"
@@ -39,11 +40,66 @@ func TestAgentSessionMoveRuntime(t *testing.T) {
 	}
 }
 
+func TestAgentSessionCaptureRuntime(t *testing.T) {
+	if os.Getenv("ROBOTGO_AGENT_CAPTURE_E2E") != "1" {
+		t.Skip("set ROBOTGO_AGENT_CAPTURE_E2E=1 to permit a real in-memory desktop capture")
+	}
+	x := requiredInteger(t, "ROBOTGO_AGENT_CAPTURE_X")
+	y := requiredInteger(t, "ROBOTGO_AGENT_CAPTURE_Y")
+	width := requiredPositiveBoundedInteger(t, "ROBOTGO_AGENT_CAPTURE_WIDTH", 4096)
+	height := requiredPositiveBoundedInteger(t, "ROBOTGO_AGENT_CAPTURE_HEIGHT", 4096)
+	displayID := requiredCoordinate(t, "ROBOTGO_AGENT_CAPTURE_DISPLAY")
+	session, err := agent.NewSession(agent.Config{Policy: agent.Policy{
+		AllowedOperations: []agent.Operation{agent.OperationObserve},
+		AllowedDisplayIDs: []int{displayID},
+		MaxObservations:   1,
+		MaxCapturePixels:  uint64(width) * uint64(height),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	observation, err := session.Observe(context.Background(), agent.ObserveRequest{
+		Capture: &agent.CaptureRegion{X: x, Y: y, Width: width, Height: height, DisplayID: displayID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = observation.Close() })
+	img, err := observation.Image()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { clear(img.Pix) })
+	if img.Bounds() != image.Rect(0, 0, width, height) {
+		t.Fatalf("capture bounds = %v", img.Bounds())
+	}
+}
+
 func requiredCoordinate(t *testing.T, name string) int {
 	t.Helper()
 	value, err := strconv.Atoi(os.Getenv(name))
 	if err != nil || value < 0 {
 		t.Fatalf("%s must be a non-negative integer", name)
+	}
+	return value
+}
+
+func requiredInteger(t *testing.T, name string) int {
+	t.Helper()
+	value, err := strconv.Atoi(os.Getenv(name))
+	if err != nil {
+		t.Fatalf("%s must be an integer", name)
+	}
+	return value
+}
+
+func requiredPositiveBoundedInteger(t *testing.T, name string, maximum int) int {
+	t.Helper()
+	value := requiredInteger(t, name)
+	if value <= 0 || value > maximum {
+		t.Fatalf("%s must be between 1 and %d", name, maximum)
 	}
 	return value
 }

--- a/agent/observation.go
+++ b/agent/observation.go
@@ -227,15 +227,14 @@ func (robotGoDriver) Capture(ctx context.Context, region CaptureRegion) (image.I
 		return nil, err
 	}
 	if runtime.GOOS == "linux" && robotgo.DetectDisplayServer() == robotgo.DisplayServerWayland {
-		if os.Getenv(disablePortalEnv) == "" {
-			if robotgo.ScreenCastCaptureReady() == nil {
-				return robotgo.CaptureScreenCastDisplay(ctx, region.DisplayID, region.X, region.Y, region.Width, region.Height)
-			}
-			return nil, fmt.Errorf(
-				"%w: agent capture will not open portal consent implicitly; start ScreenCast explicitly or set %s=1 for native-only capture",
-				robotgo.ErrNotSupported, disablePortalEnv,
-			)
-		}
+		return captureWaylandAgent(
+			ctx,
+			region,
+			os.Getenv(disablePortalEnv) != "",
+			robotgo.CaptureImgNative,
+			robotgo.ScreenCastCaptureReady,
+			robotgo.CaptureScreenCastDisplay,
+		)
 	}
 	img, err := robotgo.CaptureImg(region.X, region.Y, region.Width, region.Height, region.DisplayID)
 	if err != nil {
@@ -246,6 +245,70 @@ func (robotGoDriver) Capture(ctx context.Context, region CaptureRegion) (image.I
 		return nil, err
 	}
 	return img, nil
+}
+
+type nativeCaptureFunc func(...int) (image.Image, error)
+type screenCastReadyFunc func() error
+type screenCastDisplayCaptureFunc func(context.Context, int, ...int) (image.Image, error)
+
+func captureWaylandAgent(
+	ctx context.Context,
+	region CaptureRegion,
+	portalDisabled bool,
+	nativeCapture nativeCaptureFunc,
+	screenCastReady screenCastReadyFunc,
+	screenCastCapture screenCastDisplayCaptureFunc,
+) (image.Image, error) {
+	img, nativeErr := nativeCapture(region.X, region.Y, region.Width, region.Height, region.DisplayID)
+	if nativeErr == nil && img != nil && !img.Bounds().Empty() {
+		if err := ctx.Err(); err != nil {
+			wipeMutableImage(img)
+			return nil, err
+		}
+		return img, nil
+	}
+	if nativeErr == nil {
+		nativeErr = errors.New("native Wayland capture returned an empty image")
+	}
+	if img != nil {
+		wipeMutableImage(img)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if !portalDisabled && screenCastReady() == nil {
+		img, screenCastErr := screenCastCapture(
+			ctx,
+			region.DisplayID,
+			region.X,
+			region.Y,
+			region.Width,
+			region.Height,
+		)
+		if screenCastErr == nil && img != nil && !img.Bounds().Empty() {
+			if err := ctx.Err(); err != nil {
+				wipeMutableImage(img)
+				return nil, err
+			}
+			return img, nil
+		}
+		if screenCastErr == nil {
+			screenCastErr = errors.New("ScreenCast capture returned an empty image")
+		}
+		if img != nil {
+			wipeMutableImage(img)
+		}
+		return nil, errors.Join(nativeErr, screenCastErr)
+	}
+
+	return nil, errors.Join(
+		nativeErr,
+		fmt.Errorf(
+			"%w: native Wayland capture failed and agent capture will not open portal consent implicitly; start ScreenCast explicitly for an authorized fallback",
+			robotgo.ErrNotSupported,
+		),
+	)
 }
 
 // Observe returns a diagnostics snapshot and optional bounded capture. It is

--- a/agent/observation.go
+++ b/agent/observation.go
@@ -227,10 +227,10 @@ func (robotGoDriver) Capture(ctx context.Context, region CaptureRegion) (image.I
 		return nil, err
 	}
 	if runtime.GOOS == "linux" && robotgo.DetectDisplayServer() == robotgo.DisplayServerWayland {
-		if robotgo.ScreenCastCaptureReady() == nil {
-			return robotgo.CaptureScreenCastDisplay(ctx, region.DisplayID, region.X, region.Y, region.Width, region.Height)
-		}
 		if os.Getenv(disablePortalEnv) == "" {
+			if robotgo.ScreenCastCaptureReady() == nil {
+				return robotgo.CaptureScreenCastDisplay(ctx, region.DisplayID, region.X, region.Y, region.Width, region.Height)
+			}
 			return nil, fmt.Errorf(
 				"%w: agent capture will not open portal consent implicitly; start ScreenCast explicitly or set %s=1 for native-only capture",
 				robotgo.ErrNotSupported, disablePortalEnv,

--- a/agent/observation.go
+++ b/agent/observation.go
@@ -1,0 +1,574 @@
+package agent
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"image"
+	"image/draw"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+const (
+	// ObservationSchemaVersion identifies the serialized observation contract.
+	ObservationSchemaVersion  = "1"
+	runtimeDiagnosticsBackend = "runtime-diagnostics"
+	disablePortalEnv          = "ROBOTGO_DISABLE_PORTAL"
+	observationIDPrefix       = "observation-"
+	goOSLinux                 = "linux"
+)
+
+var (
+	observationSerial atomic.Uint64
+	// ErrObservationClosed reports access to a zeroed observation buffer.
+	ErrObservationClosed = errors.New("agent observation is closed")
+)
+
+// CaptureRegion identifies one global logical rectangle on an explicit
+// display. Width and Height are positive and bounded by session policy.
+type CaptureRegion struct {
+	X         int `json:"x"`
+	Y         int `json:"y"`
+	Width     int `json:"width"`
+	Height    int `json:"height"`
+	DisplayID int `json:"display_id"`
+}
+
+// ObserveRequest asks for sanitized diagnostics and, optionally, an in-memory
+// capture. Capture pixels are never included in JSON.
+type ObserveRequest struct {
+	Confirmed bool           `json:"confirmed,omitempty"`
+	Capture   *CaptureRegion `json:"capture,omitempty"`
+}
+
+// DiagnosticFeature is a stable, sanitized feature snapshot.
+type DiagnosticFeature struct {
+	Name        string `json:"name"`
+	Available   bool   `json:"available"`
+	Fallback    bool   `json:"fallback"`
+	Backend     string `json:"backend,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// RuntimeDiagnostics is safe to serialize and never opens desktop consent.
+type RuntimeDiagnostics struct {
+	GOOS           string              `json:"goos"`
+	GOARCH         string              `json:"goarch"`
+	CGOEnabled     bool                `json:"cgo_enabled"`
+	Implementation string              `json:"implementation"`
+	DisplayServer  string              `json:"display_server"`
+	Compositor     string              `json:"compositor,omitempty"`
+	Features       []DiagnosticFeature `json:"features"`
+}
+
+// CaptureMetadata contains bounded, serializable capture lineage. Pixels are
+// owned privately by Observation and never form part of this value.
+type CaptureMetadata struct {
+	Region CaptureRegion `json:"region"`
+	SHA256 string        `json:"sha256"`
+	Width  int           `json:"width"`
+	Height int           `json:"height"`
+}
+
+type captureBuffer struct {
+	mu     sync.Mutex
+	pixels *image.RGBA
+	closed bool
+}
+
+type capturedFrame struct {
+	metadata CaptureMetadata
+	buffer   *captureBuffer
+}
+
+func (capture *captureBuffer) image() (*image.RGBA, error) {
+	if capture == nil {
+		return nil, ErrObservationClosed
+	}
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	if capture.closed || capture.pixels == nil {
+		return nil, ErrObservationClosed
+	}
+	return cloneRGBA(capture.pixels), nil
+}
+
+func (capture *captureBuffer) close() error {
+	if capture == nil {
+		return nil
+	}
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	if capture.pixels != nil {
+		clear(capture.pixels.Pix)
+		capture.pixels = nil
+	}
+	capture.closed = true
+	return nil
+}
+
+func (capture *captureBuffer) usable() bool {
+	if capture == nil {
+		return false
+	}
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	return !capture.closed && capture.pixels != nil
+}
+
+// Observation owns optional sensitive pixels and sanitized diagnostics.
+type Observation struct {
+	SchemaVersion string             `json:"schema_version"`
+	ObservationID string             `json:"observation_id"`
+	CreatedAt     time.Time          `json:"created_at"`
+	Diagnostics   RuntimeDiagnostics `json:"diagnostics"`
+	Capture       *CaptureMetadata   `json:"capture,omitempty"`
+
+	capture *captureBuffer
+}
+
+type observationRecord struct {
+	capture    *captureBuffer
+	region     CaptureRegion
+	digest     string
+	hasCapture bool
+}
+
+// Close zeroes the optional capture. Sanitized metadata remains readable so
+// audit and stale-lineage errors can still identify the closed observation.
+func (observation *Observation) Close() error {
+	if observation == nil || observation.capture == nil {
+		return nil
+	}
+	return observation.capture.close()
+}
+
+// Image returns a defensive copy of the optional sensitive capture.
+func (observation *Observation) Image() (*image.RGBA, error) {
+	if observation == nil || observation.capture == nil {
+		return nil, ErrObservationClosed
+	}
+	return observation.capture.image()
+}
+
+// ObservationPrecondition requires the target capture to remain byte-identical
+// immediately before mutation.
+type ObservationPrecondition struct {
+	ObservationID string `json:"observation_id"`
+}
+
+// VerificationCondition identifies a bounded post-action capture predicate.
+type VerificationCondition string
+
+const (
+	VerificationCaptureChanged   VerificationCondition = "capture-changed"
+	VerificationCaptureUnchanged VerificationCondition = "capture-unchanged"
+)
+
+// VerificationRequest compares post-action captures with the precondition
+// observation. Attempt count and interval come from immutable session policy.
+type VerificationRequest struct {
+	Condition VerificationCondition `json:"condition"`
+}
+
+// VerificationStatus is the machine-readable post-action outcome.
+type VerificationStatus string
+
+const (
+	VerificationPassed VerificationStatus = "passed"
+	VerificationFailed VerificationStatus = "failed"
+)
+
+// VerificationResult never includes capture pixels or digests.
+type VerificationResult struct {
+	Status    VerificationStatus    `json:"status"`
+	Condition VerificationCondition `json:"condition"`
+	Attempts  uint32                `json:"attempts"`
+}
+
+func (robotGoDriver) RuntimeCapabilities() robotgo.RuntimeCapabilities {
+	return robotgo.GetRuntimeCapabilities()
+}
+
+func (robotGoDriver) Capture(ctx context.Context, region CaptureRegion) (image.Image, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if runtime.GOOS == "linux" && robotgo.DetectDisplayServer() == robotgo.DisplayServerWayland {
+		if robotgo.ScreenCastCaptureReady() == nil {
+			return robotgo.CaptureScreenCast(ctx, region.X, region.Y, region.Width, region.Height)
+		}
+		if os.Getenv(disablePortalEnv) == "" {
+			return nil, fmt.Errorf(
+				"%w: agent capture will not open portal consent implicitly; start ScreenCast explicitly or set %s=1 for native-only capture",
+				robotgo.ErrNotSupported, disablePortalEnv,
+			)
+		}
+	}
+	img, err := robotgo.CaptureImg(region.X, region.Y, region.Width, region.Height, region.DisplayID)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		wipeMutableImage(img)
+		return nil, err
+	}
+	return img, nil
+}
+
+// Observe returns a diagnostics snapshot and optional bounded capture. It is
+// serialized with actions so an observation cannot race a session mutation.
+func (s *Session) Observe(ctx context.Context, request ObserveRequest) (*Observation, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := s.acquire(ctx); err != nil {
+		return nil, err
+	}
+	defer s.release()
+	if err := s.ensureOpen(); err != nil {
+		return nil, err
+	}
+	if err := s.authorizeObservation(request); err != nil {
+		return nil, err
+	}
+	if s.usedObservations >= s.policy.MaxObservations {
+		return nil, observationActionError(ErrorPolicyDenied, "agent policy observation limit reached", ErrPolicyDenied)
+	}
+	if err := s.emitAudit(ctx, AuditEvent{Kind: AuditObservationStarted, Operation: OperationObserve}); err != nil {
+		return nil, observationActionError(ErrorAuditDelivery, "audit sink rejected observation intent", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, observationContextError(ctx)
+	}
+	if err := s.ensureOpen(); err != nil {
+		return nil, err
+	}
+
+	diagnostics, err := s.runtimeDiagnostics(ctx)
+	if err != nil {
+		_ = s.emitAudit(ctx, AuditEvent{Kind: AuditObservationFinished, Operation: OperationObserve, ErrorCode: classifyObservationError(err)})
+		return nil, err
+	}
+	observation := &Observation{
+		SchemaVersion: ObservationSchemaVersion,
+		ObservationID: newObservationID(),
+		CreatedAt:     time.Now().UTC(),
+		Diagnostics:   diagnostics,
+	}
+	if request.Capture != nil {
+		capture, err := s.capture(ctx, *request.Capture, true)
+		if err != nil {
+			_ = s.emitAudit(ctx, AuditEvent{Kind: AuditObservationFinished, Operation: OperationObserve, ErrorCode: classifyObservationError(err)})
+			return nil, err
+		}
+		observation.Capture = &capture.metadata
+		observation.capture = capture.buffer
+	} else {
+		s.usedObservations++
+	}
+	s.storeObservation(observation)
+	if err := s.emitAudit(ctx, AuditEvent{
+		Kind: AuditObservationFinished, Operation: OperationObserve,
+		ObservationID: observation.ObservationID,
+	}); err != nil {
+		return observation, observationActionError(ErrorAuditDelivery, "observation completed but audit delivery failed", err)
+	}
+	return observation, nil
+}
+
+func (s *Session) runtimeDiagnostics(ctx context.Context) (RuntimeDiagnostics, error) {
+	diagnostics := diagnosticsFromCapabilities(s.driver.RuntimeCapabilities())
+	if err := ctx.Err(); err != nil {
+		return RuntimeDiagnostics{}, observationContextError(ctx)
+	}
+	if err := s.ensureOpen(); err != nil {
+		return RuntimeDiagnostics{}, err
+	}
+	return diagnostics, nil
+}
+
+func newObservationID() string {
+	return observationIDPrefix + strconv.FormatUint(observationSerial.Add(1), 10)
+}
+
+func validObservationID(id string) bool {
+	digits := strings.TrimPrefix(id, observationIDPrefix)
+	if digits == id || digits == "" || len(digits) > 20 || digits[0] == '0' {
+		return false
+	}
+	value, err := strconv.ParseUint(digits, 10, 64)
+	return err == nil && value != 0 && strconv.FormatUint(value, 10) == digits
+}
+
+func (s *Session) acquire(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return observationContextError(ctx)
+	case <-s.ctx.Done():
+		return observationActionError(ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+	case <-s.actionGate:
+		return nil
+	}
+}
+
+func (s *Session) release() { s.actionGate <- struct{}{} }
+
+func (s *Session) ensureOpen() error {
+	select {
+	case <-s.ctx.Done():
+		return observationActionError(ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+	default:
+		return nil
+	}
+}
+
+func (s *Session) authorizeObservation(request ObserveRequest) error {
+	if _, allowed := s.policy.allowOperation[OperationObserve]; !allowed {
+		return observationActionError(ErrorPolicyDenied, "agent policy denied desktop observation", ErrPolicyDenied)
+	}
+	if _, required := s.policy.requireConfirmation[OperationObserve]; required && !request.Confirmed {
+		return observationActionError(ErrorPolicyDenied, "agent policy requires observation confirmation", ErrPolicyDenied)
+	}
+	if request.Capture == nil {
+		return nil
+	}
+	if s.policy.MaxCapturePixels == 0 {
+		return observationActionError(ErrorPolicyDenied, "agent policy denies desktop capture", ErrPolicyDenied)
+	}
+	if _, allowed := s.policy.allowDisplay[request.Capture.DisplayID]; !allowed {
+		return observationActionError(ErrorPolicyDenied, "agent policy denied the capture display", ErrPolicyDenied)
+	}
+	return nil
+}
+
+func (s *Session) capture(ctx context.Context, region CaptureRegion, count bool) (*capturedFrame, error) {
+	if err := validateCaptureRegion(region, s.policy.MaxCapturePixels); err != nil {
+		return nil, observationActionError(ErrorInvalidInput, "invalid capture region", err)
+	}
+	if _, allowed := s.policy.allowDisplay[region.DisplayID]; !allowed {
+		return nil, observationActionError(ErrorPolicyDenied, "agent policy denied the capture display", ErrPolicyDenied)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, observationContextError(ctx)
+	}
+	bounds, err := s.driver.DisplayBounds(region.DisplayID)
+	if err != nil {
+		code, message := classifyBackendError(err)
+		return nil, observationActionError(code, message, err)
+	}
+	if !bounds.containsRegion(region) {
+		return nil, observationActionError(ErrorPolicyDenied, "capture region is outside the allowed display", ErrPolicyDenied)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, observationContextError(ctx)
+	}
+	if count {
+		if s.usedObservations >= s.policy.MaxObservations {
+			return nil, observationActionError(ErrorPolicyDenied, "agent policy observation limit reached", ErrPolicyDenied)
+		}
+		s.usedObservations++
+	}
+	img, err := s.driver.Capture(ctx, region)
+	if err != nil {
+		wipeMutableImage(img)
+		code, message := classifyBackendError(err)
+		return nil, observationActionError(code, message, err)
+	}
+	defer wipeMutableImage(img)
+	capture, err := newCaptureObservation(region, img, s.policy.MaxCapturePixels)
+	if err != nil {
+		return nil, observationActionError(ErrorBackendFailure, "desktop backend returned an invalid capture", err)
+	}
+	if err := ctx.Err(); err != nil {
+		_ = capture.buffer.close()
+		return nil, observationContextError(ctx)
+	}
+	return capture, nil
+}
+
+func validateCaptureRegion(region CaptureRegion, maxPixels uint64) error {
+	if region.DisplayID < 0 {
+		return errors.New("capture requires a non-negative display ID")
+	}
+	if region.Width <= 0 || region.Height <= 0 {
+		return errors.New("capture width and height must be positive")
+	}
+	width, height := uint64(region.Width), uint64(region.Height)
+	if maxPixels == 0 || width > maxPixels/height {
+		return fmt.Errorf("capture exceeds the %d pixel policy limit", maxPixels)
+	}
+	return nil
+}
+
+func (b displayBounds) containsRegion(region CaptureRegion) bool {
+	return containsSpan(region.X, region.Width, b.x, b.width) &&
+		containsSpan(region.Y, region.Height, b.y, b.height)
+}
+
+func containsSpan(start, size, minimum, extent int) bool {
+	if size <= 0 || extent <= 0 || start < minimum {
+		return false
+	}
+	offset := uint(start) - uint(minimum)
+	return offset <= uint(extent) && uint(size) <= uint(extent)-offset
+}
+
+func newCaptureObservation(region CaptureRegion, source image.Image, maxPixels uint64) (*capturedFrame, error) {
+	if source == nil {
+		return nil, errors.New("capture image is nil")
+	}
+	bounds := source.Bounds()
+	width, height := bounds.Dx(), bounds.Dy()
+	if width != region.Width || height != region.Height {
+		return nil, fmt.Errorf("capture size %dx%d does not match requested %dx%d", width, height, region.Width, region.Height)
+	}
+	if err := validateCaptureRegion(CaptureRegion{Width: width, Height: height, DisplayID: region.DisplayID}, maxPixels); err != nil {
+		return nil, err
+	}
+	pixels := image.NewRGBA(image.Rect(0, 0, width, height))
+	draw.Draw(pixels, pixels.Bounds(), source, bounds.Min, draw.Src)
+	digest := sha256.Sum256(pixels.Pix)
+	return &capturedFrame{
+		metadata: CaptureMetadata{
+			Region: region, SHA256: hex.EncodeToString(digest[:]),
+			Width: width, Height: height,
+		},
+		buffer: &captureBuffer{pixels: pixels},
+	}, nil
+}
+
+func cloneRGBA(source *image.RGBA) *image.RGBA {
+	clone := image.NewRGBA(source.Bounds())
+	copy(clone.Pix, source.Pix)
+	return clone
+}
+
+func wipeMutableImage(img image.Image) {
+	switch typed := img.(type) {
+	case *image.RGBA:
+		clear(typed.Pix)
+	case *image.NRGBA:
+		clear(typed.Pix)
+	case *image.RGBA64:
+		clear(typed.Pix)
+	case *image.NRGBA64:
+		clear(typed.Pix)
+	case *image.Gray:
+		clear(typed.Pix)
+	case *image.Gray16:
+		clear(typed.Pix)
+	case *image.Alpha:
+		clear(typed.Pix)
+	case *image.Alpha16:
+		clear(typed.Pix)
+	case *image.CMYK:
+		clear(typed.Pix)
+	case *image.Paletted:
+		clear(typed.Pix)
+	case *image.YCbCr:
+		clear(typed.Y)
+		clear(typed.Cb)
+		clear(typed.Cr)
+	case *image.NYCbCrA:
+		clear(typed.Y)
+		clear(typed.Cb)
+		clear(typed.Cr)
+		clear(typed.A)
+	}
+}
+
+func (s *Session) storeObservation(observation *Observation) {
+	record := observationRecord{capture: observation.capture}
+	if observation.Capture != nil {
+		record.region = observation.Capture.Region
+		record.digest = observation.Capture.SHA256
+		record.hasCapture = true
+	}
+	s.observationMu.Lock()
+	s.observations[observation.ObservationID] = record
+	s.observationMu.Unlock()
+}
+
+func (s *Session) observation(id string) (observationRecord, bool) {
+	s.observationMu.Lock()
+	defer s.observationMu.Unlock()
+	record, ok := s.observations[id]
+	return record, ok
+}
+
+func (s *Session) closeObservations() {
+	s.observationMu.Lock()
+	defer s.observationMu.Unlock()
+	for _, record := range s.observations {
+		_ = record.capture.close()
+	}
+	clear(s.observations)
+}
+
+func diagnosticsFromCapabilities(capabilities robotgo.RuntimeCapabilities) RuntimeDiagnostics {
+	features := []struct {
+		name  string
+		value robotgo.FeatureCapability
+	}{
+		{"capture", capabilities.Capture}, {"bounds", capabilities.Bounds},
+		{"keyboard", capabilities.Keyboard}, {"mouse", capabilities.Mouse},
+		{"remote-desktop", capabilities.RemoteDesktop}, {"window", capabilities.Window},
+		{"process", capabilities.Process}, {"clipboard", capabilities.Clipboard},
+		{"hook", capabilities.Hook}, {"events", capabilities.Events},
+	}
+	diagnostics := RuntimeDiagnostics{
+		GOOS: capabilities.Runtime.GOOS, GOARCH: capabilities.Runtime.GOARCH,
+		CGOEnabled:     capabilities.Runtime.CGOEnabled,
+		Implementation: string(capabilities.Runtime.BuildImplementation),
+		DisplayServer:  string(capabilities.Runtime.DisplayServer),
+		Compositor:     capabilities.Compositor,
+		Features:       make([]DiagnosticFeature, 0, len(features)),
+	}
+	for _, feature := range features {
+		remediation := feature.value.Notes
+		if remediation == "" {
+			remediation = feature.value.Reason
+		}
+		diagnostics.Features = append(diagnostics.Features, DiagnosticFeature{
+			Name: feature.name, Available: feature.value.Available,
+			Fallback: feature.value.Fallback, Backend: feature.value.Backend,
+			Reason: feature.value.Reason, Remediation: remediation,
+		})
+	}
+	return diagnostics
+}
+
+func observationActionError(code ErrorCode, message string, cause error) *ActionError {
+	return newActionError(code, OperationObserve, message, cause)
+}
+
+func observationContextError(ctx context.Context) *ActionError {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return observationActionError(ErrorTimedOut, "observation deadline exceeded", ctx.Err())
+	}
+	return observationActionError(ErrorCanceled, "observation canceled", ctx.Err())
+}
+
+func classifyObservationError(err error) ErrorCode {
+	var actionErr *ActionError
+	if errors.As(err, &actionErr) {
+		return actionErr.Code
+	}
+	code, _ := classifyBackendError(err)
+	return code
+}

--- a/agent/observation.go
+++ b/agent/observation.go
@@ -228,7 +228,7 @@ func (robotGoDriver) Capture(ctx context.Context, region CaptureRegion) (image.I
 	}
 	if runtime.GOOS == "linux" && robotgo.DetectDisplayServer() == robotgo.DisplayServerWayland {
 		if robotgo.ScreenCastCaptureReady() == nil {
-			return robotgo.CaptureScreenCast(ctx, region.X, region.Y, region.Width, region.Height)
+			return robotgo.CaptureScreenCastDisplay(ctx, region.DisplayID, region.X, region.Y, region.Width, region.Height)
 		}
 		if os.Getenv(disablePortalEnv) == "" {
 			return nil, fmt.Errorf(

--- a/agent/observation.go
+++ b/agent/observation.go
@@ -127,6 +127,24 @@ func (capture *captureBuffer) usable() bool {
 	return !capture.closed && capture.pixels != nil
 }
 
+func (capture *captureBuffer) acquireUse() bool {
+	if capture == nil {
+		return false
+	}
+	capture.mu.Lock()
+	if capture.closed || capture.pixels == nil {
+		capture.mu.Unlock()
+		return false
+	}
+	return true
+}
+
+func (capture *captureBuffer) releaseUse() {
+	if capture != nil {
+		capture.mu.Unlock()
+	}
+}
+
 // Observation owns optional sensitive pixels and sanitized diagnostics.
 type Observation struct {
 	SchemaVersion string             `json:"schema_version"`

--- a/agent/observation_test.go
+++ b/agent/observation_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"image"
@@ -53,6 +54,7 @@ func observeCapture(t *testing.T, session *Session) *Observation {
 
 func TestObserveOwnsPixelsAndSerializesOnlyMetadata(t *testing.T) {
 	source := syntheticCapture(2, 2, 41)
+	rawPixelEncoding := base64.StdEncoding.EncodeToString(append([]byte(nil), source.Pix...))
 	driver := &fakeDriver{captureImages: []image.Image{source}}
 	session := newTestSession(t, observationPolicy(), driver)
 
@@ -78,11 +80,57 @@ func TestObserveOwnsPixelsAndSerializesOnlyMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(serialized), "Pix") || strings.Contains(string(serialized), "pixels") {
+	if strings.Contains(string(serialized), "Pix") || strings.Contains(string(serialized), "pixels") ||
+		strings.Contains(string(serialized), rawPixelEncoding) {
 		t.Fatalf("serialized observation leaked a pixel field: %s", serialized)
 	}
 	if observation.Capture == nil || observation.Capture.SHA256 == "" {
 		t.Fatalf("capture metadata = %+v", observation.Capture)
+	}
+}
+
+func TestObservationErrorsNeverSerializeBackendDetails(t *testing.T) {
+	const backendDetail = "private-backend-diagnostic"
+	driver := &fakeDriver{captureErr: errors.New(backendDetail)}
+	session := newTestSession(t, observationPolicy(), driver)
+	_, observeErr := session.Observe(context.Background(), ObserveRequest{
+		Capture: &CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+	})
+	serialized, err := json.Marshal(observeErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(serialized), backendDetail) {
+		t.Fatalf("serialized observation error leaked backend detail: %s", serialized)
+	}
+}
+
+func TestObservationPolicyDeniesBeforeDesktopIO(t *testing.T) {
+	tests := []Policy{
+		testPolicy(),
+		{
+			AllowedOperations: []Operation{OperationObserve},
+			ConfirmOperations: []Operation{OperationObserve},
+			AllowedDisplayIDs: []int{0}, MaxObservations: 1, MaxCapturePixels: 4,
+		},
+		{
+			AllowedOperations: []Operation{OperationObserve},
+			AllowedDisplayIDs: []int{0}, MaxObservations: 1,
+		},
+	}
+	for _, policy := range tests {
+		driver := &fakeDriver{}
+		session := newTestSession(t, policy, driver)
+		_, err := session.Observe(context.Background(), ObserveRequest{
+			Capture: &CaptureRegion{Width: 1, Height: 1, DisplayID: 0},
+		})
+		if !errors.Is(err, ErrPolicyDenied) {
+			t.Fatalf("Observe with policy %+v = %v", policy, err)
+		}
+		if driver.captureCount() != 0 {
+			t.Fatalf("denied observation reached capture backend %d times", driver.captureCount())
+		}
+		_ = session.Close()
 	}
 }
 
@@ -305,6 +353,28 @@ func TestSessionCloseZeroesAllOwnedCaptures(t *testing.T) {
 	}
 	if _, err := observation.Image(); !errors.Is(err, ErrObservationClosed) {
 		t.Fatalf("Image after Close = %v", err)
+	}
+	if _, err := session.Observe(context.Background(), ObserveRequest{}); !errors.Is(err, ErrSessionClosed) {
+		t.Fatalf("Observe after Close = %v", err)
+	}
+}
+
+func TestClosedObservationCannotAuthorizeMutation(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 19)}}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+	if err := observation.Close(); err != nil {
+		t.Fatal(err)
+	}
+	result, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+	})
+	if !errors.Is(err, ErrStaleTarget) || result.Error == nil || result.Error.Code != ErrorStaleTarget {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if driver.callCount() != 0 || driver.captureCount() != 1 {
+		t.Fatalf("input calls = %d, capture calls = %d", driver.callCount(), driver.captureCount())
 	}
 }
 

--- a/agent/observation_test.go
+++ b/agent/observation_test.go
@@ -654,6 +654,14 @@ func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 		t.Fatalf("portal-only capture capability = %+v", capability)
 	}
 
+	capabilities.Capture = robotgo.FeatureCapability{
+		Available: true,
+		Backend:   robotgo.FeatureBackendScreenCast,
+	}
+	if capability = buildCatalog(policy, capabilities).Operations[0]; !capability.CaptureAvailable {
+		t.Fatalf("active ScreenCast capability = %+v", capability)
+	}
+
 	t.Setenv(disablePortalEnv, "1")
 	capabilities.Capture = robotgo.FeatureCapability{Available: true, Backend: "native-wayland"}
 	if capability = buildCatalog(policy, capabilities).Operations[0]; !capability.CaptureAvailable {

--- a/agent/observation_test.go
+++ b/agent/observation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"image"
 	"image/color"
 	"runtime"
@@ -761,7 +762,7 @@ func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	capabilities.Runtime.DisplayServer = robotgo.DisplayServerWayland
 	capabilities.Capture = robotgo.FeatureCapability{Available: true, Backend: string(robotgo.BackendPortal)}
 	capability := buildCatalog(policy, capabilities).Operations[0]
-	if capability.CaptureAvailable || !strings.Contains(capability.Remediation, disablePortalEnv) {
+	if capability.CaptureAvailable || !strings.Contains(capability.Remediation, "will not open portal consent implicitly") {
 		t.Fatalf("portal-only capture capability = %+v", capability)
 	}
 
@@ -774,9 +775,100 @@ func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	}
 
 	t.Setenv(disablePortalEnv, "1")
-	capabilities.Capture = robotgo.FeatureCapability{Available: true, Backend: "native-wayland"}
+	capabilities.Capture = robotgo.FeatureCapability{
+		Available: true,
+		Backend:   robotgo.FeatureBackendWaylandScreencopy,
+	}
 	if capability = buildCatalog(policy, capabilities).Operations[0]; !capability.CaptureAvailable {
 		t.Fatalf("explicit native-only capture capability = %+v", capability)
+	}
+}
+
+func TestWaylandAgentCapturePrefersNativeBeforeActiveScreenCast(t *testing.T) {
+	want := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	var calls []string
+	img, err := captureWaylandAgent(
+		context.Background(),
+		CaptureRegion{Width: 1, Height: 1, DisplayID: 0},
+		false,
+		func(...int) (image.Image, error) {
+			calls = append(calls, "native")
+			return want, nil
+		},
+		func() error {
+			calls = append(calls, "ready")
+			return nil
+		},
+		func(context.Context, int, ...int) (image.Image, error) {
+			calls = append(calls, "screencast")
+			return nil, nil
+		},
+	)
+	if err != nil || img != want {
+		t.Fatalf("captureWaylandAgent = (%v, %v)", img, err)
+	}
+	if got := strings.Join(calls, ","); got != "native" {
+		t.Fatalf("backend order = %q, want native only", got)
+	}
+}
+
+func TestWaylandAgentCaptureUsesOnlyActiveScreenCastFallback(t *testing.T) {
+	nativeErr := errors.New("native unavailable")
+	want := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	var calls []string
+	img, err := captureWaylandAgent(
+		context.Background(),
+		CaptureRegion{X: -10, Y: 5, Width: 1, Height: 1, DisplayID: 2},
+		false,
+		func(args ...int) (image.Image, error) {
+			calls = append(calls, "native")
+			if got := fmt.Sprint(args); got != "[-10 5 1 1 2]" {
+				t.Fatalf("native args = %s", got)
+			}
+			return nil, nativeErr
+		},
+		func() error {
+			calls = append(calls, "ready")
+			return nil
+		},
+		func(_ context.Context, displayID int, region ...int) (image.Image, error) {
+			calls = append(calls, "screencast")
+			if displayID != 2 || fmt.Sprint(region) != "[-10 5 1 1]" {
+				t.Fatalf("ScreenCast target = display %d, region %v", displayID, region)
+			}
+			return want, nil
+		},
+	)
+	if err != nil || img != want {
+		t.Fatalf("captureWaylandAgent = (%v, %v)", img, err)
+	}
+	if got := strings.Join(calls, ","); got != "native,ready,screencast" {
+		t.Fatalf("backend order = %q", got)
+	}
+}
+
+func TestWaylandAgentCaptureDisabledPortalStopsAfterNative(t *testing.T) {
+	nativeErr := errors.New("native unavailable")
+	var fallbackCalled bool
+	img, err := captureWaylandAgent(
+		context.Background(),
+		CaptureRegion{Width: 1, Height: 1, DisplayID: 0},
+		true,
+		func(...int) (image.Image, error) { return nil, nativeErr },
+		func() error {
+			fallbackCalled = true
+			return nil
+		},
+		func(context.Context, int, ...int) (image.Image, error) {
+			fallbackCalled = true
+			return nil, nil
+		},
+	)
+	if img != nil || !errors.Is(err, nativeErr) || !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("captureWaylandAgent = (%v, %v)", img, err)
+	}
+	if fallbackCalled {
+		t.Fatal("portal fallback was consulted while disabled")
 	}
 }
 

--- a/agent/observation_test.go
+++ b/agent/observation_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	robotgo "github.com/marang/robotgo"
 )
@@ -441,6 +442,62 @@ func TestCaptureRegionValidationIsOverflowSafe(t *testing.T) {
 	}
 	if containsSpan(99, 2, 0, 100) {
 		t.Fatal("out-of-bounds span was accepted")
+	}
+}
+
+func TestInvalidCaptureRegionNeverReachesDesktopBackend(t *testing.T) {
+	driver := &fakeDriver{}
+	session := newTestSession(t, observationPolicy(), driver)
+	for _, region := range []CaptureRegion{
+		{Width: 0, Height: 1, DisplayID: 0},
+		{Width: 5, Height: 5, DisplayID: 0},
+		{X: 99, Y: 99, Width: 2, Height: 2, DisplayID: 0},
+		{Width: 1, Height: 1, DisplayID: -1},
+	} {
+		if _, err := session.Observe(context.Background(), ObserveRequest{Capture: &region}); err == nil {
+			t.Fatalf("invalid capture region was accepted: %+v", region)
+		}
+	}
+	if driver.captureCount() != 0 {
+		t.Fatalf("invalid regions reached capture backend %d times", driver.captureCount())
+	}
+}
+
+func TestObservationAndActionAreSerialized(t *testing.T) {
+	driver := &fakeDriver{
+		captureHit: make(chan struct{}, 1), captureGo: make(chan struct{}),
+		started: make(chan struct{}, 1),
+	}
+	session := newTestSession(t, observationPolicy(), driver)
+	observeErr := make(chan error, 1)
+	go func() {
+		observation, err := session.Observe(context.Background(), ObserveRequest{
+			Capture: &CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+		})
+		if observation != nil {
+			_ = observation.Close()
+		}
+		observeErr <- err
+	}()
+	<-driver.captureHit
+	actionErr := make(chan error, 1)
+	go func() {
+		_, err := session.Execute(context.Background(), ActionRequest{
+			Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		})
+		actionErr <- err
+	}()
+	select {
+	case <-driver.started:
+		t.Fatal("action reached input while observation still owned the session gate")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(driver.captureGo)
+	if err := <-observeErr; err != nil {
+		t.Fatalf("Observe = %v", err)
+	}
+	if err := <-actionErr; err != nil {
+		t.Fatalf("Execute = %v", err)
 	}
 }
 

--- a/agent/observation_test.go
+++ b/agent/observation_test.go
@@ -1,0 +1,580 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"image"
+	"image/color"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+const (
+	testWaylandDisplayEnv = "WAYLAND_DISPLAY"
+	testX11DisplayEnv     = "DISPLAY"
+)
+
+func observationPolicy() Policy {
+	return Policy{
+		AllowedOperations: []Operation{OperationObserve, OperationClick},
+		AllowedDisplayIDs: []int{0},
+		MaxActions:        3, MaxObservations: 8, MaxCapturePixels: 16,
+		VerificationAttempts: 2, VerificationIntervalMillis: 0,
+		VerificationTimeoutMillis: 100,
+	}
+}
+
+func syntheticCapture(width, height int, value byte) *image.RGBA {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.SetRGBA(x, y, color.RGBA{R: value, G: value + 1, B: value + 2, A: 255})
+		}
+	}
+	return img
+}
+
+func observeCapture(t *testing.T, session *Session) *Observation {
+	t.Helper()
+	observation, err := session.Observe(context.Background(), ObserveRequest{
+		Capture: &CaptureRegion{X: 1, Y: 2, Width: 2, Height: 2, DisplayID: 0},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
+}
+
+func TestObserveOwnsPixelsAndSerializesOnlyMetadata(t *testing.T) {
+	source := syntheticCapture(2, 2, 41)
+	driver := &fakeDriver{captureImages: []image.Image{source}}
+	session := newTestSession(t, observationPolicy(), driver)
+
+	observation := observeCapture(t, session)
+	for index, value := range source.Pix {
+		if value != 0 {
+			t.Fatalf("source pixel %d was not zeroed: %d", index, value)
+		}
+	}
+	first, err := observation.Image()
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.Pix[0] = 255
+	second, err := observation.Image()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Pix[0] == 255 {
+		t.Fatal("caller mutation changed the observation-owned pixels")
+	}
+	serialized, err := json.Marshal(observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(serialized), "Pix") || strings.Contains(string(serialized), "pixels") {
+		t.Fatalf("serialized observation leaked a pixel field: %s", serialized)
+	}
+	if observation.Capture == nil || observation.Capture.SHA256 == "" {
+		t.Fatalf("capture metadata = %+v", observation.Capture)
+	}
+}
+
+func TestPublicMetadataCannotChangeInternalLineage(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 8), syntheticCapture(2, 2, 8),
+	}}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+	observation.Capture.Region = CaptureRegion{X: 99, Y: 99, Width: 1, Height: 1, DisplayID: 0}
+	observation.Capture.SHA256 = "caller-controlled"
+
+	result, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+	})
+	if err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if driver.callCount() != 1 || driver.captureCount() != 2 {
+		t.Fatalf("input calls = %d, capture calls = %d", driver.callCount(), driver.captureCount())
+	}
+}
+
+func TestStalePreconditionPreventsMutation(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 1), syntheticCapture(2, 2, 2),
+	}}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+
+	result, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+	})
+	if !errors.Is(err, ErrStaleTarget) || result.Error == nil || result.Error.Code != ErrorStaleTarget {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if driver.callCount() != 0 {
+		t.Fatalf("stale target reached input driver %d times", driver.callCount())
+	}
+}
+
+func TestChangedVerificationProducesBoundedProof(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 3), syntheticCapture(2, 2, 3), syntheticCapture(2, 2, 4),
+	}}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+
+	result, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+		Verification: &VerificationRequest{Condition: VerificationCaptureChanged},
+	})
+	if err != nil || result.Status != ActionSucceeded || result.Verification == nil ||
+		result.Verification.Status != VerificationPassed || result.Verification.Attempts != 1 || result.PostObservationID == "" {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	record, ok := session.observation(result.PostObservationID)
+	if !ok || !record.hasCapture || !record.capture.usable() {
+		t.Fatalf("post observation %q was not retained safely", result.PostObservationID)
+	}
+}
+
+func TestUnchangedVerificationPasses(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 10), syntheticCapture(2, 2, 10), syntheticCapture(2, 2, 10),
+	}}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+	result, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+		Verification: &VerificationRequest{Condition: VerificationCaptureUnchanged},
+	})
+	if err != nil || result.Status != ActionSucceeded || result.Verification == nil ||
+		result.Verification.Status != VerificationPassed || result.Verification.Attempts != 1 {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+}
+
+func TestFailedVerificationIsExplicitAfterMutation(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 5), syntheticCapture(2, 2, 5),
+		syntheticCapture(2, 2, 5), syntheticCapture(2, 2, 5),
+	}}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+
+	result, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+		Verification: &VerificationRequest{Condition: VerificationCaptureChanged},
+	})
+	if !errors.Is(err, ErrVerification) || result.Status != ActionUnverified || result.Error == nil ||
+		result.Error.Code != ErrorVerification || result.Verification == nil || result.Verification.Attempts != 2 {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if driver.callCount() != 1 || driver.captureCount() != 4 {
+		t.Fatalf("input calls = %d, capture calls = %d", driver.callCount(), driver.captureCount())
+	}
+}
+
+func TestVerificationTimeoutStopsPolling(t *testing.T) {
+	policy := observationPolicy()
+	policy.VerificationAttempts = 10
+	policy.VerificationIntervalMillis = 50
+	policy.VerificationTimeoutMillis = 5
+	policy.MaxObservations = 20
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 6), syntheticCapture(2, 2, 6), syntheticCapture(2, 2, 6),
+	}}
+	session := newTestSession(t, policy, driver)
+	observation := observeCapture(t, session)
+
+	result, err := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+		Verification: &VerificationRequest{Condition: VerificationCaptureChanged},
+	})
+	if result.Status != ActionUnverified || result.Error == nil || result.Error.Code != ErrorTimedOut ||
+		!errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if driver.captureCount() != 3 {
+		t.Fatalf("bounded capture calls = %d, want 3", driver.captureCount())
+	}
+}
+
+func TestSessionCloseCancelsVerificationPolling(t *testing.T) {
+	policy := observationPolicy()
+	policy.VerificationAttempts = 10
+	policy.VerificationIntervalMillis = 1000
+	policy.VerificationTimeoutMillis = 5000
+	policy.MaxObservations = 12
+	driver := &fakeDriver{
+		captureHit: make(chan struct{}, 3),
+		captureImages: []image.Image{
+			syntheticCapture(2, 2, 12), syntheticCapture(2, 2, 12), syntheticCapture(2, 2, 12),
+		},
+	}
+	session := newTestSession(t, policy, driver)
+	observation := observeCapture(t, session)
+	<-driver.captureHit
+	resultCh := make(chan ActionResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := session.Execute(context.Background(), ActionRequest{
+			Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+			Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+			Verification: &VerificationRequest{Condition: VerificationCaptureChanged},
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	<-driver.captureHit
+	<-driver.captureHit
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+	result, err := <-resultCh, <-errCh
+	if !errors.Is(err, ErrSessionClosed) || result.Status != ActionUnverified ||
+		result.Error == nil || result.Error.Code != ErrorSessionClosed {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+}
+
+func TestVerificationCancellationCoversFinalDiagnostics(t *testing.T) {
+	policy := observationPolicy()
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 13), syntheticCapture(2, 2, 13), syntheticCapture(2, 2, 14),
+	}}
+	session := newTestSession(t, policy, driver)
+	observation := observeCapture(t, session)
+	driver.capabilityHit = make(chan struct{}, 1)
+	driver.capabilityGo = make(chan struct{})
+	resultCh := make(chan ActionResult, 1)
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		result, err := session.Execute(ctx, ActionRequest{
+			Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+			Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+			Verification: &VerificationRequest{Condition: VerificationCaptureChanged},
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	<-driver.capabilityHit
+	cancel()
+	close(driver.capabilityGo)
+	result, err := <-resultCh, <-errCh
+	if !errors.Is(err, context.Canceled) || result.Status != ActionUnverified ||
+		result.Error == nil || result.Error.Code != ErrorCanceled || result.PostObservationID != "" {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if len(session.observations) != 1 {
+		t.Fatalf("timed-out proof retained a post observation: %d", len(session.observations))
+	}
+}
+
+func TestSessionCloseZeroesAllOwnedCaptures(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 7)}}
+	policy, err := preparePolicy(observationPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := newSession(policy, driver, availableCapabilities())
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := observeCapture(t, session)
+	buffer := observation.capture
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if buffer.usable() {
+		t.Fatal("session close retained sensitive capture pixels")
+	}
+	if _, err := observation.Image(); !errors.Is(err, ErrObservationClosed) {
+		t.Fatalf("Image after Close = %v", err)
+	}
+}
+
+type recordingAuditSink struct {
+	mu     sync.Mutex
+	events []AuditEvent
+	failAt int
+}
+
+func (sink *recordingAuditSink) Record(_ context.Context, event AuditEvent) error {
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	sink.events = append(sink.events, event)
+	if sink.failAt > 0 && len(sink.events) == sink.failAt {
+		return errors.New("audit unavailable")
+	}
+	return nil
+}
+
+func TestAuditIntentFailurePreventsDesktopIO(t *testing.T) {
+	policy, err := preparePolicy(observationPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 9)}}
+	sink := &recordingAuditSink{failAt: 1}
+	session, err := newSessionWithAudit(policy, driver, availableCapabilities(), sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	if _, err := session.Observe(context.Background(), ObserveRequest{
+		Capture: &CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+	}); err == nil {
+		t.Fatal("Observe succeeded after audit intent failure")
+	}
+	if driver.captureCount() != 0 || driver.callCount() != 0 {
+		t.Fatal("audit intent failure reached desktop I/O")
+	}
+}
+
+func TestActionAuditIntentFailurePreventsBoundsAndInputIO(t *testing.T) {
+	policy := observationPolicy()
+	policy.AllowedOperations = append(policy.AllowedOperations, OperationMove)
+	prepared, err := preparePolicy(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver := &fakeDriver{boundsHit: make(chan struct{}, 1)}
+	sink := &recordingAuditSink{failAt: 1}
+	session, err := newSessionWithAudit(prepared, driver, availableCapabilities(), sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	result, executeErr := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationMove, Move: &MoveAction{X: 1, Y: 1, DisplayID: 0},
+	})
+	if result.Error == nil || result.Error.Code != ErrorAuditDelivery || !errors.Is(executeErr, ErrAuditDelivery) {
+		t.Fatalf("Execute = %+v, %v", result, executeErr)
+	}
+	select {
+	case <-driver.boundsHit:
+		t.Fatal("audit intent failure reached display bounds I/O")
+	default:
+	}
+	if driver.callCount() != 0 {
+		t.Fatal("audit intent failure reached input I/O")
+	}
+}
+
+func TestActionCompletionAuditFailurePreservesOutcome(t *testing.T) {
+	policy, err := preparePolicy(observationPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver := &fakeDriver{}
+	sink := &recordingAuditSink{failAt: 2}
+	session, err := newSessionWithAudit(policy, driver, availableCapabilities(), sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	result, executeErr := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+	})
+	var actionErr *ActionError
+	if !errors.As(executeErr, &actionErr) || actionErr.Code != ErrorAuditDelivery || !errors.Is(executeErr, ErrAuditDelivery) ||
+		result.Status != ActionSucceeded || result.Error != nil || driver.callCount() != 1 {
+		t.Fatalf("Execute = %+v, %v", result, executeErr)
+	}
+	serialized, err := json.Marshal(sink.events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(serialized), "coordinates") || strings.Contains(string(serialized), "text") ||
+		strings.Contains(string(serialized), "sha256") || strings.Contains(string(serialized), "pixels") {
+		t.Fatalf("audit leaked sensitive payload fields: %s", serialized)
+	}
+}
+
+func TestVerificationAuditFailurePreservesPassedOutcome(t *testing.T) {
+	policy, err := preparePolicy(observationPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 20), syntheticCapture(2, 2, 20), syntheticCapture(2, 2, 21),
+	}}
+	sink := &recordingAuditSink{failAt: 4}
+	session, err := newSessionWithAudit(policy, driver, availableCapabilities(), sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	observation := observeCapture(t, session)
+	result, executeErr := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+		Verification: &VerificationRequest{Condition: VerificationCaptureChanged},
+	})
+	var actionErr *ActionError
+	if !errors.As(executeErr, &actionErr) || actionErr.Code != ErrorAuditDelivery || !errors.Is(executeErr, ErrAuditDelivery) ||
+		result.Status != ActionSucceeded || result.Error != nil || result.Verification == nil ||
+		result.Verification.Status != VerificationPassed || driver.callCount() != 1 {
+		t.Fatalf("Execute = %+v, %v", result, executeErr)
+	}
+}
+
+func TestCaptureRegionValidationIsOverflowSafe(t *testing.T) {
+	if err := validateCaptureRegion(CaptureRegion{Width: int(^uint(0) >> 1), Height: 2, DisplayID: 0}, 16); err == nil {
+		t.Fatal("overflow-sized region was accepted")
+	}
+	if containsSpan(99, 2, 0, 100) {
+		t.Fatal("out-of-bounds span was accepted")
+	}
+}
+
+func TestFailedCaptureConsumesBoundedObservationAttempt(t *testing.T) {
+	policy := observationPolicy()
+	policy.MaxObservations = 1
+	policy.VerificationAttempts = 0
+	policy.VerificationIntervalMillis = 0
+	policy.VerificationTimeoutMillis = 0
+	driver := &fakeDriver{captureErr: errors.New("capture failed")}
+	session := newTestSession(t, policy, driver)
+	request := ObserveRequest{Capture: &CaptureRegion{Width: 2, Height: 2, DisplayID: 0}}
+	if _, err := session.Observe(context.Background(), request); err == nil {
+		t.Fatal("first capture unexpectedly succeeded")
+	}
+	if _, err := session.Observe(context.Background(), request); !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("second capture error = %v", err)
+	}
+	if driver.captureCount() != 1 {
+		t.Fatalf("capture attempts = %d, want 1", driver.captureCount())
+	}
+}
+
+func TestFailedBackendCaptureIsZeroed(t *testing.T) {
+	source := syntheticCapture(2, 2, 33)
+	driver := &fakeDriver{
+		captureImages: []image.Image{source}, captureErr: errors.New("partial capture failed"),
+	}
+	session := newTestSession(t, observationPolicy(), driver)
+	if _, err := session.Observe(context.Background(), ObserveRequest{
+		Capture: &CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+	}); err == nil {
+		t.Fatal("partial failed capture unexpectedly succeeded")
+	}
+	for index, value := range source.Pix {
+		if value != 0 {
+			t.Fatalf("failed capture pixel %d was not zeroed: %d", index, value)
+		}
+	}
+}
+
+func TestVerificationPolicyMustBeBounded(t *testing.T) {
+	tests := []Policy{
+		{AllowedOperations: []Operation{OperationClick}, MaxActions: 1, VerificationAttempts: 1},
+		{AllowedOperations: []Operation{OperationClick}, MaxActions: 1, VerificationTimeoutMillis: 1},
+		{AllowedOperations: []Operation{OperationClick}, MaxActions: 1, VerificationAttempts: 1, VerificationTimeoutMillis: 1},
+		{AllowedOperations: []Operation{OperationClick}, MaxActions: 1, MaxCapturePixels: maxAgentCapturePixels + 1},
+	}
+	for _, policy := range tests {
+		if _, err := preparePolicy(policy); err == nil {
+			t.Fatalf("unbounded policy was accepted: %+v", policy)
+		}
+	}
+}
+
+func TestObservationOnlyPolicyNeedsNoActionBudget(t *testing.T) {
+	policy := Policy{
+		AllowedOperations: []Operation{OperationObserve},
+		MaxObservations:   1,
+	}
+	if _, err := preparePolicy(policy); err != nil {
+		t.Fatalf("observation-only policy = %v", err)
+	}
+	policy.AllowedOperations = append(policy.AllowedOperations, OperationClick)
+	if _, err := preparePolicy(policy); err == nil {
+		t.Fatal("mutation policy without an action budget was accepted")
+	}
+}
+
+func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
+	t.Setenv(disablePortalEnv, "")
+	policy, err := preparePolicy(Policy{
+		AllowedOperations: []Operation{OperationObserve}, MaxObservations: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	capabilities := availableCapabilities()
+	capabilities.Runtime.GOOS = "linux"
+	capabilities.Runtime.DisplayServer = robotgo.DisplayServerWayland
+	capabilities.Capture = robotgo.FeatureCapability{Available: true, Backend: string(robotgo.BackendPortal)}
+	capability := buildCatalog(policy, capabilities).Operations[0]
+	if capability.CaptureAvailable || !strings.Contains(capability.Remediation, disablePortalEnv) {
+		t.Fatalf("portal-only capture capability = %+v", capability)
+	}
+
+	t.Setenv(disablePortalEnv, "1")
+	capabilities.Capture = robotgo.FeatureCapability{Available: true, Backend: "native-wayland"}
+	if capability = buildCatalog(policy, capabilities).Operations[0]; !capability.CaptureAvailable {
+		t.Fatalf("explicit native-only capture capability = %+v", capability)
+	}
+}
+
+func TestWaylandAgentCaptureNeverOpensPortalImplicitly(t *testing.T) {
+	if runtime.GOOS != goOSLinux {
+		t.Skip("Wayland environment selection is Linux-specific")
+	}
+	t.Setenv(testWaylandDisplayEnv, "robotgo-agent-test")
+	t.Setenv(testX11DisplayEnv, "")
+	t.Setenv(disablePortalEnv, "")
+	img, err := (robotGoDriver{}).Capture(context.Background(), CaptureRegion{
+		Width: 1, Height: 1, DisplayID: 0,
+	})
+	if img != nil || !errors.Is(err, robotgo.ErrNotSupported) ||
+		!strings.Contains(err.Error(), "will not open portal consent implicitly") {
+		t.Fatalf("Capture = (%v, %v)", img, err)
+	}
+}
+
+func TestInvalidPreconditionIDCannotEnterAuditTrail(t *testing.T) {
+	const secret = "customer-secret-as-observation-id"
+	policy, err := preparePolicy(observationPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &recordingAuditSink{}
+	driver := &fakeDriver{}
+	session, err := newSessionWithAudit(policy, driver, availableCapabilities(), sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	result, executeErr := session.Execute(context.Background(), ActionRequest{
+		Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+		Precondition: &ObservationPrecondition{ObservationID: secret},
+	})
+	if executeErr == nil || result.Error == nil || result.Error.Code != ErrorInvalidInput {
+		t.Fatalf("Execute = %+v, %v", result, executeErr)
+	}
+	serialized, err := json.Marshal(sink.events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(serialized), secret) || len(sink.events) != 0 {
+		t.Fatalf("invalid precondition entered audit trail: %s", serialized)
+	}
+}

--- a/agent/observation_test.go
+++ b/agent/observation_test.go
@@ -378,6 +378,117 @@ func TestClosedObservationCannotAuthorizeMutation(t *testing.T) {
 	}
 }
 
+func TestObservationCloseDuringLineageCapturePreventsMutation(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 20), syntheticCapture(2, 2, 20),
+	}}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+	driver.captureHit = make(chan struct{}, 1)
+	driver.captureGo = make(chan struct{})
+
+	resultCh := make(chan ActionResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := session.Execute(context.Background(), ActionRequest{
+			Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+			Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	<-driver.captureHit
+	if err := observation.Close(); err != nil {
+		t.Fatal(err)
+	}
+	close(driver.captureGo)
+
+	result, err := <-resultCh, <-errCh
+	if !errors.Is(err, ErrStaleTarget) || result.Error == nil || result.Error.Code != ErrorStaleTarget {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if driver.callCount() != 0 {
+		t.Fatalf("closed lineage reached input driver %d times", driver.callCount())
+	}
+}
+
+func TestObservationCloseWaitsForAuthorizedDispatch(t *testing.T) {
+	driver := &fakeDriver{
+		captureImages: []image.Image{
+			syntheticCapture(2, 2, 22), syntheticCapture(2, 2, 22),
+		},
+		started: make(chan struct{}, 1), release: make(chan struct{}),
+	}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+
+	resultCh := make(chan ActionResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := session.Execute(context.Background(), ActionRequest{
+			Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+			Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	<-driver.started
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- observation.Close() }()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Observation.Close returned during authorized dispatch: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(driver.release)
+
+	result, err := <-resultCh, <-errCh
+	if err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if err := <-closeDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSessionCloseDuringLineageCapturePreventsMutation(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{
+		syntheticCapture(2, 2, 21), syntheticCapture(2, 2, 21),
+	}}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+	driver.captureHit = make(chan struct{}, 1)
+	driver.captureGo = make(chan struct{})
+
+	resultCh := make(chan ActionResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := session.Execute(context.Background(), ActionRequest{
+			Operation: OperationClick, Click: &ClickAction{Button: MouseButtonLeft},
+			Precondition: &ObservationPrecondition{ObservationID: observation.ObservationID},
+		})
+		resultCh <- result
+		errCh <- err
+	}()
+	<-driver.captureHit
+	closeDone := make(chan struct{})
+	go func() {
+		_ = session.Close()
+		close(closeDone)
+	}()
+	<-session.ctx.Done()
+	close(driver.captureGo)
+
+	result, err := <-resultCh, <-errCh
+	if !errors.Is(err, ErrSessionClosed) || result.Error == nil || result.Error.Code != ErrorSessionClosed {
+		t.Fatalf("Execute = %+v, %v", result, err)
+	}
+	if driver.callCount() != 0 {
+		t.Fatalf("closed session reached input driver %d times", driver.callCount())
+	}
+	<-closeDone
+}
+
 type recordingAuditSink struct {
 	mu     sync.Mutex
 	events []AuditEvent

--- a/agent/policy.go
+++ b/agent/policy.go
@@ -2,42 +2,80 @@ package agent
 
 import "fmt"
 
-// Policy constrains every mutation performed by a Session. Empty allow lists
-// deny access; callers must opt in explicitly.
+const (
+	maxAgentCapturePixels          = 16 * 1024 * 1024
+	maxAgentVerificationAttempts   = 100
+	maxAgentVerificationIntervalMS = 60_000
+	maxAgentVerificationTimeoutMS  = 300_000
+)
+
+// Policy constrains every observation and mutation performed by a Session.
+// Empty allow lists deny access; callers must opt in explicitly.
 type Policy struct {
-	AllowedOperations   []Operation `json:"allowed_operations"`
-	ConfirmOperations   []Operation `json:"confirm_operations,omitempty"`
-	AllowedDisplayIDs   []int       `json:"allowed_display_ids,omitempty"`
-	MaxActions          uint64      `json:"max_actions"`
-	MaxTextRunes        int         `json:"max_text_runes"`
-	AllowDoubleClick    bool        `json:"allow_double_click,omitempty"`
-	allowOperation      map[Operation]struct{}
-	requireConfirmation map[Operation]struct{}
-	allowDisplay        map[int]struct{}
+	AllowedOperations          []Operation `json:"allowed_operations"`
+	ConfirmOperations          []Operation `json:"confirm_operations,omitempty"`
+	AllowedDisplayIDs          []int       `json:"allowed_display_ids,omitempty"`
+	MaxActions                 uint64      `json:"max_actions"`
+	MaxTextRunes               int         `json:"max_text_runes"`
+	AllowDoubleClick           bool        `json:"allow_double_click,omitempty"`
+	MaxObservations            uint64      `json:"max_observations,omitempty"`
+	MaxCapturePixels           uint64      `json:"max_capture_pixels,omitempty"`
+	VerificationAttempts       uint32      `json:"verification_attempts,omitempty"`
+	VerificationIntervalMillis int         `json:"verification_interval_ms,omitempty"`
+	VerificationTimeoutMillis  int         `json:"verification_timeout_ms,omitempty"`
+	allowOperation             map[Operation]struct{}
+	requireConfirmation        map[Operation]struct{}
+	allowDisplay               map[int]struct{}
 }
 
 func preparePolicy(input Policy) (Policy, error) {
-	if input.MaxActions == 0 {
-		return Policy{}, fmt.Errorf("agent: max actions must be positive")
-	}
 	if input.MaxTextRunes < 0 {
 		return Policy{}, fmt.Errorf("agent: max text runes must be non-negative")
+	}
+	if input.VerificationIntervalMillis < 0 {
+		return Policy{}, fmt.Errorf("agent: verification interval must be non-negative")
+	}
+	if input.MaxCapturePixels > maxAgentCapturePixels {
+		return Policy{}, fmt.Errorf("agent: max capture pixels exceeds hard limit %d", maxAgentCapturePixels)
+	}
+	if input.VerificationAttempts > maxAgentVerificationAttempts {
+		return Policy{}, fmt.Errorf("agent: verification attempts exceeds hard limit %d", maxAgentVerificationAttempts)
+	}
+	if input.VerificationIntervalMillis > maxAgentVerificationIntervalMS {
+		return Policy{}, fmt.Errorf("agent: verification interval exceeds hard limit %dms", maxAgentVerificationIntervalMS)
+	}
+	if input.VerificationTimeoutMillis < 0 || input.VerificationTimeoutMillis > maxAgentVerificationTimeoutMS {
+		return Policy{}, fmt.Errorf("agent: verification timeout must be between 0 and %dms", maxAgentVerificationTimeoutMS)
+	}
+	if (input.VerificationAttempts == 0) != (input.VerificationTimeoutMillis == 0) {
+		return Policy{}, fmt.Errorf("agent: verification attempts and timeout must both be zero or both be positive")
 	}
 	prepared := Policy{
 		AllowedOperations: append([]Operation(nil), input.AllowedOperations...),
 		ConfirmOperations: append([]Operation(nil), input.ConfirmOperations...),
 		AllowedDisplayIDs: append([]int(nil), input.AllowedDisplayIDs...),
 		MaxActions:        input.MaxActions, MaxTextRunes: input.MaxTextRunes,
-		AllowDoubleClick:    input.AllowDoubleClick,
-		allowOperation:      make(map[Operation]struct{}),
-		requireConfirmation: make(map[Operation]struct{}),
-		allowDisplay:        make(map[int]struct{}),
+		AllowDoubleClick:           input.AllowDoubleClick,
+		MaxObservations:            input.MaxObservations,
+		MaxCapturePixels:           input.MaxCapturePixels,
+		VerificationAttempts:       input.VerificationAttempts,
+		VerificationIntervalMillis: input.VerificationIntervalMillis,
+		VerificationTimeoutMillis:  input.VerificationTimeoutMillis,
+		allowOperation:             make(map[Operation]struct{}),
+		requireConfirmation:        make(map[Operation]struct{}),
+		allowDisplay:               make(map[int]struct{}),
 	}
 	for _, operation := range prepared.AllowedOperations {
 		if !knownOperation(operation) {
 			return Policy{}, fmt.Errorf("agent: unknown allowed operation %q", operation)
 		}
 		prepared.allowOperation[operation] = struct{}{}
+	}
+	if prepared.MaxActions == 0 && allowsMutation(prepared.allowOperation) {
+		return Policy{}, fmt.Errorf("agent: max actions must be positive when a mutation is allowed")
+	}
+	if _, allowed := prepared.allowOperation[OperationObserve]; allowed && prepared.MaxObservations == 0 {
+		return Policy{}, fmt.Errorf("agent: max observations must be positive when desktop.observe is allowed")
 	}
 	for _, operation := range prepared.ConfirmOperations {
 		if _, allowed := prepared.allowOperation[operation]; !allowed {
@@ -51,12 +89,31 @@ func preparePolicy(input Policy) (Policy, error) {
 		}
 		prepared.allowDisplay[displayID] = struct{}{}
 	}
+	if prepared.VerificationAttempts > 0 {
+		if _, allowed := prepared.allowOperation[OperationObserve]; !allowed ||
+			prepared.MaxCapturePixels == 0 || len(prepared.allowDisplay) == 0 {
+			return Policy{}, fmt.Errorf("agent: verification requires allowed bounded capture observations")
+		}
+		minimumObservations := uint64(prepared.VerificationAttempts) + 2
+		if prepared.MaxObservations < minimumObservations {
+			return Policy{}, fmt.Errorf("agent: verification requires at least %d observations", minimumObservations)
+		}
+	}
 	return prepared, nil
+}
+
+func allowsMutation(operations map[Operation]struct{}) bool {
+	for _, operation := range []Operation{OperationMove, OperationClick, OperationTypeText} {
+		if _, allowed := operations[operation]; allowed {
+			return true
+		}
+	}
+	return false
 }
 
 func knownOperation(operation Operation) bool {
 	switch operation {
-	case OperationMove, OperationClick, OperationTypeText:
+	case OperationMove, OperationClick, OperationTypeText, OperationObserve:
 		return true
 	default:
 		return false

--- a/agent/session.go
+++ b/agent/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"image"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,6 +18,8 @@ type inputDriver interface {
 	Move(x, y, displayID int) error
 	Click(button MouseButton, double bool) error
 	TypeText(text string) error
+	RuntimeCapabilities() robotgo.RuntimeCapabilities
+	Capture(context.Context, CaptureRegion) (image.Image, error)
 }
 
 type robotGoDriver struct{}
@@ -33,7 +36,8 @@ func (robotGoDriver) TypeText(text string) error { return robotgo.TypeStrE(text)
 
 // Config defines immutable session policy.
 type Config struct {
-	Policy Policy `json:"policy"`
+	Policy    Policy    `json:"policy"`
+	AuditSink AuditSink `json:"-"`
 }
 
 // Session serializes policy-gated desktop mutations. The underlying RobotGo
@@ -45,9 +49,14 @@ type Session struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
 
-	actionGate chan struct{}
-	used       uint64
-	closeOnce  sync.Once
+	actionGate       chan struct{}
+	used             uint64
+	closeOnce        sync.Once
+	observationMu    sync.Mutex
+	observations     map[string]observationRecord
+	usedObservations uint64
+	auditSink        AuditSink
+	auditSequence    uint64
 }
 
 var (
@@ -64,14 +73,19 @@ func NewSession(config Config) (*Session, error) {
 		return nil, err
 	}
 	capabilities := robotgo.GetRuntimeCapabilities()
-	return newSession(policy, robotGoDriver{}, capabilities)
+	return newSessionWithAudit(policy, robotGoDriver{}, capabilities, config.AuditSink)
 }
 
 func newSession(policy Policy, driver inputDriver, capabilities robotgo.RuntimeCapabilities) (*Session, error) {
+	return newSessionWithAudit(policy, driver, capabilities, nil)
+}
+
+func newSessionWithAudit(policy Policy, driver inputDriver, capabilities robotgo.RuntimeCapabilities, auditSink AuditSink) (*Session, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Session{
 		policy: policy, driver: driver, catalog: buildCatalog(policy, capabilities),
 		ctx: ctx, cancel: cancel, actionGate: make(chan struct{}, 1),
+		observations: make(map[string]observationRecord), auditSink: auditSink,
 	}
 	s.actionGate <- struct{}{}
 	ownerMu.Lock()
@@ -98,6 +112,7 @@ func (s *Session) Close() error {
 	s.closeOnce.Do(func() {
 		s.cancel()
 		<-s.actionGate
+		s.closeObservations()
 		s.actionGate <- struct{}{}
 		ownerMu.Lock()
 		if activeOwner == s {
@@ -109,7 +124,9 @@ func (s *Session) Close() error {
 }
 
 // DryRun performs the same shape, policy, quota, capability, and cancellation
-// preflight as Execute without injecting input or consuming action quota.
+// preflight as Execute without injecting input or consuming action quota. A
+// supplied observation precondition is recaptured and consumes observation
+// quota because stale-target validation is a real sensitive read.
 func (s *Session) DryRun(ctx context.Context, request ActionRequest) (ActionResult, error) {
 	return s.run(ctx, request, true)
 }
@@ -161,42 +178,135 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 	if s.used >= s.policy.MaxActions {
 		return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy action limit reached", ErrPolicyDenied)
 	}
+	if err := s.emitAudit(ctx, AuditEvent{
+		Kind: AuditActionStarted, Operation: request.Operation, ActionID: id,
+		PreconditionObservationID: preconditionID(request),
+	}); err != nil {
+		return actionFailure(id, request.Operation, started, ErrorAuditDelivery, "audit sink rejected action intent", err)
+	}
+	if err := ctx.Err(); err != nil {
+		result, actionErr := contextFailure(ctx, id, request.Operation, started)
+		return s.finishFailedActionAudit(ctx, result, actionErr)
+	}
+	select {
+	case <-s.ctx.Done():
+		result, actionErr := actionFailure(id, request.Operation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+		return s.finishFailedActionAudit(ctx, result, actionErr)
+	default:
+	}
 	if request.Move != nil {
 		if err := s.validateMoveTarget(*request.Move); err != nil {
 			if errors.Is(err, ErrPolicyDenied) {
-				return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy denied the action", err)
+				result, actionErr := actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy denied the action", err)
+				return s.finishFailedActionAudit(ctx, result, actionErr)
 			}
 			code, message := classifyBackendError(err)
 			result, actionErr := actionFailure(id, request.Operation, started, code, message, err)
 			result.Backend = capability.Backend
-			return result, actionErr
+			return s.finishFailedActionAudit(ctx, result, actionErr)
 		}
 	}
 	if err := ctx.Err(); err != nil {
-		return contextFailure(ctx, id, request.Operation, started)
+		result, actionErr := contextFailure(ctx, id, request.Operation, started)
+		return s.finishFailedActionAudit(ctx, result, actionErr)
 	}
 	select {
 	case <-s.ctx.Done():
-		return actionFailure(id, request.Operation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+		result, actionErr := actionFailure(id, request.Operation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+		return s.finishFailedActionAudit(ctx, result, actionErr)
 	default:
 	}
+	lineage, err := s.prepareActionLineage(ctx, request, dryRun)
+	if err != nil {
+		code, message := classifyLineageError(err)
+		result, actionErr := actionFailure(id, request.Operation, started, code, message, err)
+		result.Backend = capability.Backend
+		result.PreconditionObservationID = preconditionID(request)
+		return s.finishFailedActionAudit(ctx, result, actionErr)
+	}
 	if dryRun {
-		return ActionResult{
+		result := ActionResult{
 			ActionID: id, Operation: request.Operation, Status: ActionPlanned,
 			Backend: capability.Backend, DurationMillis: time.Since(started).Milliseconds(),
-		}, nil
+			PreconditionObservationID: preconditionID(request),
+		}
+		return s.finishSuccessfulActionAudit(ctx, result)
 	}
 	s.used++
 	if err := s.execute(request); err != nil {
 		code, message := classifyBackendError(err)
 		result, actionErr := actionFailure(id, request.Operation, started, code, message, err)
 		result.Backend = capability.Backend
-		return result, actionErr
+		result.PreconditionObservationID = preconditionID(request)
+		return s.finishFailedActionAudit(ctx, result, actionErr)
 	}
-	return ActionResult{
+	result := ActionResult{
 		ActionID: id, Operation: request.Operation, Status: ActionSucceeded,
-		Backend: capability.Backend, DurationMillis: time.Since(started).Milliseconds(),
-	}, nil
+		Backend: capability.Backend, PreconditionObservationID: preconditionID(request),
+	}
+	if request.Verification != nil {
+		post, verification, verifyErr := s.verifyAction(ctx, id, request, lineage)
+		result.Verification = &verification
+		if post != nil {
+			result.PostObservationID = post.ObservationID
+		}
+		if verifyErr != nil {
+			code, message := classifyLineageError(verifyErr)
+			actionErr := newActionError(code, request.Operation, message, verifyErr)
+			if code == ErrorAuditDelivery && verification.Status == VerificationPassed {
+				result.DurationMillis = time.Since(started).Milliseconds()
+				finished, finishErr := s.finishSuccessfulActionAudit(ctx, result)
+				if finishErr != nil {
+					return finished, errors.Join(actionErr, finishErr)
+				}
+				return finished, actionErr
+			}
+			result.Status = ActionUnverified
+			result.Error = actionErr
+			result.DurationMillis = time.Since(started).Milliseconds()
+			return s.finishFailedActionAudit(ctx, result, actionErr)
+		}
+	}
+	result.DurationMillis = time.Since(started).Milliseconds()
+	return s.finishSuccessfulActionAudit(ctx, result)
+}
+
+func (s *Session) finishSuccessfulActionAudit(ctx context.Context, result ActionResult) (ActionResult, error) {
+	if err := s.emitAudit(ctx, actionFinishedEvent(result)); err != nil {
+		return result, newActionError(ErrorAuditDelivery, result.Operation, "action completed but audit delivery failed", err)
+	}
+	return result, nil
+}
+
+func (s *Session) finishFailedActionAudit(ctx context.Context, result ActionResult, actionErr error) (ActionResult, error) {
+	if err := s.emitAudit(ctx, actionFinishedEvent(result)); err != nil {
+		return result, errors.Join(actionErr,
+			newActionError(ErrorAuditDelivery, result.Operation, "action completed but audit delivery failed", err))
+	}
+	return result, actionErr
+}
+
+func actionFinishedEvent(result ActionResult) AuditEvent {
+	event := AuditEvent{
+		Kind: AuditActionFinished, Operation: result.Operation, ActionID: result.ActionID,
+		PreconditionObservationID: result.PreconditionObservationID,
+		PostObservationID:         result.PostObservationID, ActionStatus: result.Status,
+	}
+	if result.Error != nil {
+		event.ErrorCode = result.Error.Code
+	}
+	if result.Verification != nil {
+		event.VerificationStatus = result.Verification.Status
+		event.VerificationAttempts = result.Verification.Attempts
+	}
+	return event
+}
+
+func preconditionID(request ActionRequest) string {
+	if request.Precondition == nil {
+		return ""
+	}
+	return request.Precondition.ObservationID
 }
 
 type displayBounds struct {
@@ -256,6 +366,22 @@ func (s *Session) authorize(request ActionRequest) error {
 }
 
 func validateRequest(request ActionRequest) error {
+	if request.Operation == OperationObserve {
+		return errors.New("desktop.observe must use Session.Observe")
+	}
+	if request.Precondition != nil && !validObservationID(request.Precondition.ObservationID) {
+		return errors.New("precondition requires a valid RobotGo observation ID")
+	}
+	if request.Verification != nil {
+		if request.Precondition == nil {
+			return errors.New("verification requires an observation precondition")
+		}
+		switch request.Verification.Condition {
+		case VerificationCaptureChanged, VerificationCaptureUnchanged:
+		default:
+			return errors.New("unsupported verification condition")
+		}
+	}
 	payloads := 0
 	if request.Move != nil {
 		payloads++

--- a/agent/session.go
+++ b/agent/session.go
@@ -50,6 +50,7 @@ type Session struct {
 	cancel  context.CancelFunc
 
 	actionGate       chan struct{}
+	dispatchMu       sync.Mutex
 	used             uint64
 	closeOnce        sync.Once
 	observationMu    sync.Mutex
@@ -110,7 +111,9 @@ func (s *Session) Close() error {
 		return nil
 	}
 	s.closeOnce.Do(func() {
+		s.dispatchMu.Lock()
 		s.cancel()
+		s.dispatchMu.Unlock()
 		<-s.actionGate
 		s.closeObservations()
 		s.actionGate <- struct{}{}
@@ -224,7 +227,21 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 		result.PreconditionObservationID = preconditionID(request)
 		return s.finishFailedActionAudit(ctx, result, actionErr)
 	}
+	if lineage != nil {
+		defer lineage.release()
+	}
+	if err := ctx.Err(); err != nil {
+		result, actionErr := contextFailure(ctx, id, request.Operation, started)
+		return s.finishFailedActionAudit(ctx, result, actionErr)
+	}
+	select {
+	case <-s.ctx.Done():
+		result, actionErr := actionFailure(id, request.Operation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+		return s.finishFailedActionAudit(ctx, result, actionErr)
+	default:
+	}
 	if dryRun {
+		lineage.release()
 		result := ActionResult{
 			ActionID: id, Operation: request.Operation, Status: ActionPlanned,
 			Backend: capability.Backend, DurationMillis: time.Since(started).Milliseconds(),
@@ -232,14 +249,15 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 		}
 		return s.finishSuccessfulActionAudit(ctx, result)
 	}
-	s.used++
-	if err := s.execute(request); err != nil {
+	if err := s.executeAuthorized(ctx, request); err != nil {
+		lineage.release()
 		code, message := classifyBackendError(err)
 		result, actionErr := actionFailure(id, request.Operation, started, code, message, err)
 		result.Backend = capability.Backend
 		result.PreconditionObservationID = preconditionID(request)
 		return s.finishFailedActionAudit(ctx, result, actionErr)
 	}
+	lineage.release()
 	result := ActionResult{
 		ActionID: id, Operation: request.Operation, Status: ActionSucceeded,
 		Backend: capability.Backend, PreconditionObservationID: preconditionID(request),
@@ -432,8 +450,25 @@ func (s *Session) execute(request ActionRequest) error {
 	}
 }
 
+func (s *Session) executeAuthorized(ctx context.Context, request ActionRequest) error {
+	s.dispatchMu.Lock()
+	defer s.dispatchMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case <-s.ctx.Done():
+		return ErrSessionClosed
+	default:
+	}
+	s.used++
+	return s.execute(request)
+}
+
 func classifyBackendError(err error) (ErrorCode, string) {
 	switch {
+	case errors.Is(err, ErrSessionClosed):
+		return ErrorSessionClosed, "agent session is closed"
 	case errors.Is(err, robotgo.ErrNotSupported):
 		return ErrorUnsupported, "operation is unsupported by the selected backend"
 	case errors.Is(err, robotgo.ErrPermissionDenied):

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"image"
+	"image/color"
 	"strings"
 	"sync"
 	"testing"
@@ -18,15 +20,22 @@ type driverCall struct {
 }
 
 type fakeDriver struct {
-	mu        sync.Mutex
-	calls     []driverCall
-	err       error
-	bounds    map[int]displayBounds
-	boundsErr error
-	boundsHit chan struct{}
-	boundsGo  chan struct{}
-	started   chan struct{}
-	release   chan struct{}
+	mu            sync.Mutex
+	calls         []driverCall
+	err           error
+	bounds        map[int]displayBounds
+	boundsErr     error
+	boundsHit     chan struct{}
+	boundsGo      chan struct{}
+	started       chan struct{}
+	release       chan struct{}
+	captureImages []image.Image
+	captureErr    error
+	captureCalls  int
+	captureHit    chan struct{}
+	capabilities  *robotgo.RuntimeCapabilities
+	capabilityHit chan struct{}
+	capabilityGo  chan struct{}
 }
 
 func (d *fakeDriver) DisplayBounds(displayID int) (displayBounds, error) {
@@ -85,6 +94,59 @@ func (d *fakeDriver) TypeText(text string) error {
 	return d.record(driverCall{operation: OperationTypeText, text: text})
 }
 
+func (d *fakeDriver) RuntimeCapabilities() robotgo.RuntimeCapabilities {
+	if d.capabilityHit != nil {
+		select {
+		case d.capabilityHit <- struct{}{}:
+		default:
+		}
+	}
+	if d.capabilityGo != nil {
+		<-d.capabilityGo
+	}
+	if d.capabilities != nil {
+		return *d.capabilities
+	}
+	return availableCapabilities()
+}
+
+func (d *fakeDriver) Capture(_ context.Context, region CaptureRegion) (image.Image, error) {
+	if d.captureHit != nil {
+		select {
+		case d.captureHit <- struct{}{}:
+		default:
+		}
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	call := d.captureCalls
+	d.captureCalls++
+	if d.captureErr != nil {
+		if call < len(d.captureImages) {
+			return d.captureImages[call], d.captureErr
+		}
+		return nil, d.captureErr
+	}
+	if len(d.captureImages) != 0 {
+		if call >= len(d.captureImages) {
+			call = len(d.captureImages) - 1
+		}
+		return d.captureImages[call], nil
+	}
+	if d.err != nil {
+		return nil, d.err
+	}
+	img := image.NewRGBA(image.Rect(0, 0, region.Width, region.Height))
+	img.SetRGBA(0, 0, color.RGBA{R: 1, G: 2, B: 3, A: 255})
+	return img, nil
+}
+
+func (d *fakeDriver) captureCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.captureCalls
+}
+
 func (d *fakeDriver) callCount() int {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -93,6 +155,8 @@ func (d *fakeDriver) callCount() int {
 
 func availableCapabilities() robotgo.RuntimeCapabilities {
 	return robotgo.RuntimeCapabilities{
+		Capture:  robotgo.FeatureCapability{Available: true, Backend: "fake-capture"},
+		Bounds:   robotgo.FeatureCapability{Available: true, Backend: "fake-bounds"},
 		Mouse:    robotgo.FeatureCapability{Available: true, Backend: "fake-mouse"},
 		Keyboard: robotgo.FeatureCapability{Available: true, Backend: "fake-keyboard"},
 	}
@@ -126,7 +190,7 @@ func TestCatalogIsStableAndDefensive(t *testing.T) {
 	if catalog.SchemaVersion != CatalogSchemaVersion {
 		t.Fatalf("schema = %q", catalog.SchemaVersion)
 	}
-	want := []Operation{OperationMove, OperationClick, OperationTypeText}
+	want := []Operation{OperationObserve, OperationMove, OperationClick, OperationTypeText}
 	for index, operation := range want {
 		got := catalog.Operations[index]
 		if got.Operation != operation || !got.Available || !got.ProcessGlobalBackend || !got.ExclusiveAgentSession {
@@ -136,8 +200,8 @@ func TestCatalogIsStableAndDefensive(t *testing.T) {
 			t.Fatalf("cancellation = %q", got.Cancellation)
 		}
 	}
-	catalog.Operations[0].Backend = "mutated"
-	if got := session.Catalog().Operations[0].Backend; got != "fake-mouse" {
+	catalog.Operations[1].Backend = "mutated"
+	if got := session.Catalog().Operations[1].Backend; got != "fake-mouse" {
 		t.Fatalf("catalog mutation leaked into session: %q", got)
 	}
 }

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -33,6 +33,7 @@ type fakeDriver struct {
 	captureErr    error
 	captureCalls  int
 	captureHit    chan struct{}
+	captureGo     chan struct{}
 	capabilities  *robotgo.RuntimeCapabilities
 	capabilityHit chan struct{}
 	capabilityGo  chan struct{}
@@ -116,6 +117,9 @@ func (d *fakeDriver) Capture(_ context.Context, region CaptureRegion) (image.Ima
 		case d.captureHit <- struct{}{}:
 		default:
 		}
+	}
+	if d.captureGo != nil {
+		<-d.captureGo
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/agent/types.go
+++ b/agent/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CatalogSchemaVersion identifies the operation catalog JSON contract.
-const CatalogSchemaVersion = "1"
+const CatalogSchemaVersion = "2"
 
 // Operation identifies one strict agent operation.
 type Operation string
@@ -19,12 +19,16 @@ const (
 	OperationMove     Operation = "pointer.move"
 	OperationClick    Operation = "pointer.click"
 	OperationTypeText Operation = "keyboard.type-text"
+	OperationObserve  Operation = "desktop.observe"
 )
 
 // RiskClass describes the policy impact of an operation.
 type RiskClass string
 
-const RiskReversibleMutation RiskClass = "reversible-mutation"
+const (
+	RiskSensitiveRead      RiskClass = "sensitive-read"
+	RiskReversibleMutation RiskClass = "reversible-mutation"
+)
 
 // CancellationSupport describes where cancellation is enforceable.
 type CancellationSupport string
@@ -45,6 +49,11 @@ type OperationCapability struct {
 	ExclusiveAgentSession bool                `json:"exclusive_agent_session"`
 	Reason                string              `json:"reason,omitempty"`
 	Remediation           string              `json:"remediation,omitempty"`
+	OptionalCapture       bool                `json:"optional_capture,omitempty"`
+	CaptureAvailable      bool                `json:"capture_available,omitempty"`
+	CapturePolicyAllowed  bool                `json:"capture_policy_allowed,omitempty"`
+	CaptureFallback       bool                `json:"capture_fallback,omitempty"`
+	CaptureBackend        string              `json:"capture_backend,omitempty"`
 }
 
 // OperationCatalog is an immutable snapshot of operation availability.
@@ -84,20 +93,23 @@ type TypeTextAction struct {
 // ActionRequest is a strict JSON-serializable action union. Exactly one action
 // payload must be present and must match Operation.
 type ActionRequest struct {
-	Operation Operation       `json:"operation"`
-	Confirmed bool            `json:"confirmed,omitempty"`
-	Move      *MoveAction     `json:"move,omitempty"`
-	Click     *ClickAction    `json:"click,omitempty"`
-	TypeText  *TypeTextAction `json:"type_text,omitempty"`
+	Operation    Operation                `json:"operation"`
+	Confirmed    bool                     `json:"confirmed,omitempty"`
+	Move         *MoveAction              `json:"move,omitempty"`
+	Click        *ClickAction             `json:"click,omitempty"`
+	TypeText     *TypeTextAction          `json:"type_text,omitempty"`
+	Precondition *ObservationPrecondition `json:"precondition,omitempty"`
+	Verification *VerificationRequest     `json:"verification,omitempty"`
 }
 
 // ActionStatus identifies the outcome of an action request.
 type ActionStatus string
 
 const (
-	ActionPlanned   ActionStatus = "planned"
-	ActionSucceeded ActionStatus = "succeeded"
-	ActionFailed    ActionStatus = "failed"
+	ActionPlanned    ActionStatus = "planned"
+	ActionSucceeded  ActionStatus = "succeeded"
+	ActionFailed     ActionStatus = "failed"
+	ActionUnverified ActionStatus = "unverified"
 )
 
 // ErrorCode is a stable machine-readable action failure category.
@@ -113,6 +125,9 @@ const (
 	ErrorCanceled         ErrorCode = "canceled"
 	ErrorTimedOut         ErrorCode = "timed-out"
 	ErrorBackendFailure   ErrorCode = "backend-failure"
+	ErrorStaleTarget      ErrorCode = "stale-target"
+	ErrorVerification     ErrorCode = "verification-failed"
+	ErrorAuditDelivery    ErrorCode = "audit-delivery-failed"
 )
 
 // ActionError is safe to serialize: Message never contains action payloads.
@@ -129,22 +144,35 @@ func (e *ActionError) Unwrap() error { return e.cause }
 // ActionResult reports one planned or attempted action without retaining its
 // input payload.
 type ActionResult struct {
-	ActionID       string       `json:"action_id"`
-	Operation      Operation    `json:"operation"`
-	Status         ActionStatus `json:"status"`
-	Backend        string       `json:"backend,omitempty"`
-	DurationMillis int64        `json:"duration_ms"`
-	Error          *ActionError `json:"error,omitempty"`
+	ActionID                  string              `json:"action_id"`
+	Operation                 Operation           `json:"operation"`
+	Status                    ActionStatus        `json:"status"`
+	Backend                   string              `json:"backend,omitempty"`
+	DurationMillis            int64               `json:"duration_ms"`
+	Error                     *ActionError        `json:"error,omitempty"`
+	PreconditionObservationID string              `json:"precondition_observation_id,omitempty"`
+	PostObservationID         string              `json:"post_observation_id,omitempty"`
+	Verification              *VerificationResult `json:"verification,omitempty"`
 }
 
 var (
 	ErrSessionBusy   = errors.New("another agent session is already active")
 	ErrSessionClosed = errors.New("agent session is closed")
 	ErrPolicyDenied  = errors.New("agent policy denied the action")
+	ErrStaleTarget   = errors.New("agent observation target is stale")
+	ErrVerification  = errors.New("agent action verification failed")
+	ErrAuditDelivery = errors.New("agent audit delivery failed")
 )
 
+func newActionError(code ErrorCode, operation Operation, message string, cause error) *ActionError {
+	if code == ErrorAuditDelivery && !errors.Is(cause, ErrAuditDelivery) {
+		cause = errors.Join(ErrAuditDelivery, cause)
+	}
+	return &ActionError{Code: code, Operation: operation, Message: message, cause: cause}
+}
+
 func actionFailure(id string, operation Operation, started time.Time, code ErrorCode, message string, cause error) (ActionResult, error) {
-	actionErr := &ActionError{Code: code, Operation: operation, Message: message, cause: cause}
+	actionErr := newActionError(code, operation, message, cause)
 	return ActionResult{
 		ActionID: id, Operation: operation, Status: ActionFailed,
 		DurationMillis: time.Since(started).Milliseconds(), Error: actionErr,

--- a/agent/verification.go
+++ b/agent/verification.go
@@ -3,12 +3,21 @@ package agent
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 )
 
 type actionLineage struct {
 	preconditionID string
 	record         observationRecord
+	releaseOnce    sync.Once
+}
+
+func (lineage *actionLineage) release() {
+	if lineage == nil {
+		return
+	}
+	lineage.releaseOnce.Do(lineage.record.capture.releaseUse)
 }
 
 func (s *Session) prepareActionLineage(ctx context.Context, request ActionRequest, dryRun bool) (*actionLineage, error) {
@@ -45,6 +54,12 @@ func (s *Session) prepareActionLineage(ctx context.Context, request ActionReques
 	defer func() { _ = current.buffer.close() }()
 	if current.metadata.SHA256 != record.digest {
 		return nil, actionLineageError(ErrorStaleTarget, "desktop target changed since the precondition observation", ErrStaleTarget)
+	}
+	// Keep the precondition capture valid until the mutation is dispatched.
+	// Observation.Close either linearizes before this acquisition and rejects
+	// the action, or waits until the authorized dispatch has completed.
+	if !record.capture.acquireUse() {
+		return nil, actionLineageError(ErrorStaleTarget, "precondition observation is unavailable or closed", ErrStaleTarget)
 	}
 	return &actionLineage{preconditionID: request.Precondition.ObservationID, record: record}, nil
 }

--- a/agent/verification.go
+++ b/agent/verification.go
@@ -1,0 +1,185 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+type actionLineage struct {
+	preconditionID string
+	record         observationRecord
+}
+
+func (s *Session) prepareActionLineage(ctx context.Context, request ActionRequest, dryRun bool) (*actionLineage, error) {
+	if request.Precondition == nil {
+		return nil, nil
+	}
+	if _, allowed := s.policy.allowOperation[OperationObserve]; !allowed {
+		return nil, actionLineageError(ErrorPolicyDenied, "agent policy denies observation lineage", ErrPolicyDenied)
+	}
+	if _, required := s.policy.requireConfirmation[OperationObserve]; required && !request.Confirmed {
+		return nil, actionLineageError(ErrorPolicyDenied, "agent policy requires observation confirmation", ErrPolicyDenied)
+	}
+	record, ok := s.observation(request.Precondition.ObservationID)
+	if !ok || !record.hasCapture || !record.capture.usable() {
+		return nil, actionLineageError(ErrorStaleTarget, "precondition observation is unavailable or closed", ErrStaleTarget)
+	}
+	requiredCaptures := uint64(1)
+	if request.Verification != nil {
+		if s.policy.VerificationAttempts == 0 || s.policy.VerificationTimeoutMillis == 0 {
+			return nil, actionLineageError(ErrorPolicyDenied, "agent policy does not permit post-action verification", ErrPolicyDenied)
+		}
+		if !dryRun {
+			requiredCaptures += uint64(s.policy.VerificationAttempts)
+		}
+	}
+	if s.usedObservations > s.policy.MaxObservations || requiredCaptures > s.policy.MaxObservations-s.usedObservations {
+		return nil, actionLineageError(ErrorPolicyDenied, "agent policy observation limit cannot satisfy lineage proof", ErrPolicyDenied)
+	}
+
+	current, err := s.capture(ctx, record.region, true)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = current.buffer.close() }()
+	if current.metadata.SHA256 != record.digest {
+		return nil, actionLineageError(ErrorStaleTarget, "desktop target changed since the precondition observation", ErrStaleTarget)
+	}
+	return &actionLineage{preconditionID: request.Precondition.ObservationID, record: record}, nil
+}
+
+func (s *Session) verifyAction(ctx context.Context, actionID string, request ActionRequest, lineage *actionLineage) (*Observation, VerificationResult, error) {
+	result := VerificationResult{Condition: request.Verification.Condition}
+	verifyCtx, cancel := context.WithTimeout(ctx, time.Duration(s.policy.VerificationTimeoutMillis)*time.Millisecond)
+	stopSessionCancel := context.AfterFunc(s.ctx, cancel)
+	defer func() {
+		stopSessionCancel()
+		cancel()
+	}()
+
+	for attempt := uint32(1); attempt <= s.policy.VerificationAttempts; attempt++ {
+		frame, err := s.capture(verifyCtx, lineage.record.region, true)
+		result.Attempts = attempt
+		if err != nil {
+			err = s.normalizeVerificationError(err)
+			result.Status = VerificationFailed
+			if auditErr := s.emitVerificationAudit(ctx, request.Operation, actionID, lineage.preconditionID, "", result, classifyObservationError(err)); auditErr != nil {
+				return nil, result, errors.Join(err, actionLineageError(ErrorAuditDelivery, "verification failed and audit delivery failed", auditErr))
+			}
+			return nil, result, err
+		}
+		matched := verificationMatches(request.Verification.Condition, frame.metadata.SHA256 == lineage.record.digest)
+		if matched || attempt == s.policy.VerificationAttempts {
+			diagnostics, diagnosticsErr := s.runtimeDiagnostics(verifyCtx)
+			if diagnosticsErr != nil {
+				_ = frame.buffer.close()
+				diagnosticsErr = s.normalizeVerificationError(diagnosticsErr)
+				result.Status = VerificationFailed
+				if auditErr := s.emitVerificationAudit(ctx, request.Operation, actionID, lineage.preconditionID, "", result, classifyObservationError(diagnosticsErr)); auditErr != nil {
+					return nil, result, errors.Join(diagnosticsErr, actionLineageError(ErrorAuditDelivery, "verification failed and audit delivery failed", auditErr))
+				}
+				return nil, result, diagnosticsErr
+			}
+			observation := observationFromFrame(frame, diagnostics)
+			s.storeObservation(observation)
+			if matched {
+				result.Status = VerificationPassed
+				if err := s.emitVerificationAudit(ctx, request.Operation, actionID, lineage.preconditionID, observation.ObservationID, result, ""); err != nil {
+					return observation, result, actionLineageError(ErrorAuditDelivery, "verification completed but audit delivery failed", err)
+				}
+				return observation, result, nil
+			}
+			result.Status = VerificationFailed
+			if err := s.emitVerificationAudit(ctx, request.Operation, actionID, lineage.preconditionID, observation.ObservationID, result, ErrorVerification); err != nil {
+				return observation, result, errors.Join(
+					actionLineageError(ErrorVerification, "post-action verification condition was not satisfied", ErrVerification),
+					actionLineageError(ErrorAuditDelivery, "verification failed and audit delivery failed", err),
+				)
+			}
+			return observation, result, actionLineageError(ErrorVerification, "post-action verification condition was not satisfied", ErrVerification)
+		}
+		_ = frame.buffer.close()
+		if err := waitForVerification(verifyCtx, time.Duration(s.policy.VerificationIntervalMillis)*time.Millisecond); err != nil {
+			err = s.normalizeVerificationError(err)
+			result.Status = VerificationFailed
+			if auditErr := s.emitVerificationAudit(ctx, request.Operation, actionID, lineage.preconditionID, "", result, classifyObservationError(err)); auditErr != nil {
+				return nil, result, errors.Join(err, actionLineageError(ErrorAuditDelivery, "verification failed and audit delivery failed", auditErr))
+			}
+			return nil, result, err
+		}
+	}
+	return nil, result, actionLineageError(ErrorVerification, "post-action verification exhausted its bounded attempts", ErrVerification)
+}
+
+func (s *Session) normalizeVerificationError(err error) error {
+	select {
+	case <-s.ctx.Done():
+		return actionLineageError(ErrorSessionClosed, "agent session closed during post-action verification", ErrSessionClosed)
+	default:
+		return err
+	}
+}
+
+func verificationMatches(condition VerificationCondition, unchanged bool) bool {
+	switch condition {
+	case VerificationCaptureChanged:
+		return !unchanged
+	case VerificationCaptureUnchanged:
+		return unchanged
+	default:
+		return false
+	}
+}
+
+func waitForVerification(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		select {
+		case <-ctx.Done():
+			return observationContextError(ctx)
+		default:
+			return nil
+		}
+	}
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return observationContextError(ctx)
+	case <-timer.C:
+		return nil
+	}
+}
+
+func observationFromFrame(frame *capturedFrame, diagnostics RuntimeDiagnostics) *Observation {
+	return &Observation{
+		SchemaVersion: ObservationSchemaVersion,
+		ObservationID: newObservationID(),
+		CreatedAt:     time.Now().UTC(),
+		Diagnostics:   diagnostics,
+		Capture:       &frame.metadata,
+		capture:       frame.buffer,
+	}
+}
+
+func (s *Session) emitVerificationAudit(ctx context.Context, operation Operation, actionID, preconditionID, postID string, result VerificationResult, code ErrorCode) error {
+	return s.emitAudit(ctx, AuditEvent{
+		Kind: AuditVerificationFinished, Operation: operation, ActionID: actionID,
+		PreconditionObservationID: preconditionID, PostObservationID: postID,
+		VerificationStatus: result.Status, VerificationAttempts: result.Attempts,
+		ErrorCode: code,
+	})
+}
+
+func actionLineageError(code ErrorCode, message string, cause error) *ActionError {
+	return newActionError(code, "", message, cause)
+}
+
+func classifyLineageError(err error) (ErrorCode, string) {
+	var actionErr *ActionError
+	if errors.As(err, &actionErr) {
+		return actionErr.Code, actionErr.Message
+	}
+	code, _ := classifyBackendError(err)
+	return code, "agent lineage proof failed"
+}

--- a/backend_info.go
+++ b/backend_info.go
@@ -13,6 +13,9 @@ const (
 	// FeatureBackendScreenCast identifies an active portal ScreenCast session
 	// whose frames are delivered through PipeWire.
 	FeatureBackendScreenCast = "portal-screencast+pipewire"
+	// FeatureBackendWaylandScreencopy identifies native Wayland capture through
+	// the compositor screencopy protocol.
+	FeatureBackendWaylandScreencopy = "wayland+screencopy"
 
 	featureBackendNativeCGO           = "native-cgo"
 	featureBackendPureGoPrefix        = "pure-go-"

--- a/backend_info.go
+++ b/backend_info.go
@@ -10,6 +10,9 @@ const (
 	RuntimeImplementationNativeCGO RuntimeImplementation = "native-cgo"
 	// RuntimeImplementationPureGo identifies a build without CGO.
 	RuntimeImplementationPureGo RuntimeImplementation = "pure-go"
+	// FeatureBackendScreenCast identifies an active portal ScreenCast session
+	// whose frames are delivered through PipeWire.
+	FeatureBackendScreenCast = "portal-screencast+pipewire"
 
 	featureBackendNativeCGO           = "native-cgo"
 	featureBackendPureGoPrefix        = "pure-go-"

--- a/docs/plan/agentic-desktop-automation.md
+++ b/docs/plan/agentic-desktop-automation.md
@@ -1,6 +1,6 @@
 # Agentic Desktop Automation Plan
 
-Status: Draft
+Status: In progress
 
 Linear coordination:
 
@@ -152,6 +152,8 @@ than coupling desktop observation and mutation in one initial change.
 
 ### 4.1 Typed session and action core
 
+Delivery status: completed by LAB-11.
+
 The first foundation slice provides:
 
 1. deterministic, process-exclusive agent session creation and close
@@ -168,12 +170,20 @@ process-global limitation.
 
 ### 4.2 Observation and verification proof
 
+Delivery status: in progress under LAB-12.
+
 The following slice completes the initial architecture proof with:
 
 1. bounded desktop observation using runtime diagnostics and optional capture
 2. observation lineage and stale-target preconditions
 3. bounded post-action verification
 4. privacy-safe audit/replay seams
+
+The accepted proof is intentionally capture-based and bounded. It uses
+diagnostics-first observation, optional in-memory pixels, SHA-256 region
+lineage, changed/unchanged verification, and payload-free audit delivery. It
+does not add OCR, accessibility, file-backed captures, implicit portal consent,
+or an MCP adapter. Those remain later slices built on the accepted Go contract.
 
 An MCP server is not required for this first slice. It should consume the
 accepted Go contract rather than define it.

--- a/docs/plan/agentic-desktop-automation.md
+++ b/docs/plan/agentic-desktop-automation.md
@@ -170,7 +170,7 @@ process-global limitation.
 
 ### 4.2 Observation and verification proof
 
-Delivery status: in progress under LAB-12.
+Delivery status: completed by LAB-12.
 
 The following slice completes the initial architecture proof with:
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -403,9 +403,10 @@ demonstrate the difference, not merely expose more functions. The standard is:
 - `docs/wayland-tasks.md` is the operational backlog and current support matrix.
 - `docs/plan/wayland-prio-plan.md` contains the detailed Wayland architecture
   and milestone history.
-- `docs/plan/agentic-desktop-automation.md` defines the planned agent-session,
-  policy, observe-act-verify, and adapter architecture. It does not supersede
-  the current reliability delivery order until an executable slice is accepted.
+- `docs/plan/agentic-desktop-automation.md` defines the accepted agent-session,
+  policy, observe-act-verify, and later adapter architecture. Its executable
+  slices remain independently reviewed and do not weaken platform reliability
+  gates.
 - This document defines product direction and delivery order.
 - A roadmap item is complete only when implementation, tests, examples where
   applicable, compatibility documentation, and required CI gates are complete.

--- a/examples/agent_session/main.go
+++ b/examples/agent_session/main.go
@@ -19,50 +19,109 @@ func main() {
 
 func run() error {
 	act := flag.Bool("act", false, "perform the action; default is validation-only dry-run")
-	operation := flag.String("operation", "move", "move, click, or type")
+	operation := flag.String("operation", "move", "observe, move, click, or type")
 	x := flag.Int("x", 0, "move destination x")
 	y := flag.Int("y", 0, "move destination y")
 	displayID := flag.Int("display", 0, "explicit display ID")
 	text := flag.String("text", "RobotGo agent session", "text used only with -operation type")
+	capture := flag.Bool("capture", false, "capture an in-memory region with -operation observe")
+	verify := flag.String("verify", "", "post-action capture proof: changed or unchanged (requires -act)")
+	width := flag.Int("width", 320, "capture width")
+	height := flag.Int("height", 200, "capture height")
 	flag.Parse()
 
 	session, err := agent.NewSession(agent.Config{Policy: agent.Policy{
 		AllowedOperations: []agent.Operation{
-			agent.OperationMove, agent.OperationClick, agent.OperationTypeText,
+			agent.OperationObserve, agent.OperationMove, agent.OperationClick, agent.OperationTypeText,
 		},
 		ConfirmOperations: []agent.Operation{
-			agent.OperationMove, agent.OperationClick, agent.OperationTypeText,
+			agent.OperationObserve, agent.OperationMove, agent.OperationClick, agent.OperationTypeText,
 		},
 		AllowedDisplayIDs: []int{*displayID},
 		MaxActions:        1, MaxTextRunes: 256,
+		MaxObservations: 4, MaxCapturePixels: 4 * 1024 * 1024,
+		VerificationAttempts: 2, VerificationIntervalMillis: 50,
+		VerificationTimeoutMillis: 1000,
 	}})
 	if err != nil {
 		return err
 	}
 	defer func() { _ = session.Close() }()
 
-	request, err := requestFor(*operation, *x, *y, *displayID, *text)
-	if err != nil {
-		return err
-	}
-	var result agent.ActionResult
-	if *act {
-		request.Confirmed = true
-		result, err = session.Execute(context.Background(), request)
-	} else {
-		// DryRun applies the same validation, policy, quota, and capability
-		// preflight but never injects desktop input.
-		request.Confirmed = true
-		result, err = session.DryRun(context.Background(), request)
-	}
 	output := struct {
-		Catalog agent.OperationCatalog `json:"catalog"`
-		Result  agent.ActionResult     `json:"result"`
-	}{Catalog: session.Catalog(), Result: result}
+		Catalog     agent.OperationCatalog `json:"catalog"`
+		Observation *agent.Observation     `json:"observation,omitempty"`
+		Result      *agent.ActionResult    `json:"result,omitempty"`
+	}{Catalog: session.Catalog()}
+	if *operation == "observe" {
+		if *verify != "" {
+			return fmt.Errorf("-verify requires a mutating operation")
+		}
+		observeRequest := agent.ObserveRequest{Confirmed: true}
+		if *capture {
+			observeRequest.Capture = &agent.CaptureRegion{
+				X: *x, Y: *y, Width: *width, Height: *height, DisplayID: *displayID,
+			}
+		}
+		output.Observation, err = session.Observe(context.Background(), observeRequest)
+		if output.Observation != nil {
+			defer func() { _ = output.Observation.Close() }()
+		}
+	} else {
+		if *capture {
+			return fmt.Errorf("-capture is only valid with -operation observe; use -verify for an action proof")
+		}
+		request, requestErr := requestFor(*operation, *x, *y, *displayID, *text)
+		if requestErr != nil {
+			return requestErr
+		}
+		request.Confirmed = true
+		if *verify != "" {
+			if !*act {
+				return fmt.Errorf("-verify requires -act because dry-run performs no post-action proof")
+			}
+			condition, conditionErr := verificationCondition(*verify)
+			if conditionErr != nil {
+				return conditionErr
+			}
+			output.Observation, err = session.Observe(context.Background(), agent.ObserveRequest{
+				Confirmed: true,
+				Capture: &agent.CaptureRegion{
+					X: *x, Y: *y, Width: *width, Height: *height, DisplayID: *displayID,
+				},
+			})
+			if err != nil {
+				return err
+			}
+			defer func() { _ = output.Observation.Close() }()
+			request.Precondition = &agent.ObservationPrecondition{ObservationID: output.Observation.ObservationID}
+			request.Verification = &agent.VerificationRequest{Condition: condition}
+		}
+		var result agent.ActionResult
+		if *act {
+			result, err = session.Execute(context.Background(), request)
+		} else {
+			// DryRun applies the same validation, policy, quota, and capability
+			// preflight but never injects desktop input.
+			result, err = session.DryRun(context.Background(), request)
+		}
+		output.Result = &result
+	}
 	if encodeErr := json.NewEncoder(os.Stdout).Encode(output); encodeErr != nil {
 		return encodeErr
 	}
 	return err
+}
+
+func verificationCondition(value string) (agent.VerificationCondition, error) {
+	switch value {
+	case "changed":
+		return agent.VerificationCaptureChanged, nil
+	case "unchanged":
+		return agent.VerificationCaptureUnchanged, nil
+	default:
+		return "", fmt.Errorf("unknown verification condition %q", value)
+	}
 }
 
 func requestFor(operation string, x, y, displayID int, text string) (agent.ActionRequest, error) {

--- a/examples/screencast_capture/main.go
+++ b/examples/screencast_capture/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"image"
 	"image/png"
 	"os"
 	"os/signal"
@@ -18,6 +19,7 @@ import (
 func main() {
 	output := flag.String("output", "screencast.png", "PNG output path")
 	stream := flag.Int("stream", 0, "selected portal stream index")
+	display := flag.Int("display", -1, "require the selected monitor to match this display ID")
 	flag.Parse()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -38,7 +40,15 @@ func main() {
 	}()
 
 	frameCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	frame, err := robotgo.CaptureScreenCast(frameCtx)
+	var (
+		frame image.Image
+		err   error
+	)
+	if *display >= 0 {
+		frame, err = robotgo.CaptureScreenCastDisplay(frameCtx, *display)
+	} else {
+		frame, err = robotgo.CaptureScreenCast(frameCtx)
+	}
 	cancel()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "capture frame:", err)

--- a/robotgo.go
+++ b/robotgo.go
@@ -291,27 +291,29 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		portalAvailable := portalAllowed && portalAvailabilityProbe()
 		persistentCapture := portalAllowed && ScreenCastCaptureReady() == nil
 		switch {
-		case persistentCapture:
-			c.Capture = FeatureCapability{
-				Available: true,
-				Fallback:  nativeCapture || portalAvailable,
-				Backend:   FeatureBackendScreenCast,
-				Reason:    "an active ScreenCast session provides reusable PipeWire frames",
-				Notes:     screenCastCapabilityNotes(),
-			}
 		case nativeCapture:
 			c.Capture = FeatureCapability{
 				Available: true,
-				Fallback:  portalAvailable,
-				Backend:   "wayland+screencopy",
+				Fallback:  persistentCapture || portalAvailable,
+				Backend:   FeatureBackendWaylandScreencopy,
 				Reason:    "screencopy manager and compatible buffer backend detected",
 				Notes:     "native screencopy path (dmabuf/wl_shm)",
 			}
-			if portalAvailable {
+			if persistentCapture {
+				c.Capture.Notes += "; active ScreenCast fallback: " + screenCastCapabilityNotes()
+			} else if portalAvailable {
 				c.Capture.Notes += "; desktop portal fallback detected"
 				if screenCastCaptureCompiled() {
 					c.Capture.Notes += "; " + screenCastCapabilityNotes()
 				}
+			}
+		case persistentCapture:
+			c.Capture = FeatureCapability{
+				Available: true,
+				Fallback:  portalAvailable,
+				Backend:   FeatureBackendScreenCast,
+				Reason:    "an active ScreenCast session provides reusable PipeWire frames",
+				Notes:     screenCastCapabilityNotes(),
 			}
 		case portalAvailable:
 			c.Capture = FeatureCapability{
@@ -1302,6 +1304,10 @@ func GetScaleSize(displayId ...int) (int, int) {
 //
 // robotgo.CaptureScreen(x, y, w, h int)
 func CaptureScreen(args ...int) (CBitmap, error) {
+	return captureScreen(true, args...)
+}
+
+func captureScreen(allowPortal bool, args ...int) (CBitmap, error) {
 	argX, argY, argW, argH, argErr := captureRegionFromArgs(args)
 	if argErr != nil {
 		return nil, argErr
@@ -1349,9 +1355,9 @@ func CaptureScreen(args ...int) (CBitmap, error) {
 		// Allow tests or environments to force the portal backend regardless
 		// of the detected display server.
 		backendOverride := strings.ToLower(strings.TrimSpace(os.Getenv(envWaylandBackend)))
-		forcePortal := os.Getenv(envForcePortal) != "" || backendOverride == waylandBackendPortalName
+		forcePortal := allowPortal && (os.Getenv(envForcePortal) != "" || backendOverride == waylandBackendPortalName)
 		if len(args) <= 3 && ds == DisplayServerX11 &&
-			(forcePortal || backendOverride == waylandBackendScreenCast) {
+			(forcePortal || allowPortal && backendOverride == waylandBackendScreenCast) {
 			// Preserve argumentless X11 crop semantics without holding the native
 			// display lease during portal or PipeWire I/O.
 			unlockDisplay := lockNativeX11Display()
@@ -1366,7 +1372,7 @@ func CaptureScreen(args ...int) (CBitmap, error) {
 			}
 			unlockDisplay()
 		}
-		if backendOverride == waylandBackendScreenCast {
+		if allowPortal && backendOverride == waylandBackendScreenCast {
 			bitmap, err := captureViaPersistentScreenCast(x, y, w, h)
 			if err != nil {
 				return nil, errors.Join(ErrPortalFailed, err)
@@ -1399,26 +1405,31 @@ func CaptureScreen(args ...int) (CBitmap, error) {
 			if bit == nil {
 				err := waylandErr(cerr)
 				captureDebugf("wayland screencopy failed: %v", err)
-				if cb, streamErr := captureViaPersistentScreenCast(x, y, w, h); streamErr == nil {
-					captureDebugf("fallback to persistent ScreenCast backend")
-					return cb, nil
-				}
-				// Try portal screenshot (real pixels) when available.
-				if cb, pErr := captureViaPortalScreenshot(x, y, w, h); pErr == nil {
-					captureDebugf("fallback to portal screenshot backend")
-					return cb, nil
-				}
-				// Optional fallback to C portal stub for tests only.
 				var sErr error
-				if portalStubEnabled() {
-					var cb CBitmap
-					cb, sErr = captureViaPortalStub(x, y, w, h, displayId, isPid)
-					if sErr == nil {
-						captureDebugf("fallback to C portal stub backend")
+				if allowPortal {
+					if cb, streamErr := captureViaPersistentScreenCast(x, y, w, h); streamErr == nil {
+						captureDebugf("fallback to persistent ScreenCast backend")
 						return cb, nil
+					}
+					// Try portal screenshot (real pixels) when available.
+					if cb, pErr := captureViaPortalScreenshot(x, y, w, h); pErr == nil {
+						captureDebugf("fallback to portal screenshot backend")
+						return cb, nil
+					}
+					// Optional fallback to C portal stub for tests only.
+					if portalStubEnabled() {
+						var cb CBitmap
+						cb, sErr = captureViaPortalStub(x, y, w, h, displayId, isPid)
+						if sErr == nil {
+							captureDebugf("fallback to C portal stub backend")
+							return cb, nil
+						}
 					}
 				}
 				if errors.Is(err, ErrNoScreencopy) {
+					if !allowPortal {
+						return nil, err
+					}
 					if sErr != nil {
 						return nil, fmt.Errorf("%w; %v", err, sErr)
 					}
@@ -1483,6 +1494,23 @@ func CaptureImg(args ...int) (image.Image, error) {
 		return img, err
 	}
 	bit, err := CaptureScreen(args...)
+	if err != nil {
+		return nil, err
+	}
+	defer FreeBitmap(bit)
+
+	return ToImage(bit), nil
+}
+
+// CaptureImgNative captures through the session's native backend without
+// opening or reusing a desktop portal. On Wayland this attempts compositor
+// screencopy only; callers may choose an already-authorized portal fallback
+// explicitly after inspecting the returned error.
+func CaptureImgNative(args ...int) (image.Image, error) {
+	if img, handled, err := platformCaptureImgNativeFallback(args...); handled {
+		return img, err
+	}
+	bit, err := captureScreen(false, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/robotgo.go
+++ b/robotgo.go
@@ -287,8 +287,9 @@ func GetLinuxCapabilities() LinuxCapabilities {
 		c.Compositor = detectWaylandCompositor()
 		c.RemoteDesktop = probeRemoteDesktopCapability()
 		nativeCapture := waylandCaptureAvailabilityProbe()
-		portalAvailable := portalAvailabilityProbe()
-		persistentCapture := ScreenCastCaptureReady() == nil
+		portalAllowed := os.Getenv(envDisablePortal) == ""
+		portalAvailable := portalAllowed && portalAvailabilityProbe()
+		persistentCapture := portalAllowed && ScreenCastCaptureReady() == nil
 		switch {
 		case persistentCapture:
 			c.Capture = FeatureCapability{
@@ -979,6 +980,9 @@ func captureViaPortalScreenshot(x, y, w, h C.int32_t) (CBitmap, error) {
 }
 
 func captureViaPersistentScreenCast(x, y, w, h C.int32_t) (CBitmap, error) {
+	if os.Getenv(envDisablePortal) != "" {
+		return nil, fmt.Errorf("%w: persistent ScreenCast disabled by %s", ErrPortalFailed, envDisablePortal)
+	}
 	img, err := captureViaScreenCast(context.Background(), int(x), int(y), int(w), int(h))
 	if err != nil {
 		captureDebugf("persistent ScreenCast failed: %v", err)

--- a/robotgo.go
+++ b/robotgo.go
@@ -294,7 +294,7 @@ func GetLinuxCapabilities() LinuxCapabilities {
 			c.Capture = FeatureCapability{
 				Available: true,
 				Fallback:  nativeCapture || portalAvailable,
-				Backend:   "portal-screencast+pipewire",
+				Backend:   FeatureBackendScreenCast,
 				Reason:    "an active ScreenCast session provides reusable PipeWire frames",
 				Notes:     screenCastCapabilityNotes(),
 			}

--- a/robotgo_nocgo_capture.go
+++ b/robotgo_nocgo_capture.go
@@ -86,6 +86,33 @@ func CaptureImg(args ...int) (image.Image, error) {
 			return nil, fmt.Errorf("%w: no supported Linux display server detected", ErrNotSupported)
 		}
 	}
+	return capturePureGoNative(args)
+}
+
+// CaptureImgNative captures through a Pure-Go native backend without opening
+// or reusing a desktop portal. Pure-Go Wayland screencopy is not available, so
+// Wayland callers receive ErrNotSupported explicitly.
+func CaptureImgNative(args ...int) (image.Image, error) {
+	if err := validateCaptureArguments(args); err != nil {
+		return nil, err
+	}
+	if runtime.GOOS == "linux" {
+		switch DetectDisplayServer() {
+		case DisplayServerWayland:
+			return nil, fmt.Errorf(
+				"%w: native Wayland screencopy requires a CGO Wayland build",
+				ErrNotSupported,
+			)
+		case DisplayServerX11:
+			// Continue with the Pure-Go X11 backend below.
+		default:
+			return nil, fmt.Errorf("%w: no supported Linux display server detected", ErrNotSupported)
+		}
+	}
+	return capturePureGoNative(args)
+}
+
+func capturePureGoNative(args []int) (image.Image, error) {
 	if !pureGoScreenshotSupported(runtime.GOOS, runtime.GOARCH) {
 		return nil, fmt.Errorf("%w: Pure-Go capture is unavailable on %s/%s", ErrNotSupported, runtime.GOOS, runtime.GOARCH)
 	}

--- a/robotgo_nocgo_capture_test.go
+++ b/robotgo_nocgo_capture_test.go
@@ -388,6 +388,24 @@ func TestPureGoCaptureImgUsesHardenedWaylandPortal(t *testing.T) {
 	}
 }
 
+func TestPureGoCaptureImgNativeNeverUsesWaylandPortal(t *testing.T) {
+	preservePureGoCaptureFakes(t)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-test")
+	t.Setenv("DISPLAY", "")
+	portalCalled := false
+	pureGoPortalCaptureImage = func(context.Context, int, int, int, int) (image.Image, error) {
+		portalCalled = true
+		return image.NewRGBA(image.Rect(0, 0, 1, 1)), nil
+	}
+
+	if _, err := CaptureImgNative(0, 0, 1, 1, 0); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("CaptureImgNative error = %v, want ErrNotSupported", err)
+	}
+	if portalCalled {
+		t.Fatal("CaptureImgNative opened the Wayland portal")
+	}
+}
+
 func TestPureGoCaptureAliasUsesWaylandPortalWithoutX11Bounds(t *testing.T) {
 	preservePureGoCaptureFakes(t)
 	t.Setenv(envWaylandDisplay, "wayland-test")

--- a/robotgo_wayland_cap_test.go
+++ b/robotgo_wayland_cap_test.go
@@ -37,6 +37,24 @@ func TestCaptureStateConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
+func TestCaptureImgNativeIgnoresPortalOverrides(t *testing.T) {
+	t.Setenv("WAYLAND_DISPLAY", "robotgo-native-capture-test")
+	t.Setenv("DISPLAY", "")
+	t.Setenv(envForcePortal, "1")
+	t.Setenv(envWaylandBackend, waylandBackendPortalName)
+	t.Setenv(envPortalStubGreen, "1")
+	setLastBackend(BackendNone)
+	t.Cleanup(func() { setLastBackend(BackendNone) })
+
+	img, err := CaptureImgNative(0, 0, 1, 1, 0)
+	if img != nil || err == nil {
+		t.Fatalf("CaptureImgNative = (%v, %v), want native Wayland failure", img, err)
+	}
+	if LastBackend() == BackendPortal {
+		t.Fatal("CaptureImgNative used the forced portal backend")
+	}
+}
+
 func resetWaylandBoundsCacheForTest() {
 	waylandBoundsMu.Lock()
 	waylandBoundsCached = Rect{}
@@ -84,20 +102,37 @@ func TestGetLinuxCapabilitiesReportsActiveScreenCast(t *testing.T) {
 	screenCastCaptureState.Unlock()
 
 	capabilities := GetLinuxCapabilities()
-	if !capabilities.Capture.Available || capabilities.Capture.Backend != FeatureBackendScreenCast {
+	if !capabilities.Capture.Available || capabilities.Capture.Backend != FeatureBackendWaylandScreencopy {
 		t.Fatalf("active ScreenCast capability = %+v", capabilities.Capture)
 	}
 	if !capabilities.Capture.Fallback {
 		t.Fatal("active ScreenCast capability did not report available fallback paths")
 	}
-	if !strings.Contains(capabilities.Capture.Notes, "interface version=5") {
+	if !strings.Contains(capabilities.Capture.Notes, "active ScreenCast fallback") ||
+		!strings.Contains(capabilities.Capture.Notes, "interface version=5") {
 		t.Fatalf("ScreenCast protocol diagnostics missing: %q", capabilities.Capture.Notes)
 	}
 
 	t.Setenv(envDisablePortal, "1")
 	capabilities = GetLinuxCapabilities()
-	if !capabilities.Capture.Available || capabilities.Capture.Backend != "wayland+screencopy" || capabilities.Capture.Fallback {
+	if !capabilities.Capture.Available || capabilities.Capture.Backend != FeatureBackendWaylandScreencopy || capabilities.Capture.Fallback {
 		t.Fatalf("native-only capability = %+v", capabilities.Capture)
+	}
+}
+
+func TestGetLinuxCapabilitiesUsesActiveScreenCastWhenNativeUnavailable(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+	prepareScreenCastCaptureTest(t)
+	stubCaptureCapabilityProbes(t, false, true)
+	screenCastCaptureState.Lock()
+	screenCastCaptureState.capture = &fakeScreenCastCapture{}
+	screenCastCaptureState.Unlock()
+
+	capabilities := GetLinuxCapabilities()
+	if !capabilities.Capture.Available || capabilities.Capture.Backend != FeatureBackendScreenCast {
+		t.Fatalf("active ScreenCast capability = %+v", capabilities.Capture)
 	}
 }
 

--- a/robotgo_wayland_cap_test.go
+++ b/robotgo_wayland_cap_test.go
@@ -93,6 +93,12 @@ func TestGetLinuxCapabilitiesReportsActiveScreenCast(t *testing.T) {
 	if !strings.Contains(capabilities.Capture.Notes, "interface version=5") {
 		t.Fatalf("ScreenCast protocol diagnostics missing: %q", capabilities.Capture.Notes)
 	}
+
+	t.Setenv(envDisablePortal, "1")
+	capabilities = GetLinuxCapabilities()
+	if !capabilities.Capture.Available || capabilities.Capture.Backend != "wayland+screencopy" || capabilities.Capture.Fallback {
+		t.Fatalf("native-only capability = %+v", capabilities.Capture)
+	}
 }
 
 func writeWaylandInfoStub(t *testing.T, dir string) {

--- a/robotgo_wayland_cap_test.go
+++ b/robotgo_wayland_cap_test.go
@@ -84,7 +84,7 @@ func TestGetLinuxCapabilitiesReportsActiveScreenCast(t *testing.T) {
 	screenCastCaptureState.Unlock()
 
 	capabilities := GetLinuxCapabilities()
-	if !capabilities.Capture.Available || capabilities.Capture.Backend != "portal-screencast+pipewire" {
+	if !capabilities.Capture.Available || capabilities.Capture.Backend != FeatureBackendScreenCast {
 		t.Fatalf("active ScreenCast capability = %+v", capabilities.Capture)
 	}
 	if !capabilities.Capture.Fallback {

--- a/runtime_diagnostics_linux.go
+++ b/runtime_diagnostics_linux.go
@@ -20,7 +20,7 @@ const (
 	backendWaylandVirtualKeyboard  = "wayland-virtual-keyboard"
 	backendWaylandVirtualPointer   = "wayland-virtual-pointer"
 	backendPortalRemoteDesktop     = "portal-remote-desktop"
-	backendPortalScreenCast        = "portal-screencast+pipewire"
+	backendPortalScreenCast        = FeatureBackendScreenCast
 )
 
 var (

--- a/screen/portal/pipewire.go
+++ b/screen/portal/pipewire.go
@@ -89,6 +89,15 @@ func (c *PipeWireCapture) Streams() []ScreenCastStream {
 	return c.session.Streams()
 }
 
+// SelectedStream returns the immutable metadata for the stream consumed by
+// this capture, rather than all streams selected in the portal session.
+func (c *PipeWireCapture) SelectedStream() ScreenCastStream {
+	if c == nil {
+		return ScreenCastStream{}
+	}
+	return c.stream
+}
+
 // RestoreToken returns the latest single-use ScreenCast restore token.
 func (c *PipeWireCapture) RestoreToken() string {
 	if c == nil || c.session == nil {

--- a/screen/portal/pipewire_test.go
+++ b/screen/portal/pipewire_test.go
@@ -114,7 +114,8 @@ func TestPipeWireCaptureMapsLogicalFractionalScaleRegion(t *testing.T) {
 	if got := img.Bounds(); got != image.Rect(0, 0, 75, 50) {
 		t.Fatalf("scaled crop bounds = %v, want 75x50", got)
 	}
-	if capture.RestoreToken() != "restore-next" || len(capture.Streams()) != 1 {
+	if capture.RestoreToken() != "restore-next" || len(capture.Streams()) != 1 ||
+		!reflect.DeepEqual(capture.SelectedStream(), stream) {
 		t.Fatal("capture session metadata was not retained")
 	}
 	if err := capture.Close(); err != nil {

--- a/screen_backend_linux_cgo.go
+++ b/screen_backend_linux_cgo.go
@@ -156,15 +156,57 @@ func platformCaptureImgFallback(args ...int) (image.Image, bool, error) {
 		linuxCaptureUsesPortalBackend() {
 		return nil, false, nil
 	}
+	img, err := capturePortableX11Image(args)
+	return img, true, err
+}
+
+func platformCaptureImgNativeFallback(args ...int) (image.Image, bool, error) {
+	if nativeX11BackendCompiled() || selectedDisplayServer() != DisplayServerX11 {
+		return nil, false, nil
+	}
+	img, err := capturePortableX11Image(args)
+	return img, true, err
+}
+
+func capturePortableX11Image(args []int) (image.Image, error) {
 	if err := validateCaptureArguments(args); err != nil {
-		return nil, true, err
+		return nil, err
 	}
 	if len(args) > 5 {
-		return nil, true, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%w: process-targeted X11 capture is unavailable in a Wayland-enabled build",
 			ErrNotSupported,
 		)
 	}
-	img, err := Capture(args...)
-	return img, true, err
+	if err := linuxX11SessionConflictError("capture"); err != nil {
+		return nil, err
+	}
+
+	displayID := currentDisplayID()
+	if displayID < 0 {
+		displayID = 0
+	}
+	if len(args) > 4 {
+		displayID = args[4]
+	}
+	x, y, width, height, err := captureRegionFromArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	if len(args) <= 3 {
+		bounds, boundsErr := x11DisplayBounds(displayID)
+		if boundsErr != nil {
+			return nil, boundsErr
+		}
+		x, y, width, height = bounds.Min.X, bounds.Min.Y, bounds.Dx(), bounds.Dy()
+	}
+	if err := validateCaptureRegionRequest(x, y, width, height); err != nil {
+		return nil, err
+	}
+	img, err := screenshot.Capture(x, y, width, height)
+	if err != nil {
+		return nil, fmt.Errorf("robotgo: capture X11 from a Wayland-enabled build: %w", err)
+	}
+	setLastBackend(BackendX11)
+	return img, nil
 }

--- a/screen_capture_img_fallback_other.go
+++ b/screen_capture_img_fallback_other.go
@@ -7,3 +7,7 @@ import "image"
 func platformCaptureImgFallback(...int) (image.Image, bool, error) {
 	return nil, false, nil
 }
+
+func platformCaptureImgNativeFallback(...int) (image.Image, bool, error) {
+	return nil, false, nil
+}

--- a/screencast_capture.go
+++ b/screencast_capture.go
@@ -35,6 +35,7 @@ type screenCastFrameCapture interface {
 	Ready() error
 	Capture(context.Context, int, int, int, int) (image.Image, error)
 	Streams() []portalpkg.ScreenCastStream
+	SelectedStream() portalpkg.ScreenCastStream
 	RestoreToken() string
 	Close() error
 }
@@ -44,6 +45,8 @@ var (
 		return portalpkg.OpenPipeWireCapture(ctx, options, streamIndex)
 	}
 	screenCastCaptureCompiled  = portalpkg.PipeWireCaptureCompiled
+	screenCastDisplayBounds    = GetDisplayBoundsE
+	screenCastDisplaysNum      = DisplaysNumE
 	screenCastCaptureOperation sync.Mutex
 	screenCastCapturePending   struct {
 		sync.Mutex
@@ -169,6 +172,82 @@ func CaptureScreenCast(ctx context.Context, region ...int) (image.Image, error) 
 		return captureViaScreenCast(ctx, 0, 0, 0, 0)
 	}
 	return captureViaScreenCast(ctx, region[0], region[1], region[2], region[3])
+}
+
+// CaptureScreenCastDisplay returns a region only when the active selected
+// stream is an unambiguous monitor match for displayID. Window, virtual,
+// metadata-incomplete, mismatched, and geometrically ambiguous streams fail
+// closed before any frame is read.
+func CaptureScreenCastDisplay(ctx context.Context, displayID int, region ...int) (image.Image, error) {
+	if displayID < 0 {
+		return nil, fmt.Errorf("ScreenCast capture requires a non-negative display ID")
+	}
+	if len(region) != 0 && len(region) != 4 {
+		return nil, errors.New("ScreenCast capture region must be empty or x, y, width, height")
+	}
+	if len(region) == 4 && (region[2] <= 0 || region[3] <= 0) {
+		return nil, fmt.Errorf("ScreenCast capture region has invalid size %dx%d", region[2], region[3])
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	screenCastCaptureState.RLock()
+	capture := screenCastCaptureState.capture
+	screenCastCaptureState.RUnlock()
+	if capture == nil {
+		return nil, fmt.Errorf("%w: no active ScreenCast capture", ErrNotSupported)
+	}
+	if err := validateScreenCastDisplay(capture.SelectedStream(), displayID); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(region) == 0 {
+		return capture.Capture(ctx, 0, 0, 0, 0)
+	}
+	return capture.Capture(ctx, region[0], region[1], region[2], region[3])
+}
+
+func validateScreenCastDisplay(stream portalpkg.ScreenCastStream, displayID int) error {
+	if stream.SourceType != portalpkg.ScreenCastSourceMonitor {
+		return fmt.Errorf("%w: selected ScreenCast stream is not a monitor", ErrNotSupported)
+	}
+	if !stream.HasPosition || !stream.HasSize || stream.Size.Width <= 0 || stream.Size.Height <= 0 {
+		return fmt.Errorf("%w: selected ScreenCast monitor lacks complete logical geometry", ErrNotSupported)
+	}
+	x, y, width, height, err := screenCastDisplayBounds(displayID)
+	if err != nil {
+		return err
+	}
+	if !screenCastGeometryMatches(stream, x, y, width, height) {
+		return fmt.Errorf("%w: selected ScreenCast monitor does not match display %d", ErrNotSupported, displayID)
+	}
+	displays, err := screenCastDisplaysNum()
+	if err != nil {
+		return err
+	}
+	for candidate := 0; candidate < displays; candidate++ {
+		if candidate == displayID {
+			continue
+		}
+		otherX, otherY, otherWidth, otherHeight, boundsErr := screenCastDisplayBounds(candidate)
+		if boundsErr != nil {
+			return boundsErr
+		}
+		if screenCastGeometryMatches(stream, otherX, otherY, otherWidth, otherHeight) {
+			return fmt.Errorf("%w: selected ScreenCast monitor geometry matches multiple displays", ErrNotSupported)
+		}
+	}
+	return nil
+}
+
+func screenCastGeometryMatches(stream portalpkg.ScreenCastStream, x, y, width, height int) bool {
+	return int64(stream.Position.X) == int64(x) && int64(stream.Position.Y) == int64(y) &&
+		int64(stream.Size.Width) == int64(width) && int64(stream.Size.Height) == int64(height)
 }
 
 // CloseScreenCastCapture stops PipeWire and closes the portal session.

--- a/screencast_capture.go
+++ b/screencast_capture.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"os"
 	"runtime"
 	"sync"
 
@@ -66,6 +67,9 @@ func StartScreenCastCapture(ctx context.Context, options ScreenCastCaptureOption
 	if runtime.GOOS != "linux" || DetectDisplayServer() != DisplayServerWayland {
 		return fmt.Errorf("%w: ScreenCast capture requires a Linux Wayland session", ErrNotSupported)
 	}
+	if os.Getenv(envDisablePortal) != "" {
+		return fmt.Errorf("%w: ScreenCast capture is disabled by %s", ErrNotSupported, envDisablePortal)
+	}
 	if !screenCastCaptureCompiled() {
 		return fmt.Errorf("%w: build with -tags pipewire and install libpipewire development files", ErrNotSupported)
 	}
@@ -126,6 +130,9 @@ func StartScreenCastCapture(ctx context.Context, options ScreenCastCaptureOption
 
 // ScreenCastCaptureReady reports whether a reusable PipeWire capture is active.
 func ScreenCastCaptureReady() error {
+	if os.Getenv(envDisablePortal) != "" {
+		return fmt.Errorf("%w: ScreenCast capture is disabled by %s", ErrNotSupported, envDisablePortal)
+	}
 	screenCastCaptureState.RLock()
 	capture := screenCastCaptureState.capture
 	screenCastCaptureState.RUnlock()
@@ -179,6 +186,9 @@ func CaptureScreenCast(ctx context.Context, region ...int) (image.Image, error) 
 // metadata-incomplete, mismatched, and geometrically ambiguous streams fail
 // closed before any frame is read.
 func CaptureScreenCastDisplay(ctx context.Context, displayID int, region ...int) (image.Image, error) {
+	if os.Getenv(envDisablePortal) != "" {
+		return nil, fmt.Errorf("%w: ScreenCast capture is disabled by %s", ErrNotSupported, envDisablePortal)
+	}
 	if displayID < 0 {
 		return nil, fmt.Errorf("ScreenCast capture requires a non-negative display ID")
 	}
@@ -277,6 +287,9 @@ func CloseScreenCastCapture() error {
 }
 
 func captureViaScreenCast(ctx context.Context, x, y, width, height int) (image.Image, error) {
+	if os.Getenv(envDisablePortal) != "" {
+		return nil, fmt.Errorf("%w: ScreenCast capture is disabled by %s", ErrNotSupported, envDisablePortal)
+	}
 	screenCastCaptureState.RLock()
 	capture := screenCastCaptureState.capture
 	screenCastCaptureState.RUnlock()

--- a/screencast_capture_cgo_test.go
+++ b/screencast_capture_cgo_test.go
@@ -39,3 +39,20 @@ func TestCaptureScreenForcedScreenCastRequiresActiveSession(t *testing.T) {
 		t.Fatalf("CaptureScreen = (%v, %v), want explicit unavailable error", bitmap, err)
 	}
 }
+
+func TestCaptureScreenForcedScreenCastHonorsDisablePortal(t *testing.T) {
+	prepareScreenCastCaptureTest(t)
+	t.Setenv(envWaylandBackend, waylandBackendScreenCast)
+	t.Setenv(envDisablePortal, "1")
+	capture := &fakeScreenCastCapture{frame: image.NewRGBA(image.Rect(0, 0, 2, 2))}
+	screenCastCaptureState.Lock()
+	screenCastCaptureState.capture = capture
+	screenCastCaptureState.Unlock()
+
+	if bitmap, err := CaptureScreen(0, 0, 2, 2); bitmap != nil || err == nil {
+		t.Fatalf("CaptureScreen = (%v, %v), want disabled portal error", bitmap, err)
+	}
+	if capture.captureCount() != 0 {
+		t.Fatalf("disabled ScreenCast read %d frames", capture.captureCount())
+	}
+}

--- a/screencast_capture_test.go
+++ b/screencast_capture_test.go
@@ -64,6 +64,7 @@ func prepareScreenCastCaptureTest(t *testing.T) {
 	t.Helper()
 	t.Setenv("WAYLAND_DISPLAY", "robotgo-test-wayland")
 	t.Setenv("DISPLAY", "")
+	t.Setenv(envDisablePortal, "")
 
 	oldOpen := screenCastCaptureOpen
 	oldCompiled := screenCastCaptureCompiled
@@ -362,6 +363,34 @@ func TestStartScreenCastCaptureRequiresWaylandAndPipeWireBuild(t *testing.T) {
 	screenCastCaptureCompiled = func() bool { return false }
 	if err := StartScreenCastCapture(context.Background(), ScreenCastCaptureOptions{}); !errors.Is(err, ErrNotSupported) {
 		t.Fatalf("non-PipeWire error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestDisablePortalPreventsScreenCastStartReadyAndCapture(t *testing.T) {
+	prepareScreenCastCaptureTest(t)
+	t.Setenv(envDisablePortal, "1")
+	screenCastCaptureOpen = func(context.Context, portalpkg.ScreenCastOptions, int) (screenCastFrameCapture, error) {
+		t.Fatal("disabled ScreenCast reached portal open")
+		return nil, nil
+	}
+	if err := StartScreenCastCapture(context.Background(), ScreenCastCaptureOptions{}); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("StartScreenCastCapture error = %v, want ErrNotSupported", err)
+	}
+	capture := &fakeScreenCastCapture{frame: image.NewRGBA(image.Rect(0, 0, 1, 1))}
+	screenCastCaptureState.Lock()
+	screenCastCaptureState.capture = capture
+	screenCastCaptureState.Unlock()
+	if err := ScreenCastCaptureReady(); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("ScreenCastCaptureReady error = %v, want ErrNotSupported", err)
+	}
+	if _, err := CaptureScreenCast(context.Background()); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("CaptureScreenCast error = %v, want ErrNotSupported", err)
+	}
+	if _, err := CaptureScreenCastDisplay(context.Background(), 0); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("CaptureScreenCastDisplay error = %v, want ErrNotSupported", err)
+	}
+	if capture.captureCount() != 0 {
+		t.Fatalf("disabled ScreenCast read %d frames", capture.captureCount())
 	}
 }
 

--- a/screencast_capture_test.go
+++ b/screencast_capture_test.go
@@ -16,21 +16,28 @@ type fakeScreenCastCapture struct {
 	mu           sync.Mutex
 	frame        image.Image
 	streams      []portalpkg.ScreenCastStream
+	selected     portalpkg.ScreenCastStream
 	restoreToken string
 	readyErr     error
 	closeErr     error
 	closed       int
+	captures     int
 }
 
 func (c *fakeScreenCastCapture) Ready() error { return c.readyErr }
 
 func (c *fakeScreenCastCapture) Capture(context.Context, int, int, int, int) (image.Image, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.captures++
 	return c.frame, nil
 }
 
 func (c *fakeScreenCastCapture) Streams() []portalpkg.ScreenCastStream {
 	return append([]portalpkg.ScreenCastStream(nil), c.streams...)
 }
+
+func (c *fakeScreenCastCapture) SelectedStream() portalpkg.ScreenCastStream { return c.selected }
 
 func (c *fakeScreenCastCapture) RestoreToken() string { return c.restoreToken }
 
@@ -47,6 +54,12 @@ func (c *fakeScreenCastCapture) closeCount() int {
 	return c.closed
 }
 
+func (c *fakeScreenCastCapture) captureCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.captures
+}
+
 func prepareScreenCastCaptureTest(t *testing.T) {
 	t.Helper()
 	t.Setenv("WAYLAND_DISPLAY", "robotgo-test-wayland")
@@ -54,6 +67,8 @@ func prepareScreenCastCaptureTest(t *testing.T) {
 
 	oldOpen := screenCastCaptureOpen
 	oldCompiled := screenCastCaptureCompiled
+	oldDisplayBounds := screenCastDisplayBounds
+	oldDisplaysNum := screenCastDisplaysNum
 	screenCastCaptureState.Lock()
 	oldCapture := screenCastCaptureState.capture
 	screenCastCaptureState.capture = nil
@@ -63,6 +78,8 @@ func prepareScreenCastCaptureTest(t *testing.T) {
 		_ = CloseScreenCastCapture()
 		screenCastCaptureOpen = oldOpen
 		screenCastCaptureCompiled = oldCompiled
+		screenCastDisplayBounds = oldDisplayBounds
+		screenCastDisplaysNum = oldDisplaysNum
 		screenCastCaptureState.Lock()
 		screenCastCaptureState.capture = oldCapture
 		screenCastCaptureState.Unlock()
@@ -217,6 +234,111 @@ func TestCaptureScreenCastUsesActiveSessionAndValidatesRegion(t *testing.T) {
 	}
 	if _, err := CaptureScreenCast(context.Background(), 0, 0, 10, 0); err == nil {
 		t.Fatal("CaptureScreenCast accepted a non-positive region")
+	}
+}
+
+func TestCaptureScreenCastDisplayBindsSelectedMonitor(t *testing.T) {
+	prepareScreenCastCaptureTest(t)
+	want := image.NewRGBA(image.Rect(0, 0, 3, 2))
+	capture := &fakeScreenCastCapture{
+		frame: want,
+		selected: portalpkg.ScreenCastStream{
+			SourceType: portalpkg.ScreenCastSourceMonitor,
+			Position:   portalpkg.ScreenCastPoint{X: -1920, Y: 0}, HasPosition: true,
+			Size: portalpkg.ScreenCastSize{Width: 1920, Height: 1080}, HasSize: true,
+		},
+	}
+	screenCastCaptureState.Lock()
+	screenCastCaptureState.capture = capture
+	screenCastCaptureState.Unlock()
+	screenCastDisplaysNum = func() (int, error) { return 2, nil }
+	screenCastDisplayBounds = func(displayID int) (int, int, int, int, error) {
+		if displayID == 0 {
+			return -1920, 0, 1920, 1080, nil
+		}
+		return 0, 0, 2560, 1440, nil
+	}
+
+	got, err := CaptureScreenCastDisplay(context.Background(), 0, -1900, 10, 20, 20)
+	if err != nil || got != want || capture.captureCount() != 1 {
+		t.Fatalf("CaptureScreenCastDisplay = (%v, %v), captures=%d", got, err, capture.captureCount())
+	}
+}
+
+func TestCaptureScreenCastDisplayRejectsUnboundStreamsBeforeFrameRead(t *testing.T) {
+	prepareScreenCastCaptureTest(t)
+	monitor := portalpkg.ScreenCastStream{
+		SourceType: portalpkg.ScreenCastSourceMonitor,
+		Position:   portalpkg.ScreenCastPoint{X: 0, Y: 0}, HasPosition: true,
+		Size: portalpkg.ScreenCastSize{Width: 100, Height: 100}, HasSize: true,
+	}
+	tests := []struct {
+		name     string
+		stream   portalpkg.ScreenCastStream
+		displays [][4]int
+	}{
+		{name: "window source", stream: func() portalpkg.ScreenCastStream {
+			stream := monitor
+			stream.SourceType = portalpkg.ScreenCastSourceWindow
+			return stream
+		}(), displays: [][4]int{{0, 0, 100, 100}}},
+		{name: "missing position", stream: func() portalpkg.ScreenCastStream {
+			stream := monitor
+			stream.HasPosition = false
+			return stream
+		}(), displays: [][4]int{{0, 0, 100, 100}}},
+		{name: "different monitor", stream: monitor, displays: [][4]int{{100, 0, 100, 100}}},
+		{name: "ambiguous mirrored geometry", stream: monitor, displays: [][4]int{{0, 0, 100, 100}, {0, 0, 100, 100}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capture := &fakeScreenCastCapture{frame: image.NewRGBA(image.Rect(0, 0, 1, 1)), selected: test.stream}
+			screenCastCaptureState.Lock()
+			screenCastCaptureState.capture = capture
+			screenCastCaptureState.Unlock()
+			screenCastDisplaysNum = func() (int, error) { return len(test.displays), nil }
+			screenCastDisplayBounds = func(displayID int) (int, int, int, int, error) {
+				bounds := test.displays[displayID]
+				return bounds[0], bounds[1], bounds[2], bounds[3], nil
+			}
+
+			if _, err := CaptureScreenCastDisplay(context.Background(), 0); !errors.Is(err, ErrNotSupported) {
+				t.Fatalf("CaptureScreenCastDisplay error = %v, want ErrNotSupported", err)
+			}
+			if capture.captureCount() != 0 {
+				t.Fatalf("unbound stream read %d frames", capture.captureCount())
+			}
+		})
+	}
+}
+
+func TestCaptureScreenCastDisplayUsesValidatedCaptureInstance(t *testing.T) {
+	prepareScreenCastCaptureTest(t)
+	stream := portalpkg.ScreenCastStream{
+		SourceType: portalpkg.ScreenCastSourceMonitor,
+		Position:   portalpkg.ScreenCastPoint{}, HasPosition: true,
+		Size: portalpkg.ScreenCastSize{Width: 100, Height: 100}, HasSize: true,
+	}
+	want := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	original := &fakeScreenCastCapture{frame: want, selected: stream}
+	replacement := &fakeScreenCastCapture{frame: image.NewRGBA(image.Rect(0, 0, 9, 9))}
+	screenCastCaptureState.Lock()
+	screenCastCaptureState.capture = original
+	screenCastCaptureState.Unlock()
+	screenCastDisplaysNum = func() (int, error) { return 1, nil }
+	screenCastDisplayBounds = func(int) (int, int, int, int, error) {
+		screenCastCaptureState.Lock()
+		screenCastCaptureState.capture = replacement
+		screenCastCaptureState.Unlock()
+		return 0, 0, 100, 100, nil
+	}
+
+	got, err := CaptureScreenCastDisplay(context.Background(), 0)
+	if err != nil || got != want || original.captureCount() != 1 || replacement.captureCount() != 0 {
+		t.Fatalf(
+			"CaptureScreenCastDisplay = (%v, %v), original=%d replacement=%d",
+			got, err, original.captureCount(), replacement.captureCount(),
+		)
 	}
 }
 


### PR DESCRIPTION
## Outcome

Completes the second agentic-automation architecture proof with bounded diagnostics-first observation, optional in-memory capture, immutable observation lineage, stale-target preconditions, bounded post-action verification, and a payload-free audit sink.

Linear: https://linear.app/riotbox/issue/LAB-12/add-bounded-observation-lineage-and-verification-proof

## Behavior

- adds `desktop.observe` to catalog schema v2 with separate capture availability/policy/backend/fallback signals
- introduces explicit observation, capture-region, precondition, verification, audit, and structured error contracts
- enforces action, observation, pixel, display, attempt, interval, and timeout budgets with hard safety ceilings
- recaptures the internally retained region before mutation and rejects stale targets without injecting input
- reports completed-but-unproven mutations as `unverified`, preventing unsafe blind retries
- preserves successful mutation/verification outcomes when only completion-audit delivery fails

## Backend and privacy boundaries

- Wayland capture uses an already-active ScreenCast stream, or an explicitly selected native-only path; the agent layer never opens portal consent implicitly
- default tests use synthetic in-memory images only and never access the real desktop, clipboard, OCR, or input
- pixel bytes are excluded from JSON and audit events, defensive copies are returned to callers, and RobotGo-owned source/intermediate/session buffers are deterministically zeroed on success, failure, timeout, cancellation, observation close, and session close
- audit precondition IDs are restricted to canonical RobotGo-generated values so request payloads cannot be smuggled into logs
- legacy package-level RobotGo APIs and existing action signatures remain source-compatible; catalog schema changes intentionally from v1 to v2

## Validation

- `go test -race ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -tags wayland ./agent -count=1`
- `go test -tags integration ./agent -run '^$' -count=1`
- `go vet ./...`
- `golangci-lint run`
- `git diff --check`

The opt-in real capture integration path is compiled and documented but was not executed because it intentionally requires an authorized graphical session. It writes no file and explicitly zeroes both returned and session-owned memory. Real changed/unchanged verification is deliberately covered by the hermetic fake driver instead: automating it against an uncontrolled developer desktop would require both mutation and repeated inspection of private content. No OCR, accessibility, MCP adapter, file-backed capture, or implicit consent is included in this slice.

## Review focus

Please focus on capture ownership/zeroing, audit failure semantics, quota reservation, context/session cancellation during verification, concurrent observation/action serialization, and Wayland no-implicit-consent behavior.