### PR TITLE
feat(agent): add safe visual conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,9 +756,10 @@ The `agent` package adds a strict Go boundary for automation agents without
 changing the legacy package-level API. One process-exclusive session exposes a
 versioned operation catalog, policy and confirmation gates, bounded observation,
 dry-run, typed move/click/text requests, stale-target protection, post-action
-verification, and sanitized structured results. Its catalog reports that the
-underlying input backend remains process-global and that cancellation is
-currently guaranteed before dispatch, not during a synchronous OS input call.
+verification, privacy-safe visual conditions, and sanitized structured results.
+Its catalog reports that the underlying input backend remains process-global
+and that cancellation is currently guaranteed before dispatch, not during a
+synchronous OS input call.
 Direct callers of legacy RobotGo APIs remain outside this exclusivity.
 For pointer moves, `AllowedDisplayIDs` fails closed: the selected display must
 be allowed and the global target coordinates must fall within its live bounds.
@@ -771,11 +772,23 @@ audit events; `Observation.Image` returns a defensive copy, while
 `Observation.Close` and `Session.Close` zero RobotGo-owned capture buffers.
 The implementation also enforces hard ceilings of 16,777,216 pixels per frame,
 100 verification attempts, 60 seconds between attempts, and five minutes per
-verification, even when a caller requests larger policy values.
+verification, plus 1,000,000 visual queries, 100 wait attempts, 60 seconds
+between wait attempts, and five minutes per wait, even when a caller requests
+larger policy values.
 On Wayland, agent capture uses an already-active ScreenCast stream when
 available. It never opens a portal consent dialog implicitly; callers must
 start consent-aware ScreenCast themselves or explicitly select native-only
 capture with `ROBOTGO_DISABLE_PORTAL=1`.
+
+`Session.FindColor` searches only a live capture already owned by an explicit
+observation; it never captures the desktop implicitly. `Session.WaitColor`
+polls one explicit `CaptureRegion` within `MaxQueries`, `MaxObservations`,
+`MaxCapturePixels`, display, attempt, interval, timeout, and confirmation
+limits. Results expose match state and global logical coordinates but never
+pixels, capture digests, or the target color. Every nonmatching or failed frame
+is zeroed immediately. A successful wait returns an observation ID for later
+conditions or action lineage; `Session.ReleaseObservation` promptly zeroes and
+removes that final sensitive buffer without exposing its capture digest.
 
 An action can reference a captured observation through
 `ObservationPrecondition`. RobotGo recaptures the same internally retained
@@ -802,6 +815,15 @@ go run ./examples/agent_session -operation move -x 100 -y 100 -display 0
 go run ./examples/agent_session -act -operation move -x 100 -y 100 -display 0
 # Explicit sensitive read plus click mutation and bounded changed-region proof.
 go run ./examples/agent_session -act -operation click -verify changed \
+  -x 0 -y 0 -width 320 -height 200 -display 0
+# Inspection-only by default; performs no capture.
+go run ./examples/agent_conditions
+# Explicit in-memory search or bounded wait; no image is written to disk.
+go run ./examples/agent_conditions -allow-capture -mode find \
+  -red 0 -green 120 -blue 255 -tolerance 0.05 \
+  -x 0 -y 0 -width 320 -height 200 -display 0
+go run ./examples/agent_conditions -allow-capture -mode wait \
+  -red 0 -green 120 -blue 255 -tolerance 0.05 \
   -x 0 -y 0 -width 320 -height 200 -display 0
 ```
 
@@ -857,6 +879,10 @@ and optional geometry, but never pixels or internal capture digests. Session
 close zeroes any in-memory captures. See the
 [adapter and evaluation plan](docs/plan/agent-adapter-evaluation.md) for the
 security boundary and intentionally deferred tools.
+The Go session catalog already reports `desktop.find-color` and
+`desktop.wait-color`, but the accepted MCP boundary intentionally does not yet
+expose `robotgo_find` or `robotgo_wait`; that protocol expansion follows after
+the Go contract's cleanup and privacy evidence is accepted.
 
 ## Examples
 
@@ -868,6 +894,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Full-screen capture with backend reporting](examples/screen_full/main.go)
 - [Cross-platform aggregate and per-output bounds](examples/display_bounds/main.go)
 - [Policy-gated agent session](examples/agent_session/main.go)
+- [Privacy-safe agent visual conditions](examples/agent_conditions/main.go)
 - [Linux capabilities](examples/linux_capabilities/main.go)
 - [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
 - [Versioned runtime diagnostics](examples/runtime_diagnostics/main.go)

--- a/README.md
+++ b/README.md
@@ -781,7 +781,9 @@ start consent-aware ScreenCast themselves or explicitly select native-only
 capture with `ROBOTGO_DISABLE_PORTAL=1`.
 
 `Session.FindColor` searches only a live capture already owned by an explicit
-observation; it never captures the desktop implicitly. `Session.WaitColor`
+observation; it never captures the desktop implicitly. Enabling it requires
+`desktop.observe` plus bounded capture and display policy so such an observation
+can actually be created. `Session.WaitColor`
 polls one explicit `CaptureRegion` within `MaxQueries`, `MaxObservations`,
 `MaxCapturePixels`, display, attempt, interval, timeout, and confirmation
 limits. Results expose match state and global logical coordinates but never

--- a/TEST.md
+++ b/TEST.md
@@ -103,9 +103,11 @@ strict request validation, policy/confirmation/display/text/action limits,
 live display-bound enforcement, dry-run, quota handling, sanitized results,
 backend errors, bounded synthetic capture, defensive pixel ownership and
 zeroing, stale-target rejection, changed/unchanged verification, timeout and
-attempt bounds, payload-free audit events, and the documented preflight-only
-cancellation boundary. No agent unit test reads or persists the developer's
-desktop, clipboard, OCR input, or other private data:
+attempt bounds, explicit-observation color search, bounded region waits, query
+and observation quotas, no-match/timeout cleanup, payload-free audit events,
+and the documented input and capture cancellation boundaries. No agent unit
+test reads or persists the developer's desktop, clipboard, OCR input, or other
+private data:
 
 ```bash
 go test -race ./agent
@@ -139,9 +141,11 @@ Run it only in a graphical session where global pointer movement is intended.
 It creates no screenshot, clipboard, OCR, or other persistent artifact.
 
 The separate opt-in capture path reads one explicit real region into memory,
-checks its dimensions, and zeroes both the returned copy and session-owned
-buffer on every test cleanup path. It never writes a screenshot to disk and,
-on Wayland, never opens portal consent implicitly:
+checks its dimensions, searches its retained observation, performs one bounded
+single-attempt region wait, and zeroes every returned copy and session-owned
+buffer on every test cleanup path. The wait uses maximum RGB tolerance so the
+test does not retain or print a real desktop color. It never writes a screenshot
+to disk and, on Wayland, never opens portal consent implicitly:
 
 ```bash
 ROBOTGO_AGENT_CAPTURE_E2E=1 \
@@ -154,6 +158,17 @@ go test -tags integration ./agent -run TestAgentSessionCaptureRuntime -v
 Start a consent-aware ScreenCast session before that command when portal
 capture is required, or explicitly set `ROBOTGO_DISABLE_PORTAL=1` to test only
 a native capture path.
+
+The visual-condition example is inspection-only unless `-allow-capture` is
+supplied. Both active modes keep pixels in memory and create no screenshot or
+template file:
+
+```bash
+go run ./examples/agent_conditions
+go run ./examples/agent_conditions -allow-capture -mode find \
+  -red 0 -green 120 -blue 255 -tolerance 0.05 \
+  -x 0 -y 0 -width 320 -height 200 -display 0
+```
 
 Real post-action changed/unchanged verification is intentionally not automated
 in this integration suite: it would require mutating and repeatedly inspecting

--- a/agent/audit.go
+++ b/agent/audit.go
@@ -6,7 +6,7 @@ import (
 )
 
 // AuditSchemaVersion identifies the payload-free audit event contract.
-const AuditSchemaVersion = "1"
+const AuditSchemaVersion = "2"
 
 // AuditKind identifies a sanitized session lifecycle event.
 type AuditKind string
@@ -17,6 +17,8 @@ const (
 	AuditActionStarted        AuditKind = "action.started"
 	AuditActionFinished       AuditKind = "action.finished"
 	AuditVerificationFinished AuditKind = "verification.finished"
+	AuditConditionStarted     AuditKind = "condition.started"
+	AuditConditionFinished    AuditKind = "condition.finished"
 )
 
 // AuditEvent deliberately contains no request payload, coordinates, text,
@@ -34,6 +36,9 @@ type AuditEvent struct {
 	ActionStatus              ActionStatus       `json:"action_status,omitempty"`
 	VerificationStatus        VerificationStatus `json:"verification_status,omitempty"`
 	VerificationAttempts      uint32             `json:"verification_attempts,omitempty"`
+	ConditionID               string             `json:"condition_id,omitempty"`
+	ConditionStatus           ConditionStatus    `json:"condition_status,omitempty"`
+	ConditionAttempts         uint32             `json:"condition_attempts,omitempty"`
 	ErrorCode                 ErrorCode          `json:"error_code,omitempty"`
 }
 

--- a/agent/catalog.go
+++ b/agent/catalog.go
@@ -7,7 +7,7 @@ func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) Opera
 		SchemaVersion: CatalogSchemaVersion,
 		Operations: []OperationCapability{
 			observationCapability(policy, capabilities),
-			findColorCapability(policy),
+			findColorCapability(policy, capabilities),
 			waitColorCapability(policy, capabilities),
 			operationCapability(OperationMove, policy, capabilities.Mouse),
 			operationCapability(OperationClick, policy, capabilities.Mouse),
@@ -36,17 +36,25 @@ func observationCapability(policy Policy, capabilities robotgo.RuntimeCapabiliti
 	}
 }
 
-func findColorCapability(policy Policy) OperationCapability {
+func findColorCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
 	_, confirmationRequired := policy.requireConfirmation[OperationFindColor]
 	_, policyAllowed := policy.allowOperation[OperationFindColor]
+	captureAvailable, captureBackend, captureFallback, remediation := agentCaptureCapability(capabilities)
+	capturePolicyAllowed := policyAllowed && policy.MaxQueries > 0 && policy.MaxCapturePixels > 0 &&
+		len(policy.allowDisplay) > 0
 	return OperationCapability{
-		Operation: OperationFindColor, Available: true,
-		PolicyAllowed: policyAllowed && policy.MaxQueries > 0,
+		Operation: OperationFindColor, Available: captureAvailable,
+		PolicyAllowed: capturePolicyAllowed,
 		Backend:       "in-memory-observation", Risk: RiskSensitiveRead,
 		ConfirmationRequired:  confirmationRequired,
 		Cancellation:          CancellationCooperative,
 		ExclusiveAgentSession: true,
-		Reason:                "color search uses only a live capture already owned by this session",
+		Reason:                "color search uses only a live capture already owned by this session; creating one requires the reported capture backend",
+		Remediation:           remediation,
+		CaptureAvailable:      captureAvailable,
+		CapturePolicyAllowed:  capturePolicyAllowed,
+		CaptureFallback:       captureFallback,
+		CaptureBackend:        captureBackend,
 	}
 }
 

--- a/agent/catalog.go
+++ b/agent/catalog.go
@@ -7,6 +7,8 @@ func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) Opera
 		SchemaVersion: CatalogSchemaVersion,
 		Operations: []OperationCapability{
 			observationCapability(policy, capabilities),
+			findColorCapability(policy),
+			waitColorCapability(policy, capabilities),
 			operationCapability(OperationMove, policy, capabilities.Mouse),
 			operationCapability(OperationClick, policy, capabilities.Mouse),
 			operationCapability(OperationTypeText, policy, capabilities.Keyboard),
@@ -17,20 +19,8 @@ func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) Opera
 func observationCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
 	_, confirmationRequired := policy.requireConfirmation[OperationObserve]
 	_, policyAllowed := policy.allowOperation[OperationObserve]
-	remediation := capabilities.Capture.Notes
-	if remediation == "" {
-		remediation = capabilities.Capture.Reason
-	}
-	captureAvailable := capabilities.Capture.Available
-	captureBackend := capabilities.Capture.Backend
+	captureAvailable, captureBackend, captureFallback, remediation := agentCaptureCapability(capabilities)
 	capturePolicyAllowed := policyAllowed && policy.MaxCapturePixels > 0 && len(policy.allowDisplay) > 0
-	if capabilities.Runtime.GOOS == goOSLinux &&
-		capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland &&
-		captureBackend != robotgo.FeatureBackendScreenCast &&
-		captureBackend != robotgo.FeatureBackendWaylandScreencopy {
-		captureAvailable = false
-		remediation = "agent capture attempts native screencopy first and will not open portal consent implicitly; start ScreenCast explicitly for an authorized fallback"
-	}
 	return OperationCapability{
 		Operation: OperationObserve, Available: true, PolicyAllowed: policyAllowed,
 		Backend: runtimeDiagnosticsBackend, Risk: RiskSensitiveRead,
@@ -41,9 +31,59 @@ func observationCapability(policy Policy, capabilities robotgo.RuntimeCapabiliti
 		Remediation: remediation, OptionalCapture: true,
 		CaptureAvailable:     captureAvailable,
 		CapturePolicyAllowed: capturePolicyAllowed,
-		CaptureFallback:      capabilities.Capture.Fallback,
+		CaptureFallback:      captureFallback,
 		CaptureBackend:       captureBackend,
 	}
+}
+
+func findColorCapability(policy Policy) OperationCapability {
+	_, confirmationRequired := policy.requireConfirmation[OperationFindColor]
+	_, policyAllowed := policy.allowOperation[OperationFindColor]
+	return OperationCapability{
+		Operation: OperationFindColor, Available: true,
+		PolicyAllowed: policyAllowed && policy.MaxQueries > 0,
+		Backend:       "in-memory-observation", Risk: RiskSensitiveRead,
+		ConfirmationRequired:  confirmationRequired,
+		Cancellation:          CancellationCooperative,
+		ExclusiveAgentSession: true,
+		Reason:                "color search uses only a live capture already owned by this session",
+	}
+}
+
+func waitColorCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
+	_, confirmationRequired := policy.requireConfirmation[OperationWaitColor]
+	_, policyAllowed := policy.allowOperation[OperationWaitColor]
+	captureAvailable, captureBackend, captureFallback, remediation := agentCaptureCapability(capabilities)
+	capturePolicyAllowed := policyAllowed && policy.MaxQueries > 0 && policy.WaitAttempts > 0 &&
+		policy.MaxCapturePixels > 0 && len(policy.allowDisplay) > 0
+	return OperationCapability{
+		Operation: OperationWaitColor, Available: captureAvailable,
+		PolicyAllowed: capturePolicyAllowed,
+		Backend:       captureBackend, Fallback: captureFallback, Risk: RiskSensitiveRead,
+		ConfirmationRequired: confirmationRequired,
+		Cancellation:         CancellationCooperative,
+		ProcessGlobalBackend: true, ExclusiveAgentSession: true,
+		Reason: capabilities.Capture.Reason, Remediation: remediation,
+		CaptureAvailable: captureAvailable, CapturePolicyAllowed: capturePolicyAllowed,
+		CaptureFallback: captureFallback, CaptureBackend: captureBackend,
+	}
+}
+
+func agentCaptureCapability(capabilities robotgo.RuntimeCapabilities) (bool, string, bool, string) {
+	feature := capabilities.Capture
+	remediation := feature.Notes
+	if remediation == "" {
+		remediation = feature.Reason
+	}
+	available := feature.Available
+	if capabilities.Runtime.GOOS == goOSLinux &&
+		capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland &&
+		feature.Backend != robotgo.FeatureBackendScreenCast &&
+		feature.Backend != robotgo.FeatureBackendWaylandScreencopy {
+		available = false
+		remediation = "agent capture attempts native screencopy first and will not open portal consent implicitly; start ScreenCast explicitly for an authorized fallback"
+	}
+	return available, feature.Backend, feature.Fallback, remediation
 }
 
 func operationCapability(operation Operation, policy Policy, feature robotgo.FeatureCapability) OperationCapability {

--- a/agent/condition.go
+++ b/agent/condition.go
@@ -1,0 +1,394 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// ConditionSchemaVersion identifies the serialized visual-condition contract.
+	ConditionSchemaVersion = "1"
+	conditionIDPrefix      = "condition-"
+	maximumRGBDistance     = 442.0
+)
+
+var conditionSerial atomic.Uint64
+
+// ColorCondition describes one RGB target. Tolerance is a normalized
+// Euclidean RGB distance in the inclusive range 0 through 1. Alpha is ignored.
+type ColorCondition struct {
+	Red       uint8   `json:"red"`
+	Green     uint8   `json:"green"`
+	Blue      uint8   `json:"blue"`
+	Tolerance float64 `json:"tolerance"`
+}
+
+// FindColorRequest searches only a previously captured, live observation. It
+// never causes an implicit desktop capture.
+type FindColorRequest struct {
+	ObservationID string         `json:"observation_id"`
+	Condition     ColorCondition `json:"condition"`
+	Confirmed     bool           `json:"confirmed,omitempty"`
+}
+
+// WaitColorRequest polls one explicit capture region using the immutable
+// attempt, interval, timeout, and quota limits in Policy.
+type WaitColorRequest struct {
+	Region    CaptureRegion  `json:"region"`
+	Condition ColorCondition `json:"condition"`
+	Confirmed bool           `json:"confirmed,omitempty"`
+}
+
+// VisualMatch identifies the first matching global logical coordinate.
+type VisualMatch struct {
+	X         int `json:"x"`
+	Y         int `json:"y"`
+	DisplayID int `json:"display_id"`
+}
+
+// ConditionStatus identifies whether a visual condition matched.
+type ConditionStatus string
+
+const (
+	ConditionMatched    ConditionStatus = "matched"
+	ConditionNotMatched ConditionStatus = "not-matched"
+)
+
+// FindColorResult contains no pixels, capture digest, or target color.
+type FindColorResult struct {
+	SchemaVersion string          `json:"schema_version"`
+	ConditionID   string          `json:"condition_id"`
+	ObservationID string          `json:"observation_id"`
+	Status        ConditionStatus `json:"status"`
+	Match         *VisualMatch    `json:"match,omitempty"`
+}
+
+// WaitColorResult contains bounded polling evidence but no pixels, capture
+// digest, or target color. A matched result identifies the retained observation.
+type WaitColorResult struct {
+	SchemaVersion string          `json:"schema_version"`
+	ConditionID   string          `json:"condition_id"`
+	Status        ConditionStatus `json:"status"`
+	Attempts      uint32          `json:"attempts"`
+	ObservationID string          `json:"observation_id,omitempty"`
+	Match         *VisualMatch    `json:"match,omitempty"`
+}
+
+// FindColor evaluates a color condition against an explicit session-owned
+// observation without touching the desktop.
+func (s *Session) FindColor(ctx context.Context, request FindColorRequest) (FindColorResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result := FindColorResult{
+		SchemaVersion: ConditionSchemaVersion,
+		ConditionID:   newConditionID(),
+		Status:        ConditionNotMatched,
+	}
+	if err := validateFindColorRequest(request); err != nil {
+		return result, conditionError(ErrorInvalidInput, OperationFindColor, "invalid color-search request", err)
+	}
+	result.ObservationID = request.ObservationID
+	if err := s.acquire(ctx); err != nil {
+		return result, conditionOperationError(OperationFindColor, err)
+	}
+	defer s.release()
+	if err := ctx.Err(); err != nil {
+		return result, conditionOperationError(OperationFindColor, observationContextError(ctx))
+	}
+	if err := s.ensureOpen(); err != nil {
+		return result, conditionOperationError(OperationFindColor, err)
+	}
+	if err := s.authorizeCondition(OperationFindColor, request.Confirmed); err != nil {
+		return result, err
+	}
+	if s.usedQueries >= s.policy.MaxQueries {
+		return result, conditionError(ErrorPolicyDenied, OperationFindColor, "agent policy query limit reached", ErrPolicyDenied)
+	}
+	record, ok := s.observation(request.ObservationID)
+	if !ok || !record.hasCapture || !record.capture.usable() {
+		return result, conditionError(ErrorStaleTarget, OperationFindColor, "color-search observation is unavailable", ErrStaleTarget)
+	}
+	if err := s.emitConditionAudit(ctx, AuditConditionStarted, OperationFindColor, result.ConditionID, request.ObservationID, "", 0, ""); err != nil {
+		return result, conditionError(ErrorAuditDelivery, OperationFindColor, "audit sink rejected color-search intent", err)
+	}
+	s.usedQueries++
+	findCtx, cancel := context.WithCancel(ctx)
+	stopSessionCancel := context.AfterFunc(s.ctx, cancel)
+	defer func() {
+		stopSessionCancel()
+		cancel()
+	}()
+	match, err := findColorInCapture(findCtx, record.capture, record.region, request.Condition)
+	if err != nil {
+		err = s.normalizeConditionError(OperationFindColor, err)
+		return result, s.finishConditionFailure(ctx, OperationFindColor, result.ConditionID, request.ObservationID, result.Status, 1, err)
+	}
+	if match != nil {
+		result.Status = ConditionMatched
+		result.Match = match
+	}
+	if err := s.emitConditionAudit(ctx, AuditConditionFinished, OperationFindColor, result.ConditionID, request.ObservationID, result.Status, 1, ""); err != nil {
+		return result, conditionError(ErrorAuditDelivery, OperationFindColor, "color search completed but audit delivery failed", err)
+	}
+	return result, nil
+}
+
+// WaitColor captures and evaluates an explicit region until it matches or the
+// bounded policy is exhausted. A successful result references the sole
+// retained observation by ID; callers should pass it to ReleaseObservation
+// when no longer needed. Every other temporary frame is zeroed before return.
+func (s *Session) WaitColor(ctx context.Context, request WaitColorRequest) (WaitColorResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result := WaitColorResult{
+		SchemaVersion: ConditionSchemaVersion,
+		ConditionID:   newConditionID(),
+		Status:        ConditionNotMatched,
+	}
+	if err := validateWaitColorRequest(request); err != nil {
+		return result, conditionError(ErrorInvalidInput, OperationWaitColor, "invalid color-wait request", err)
+	}
+	if err := s.acquire(ctx); err != nil {
+		return result, conditionOperationError(OperationWaitColor, err)
+	}
+	defer s.release()
+	if err := ctx.Err(); err != nil {
+		return result, conditionOperationError(OperationWaitColor, observationContextError(ctx))
+	}
+	if err := s.ensureOpen(); err != nil {
+		return result, conditionOperationError(OperationWaitColor, err)
+	}
+	if err := s.authorizeCondition(OperationWaitColor, request.Confirmed); err != nil {
+		return result, err
+	}
+	if _, allowed := s.policy.allowDisplay[request.Region.DisplayID]; !allowed {
+		return result, conditionError(ErrorPolicyDenied, OperationWaitColor, "agent policy denied the wait display", ErrPolicyDenied)
+	}
+	if err := validateCaptureRegion(request.Region, s.policy.MaxCapturePixels); err != nil {
+		return result, conditionError(ErrorPolicyDenied, OperationWaitColor, "agent policy denied the wait capture size", ErrPolicyDenied)
+	}
+	if s.usedQueries >= s.policy.MaxQueries {
+		return result, conditionError(ErrorPolicyDenied, OperationWaitColor, "agent policy query limit reached", ErrPolicyDenied)
+	}
+	required := uint64(s.policy.WaitAttempts)
+	if s.usedObservations > s.policy.MaxObservations || required > s.policy.MaxObservations-s.usedObservations {
+		return result, conditionError(ErrorPolicyDenied, OperationWaitColor, "agent policy observation limit cannot satisfy bounded wait", ErrPolicyDenied)
+	}
+	if err := s.emitConditionAudit(ctx, AuditConditionStarted, OperationWaitColor, result.ConditionID, "", "", 0, ""); err != nil {
+		return result, conditionError(ErrorAuditDelivery, OperationWaitColor, "audit sink rejected color-wait intent", err)
+	}
+	s.usedQueries++
+	waitCtx, cancel := context.WithTimeout(ctx, time.Duration(s.policy.WaitTimeoutMillis)*time.Millisecond)
+	stopSessionCancel := context.AfterFunc(s.ctx, cancel)
+	defer func() {
+		stopSessionCancel()
+		cancel()
+	}()
+
+	for attempt := uint32(1); attempt <= s.policy.WaitAttempts; attempt++ {
+		result.Attempts = attempt
+		frame, err := s.capture(waitCtx, request.Region, true)
+		if err != nil {
+			err = s.normalizeConditionError(OperationWaitColor, err)
+			return result, s.finishConditionFailure(ctx, OperationWaitColor, result.ConditionID, "", result.Status, attempt, err)
+		}
+		match, matchErr := findColorInCapture(waitCtx, frame.buffer, request.Region, request.Condition)
+		if matchErr != nil {
+			_ = frame.buffer.close()
+			matchErr = s.normalizeConditionError(OperationWaitColor, matchErr)
+			return result, s.finishConditionFailure(ctx, OperationWaitColor, result.ConditionID, "", result.Status, attempt, matchErr)
+		}
+		if match != nil {
+			diagnostics, diagnosticsErr := s.runtimeDiagnostics(waitCtx)
+			if diagnosticsErr != nil {
+				_ = frame.buffer.close()
+				diagnosticsErr = s.normalizeConditionError(OperationWaitColor, diagnosticsErr)
+				return result, s.finishConditionFailure(ctx, OperationWaitColor, result.ConditionID, "", result.Status, attempt, diagnosticsErr)
+			}
+			observation := observationFromFrame(frame, diagnostics)
+			s.storeObservation(observation)
+			result.Status = ConditionMatched
+			result.Match = match
+			result.ObservationID = observation.ObservationID
+			if auditErr := s.emitConditionAudit(ctx, AuditConditionFinished, OperationWaitColor, result.ConditionID, observation.ObservationID, result.Status, attempt, ""); auditErr != nil {
+				return result, conditionError(ErrorAuditDelivery, OperationWaitColor, "color wait completed but audit delivery failed", auditErr)
+			}
+			return result, nil
+		}
+		_ = frame.buffer.close()
+		if attempt == s.policy.WaitAttempts {
+			err = conditionError(ErrorConditionNotMet, OperationWaitColor, "color wait exhausted its bounded attempts", ErrConditionNotMet)
+			return result, s.finishConditionFailure(ctx, OperationWaitColor, result.ConditionID, "", result.Status, attempt, err)
+		}
+		if err := waitForCondition(waitCtx, time.Duration(s.policy.WaitIntervalMillis)*time.Millisecond); err != nil {
+			err = s.normalizeConditionError(OperationWaitColor, err)
+			return result, s.finishConditionFailure(ctx, OperationWaitColor, result.ConditionID, "", result.Status, attempt, err)
+		}
+	}
+	err := conditionError(ErrorConditionNotMet, OperationWaitColor, "color wait exhausted its bounded attempts", ErrConditionNotMet)
+	return result, s.finishConditionFailure(ctx, OperationWaitColor, result.ConditionID, "", result.Status, result.Attempts, err)
+}
+
+func validateFindColorRequest(request FindColorRequest) error {
+	if !validObservationID(request.ObservationID) {
+		return errors.New("color search requires a valid RobotGo observation ID")
+	}
+	return validateColorCondition(request.Condition)
+}
+
+func validateWaitColorRequest(request WaitColorRequest) error {
+	if err := validateCaptureRegion(request.Region, maxAgentCapturePixels); err != nil {
+		return err
+	}
+	return validateColorCondition(request.Condition)
+}
+
+func validateColorCondition(condition ColorCondition) error {
+	if math.IsNaN(condition.Tolerance) || math.IsInf(condition.Tolerance, 0) ||
+		condition.Tolerance < 0 || condition.Tolerance > 1 {
+		return errors.New("color tolerance must be a finite value from 0 through 1")
+	}
+	return nil
+}
+
+func (s *Session) authorizeCondition(operation Operation, confirmed bool) error {
+	if _, allowed := s.policy.allowOperation[operation]; !allowed {
+		return conditionError(ErrorPolicyDenied, operation, "agent policy denied the visual condition", ErrPolicyDenied)
+	}
+	if _, required := s.policy.requireConfirmation[operation]; required && !confirmed {
+		return conditionError(ErrorPolicyDenied, operation, "agent policy requires visual-condition confirmation", ErrPolicyDenied)
+	}
+	return nil
+}
+
+func findColorInCapture(ctx context.Context, capture *captureBuffer, region CaptureRegion, condition ColorCondition) (*VisualMatch, error) {
+	if !capture.acquireUse() {
+		return nil, conditionError(ErrorStaleTarget, OperationFindColor, "visual-condition observation is unavailable or closed", ErrStaleTarget)
+	}
+	defer capture.releaseUse()
+	pixels := capture.pixels
+	for y := pixels.Bounds().Min.Y; y < pixels.Bounds().Max.Y; y++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for x := pixels.Bounds().Min.X; x < pixels.Bounds().Max.X; x++ {
+			offset := pixels.PixOffset(x, y)
+			if colorMatches(pixels.Pix[offset], pixels.Pix[offset+1], pixels.Pix[offset+2], condition) {
+				return &VisualMatch{
+					X:         region.X + x - pixels.Bounds().Min.X,
+					Y:         region.Y + y - pixels.Bounds().Min.Y,
+					DisplayID: region.DisplayID,
+				}, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func colorMatches(red, green, blue uint8, condition ColorCondition) bool {
+	if condition.Tolerance == 0 {
+		return red == condition.Red && green == condition.Green && blue == condition.Blue
+	}
+	dr := float64(int(red) - int(condition.Red))
+	dg := float64(int(green) - int(condition.Green))
+	db := float64(int(blue) - int(condition.Blue))
+	maximum := condition.Tolerance * maximumRGBDistance
+	return dr*dr+dg*dg+db*db <= maximum*maximum
+}
+
+func waitForCondition(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func newConditionID() string {
+	return conditionIDPrefix + strconv.FormatUint(conditionSerial.Add(1), 10)
+}
+
+func (s *Session) normalizeConditionError(operation Operation, err error) error {
+	select {
+	case <-s.ctx.Done():
+		return conditionError(ErrorSessionClosed, operation, "agent session closed during visual condition", ErrSessionClosed)
+	default:
+	}
+	var actionErr *ActionError
+	if errors.As(err, &actionErr) {
+		if actionErr.Operation == operation {
+			return err
+		}
+		return conditionError(actionErr.Code, operation, actionErr.Message, err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return conditionError(ErrorTimedOut, operation, "visual condition deadline exceeded", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		return conditionError(ErrorCanceled, operation, "visual condition canceled", err)
+	}
+	code, message := classifyBackendError(err)
+	return conditionError(code, operation, message, err)
+}
+
+func conditionOperationError(operation Operation, err error) error {
+	var actionErr *ActionError
+	if errors.As(err, &actionErr) {
+		return conditionError(actionErr.Code, operation, actionErr.Message, err)
+	}
+	return err
+}
+
+func conditionError(code ErrorCode, operation Operation, message string, cause error) *ActionError {
+	return newActionError(code, operation, message, cause)
+}
+
+func (s *Session) finishConditionFailure(
+	ctx context.Context,
+	operation Operation,
+	conditionID string,
+	observationID string,
+	status ConditionStatus,
+	attempts uint32,
+	err error,
+) error {
+	code := classifyObservationError(err)
+	if auditErr := s.emitConditionAudit(ctx, AuditConditionFinished, operation, conditionID, observationID, status, attempts, code); auditErr != nil {
+		return errors.Join(err, conditionError(ErrorAuditDelivery, operation, "visual condition failed and audit delivery failed", auditErr))
+	}
+	return err
+}
+
+func (s *Session) emitConditionAudit(
+	ctx context.Context,
+	kind AuditKind,
+	operation Operation,
+	conditionID string,
+	observationID string,
+	status ConditionStatus,
+	attempts uint32,
+	code ErrorCode,
+) error {
+	return s.emitAudit(ctx, AuditEvent{
+		Kind: kind, Operation: operation, ConditionID: conditionID,
+		ObservationID: observationID, ConditionStatus: status,
+		ConditionAttempts: attempts, ErrorCode: code,
+	})
+}

--- a/agent/condition_test.go
+++ b/agent/condition_test.go
@@ -471,6 +471,8 @@ func TestVisualConditionPolicyMustBeBounded(t *testing.T) {
 	tests := []Policy{
 		{AllowedOperations: []Operation{OperationFindColor}, MaxQueries: 1},
 		{AllowedOperations: []Operation{OperationObserve, OperationFindColor}, MaxObservations: 1},
+		{AllowedOperations: []Operation{OperationObserve, OperationFindColor}, MaxObservations: 1, MaxQueries: 1},
+		{AllowedOperations: []Operation{OperationObserve, OperationFindColor}, MaxObservations: 1, MaxQueries: 1, MaxCapturePixels: 1},
 		{AllowedOperations: []Operation{OperationWaitColor}, AllowedDisplayIDs: []int{0}, MaxQueries: 1, MaxObservations: 1, MaxCapturePixels: 1},
 		{AllowedOperations: []Operation{OperationWaitColor}, AllowedDisplayIDs: []int{0}, MaxQueries: 1, MaxObservations: 1, MaxCapturePixels: 1, WaitAttempts: 1},
 		{AllowedOperations: []Operation{OperationWaitColor}, AllowedDisplayIDs: []int{0}, MaxQueries: 1, MaxObservations: 1, MaxCapturePixels: 1, WaitTimeoutMillis: 1},

--- a/agent/condition_test.go
+++ b/agent/condition_test.go
@@ -1,0 +1,530 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"image"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func conditionPolicy() Policy {
+	return Policy{
+		AllowedOperations:  []Operation{OperationObserve, OperationFindColor, OperationWaitColor},
+		AllowedDisplayIDs:  []int{0},
+		MaxObservations:    8,
+		MaxCapturePixels:   16,
+		MaxQueries:         4,
+		WaitAttempts:       3,
+		WaitIntervalMillis: 0,
+		WaitTimeoutMillis:  100,
+	}
+}
+
+func TestFindColorUsesOnlyExplicitObservation(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 41)}}
+	session := newTestSession(t, conditionPolicy(), driver)
+	observation := observeCapture(t, session)
+
+	result, err := session.FindColor(context.Background(), FindColorRequest{
+		ObservationID: observation.ObservationID,
+		Condition:     ColorCondition{Red: 41, Green: 42, Blue: 43},
+	})
+	if err != nil || result.Status != ConditionMatched || result.Match == nil {
+		t.Fatalf("FindColor = %+v, %v", result, err)
+	}
+	if *result.Match != (VisualMatch{X: 1, Y: 2, DisplayID: 0}) {
+		t.Fatalf("match = %+v", result.Match)
+	}
+	if driver.captureCount() != 1 {
+		t.Fatalf("FindColor performed implicit capture; calls = %d", driver.captureCount())
+	}
+	if result.ObservationID != observation.ObservationID || result.ConditionID == "" {
+		t.Fatalf("result lineage = %+v", result)
+	}
+
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"sha256", "pixels", "tolerance", `"red"`, `"green"`, `"blue"`} {
+		if strings.Contains(string(serialized), forbidden) {
+			t.Fatalf("result leaked %q: %s", forbidden, serialized)
+		}
+	}
+}
+
+func TestFindColorNoMatchIsSuccessfulAndConsumesQueryQuota(t *testing.T) {
+	policy := conditionPolicy()
+	policy.MaxQueries = 1
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 5)}}
+	session := newTestSession(t, policy, driver)
+	observation := observeCapture(t, session)
+	request := FindColorRequest{
+		ObservationID: observation.ObservationID,
+		Condition:     ColorCondition{Red: 200, Green: 201, Blue: 202},
+	}
+	result, err := session.FindColor(context.Background(), request)
+	if err != nil || result.Status != ConditionNotMatched || result.Match != nil {
+		t.Fatalf("FindColor = %+v, %v", result, err)
+	}
+	if _, err := session.FindColor(context.Background(), request); !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("second FindColor = %v", err)
+	}
+	if driver.captureCount() != 1 {
+		t.Fatalf("FindColor performed implicit capture; calls = %d", driver.captureCount())
+	}
+}
+
+func TestFindColorRejectsInvalidOrClosedObservation(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 5)}}
+	session := newTestSession(t, conditionPolicy(), driver)
+	result, err := session.FindColor(context.Background(), FindColorRequest{
+		ObservationID: "private-caller-value",
+	})
+	if !hasErrorCode(err, ErrorInvalidInput) || result.ObservationID != "" {
+		t.Fatalf("invalid ID error = %v", err)
+	}
+	observation := observeCapture(t, session)
+	if err := observation.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.FindColor(context.Background(), FindColorRequest{
+		ObservationID: observation.ObservationID,
+	}); !errors.Is(err, ErrStaleTarget) || !hasErrorCode(err, ErrorStaleTarget) {
+		t.Fatalf("closed observation error = %v", err)
+	}
+}
+
+func TestVisualConditionsReportCanceledAndClosedSessions(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 5)}}
+	session := newTestSession(t, conditionPolicy(), driver)
+	observation := observeCapture(t, session)
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := session.FindColor(canceled, FindColorRequest{
+		ObservationID: observation.ObservationID,
+	}); !hasErrorCode(err, ErrorCanceled) {
+		t.Fatalf("canceled FindColor = %v", err)
+	}
+	if _, err := session.WaitColor(canceled, WaitColorRequest{
+		Region: CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+	}); !hasErrorCode(err, ErrorCanceled) {
+		t.Fatalf("canceled WaitColor = %v", err)
+	}
+	if session.usedQueries != 0 || driver.captureCount() != 1 {
+		t.Fatalf("pre-canceled conditions consumed quota or capture: queries=%d captures=%d",
+			session.usedQueries, driver.captureCount())
+	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.FindColor(context.Background(), FindColorRequest{
+		ObservationID: observation.ObservationID,
+	}); !errors.Is(err, ErrSessionClosed) || !hasErrorCode(err, ErrorSessionClosed) {
+		t.Fatalf("closed FindColor = %v", err)
+	}
+	if _, err := session.WaitColor(context.Background(), WaitColorRequest{
+		Region: CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+	}); !errors.Is(err, ErrSessionClosed) || !hasErrorCode(err, ErrorSessionClosed) {
+		t.Fatalf("closed WaitColor = %v", err)
+	}
+}
+
+func TestVisualConditionValidationAndConfirmationPrecedeDesktopIO(t *testing.T) {
+	policy := conditionPolicy()
+	policy.ConfirmOperations = []Operation{OperationWaitColor}
+	driver := &fakeDriver{}
+	session := newTestSession(t, policy, driver)
+	request := WaitColorRequest{
+		Region:    CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+		Condition: ColorCondition{Tolerance: math.NaN()},
+		Confirmed: true,
+	}
+	if _, err := session.WaitColor(context.Background(), request); !hasErrorCode(err, ErrorInvalidInput) {
+		t.Fatalf("invalid wait error = %v", err)
+	}
+	request.Condition.Tolerance = 0
+	request.Confirmed = false
+	if _, err := session.WaitColor(context.Background(), request); !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("unconfirmed wait error = %v", err)
+	}
+	if driver.captureCount() != 0 {
+		t.Fatalf("denied waits reached capture backend %d times", driver.captureCount())
+	}
+}
+
+func TestWaitColorDistinguishesInvalidShapeFromPolicySize(t *testing.T) {
+	policy := conditionPolicy()
+	policy.MaxCapturePixels = 1
+	driver := &fakeDriver{}
+	session := newTestSession(t, policy, driver)
+	if _, err := session.WaitColor(context.Background(), WaitColorRequest{
+		Region: CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+	}); !errors.Is(err, ErrPolicyDenied) || !hasErrorCode(err, ErrorPolicyDenied) {
+		t.Fatalf("policy-sized WaitColor = %v", err)
+	}
+	if _, err := session.WaitColor(context.Background(), WaitColorRequest{
+		Region: CaptureRegion{Width: maxAgentCapturePixels + 1, Height: 1, DisplayID: 0},
+	}); !hasErrorCode(err, ErrorInvalidInput) {
+		t.Fatalf("hard-limit WaitColor = %v", err)
+	}
+	if driver.captureCount() != 0 {
+		t.Fatalf("rejected wait reached capture backend %d times", driver.captureCount())
+	}
+}
+
+func TestWaitColorRetainsOnlyMatchedObservation(t *testing.T) {
+	first := syntheticCapture(2, 2, 1)
+	second := syntheticCapture(2, 2, 9)
+	driver := &fakeDriver{captureImages: []image.Image{first, second}}
+	session := newTestSession(t, conditionPolicy(), driver)
+	result, err := session.WaitColor(context.Background(), WaitColorRequest{
+		Region:    CaptureRegion{X: 10, Y: 20, Width: 2, Height: 2, DisplayID: 0},
+		Condition: ColorCondition{Red: 9, Green: 10, Blue: 11},
+	})
+	if err != nil || result.Status != ConditionMatched ||
+		result.Attempts != 2 || result.Match == nil || result.ObservationID == "" {
+		t.Fatalf("WaitColor = (%+v, %v)", result, err)
+	}
+	if *result.Match != (VisualMatch{X: 10, Y: 20, DisplayID: 0}) {
+		t.Fatalf("match = %+v", result.Match)
+	}
+	serialized, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"sha256", "pixels", "tolerance", `"red"`, `"green"`, `"blue"`} {
+		if strings.Contains(string(serialized), forbidden) {
+			t.Fatalf("wait result leaked %q: %s", forbidden, serialized)
+		}
+	}
+	if len(session.observations) != 1 {
+		t.Fatalf("retained observations = %d, want matched frame only", len(session.observations))
+	}
+	for name, source := range map[string]*image.RGBA{"first": first, "second": second} {
+		for index, value := range source.Pix {
+			if value != 0 {
+				t.Fatalf("%s source pixel %d was not zeroed: %d", name, index, value)
+			}
+		}
+	}
+	record, ok := session.observation(result.ObservationID)
+	if !ok || !record.capture.usable() {
+		t.Fatal("matched observation was not retained")
+	}
+	if err := session.ReleaseObservation(result.ObservationID); err != nil {
+		t.Fatal(err)
+	}
+	if record.capture.usable() || len(session.observations) != 0 {
+		t.Fatal("released matched observation retained sensitive pixels or lineage")
+	}
+	if err := session.ReleaseObservation(result.ObservationID); err != nil {
+		t.Fatalf("idempotent ReleaseObservation = %v", err)
+	}
+}
+
+func TestWaitColorExhaustionLeavesNoObservation(t *testing.T) {
+	source := syntheticCapture(2, 2, 3)
+	driver := &fakeDriver{captureImages: []image.Image{source}}
+	session := newTestSession(t, conditionPolicy(), driver)
+	result, err := session.WaitColor(context.Background(), WaitColorRequest{
+		Region:    CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+		Condition: ColorCondition{Red: 90, Green: 91, Blue: 92},
+	})
+	if result.Status != ConditionNotMatched || result.Attempts != 3 ||
+		!errors.Is(err, ErrConditionNotMet) || !hasErrorCode(err, ErrorConditionNotMet) {
+		t.Fatalf("WaitColor = (%+v, %v)", result, err)
+	}
+	if len(session.observations) != 0 || driver.captureCount() != 3 {
+		t.Fatalf("retained=%d captures=%d", len(session.observations), driver.captureCount())
+	}
+	for index, value := range source.Pix {
+		if value != 0 {
+			t.Fatalf("source pixel %d was not zeroed: %d", index, value)
+		}
+	}
+}
+
+func TestWaitColorBackendFailureZeroesPartialCaptureAndSanitizesError(t *testing.T) {
+	const privateDetail = "private-capture-backend-detail"
+	source := syntheticCapture(2, 2, 3)
+	driver := &fakeDriver{
+		captureImages: []image.Image{source},
+		captureErr:    errors.New(privateDetail),
+	}
+	session := newTestSession(t, conditionPolicy(), driver)
+	result, waitErr := session.WaitColor(context.Background(), WaitColorRequest{
+		Region: CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+	})
+	if result.Attempts != 1 || !hasErrorCode(waitErr, ErrorBackendFailure) {
+		t.Fatalf("WaitColor backend failure = (%+v, %v)", result, waitErr)
+	}
+	serialized, err := json.Marshal(waitErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(serialized), privateDetail) {
+		t.Fatalf("WaitColor error leaked backend detail: %s", serialized)
+	}
+	for index, value := range source.Pix {
+		if value != 0 {
+			t.Fatalf("failed source pixel %d was not zeroed: %d", index, value)
+		}
+	}
+	if len(session.observations) != 0 {
+		t.Fatalf("backend failure retained observations = %d", len(session.observations))
+	}
+}
+
+func TestWaitColorTimeoutStopsPollingAndRetainsNothing(t *testing.T) {
+	policy := conditionPolicy()
+	policy.WaitAttempts = 8
+	policy.WaitIntervalMillis = 50
+	policy.WaitTimeoutMillis = 5
+	policy.MaxObservations = 8
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 3)}}
+	session := newTestSession(t, policy, driver)
+	result, err := session.WaitColor(context.Background(), WaitColorRequest{
+		Region:    CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+		Condition: ColorCondition{Red: 90, Green: 91, Blue: 92},
+	})
+	if result.Attempts != 1 || !errors.Is(err, context.DeadlineExceeded) ||
+		!hasErrorCode(err, ErrorTimedOut) {
+		t.Fatalf("WaitColor = (%+v, %v)", result, err)
+	}
+	if len(session.observations) != 0 || driver.captureCount() != 1 {
+		t.Fatalf("retained=%d captures=%d", len(session.observations), driver.captureCount())
+	}
+}
+
+func TestWaitColorRequiresCompleteObservationBudgetBeforeCapture(t *testing.T) {
+	policy := conditionPolicy()
+	policy.MaxObservations = 3
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 3)}}
+	session := newTestSession(t, policy, driver)
+	_ = observeCapture(t, session)
+	if _, err := session.WaitColor(context.Background(), WaitColorRequest{
+		Region:    CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+		Condition: ColorCondition{Red: 90, Green: 91, Blue: 92},
+	}); !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("WaitColor observation budget = %v", err)
+	}
+	if driver.captureCount() != 1 {
+		t.Fatalf("budget-denied wait reached capture backend; calls = %d", driver.captureCount())
+	}
+}
+
+func TestSessionCloseCancelsWaitAndLeavesNoObservation(t *testing.T) {
+	policy := conditionPolicy()
+	policy.WaitIntervalMillis = 1000
+	policy.WaitTimeoutMillis = 5000
+	source := syntheticCapture(2, 2, 3)
+	driver := &fakeDriver{
+		captureImages: []image.Image{source},
+		captureHit:    make(chan struct{}, 1),
+		captureGo:     make(chan struct{}),
+	}
+	session := newTestSession(t, policy, driver)
+	type waitOutcome struct {
+		result WaitColorResult
+		err    error
+	}
+	waitDone := make(chan waitOutcome, 1)
+	go func() {
+		result, err := session.WaitColor(context.Background(), WaitColorRequest{
+			Region:    CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+			Condition: ColorCondition{Red: 90, Green: 91, Blue: 92},
+		})
+		waitDone <- waitOutcome{result: result, err: err}
+	}()
+	<-driver.captureHit
+	closeDone := make(chan struct{})
+	go func() {
+		_ = session.Close()
+		close(closeDone)
+	}()
+	<-session.ctx.Done()
+	close(driver.captureGo)
+	outcome := <-waitDone
+	if !errors.Is(outcome.err, ErrSessionClosed) ||
+		!hasErrorCode(outcome.err, ErrorSessionClosed) {
+		t.Fatalf("WaitColor during close = (%+v, %v)", outcome.result, outcome.err)
+	}
+	<-closeDone
+	if len(session.observations) != 0 {
+		t.Fatalf("closed wait retained observations = %d", len(session.observations))
+	}
+	for index, value := range source.Pix {
+		if value != 0 {
+			t.Fatalf("canceled source pixel %d was not zeroed: %d", index, value)
+		}
+	}
+}
+
+func TestWaitColorAuditIsPayloadFreeAndIntentFailurePreventsCapture(t *testing.T) {
+	policy, err := preparePolicy(conditionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 9)}}
+	sink := &recordingAuditSink{failAt: 1}
+	session, err := newSessionWithAudit(policy, driver, availableCapabilities(), sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	request := WaitColorRequest{
+		Region:    CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+		Condition: ColorCondition{Red: 9, Green: 10, Blue: 11},
+	}
+	if _, err := session.WaitColor(context.Background(), request); !errors.Is(err, ErrAuditDelivery) {
+		t.Fatalf("WaitColor audit failure = %v", err)
+	}
+	if driver.captureCount() != 0 || session.usedQueries != 0 || session.usedObservations != 0 {
+		t.Fatalf("intent failure reached IO/quota: captures=%d queries=%d observations=%d",
+			driver.captureCount(), session.usedQueries, session.usedObservations)
+	}
+	serialized, err := json.Marshal(sink.events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"sha256", "pixels", "tolerance", `"red"`, `"green"`, `"blue"`} {
+		if strings.Contains(string(serialized), forbidden) {
+			t.Fatalf("audit leaked %q: %s", forbidden, serialized)
+		}
+	}
+}
+
+func TestFindColorAuditRecordsOnlySanitizedLifecycle(t *testing.T) {
+	policy, err := preparePolicy(conditionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &recordingAuditSink{}
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 9)}}
+	session, err := newSessionWithAudit(policy, driver, availableCapabilities(), sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	observation := observeCapture(t, session)
+	result, err := session.FindColor(context.Background(), FindColorRequest{
+		ObservationID: observation.ObservationID,
+		Condition:     ColorCondition{Red: 9, Green: 10, Blue: 11},
+	})
+	if err != nil || result.Status != ConditionMatched {
+		t.Fatalf("FindColor = %+v, %v", result, err)
+	}
+	if len(sink.events) != 4 {
+		t.Fatalf("audit events = %+v", sink.events)
+	}
+	started, finished := sink.events[2], sink.events[3]
+	if started.SchemaVersion != AuditSchemaVersion || started.Kind != AuditConditionStarted ||
+		started.ConditionID != result.ConditionID || started.ObservationID != observation.ObservationID ||
+		started.ConditionStatus != "" || started.ConditionAttempts != 0 {
+		t.Fatalf("condition started audit = %+v", started)
+	}
+	if finished.Kind != AuditConditionFinished || finished.ConditionStatus != ConditionMatched ||
+		finished.ConditionAttempts != 1 || finished.ErrorCode != "" {
+		t.Fatalf("condition finished audit = %+v", finished)
+	}
+	serialized, err := json.Marshal(sink.events[2:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"sha256", "pixels", "tolerance", `"red"`, `"green"`, `"blue"`} {
+		if strings.Contains(string(serialized), forbidden) {
+			t.Fatalf("condition audit leaked %q: %s", forbidden, serialized)
+		}
+	}
+}
+
+func TestWaitColorCompletionAuditFailureReturnsOwnedObservation(t *testing.T) {
+	policy, err := preparePolicy(conditionPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 9)}}
+	sink := &recordingAuditSink{failAt: 2}
+	session, err := newSessionWithAudit(policy, driver, availableCapabilities(), sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	result, waitErr := session.WaitColor(context.Background(), WaitColorRequest{
+		Region:    CaptureRegion{Width: 2, Height: 2, DisplayID: 0},
+		Condition: ColorCondition{Red: 9, Green: 10, Blue: 11},
+	})
+	if result.ObservationID == "" || result.Status != ConditionMatched || !errors.Is(waitErr, ErrAuditDelivery) {
+		t.Fatalf("WaitColor = (%+v, %v)", result, waitErr)
+	}
+	if err := session.ReleaseObservation(result.ObservationID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVisualConditionPolicyMustBeBounded(t *testing.T) {
+	tests := []Policy{
+		{AllowedOperations: []Operation{OperationFindColor}, MaxQueries: 1},
+		{AllowedOperations: []Operation{OperationObserve, OperationFindColor}, MaxObservations: 1},
+		{AllowedOperations: []Operation{OperationWaitColor}, AllowedDisplayIDs: []int{0}, MaxQueries: 1, MaxObservations: 1, MaxCapturePixels: 1},
+		{AllowedOperations: []Operation{OperationWaitColor}, AllowedDisplayIDs: []int{0}, MaxQueries: 1, MaxObservations: 1, MaxCapturePixels: 1, WaitAttempts: 1},
+		{AllowedOperations: []Operation{OperationWaitColor}, AllowedDisplayIDs: []int{0}, MaxQueries: 1, MaxObservations: 1, MaxCapturePixels: 1, WaitTimeoutMillis: 1},
+		{AllowedOperations: []Operation{OperationWaitColor}, MaxQueries: 1, MaxObservations: 1, MaxCapturePixels: 1, WaitAttempts: 1, WaitTimeoutMillis: 1},
+	}
+	for _, policy := range tests {
+		if _, err := preparePolicy(policy); err == nil {
+			t.Fatalf("unbounded visual-condition policy was accepted: %+v", policy)
+		}
+	}
+}
+
+func TestActionAPIRejectsVisualQueryOperations(t *testing.T) {
+	session := newTestSession(t, conditionPolicy(), &fakeDriver{})
+	for _, operation := range []Operation{OperationFindColor, OperationWaitColor} {
+		result, err := session.Execute(context.Background(), ActionRequest{
+			Operation: operation,
+			Move:      &MoveAction{DisplayID: 0},
+		})
+		if !hasErrorCode(err, ErrorInvalidInput) || result.Error == nil {
+			t.Fatalf("Execute(%s) = %+v, %v", operation, result, err)
+		}
+	}
+}
+
+func hasErrorCode(err error, code ErrorCode) bool {
+	var actionErr *ActionError
+	return errors.As(err, &actionErr) && actionErr.Code == code
+}
+
+func TestWaitForConditionHonorsCancellationWithoutSleeping(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+	if err := waitForCondition(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForCondition = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("canceled wait took %v", elapsed)
+	}
+}
+
+func TestColorMatchesUsesNormalizedEuclideanTolerance(t *testing.T) {
+	if !colorMatches(1, 2, 3, ColorCondition{Red: 1, Green: 2, Blue: 3}) {
+		t.Fatal("exact RGB match failed")
+	}
+	if colorMatches(1, 2, 4, ColorCondition{Red: 1, Green: 2, Blue: 3}) {
+		t.Fatal("exact RGB mismatch passed")
+	}
+	condition := ColorCondition{Tolerance: 0.5}
+	if !colorMatches(127, 127, 127, condition) {
+		t.Fatal("color inside normalized tolerance did not match")
+	}
+	if colorMatches(128, 128, 128, condition) {
+		t.Fatal("color outside normalized tolerance matched")
+	}
+}

--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -5,6 +5,7 @@ package agent_test
 import (
 	"context"
 	"image"
+	"image/color"
 	"os"
 	"strconv"
 	"testing"
@@ -50,10 +51,15 @@ func TestAgentSessionCaptureRuntime(t *testing.T) {
 	height := requiredPositiveBoundedInteger(t, "ROBOTGO_AGENT_CAPTURE_HEIGHT", 4096)
 	displayID := requiredCoordinate(t, "ROBOTGO_AGENT_CAPTURE_DISPLAY")
 	session, err := agent.NewSession(agent.Config{Policy: agent.Policy{
-		AllowedOperations: []agent.Operation{agent.OperationObserve},
+		AllowedOperations: []agent.Operation{
+			agent.OperationObserve, agent.OperationFindColor, agent.OperationWaitColor,
+		},
 		AllowedDisplayIDs: []int{displayID},
-		MaxObservations:   1,
+		MaxObservations:   2,
 		MaxCapturePixels:  uint64(width) * uint64(height),
+		MaxQueries:        2,
+		WaitAttempts:      1,
+		WaitTimeoutMillis: 1000,
 	}})
 	if err != nil {
 		t.Fatal(err)
@@ -74,6 +80,32 @@ func TestAgentSessionCaptureRuntime(t *testing.T) {
 	t.Cleanup(func() { clear(img.Pix) })
 	if img.Bounds() != image.Rect(0, 0, width, height) {
 		t.Fatalf("capture bounds = %v", img.Bounds())
+	}
+	pixel := img.RGBAAt(0, 0)
+	clear(img.Pix)
+	findResult, err := session.FindColor(context.Background(), agent.FindColorRequest{
+		ObservationID: observation.ObservationID,
+		Condition: agent.ColorCondition{
+			Red: pixel.R, Green: pixel.G, Blue: pixel.B,
+		},
+	})
+	pixel = color.RGBA{}
+	if err != nil || findResult.Status != agent.ConditionMatched || findResult.Match == nil ||
+		findResult.Match.X != x || findResult.Match.Y != y || findResult.Match.DisplayID != displayID {
+		t.Fatalf("FindColor = %+v, %v", findResult, err)
+	}
+	waitResult, err := session.WaitColor(context.Background(), agent.WaitColorRequest{
+		Region: agent.CaptureRegion{X: x, Y: y, Width: width, Height: height, DisplayID: displayID},
+		// Maximum normalized tolerance matches the first RGB pixel without
+		// retaining any real desktop color in test output.
+		Condition: agent.ColorCondition{Tolerance: 1},
+	})
+	if err != nil || waitResult.ObservationID == "" || waitResult.Status != agent.ConditionMatched ||
+		waitResult.Attempts != 1 || waitResult.Match == nil {
+		t.Fatalf("WaitColor = (%+v, %v)", waitResult, err)
+	}
+	if err := session.ReleaseObservation(waitResult.ObservationID); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/agent/observation.go
+++ b/agent/observation.go
@@ -592,6 +592,25 @@ func (s *Session) observation(id string) (observationRecord, bool) {
 	return record, ok
 }
 
+// ReleaseObservation idempotently removes one valid observation from the
+// session and zeroes its optional capture. It can release observations returned
+// directly by Observe or referenced by wait/verification results.
+func (s *Session) ReleaseObservation(id string) error {
+	if !validObservationID(id) {
+		return observationActionError(ErrorInvalidInput, "invalid RobotGo observation ID", nil)
+	}
+	s.observationMu.Lock()
+	record, ok := s.observations[id]
+	if ok {
+		delete(s.observations, id)
+	}
+	s.observationMu.Unlock()
+	if !ok {
+		return nil
+	}
+	return record.capture.close()
+}
+
 func (s *Session) closeObservations() {
 	s.observationMu.Lock()
 	defer s.observationMu.Unlock()

--- a/agent/observation_test.go
+++ b/agent/observation_test.go
@@ -360,6 +360,28 @@ func TestSessionCloseZeroesAllOwnedCaptures(t *testing.T) {
 	}
 }
 
+func TestReleaseObservationZeroesAndRemovesCapture(t *testing.T) {
+	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 17)}}
+	session := newTestSession(t, observationPolicy(), driver)
+	observation := observeCapture(t, session)
+	buffer := observation.capture
+	if err := session.ReleaseObservation(observation.ObservationID); err != nil {
+		t.Fatal(err)
+	}
+	if buffer.usable() || len(session.observations) != 0 {
+		t.Fatal("ReleaseObservation retained sensitive capture state")
+	}
+	if _, err := observation.Image(); !errors.Is(err, ErrObservationClosed) {
+		t.Fatalf("Image after ReleaseObservation = %v", err)
+	}
+	if err := session.ReleaseObservation(observation.ObservationID); err != nil {
+		t.Fatalf("idempotent ReleaseObservation = %v", err)
+	}
+	if err := session.ReleaseObservation("caller-controlled"); !hasErrorCode(err, ErrorInvalidInput) {
+		t.Fatalf("invalid ReleaseObservation = %v", err)
+	}
+}
+
 func TestClosedObservationCannotAuthorizeMutation(t *testing.T) {
 	driver := &fakeDriver{captureImages: []image.Image{syntheticCapture(2, 2, 19)}}
 	session := newTestSession(t, observationPolicy(), driver)
@@ -752,7 +774,9 @@ func TestObservationOnlyPolicyNeedsNoActionBudget(t *testing.T) {
 func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	t.Setenv(disablePortalEnv, "")
 	policy, err := preparePolicy(Policy{
-		AllowedOperations: []Operation{OperationObserve}, MaxObservations: 1,
+		AllowedOperations: []Operation{OperationObserve, OperationWaitColor},
+		AllowedDisplayIDs: []int{0}, MaxObservations: 1, MaxCapturePixels: 1,
+		MaxQueries: 1, WaitAttempts: 1, WaitTimeoutMillis: 1,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -765,6 +789,10 @@ func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	if capability.CaptureAvailable || !strings.Contains(capability.Remediation, "will not open portal consent implicitly") {
 		t.Fatalf("portal-only capture capability = %+v", capability)
 	}
+	waitCapability := buildCatalog(policy, capabilities).Operations[2]
+	if waitCapability.Available || !strings.Contains(waitCapability.Remediation, "will not open portal consent implicitly") {
+		t.Fatalf("portal-only wait capability = %+v", waitCapability)
+	}
 
 	capabilities.Capture = robotgo.FeatureCapability{
 		Available: true,
@@ -772,6 +800,9 @@ func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	}
 	if capability = buildCatalog(policy, capabilities).Operations[0]; !capability.CaptureAvailable {
 		t.Fatalf("active ScreenCast capability = %+v", capability)
+	}
+	if waitCapability = buildCatalog(policy, capabilities).Operations[2]; !waitCapability.Available {
+		t.Fatalf("active ScreenCast wait capability = %+v", waitCapability)
 	}
 
 	t.Setenv(disablePortalEnv, "1")
@@ -781,6 +812,9 @@ func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	}
 	if capability = buildCatalog(policy, capabilities).Operations[0]; !capability.CaptureAvailable {
 		t.Fatalf("explicit native-only capture capability = %+v", capability)
+	}
+	if waitCapability = buildCatalog(policy, capabilities).Operations[2]; !waitCapability.Available {
+		t.Fatalf("explicit native-only wait capability = %+v", waitCapability)
 	}
 }
 

--- a/agent/observation_test.go
+++ b/agent/observation_test.go
@@ -774,7 +774,7 @@ func TestObservationOnlyPolicyNeedsNoActionBudget(t *testing.T) {
 func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	t.Setenv(disablePortalEnv, "")
 	policy, err := preparePolicy(Policy{
-		AllowedOperations: []Operation{OperationObserve, OperationWaitColor},
+		AllowedOperations: []Operation{OperationObserve, OperationFindColor, OperationWaitColor},
 		AllowedDisplayIDs: []int{0}, MaxObservations: 1, MaxCapturePixels: 1,
 		MaxQueries: 1, WaitAttempts: 1, WaitTimeoutMillis: 1,
 	})
@@ -793,6 +793,10 @@ func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	if waitCapability.Available || !strings.Contains(waitCapability.Remediation, "will not open portal consent implicitly") {
 		t.Fatalf("portal-only wait capability = %+v", waitCapability)
 	}
+	findCapability := buildCatalog(policy, capabilities).Operations[1]
+	if findCapability.Available || !strings.Contains(findCapability.Remediation, "will not open portal consent implicitly") {
+		t.Fatalf("portal-only find capability = %+v", findCapability)
+	}
 
 	capabilities.Capture = robotgo.FeatureCapability{
 		Available: true,
@@ -803,6 +807,9 @@ func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	}
 	if waitCapability = buildCatalog(policy, capabilities).Operations[2]; !waitCapability.Available {
 		t.Fatalf("active ScreenCast wait capability = %+v", waitCapability)
+	}
+	if findCapability = buildCatalog(policy, capabilities).Operations[1]; !findCapability.Available {
+		t.Fatalf("active ScreenCast find capability = %+v", findCapability)
 	}
 
 	t.Setenv(disablePortalEnv, "1")
@@ -815,6 +822,9 @@ func TestWaylandCatalogDoesNotAdvertiseImplicitPortalCapture(t *testing.T) {
 	}
 	if waitCapability = buildCatalog(policy, capabilities).Operations[2]; !waitCapability.Available {
 		t.Fatalf("explicit native-only wait capability = %+v", waitCapability)
+	}
+	if findCapability = buildCatalog(policy, capabilities).Operations[1]; !findCapability.Available {
+		t.Fatalf("explicit native-only find capability = %+v", findCapability)
 	}
 }
 

--- a/agent/policy.go
+++ b/agent/policy.go
@@ -125,6 +125,9 @@ func preparePolicy(input Policy) (Policy, error) {
 		if _, observeAllowed := prepared.allowOperation[OperationObserve]; !observeAllowed {
 			return Policy{}, fmt.Errorf("agent: desktop.find-color requires desktop.observe")
 		}
+		if prepared.MaxCapturePixels == 0 || len(prepared.allowDisplay) == 0 {
+			return Policy{}, fmt.Errorf("agent: desktop.find-color requires allowed bounded captures")
+		}
 	}
 	if waitAllowed {
 		if prepared.WaitAttempts == 0 || prepared.WaitTimeoutMillis == 0 {

--- a/agent/policy.go
+++ b/agent/policy.go
@@ -4,12 +4,16 @@ import "fmt"
 
 const (
 	maxAgentCapturePixels          = 16 * 1024 * 1024
+	maxAgentQueries                = 1_000_000
 	maxAgentVerificationAttempts   = 100
 	maxAgentVerificationIntervalMS = 60_000
 	maxAgentVerificationTimeoutMS  = 300_000
+	maxAgentWaitAttempts           = 100
+	maxAgentWaitIntervalMS         = 60_000
+	maxAgentWaitTimeoutMS          = 300_000
 )
 
-// Policy constrains every observation and mutation performed by a Session.
+// Policy constrains every observation, query, and mutation performed by a Session.
 // Empty allow lists deny access; callers must opt in explicitly.
 type Policy struct {
 	AllowedOperations          []Operation `json:"allowed_operations"`
@@ -20,6 +24,10 @@ type Policy struct {
 	AllowDoubleClick           bool        `json:"allow_double_click,omitempty"`
 	MaxObservations            uint64      `json:"max_observations,omitempty"`
 	MaxCapturePixels           uint64      `json:"max_capture_pixels,omitempty"`
+	MaxQueries                 uint64      `json:"max_queries,omitempty"`
+	WaitAttempts               uint32      `json:"wait_attempts,omitempty"`
+	WaitIntervalMillis         int         `json:"wait_interval_ms,omitempty"`
+	WaitTimeoutMillis          int         `json:"wait_timeout_ms,omitempty"`
 	VerificationAttempts       uint32      `json:"verification_attempts,omitempty"`
 	VerificationIntervalMillis int         `json:"verification_interval_ms,omitempty"`
 	VerificationTimeoutMillis  int         `json:"verification_timeout_ms,omitempty"`
@@ -34,6 +42,21 @@ func preparePolicy(input Policy) (Policy, error) {
 	}
 	if input.VerificationIntervalMillis < 0 {
 		return Policy{}, fmt.Errorf("agent: verification interval must be non-negative")
+	}
+	if input.MaxQueries > maxAgentQueries {
+		return Policy{}, fmt.Errorf("agent: max queries exceeds hard limit %d", maxAgentQueries)
+	}
+	if input.WaitAttempts > maxAgentWaitAttempts {
+		return Policy{}, fmt.Errorf("agent: wait attempts exceeds hard limit %d", maxAgentWaitAttempts)
+	}
+	if input.WaitIntervalMillis < 0 || input.WaitIntervalMillis > maxAgentWaitIntervalMS {
+		return Policy{}, fmt.Errorf("agent: wait interval must be between 0 and %dms", maxAgentWaitIntervalMS)
+	}
+	if input.WaitTimeoutMillis < 0 || input.WaitTimeoutMillis > maxAgentWaitTimeoutMS {
+		return Policy{}, fmt.Errorf("agent: wait timeout must be between 0 and %dms", maxAgentWaitTimeoutMS)
+	}
+	if (input.WaitAttempts == 0) != (input.WaitTimeoutMillis == 0) {
+		return Policy{}, fmt.Errorf("agent: wait attempts and timeout must both be zero or both be positive")
 	}
 	if input.MaxCapturePixels > maxAgentCapturePixels {
 		return Policy{}, fmt.Errorf("agent: max capture pixels exceeds hard limit %d", maxAgentCapturePixels)
@@ -58,6 +81,10 @@ func preparePolicy(input Policy) (Policy, error) {
 		AllowDoubleClick:           input.AllowDoubleClick,
 		MaxObservations:            input.MaxObservations,
 		MaxCapturePixels:           input.MaxCapturePixels,
+		MaxQueries:                 input.MaxQueries,
+		WaitAttempts:               input.WaitAttempts,
+		WaitIntervalMillis:         input.WaitIntervalMillis,
+		WaitTimeoutMillis:          input.WaitTimeoutMillis,
 		VerificationAttempts:       input.VerificationAttempts,
 		VerificationIntervalMillis: input.VerificationIntervalMillis,
 		VerificationTimeoutMillis:  input.VerificationTimeoutMillis,
@@ -89,6 +116,27 @@ func preparePolicy(input Policy) (Policy, error) {
 		}
 		prepared.allowDisplay[displayID] = struct{}{}
 	}
+	_, findAllowed := prepared.allowOperation[OperationFindColor]
+	_, waitAllowed := prepared.allowOperation[OperationWaitColor]
+	if (findAllowed || waitAllowed) && prepared.MaxQueries == 0 {
+		return Policy{}, fmt.Errorf("agent: max queries must be positive when a visual query is allowed")
+	}
+	if findAllowed {
+		if _, observeAllowed := prepared.allowOperation[OperationObserve]; !observeAllowed {
+			return Policy{}, fmt.Errorf("agent: desktop.find-color requires desktop.observe")
+		}
+	}
+	if waitAllowed {
+		if prepared.WaitAttempts == 0 || prepared.WaitTimeoutMillis == 0 {
+			return Policy{}, fmt.Errorf("agent: desktop.wait-color requires bounded wait attempts and timeout")
+		}
+		if prepared.MaxCapturePixels == 0 || len(prepared.allowDisplay) == 0 {
+			return Policy{}, fmt.Errorf("agent: desktop.wait-color requires allowed bounded captures")
+		}
+		if prepared.MaxObservations < uint64(prepared.WaitAttempts) {
+			return Policy{}, fmt.Errorf("agent: desktop.wait-color requires at least %d observations", prepared.WaitAttempts)
+		}
+	}
 	if prepared.VerificationAttempts > 0 {
 		if _, allowed := prepared.allowOperation[OperationObserve]; !allowed ||
 			prepared.MaxCapturePixels == 0 || len(prepared.allowDisplay) == 0 {
@@ -113,7 +161,7 @@ func allowsMutation(operations map[Operation]struct{}) bool {
 
 func knownOperation(operation Operation) bool {
 	switch operation {
-	case OperationMove, OperationClick, OperationTypeText, OperationObserve:
+	case OperationMove, OperationClick, OperationTypeText, OperationObserve, OperationFindColor, OperationWaitColor:
 		return true
 	default:
 		return false

--- a/agent/session.go
+++ b/agent/session.go
@@ -56,6 +56,7 @@ type Session struct {
 	observationMu    sync.Mutex
 	observations     map[string]observationRecord
 	usedObservations uint64
+	usedQueries      uint64
 	auditSink        AuditSink
 	auditSequence    uint64
 }
@@ -384,8 +385,13 @@ func (s *Session) authorize(request ActionRequest) error {
 }
 
 func validateRequest(request ActionRequest) error {
-	if request.Operation == OperationObserve {
+	switch request.Operation {
+	case OperationObserve:
 		return errors.New("desktop.observe must use Session.Observe")
+	case OperationFindColor:
+		return errors.New("desktop.find-color must use Session.FindColor")
+	case OperationWaitColor:
+		return errors.New("desktop.wait-color must use Session.WaitColor")
 	}
 	if request.Precondition != nil && !validObservationID(request.Precondition.ObservationID) {
 		return errors.New("precondition requires a valid RobotGo observation ID")

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -194,18 +194,28 @@ func TestCatalogIsStableAndDefensive(t *testing.T) {
 	if catalog.SchemaVersion != CatalogSchemaVersion {
 		t.Fatalf("schema = %q", catalog.SchemaVersion)
 	}
-	want := []Operation{OperationObserve, OperationMove, OperationClick, OperationTypeText}
+	want := []Operation{
+		OperationObserve, OperationFindColor, OperationWaitColor,
+		OperationMove, OperationClick, OperationTypeText,
+	}
 	for index, operation := range want {
 		got := catalog.Operations[index]
-		if got.Operation != operation || !got.Available || !got.ProcessGlobalBackend || !got.ExclusiveAgentSession {
+		if got.Operation != operation || !got.Available || !got.ExclusiveAgentSession {
 			t.Fatalf("operation[%d] = %+v", index, got)
 		}
-		if got.Cancellation != CancellationPreflightOnly {
+		wantCancellation := CancellationPreflightOnly
+		if operation == OperationFindColor || operation == OperationWaitColor {
+			wantCancellation = CancellationCooperative
+		}
+		if got.Cancellation != wantCancellation {
 			t.Fatalf("cancellation = %q", got.Cancellation)
 		}
+		if got.ProcessGlobalBackend != (operation != OperationFindColor) {
+			t.Fatalf("process-global operation[%d] = %+v", index, got)
+		}
 	}
-	catalog.Operations[1].Backend = "mutated"
-	if got := session.Catalog().Operations[1].Backend; got != "fake-mouse" {
+	catalog.Operations[3].Backend = "mutated"
+	if got := session.Catalog().Operations[3].Backend; got != "fake-mouse" {
 		t.Fatalf("catalog mutation leaked into session: %q", got)
 	}
 }

--- a/agent/types.go
+++ b/agent/types.go
@@ -10,16 +10,18 @@ import (
 )
 
 // CatalogSchemaVersion identifies the operation catalog JSON contract.
-const CatalogSchemaVersion = "2"
+const CatalogSchemaVersion = "3"
 
 // Operation identifies one strict agent operation.
 type Operation string
 
 const (
-	OperationMove     Operation = "pointer.move"
-	OperationClick    Operation = "pointer.click"
-	OperationTypeText Operation = "keyboard.type-text"
-	OperationObserve  Operation = "desktop.observe"
+	OperationMove      Operation = "pointer.move"
+	OperationClick     Operation = "pointer.click"
+	OperationTypeText  Operation = "keyboard.type-text"
+	OperationObserve   Operation = "desktop.observe"
+	OperationFindColor Operation = "desktop.find-color"
+	OperationWaitColor Operation = "desktop.wait-color"
 )
 
 // RiskClass describes the policy impact of an operation.
@@ -33,7 +35,10 @@ const (
 // CancellationSupport describes where cancellation is enforceable.
 type CancellationSupport string
 
-const CancellationPreflightOnly CancellationSupport = "preflight-only"
+const (
+	CancellationPreflightOnly CancellationSupport = "preflight-only"
+	CancellationCooperative   CancellationSupport = "cooperative"
+)
 
 // OperationCapability is one stable entry in an operation catalog.
 type OperationCapability struct {
@@ -128,6 +133,7 @@ const (
 	ErrorStaleTarget      ErrorCode = "stale-target"
 	ErrorVerification     ErrorCode = "verification-failed"
 	ErrorAuditDelivery    ErrorCode = "audit-delivery-failed"
+	ErrorConditionNotMet  ErrorCode = "condition-not-met"
 )
 
 // ActionError is safe to serialize: Message never contains action payloads.
@@ -156,12 +162,13 @@ type ActionResult struct {
 }
 
 var (
-	ErrSessionBusy   = errors.New("another agent session is already active")
-	ErrSessionClosed = errors.New("agent session is closed")
-	ErrPolicyDenied  = errors.New("agent policy denied the action")
-	ErrStaleTarget   = errors.New("agent observation target is stale")
-	ErrVerification  = errors.New("agent action verification failed")
-	ErrAuditDelivery = errors.New("agent audit delivery failed")
+	ErrSessionBusy     = errors.New("another agent session is already active")
+	ErrSessionClosed   = errors.New("agent session is closed")
+	ErrPolicyDenied    = errors.New("agent policy denied the action")
+	ErrStaleTarget     = errors.New("agent observation target is stale")
+	ErrVerification    = errors.New("agent action verification failed")
+	ErrAuditDelivery   = errors.New("agent audit delivery failed")
+	ErrConditionNotMet = errors.New("agent visual condition was not met")
 )
 
 func newActionError(code ErrorCode, operation Operation, message string, cause error) *ActionError {

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ Use the following documents as the primary entry points:
 - [Agent adapter and evaluation plan](plan/agent-adapter-evaluation.md) for the
   local MCP stdio boundary, default-deny policy, privacy projection, and
   hermetic protocol evidence.
+- [Safe agent visual conditions plan](plan/agent-visual-conditions.md) for
+  explicit-observation color search, bounded region waits, quotas, and cleanup.
 - [Wayland status](wayland-tasks.md) for backend support and open Wayland work.
 - [Upstream compatibility audit](compatibility/upstream-master.md) for
   selectively adopted and intentionally rejected upstream changes.

--- a/docs/plan/agent-adapter-evaluation.md
+++ b/docs/plan/agent-adapter-evaluation.md
@@ -1,6 +1,6 @@
 # Agent Adapter and Evaluation Plan
 
-Status: In progress
+Status: Completed by LAB-13
 
 Linear coordination:
 

--- a/docs/plan/agent-visual-conditions.md
+++ b/docs/plan/agent-visual-conditions.md
@@ -39,8 +39,10 @@ receiving capture metadata. Session close remains the final cleanup boundary.
 
 The catalog adds `desktop.find-color` and `desktop.wait-color` as sensitive
 reads. `desktop.find-color` also requires `desktop.observe`, because it can
-only consume an observation created inside the session. `desktop.wait-color`
-requires explicit capture/display limits and positive bounded wait settings.
+only consume an observation created inside the session. It therefore also
+requires explicit capture/display limits, and its catalog entry reports the
+capture backend needed to create that observation. `desktop.wait-color`
+requires the same capture/display limits and positive bounded wait settings.
 Both share `MaxQueries`; wait attempts additionally consume the existing
 `MaxObservations` budget.
 

--- a/docs/plan/agent-visual-conditions.md
+++ b/docs/plan/agent-visual-conditions.md
@@ -1,0 +1,85 @@
+# Safe Agent Visual Conditions Plan
+
+Status: Initial Go contract active in LAB-14
+
+Linear coordination:
+
+- Project: [`RobotGo | P004 | Safe Visual Conditions`](https://linear.app/riotbox/project/robotgo-or-p004-or-safe-visual-conditions-9eebd34245ff)
+- Project ID: `94e14e7f-81c0-4808-b932-a8211ece1b8b`
+- Issue: [`LAB-14 — Add bounded visual find and wait conditions`](https://linear.app/riotbox/issue/LAB-14/add-bounded-visual-find-and-wait-conditions)
+
+## Outcome
+
+Provide reusable, privacy-aware visual conditions above `agent.Session` before
+adding protocol tools or broader semantic grounding. A caller can search one
+explicit observation or wait on one explicit region without implicit
+full-screen capture, fixed sleeps, file-backed screenshots, or sensitive
+payloads in results and audit events.
+
+## Initial contract
+
+`Session.FindColor` evaluates a typed RGB/tolerance condition against a live
+capture already owned by the same session. It never calls a desktop capture
+backend. The result contains only match state, global logical coordinates,
+display ID, condition ID, and observation lineage.
+
+`Session.WaitColor` performs finite capture attempts for one explicit
+`CaptureRegion`. Attempts, interval, timeout, query count, observation count,
+pixel count, display access, and optional confirmation all come from immutable
+session policy. Cooperative cancellation is checked between captures and on
+each scanned row; a synchronous platform capture may still need to return
+before its buffer can be zeroed.
+
+Every nonmatching or failed frame is zeroed immediately. Only a matched frame
+may remain session-owned. The sanitized result references it by observation ID,
+and `Session.ReleaseObservation` lets callers zero and remove it without
+receiving capture metadata. Session close remains the final cleanup boundary.
+
+## Policy and capability boundary
+
+The catalog adds `desktop.find-color` and `desktop.wait-color` as sensitive
+reads. `desktop.find-color` also requires `desktop.observe`, because it can
+only consume an observation created inside the session. `desktop.wait-color`
+requires explicit capture/display limits and positive bounded wait settings.
+Both share `MaxQueries`; wait attempts additionally consume the existing
+`MaxObservations` budget.
+
+The local MCP adapter remains at its accepted four-tool boundary. It may report
+the new Go operations in the session catalog, but it does not yet expose
+`robotgo_find` or `robotgo_wait`. Protocol expansion is a later P004 slice
+after this API and its privacy/cleanup evidence are accepted.
+
+## Privacy and safety constraints
+
+- no implicit capture or portal-consent request
+- no pixels, target RGB values, tolerance, or capture digest in results/audit
+- no screenshot, template, OCR, clipboard, or replay file on disk
+- invalid input, policy denial, and audit-intent failure precede desktop I/O
+- timeout, cancellation, backend failure, no-match, and audit failure have
+  explicit structured errors and deterministic cleanup
+- examples are inspection-only until an explicit capture flag is supplied
+
+## Validation
+
+Hermetic fake-driver tests cover match/no-match, absolute coordinates,
+tolerance validation, confirmation, query and observation quotas, stale/closed
+observations, bounded exhaustion, timeout, payload-free audit, audit failures,
+and source/retained-buffer cleanup. The opt-in agent capture integration path
+also exercises both operations without writing a desktop artifact.
+
+## Non-goals for LAB-14
+
+- OCR or accessibility-tree queries
+- bitmap/template files or caller-supplied screenshot persistence
+- implicit full-screen capture or unbounded polling
+- window/process conditions
+- MCP tool-surface expansion
+
+## Exit criteria
+
+- the Go contract, policy fields, capability catalog, error model, and audit
+  schema are versioned and documented
+- all temporary sensitive buffers are zeroed on every return path
+- default, race, non-CGO, lint, vet, tagged capture, and integration compile
+  gates pass
+- GitHub CI and configured review surfaces are green with no unresolved finding

--- a/docs/plan/agentic-desktop-automation.md
+++ b/docs/plan/agentic-desktop-automation.md
@@ -1,6 +1,6 @@
 # Agentic Desktop Automation Plan
 
-Status: Initial architecture proof completed; follow-on delivery active
+Status: Initial architecture proof and MCP adapter completed; visual-condition delivery active
 
 Linear coordination:
 
@@ -196,7 +196,7 @@ accepted Go contract rather than define it.
 
 ### 4.3 Local MCP adapter and evaluation
 
-Delivery status: active in LAB-13.
+Delivery status: completed by LAB-13.
 
 This follow-on slice consumes the accepted Go boundary through an official-SDK
 stdio adapter. It keeps dry-run as the default, requires explicit policy and
@@ -204,6 +204,16 @@ execute intent for mutation, projects observations without pixels or lineage
 digests, and validates the complete protocol lifecycle with in-memory fakes.
 See the [dedicated delivery plan](agent-adapter-evaluation.md) for its exact
 surface and non-goals.
+
+### 4.4 Safe visual conditions
+
+Delivery status: active in LAB-14.
+
+The next Go-first slice adds color search over an explicit retained observation
+and bounded waiting over an explicit capture region. It adds no OCR,
+accessibility, file-backed template, or MCP tool. See the
+[Safe Agent Visual Conditions Plan](agent-visual-conditions.md) for its policy,
+privacy, cleanup, and validation contract.
 
 ## 5. Exit criteria
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -29,7 +29,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
   Weston integration, race, vet, and native sanitizer/leak variants.
 
-## Execution Status (2026-07-19)
+## Execution Status (2026-07-21)
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
@@ -44,9 +44,11 @@ No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
 an infrastructure blocker. The active implementation slice is Phase 5
 reliability hardening; protected real-desktop evidence remains runner-dependent.
-The adjacent [Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md)
-builds a local, policy-gated MCP boundary on the completed agent-session proof;
-it does not broaden platform backend support or replace the phase exit gates.
+The completed [Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md)
+provides a local, policy-gated MCP boundary on the agent-session proof. The
+adjacent [Safe Agent Visual Conditions Plan](agent-visual-conditions.md) now
+builds bounded `find` and `wait` semantics in Go before protocol expansion;
+neither effort broadens platform backend support or replaces phase exit gates.
 
 ## Delivery Order
 
@@ -410,6 +412,8 @@ demonstrate the difference, not merely expose more functions. The standard is:
   policy, observe-act-verify, and later adapter architecture. Its executable
   slices remain independently reviewed and do not weaken platform reliability
   gates.
+- `docs/plan/agent-visual-conditions.md` defines privacy-safe visual search and
+  bounded wait semantics above the accepted agent session.
 - This document defines product direction and delivery order.
 - A roadmap item is complete only when implementation, tests, examples where
   applicable, compatibility documentation, and required CI gates are complete.

--- a/examples/agent_conditions/main.go
+++ b/examples/agent_conditions/main.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+
+	"github.com/marang/robotgo/agent"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	allowCapture := flag.Bool("allow-capture", false, "explicitly permit in-memory capture; no image is written to disk")
+	mode := flag.String("mode", "find", "condition mode: find or wait")
+	x := flag.Int("x", 0, "global logical capture x")
+	y := flag.Int("y", 0, "global logical capture y")
+	width := flag.Int("width", 320, "capture width")
+	height := flag.Int("height", 200, "capture height")
+	displayID := flag.Int("display", 0, "explicit display ID")
+	red := flag.Uint("red", 0, "target red channel (0-255)")
+	green := flag.Uint("green", 0, "target green channel (0-255)")
+	blue := flag.Uint("blue", 0, "target blue channel (0-255)")
+	tolerance := flag.Float64("tolerance", 0, "normalized RGB tolerance (0-1)")
+	flag.Parse()
+
+	condition, err := colorCondition(*red, *green, *blue, *tolerance)
+	if err != nil {
+		return err
+	}
+	region := agent.CaptureRegion{
+		X: *x, Y: *y, Width: *width, Height: *height, DisplayID: *displayID,
+	}
+	session, err := agent.NewSession(agent.Config{Policy: agent.Policy{
+		AllowedOperations: []agent.Operation{
+			agent.OperationObserve, agent.OperationFindColor, agent.OperationWaitColor,
+		},
+		ConfirmOperations: []agent.Operation{
+			agent.OperationObserve, agent.OperationFindColor, agent.OperationWaitColor,
+		},
+		AllowedDisplayIDs:  []int{*displayID},
+		MaxObservations:    11,
+		MaxCapturePixels:   4 * 1024 * 1024,
+		MaxQueries:         2,
+		WaitAttempts:       10,
+		WaitIntervalMillis: 100,
+		WaitTimeoutMillis:  5000,
+	}})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = session.Close() }()
+
+	output := struct {
+		Catalog agent.OperationCatalog `json:"catalog"`
+		Note    string                 `json:"note,omitempty"`
+		Find    *agent.FindColorResult `json:"find,omitempty"`
+		Wait    *agent.WaitColorResult `json:"wait,omitempty"`
+	}{Catalog: session.Catalog()}
+	if !*allowCapture {
+		output.Note = "inspection only; pass -allow-capture to evaluate the explicit region in memory"
+		return json.NewEncoder(os.Stdout).Encode(output)
+	}
+
+	switch *mode {
+	case "find":
+		observation, observeErr := session.Observe(context.Background(), agent.ObserveRequest{
+			Confirmed: true,
+			Capture:   &region,
+		})
+		if observeErr != nil {
+			return observeErr
+		}
+		defer func() { _ = observation.Close() }()
+		result, findErr := session.FindColor(context.Background(), agent.FindColorRequest{
+			ObservationID: observation.ObservationID,
+			Condition:     condition,
+			Confirmed:     true,
+		})
+		output.Find = &result
+		err = findErr
+	case "wait":
+		result, waitErr := session.WaitColor(context.Background(), agent.WaitColorRequest{
+			Region: region, Condition: condition, Confirmed: true,
+		})
+		if result.ObservationID != "" {
+			defer func() { _ = session.ReleaseObservation(result.ObservationID) }()
+		}
+		output.Wait = &result
+		err = waitErr
+	default:
+		return fmt.Errorf("unknown mode %q", *mode)
+	}
+	if encodeErr := json.NewEncoder(os.Stdout).Encode(output); encodeErr != nil {
+		return encodeErr
+	}
+	return err
+}
+
+func colorCondition(red, green, blue uint, tolerance float64) (agent.ColorCondition, error) {
+	if red > 255 || green > 255 || blue > 255 {
+		return agent.ColorCondition{}, fmt.Errorf("RGB channels must be between 0 and 255")
+	}
+	if math.IsNaN(tolerance) || math.IsInf(tolerance, 0) || tolerance < 0 || tolerance > 1 {
+		return agent.ColorCondition{}, fmt.Errorf("tolerance must be between 0 and 1")
+	}
+	return agent.ColorCondition{
+		Red: uint8(red), Green: uint8(green), Blue: uint8(blue), Tolerance: tolerance,
+	}, nil
+}


### PR DESCRIPTION
## Outcome

Adds a reusable Go-first contract for privacy-safe visual conditions under LAB-14.

- `Session.FindColor` searches only an explicit live session observation and never captures implicitly.
- `Session.WaitColor` polls one explicit region within immutable attempt, interval, timeout, query, observation, pixel, display, and confirmation limits.
- matched waits return only sanitized lineage; `Session.ReleaseObservation` idempotently zeroes and removes the retained buffer.
- the operation catalog, policy, structured error model, and payload-free audit schema are versioned.
- MCP remains at its accepted four-tool boundary; find/wait tool exposure is deferred until this Go contract is accepted.

## Safety and compatibility

- no screenshot, template, OCR, clipboard, or replay files are created
- nonmatching, error, timeout, cancellation, audit-failure, and session-close paths zero temporary captures
- invalid input, policy denial, quota exhaustion, and audit-intent failure occur before desktop capture
- Wayland capture still never opens portal consent implicitly
- existing legacy RobotGo APIs and platform boundaries remain unchanged
- catalog schema advances to v3 and audit schema to v2

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./agent ./agent/mcpserver ./cmd/robotgo-mcp`
- `go vet ./...`
- `golangci-lint run --timeout=5m ./...`
- `go test -race -tags wayland ./agent`
- `go test -tags integration ./agent -run '^$'`
- Windows amd64 and macOS arm64 non-CGO cross-builds for `./agent` and the new example
- portal, screencopy, DRM, Wayland public API, and Wayland keyboard tagged suites

Real capture evidence remains explicitly opt-in through `ROBOTGO_AGENT_CAPTURE_E2E=1`; local validation used only hermetic fixtures and created no desktop artifact.

Linear: https://linear.app/riotbox/issue/LAB-14/add-bounded-visual-find-and-wait-conditions