### PR TITLE
feat(agent): expose safe visual conditions over MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,10 +832,11 @@ go run ./examples/agent_conditions -allow-capture -mode wait \
 ### Local MCP adapter for agents
 
 `robotgo-mcp` exposes the policy-gated session to a local MCP client over
-stdio. It has four focused tools: `robotgo_capabilities`, `robotgo_observe`,
-`robotgo_act`, and `robotgo_close`. With no policy flag it is diagnostics-only:
-capture, display access, and desktop mutation are denied. `robotgo_act` is also
-dry-run by default, so actual input needs both an explicit policy and
+stdio. It has seven focused tools: `robotgo_capabilities`, `robotgo_observe`,
+`robotgo_find`, `robotgo_wait`, `robotgo_release_observation`, `robotgo_act`,
+and `robotgo_close`. With no policy flag it is diagnostics-only: capture,
+visual queries, display access, and desktop mutation are denied. `robotgo_act`
+is also dry-run by default, so actual input needs both an explicit policy and
 `mode: "execute"`; normal session confirmation rules still apply.
 
 Run it directly from the repository:
@@ -878,13 +879,68 @@ robotgo-mcp -policy /absolute/path/to/policy.json
 Policy input is size-bounded, rejects unknown fields and trailing JSON, and is
 never read from stdin. MCP observation output includes sanitized diagnostics
 and optional geometry, but never pixels or internal capture digests. Session
-close zeroes any in-memory captures. See the
-[adapter and evaluation plan](docs/plan/agent-adapter-evaluation.md) for the
-security boundary and intentionally deferred tools.
-The Go session catalog already reports `desktop.find-color` and
-`desktop.wait-color`, but the accepted MCP boundary intentionally does not yet
-expose `robotgo_find` or `robotgo_wait`; that protocol expansion follows after
-the Go contract's cleanup and privacy evidence is accepted.
+close zeroes any in-memory captures.
+
+Visual tools use the same explicit, bounded model as the Go API:
+
+1. `robotgo_observe` can create one policy-approved in-memory capture.
+2. `robotgo_find` searches only the supplied live observation ID and never
+   captures implicitly.
+3. `robotgo_wait` polls only the supplied region, with attempts, interval,
+   timeout, display, query, observation, and pixel limits fixed by policy.
+4. A matched wait retains one observation for follow-up queries. Call
+   `robotgo_release_observation` as soon as it is no longer needed; closing the
+   session remains the final cleanup boundary.
+
+For example, a policy can opt into bounded visual queries on display 0 without
+granting input control:
+
+```json
+{
+  "allowed_operations": [
+    "desktop.observe",
+    "desktop.find-color",
+    "desktop.wait-color"
+  ],
+  "allowed_display_ids": [0],
+  "max_actions": 0,
+  "max_text_runes": 0,
+  "max_observations": 20,
+  "max_capture_pixels": 76800,
+  "max_queries": 20,
+  "wait_attempts": 5,
+  "wait_interval_ms": 250,
+  "wait_timeout_ms": 5000
+}
+```
+
+Find/wait results contain match state, global coordinates, attempts, and
+observation lineage only. Target colors, tolerance, pixels, capture digests,
+and raw backend errors never cross the MCP output boundary. See the
+[adapter plan](docs/plan/agent-adapter-evaluation.md) and
+[visual-condition plan](docs/plan/agent-visual-conditions.md) for the complete
+security contract.
+
+The condition is RGB with a normalized Euclidean tolerance from `0` (exact)
+through `1` (maximum distance). Typical tool arguments are:
+
+```json
+{"observation_id":"observation-7","condition":{"red":0,"green":120,"blue":255,"tolerance":0.05}}
+```
+
+```json
+{"region":{"x":0,"y":0,"width":320,"height":240,"display_id":0},"condition":{"red":0,"green":120,"blue":255,"tolerance":0.05}}
+```
+
+Release the observation ID returned by a matched wait with:
+
+```json
+{"observation_id":"observation-8"}
+```
+
+Release is cleanup-only and requires no additional desktop permission. Tool
+listing and annotations describe the protocol surface; the immutable session
+catalog and policy remain the authorization source of truth.
 
 ## Examples
 

--- a/TEST.md
+++ b/TEST.md
@@ -116,9 +116,10 @@ CGO_ENABLED=0 go test ./agent
 
 The MCP adapter suite uses the official SDK's paired in-memory transports and a
 fake session. It performs real protocol initialization, listing, typed calls,
-cancellation, concurrent close, output-redaction, and transport-cleanup checks
-without reading or changing the developer's desktop. The command tests use only
-private `t.TempDir()` policy fixtures, which test cleanup removes:
+find/wait projection, explicit observation release, cancellation, concurrent
+close, schema rejection, output-redaction, and transport-cleanup checks without
+reading or changing the developer's desktop. The command tests use only private
+`t.TempDir()` policy fixtures, which test cleanup removes:
 
 ```bash
 go test -race ./agent/mcpserver ./cmd/robotgo-mcp
@@ -126,7 +127,9 @@ CGO_ENABLED=0 go test ./agent/mcpserver ./cmd/robotgo-mcp
 ```
 
 No MCP test starts stdio, opens portal consent, captures pixels, injects input,
-or persists protocol data.
+or persists protocol data. Condition fixtures stay in memory, and serialized
+results are checked for target-color, tolerance, pixel, digest, and backend
+payload leakage.
 
 The opt-in runtime path performs one real pointer move to explicit coordinates:
 

--- a/agent/mcpserver/condition.go
+++ b/agent/mcpserver/condition.go
@@ -1,0 +1,129 @@
+package mcpserver
+
+import (
+	"context"
+
+	"github.com/marang/robotgo/agent"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var _ VisualConditionSession = (*agent.Session)(nil)
+
+const (
+	// ToolFind evaluates a visual condition against one explicit observation.
+	ToolFind = "robotgo_find"
+	// ToolWait performs one policy-bounded visual wait over an explicit region.
+	ToolWait = "robotgo_wait"
+	// ToolReleaseObservation zeroes and removes one retained observation.
+	ToolReleaseObservation = "robotgo_release_observation"
+)
+
+// FindOutput is the privacy-reduced output of robotgo_find.
+type FindOutput struct {
+	Result *agent.FindColorResult `json:"result,omitempty"`
+	Error  *ToolError             `json:"error,omitempty"`
+}
+
+// WaitOutput is the privacy-reduced output of robotgo_wait.
+type WaitOutput struct {
+	Result *agent.WaitColorResult `json:"result,omitempty"`
+	Error  *ToolError             `json:"error,omitempty"`
+}
+
+// ReleaseObservationInput identifies session-owned capture state to zero.
+type ReleaseObservationInput struct {
+	ObservationID string `json:"observation_id"`
+}
+
+// ReleaseObservationOutput confirms that no retained observation with the
+// requested ID remains. Releasing the same valid ID repeatedly is successful.
+type ReleaseObservationOutput struct {
+	Released bool       `json:"released"`
+	Error    *ToolError `json:"error,omitempty"`
+}
+
+func (s *Server) registerConditionTools() {
+	closedWorld := false
+	openWorld := true
+	nondestructive := false
+
+	mcp.AddTool(s.protocol, &mcp.Tool{
+		Name:        ToolFind,
+		Title:       "Find a color in an observation",
+		Description: "Evaluate one typed color condition against an explicit live RobotGo observation. This never captures the desktop and returns no pixels, digest, or target color.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &closedWorld},
+	}, s.find)
+
+	mcp.AddTool(s.protocol, &mcp.Tool{
+		Name:        ToolWait,
+		Title:       "Wait for a color in a region",
+		Description: "Perform a finite, policy-bounded visual wait over one explicit display region. A match retains one in-memory observation until it is released or the session closes.",
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
+	}, s.wait)
+
+	mcp.AddTool(s.protocol, &mcp.Tool{
+		Name:        ToolReleaseObservation,
+		Title:       "Release a RobotGo observation",
+		Description: "Idempotently zero and remove one retained in-memory observation. No desktop backend is contacted.",
+		Annotations: &mcp.ToolAnnotations{DestructiveHint: &nondestructive, IdempotentHint: true, OpenWorldHint: &closedWorld},
+	}, s.releaseObservation)
+}
+
+func (s *Server) find(ctx context.Context, _ *mcp.CallToolRequest, input agent.FindColorRequest) (*mcp.CallToolResult, FindOutput, error) {
+	session, toolErr := s.adapter.begin()
+	if toolErr != nil {
+		return errorResult(), FindOutput{Error: toolErr}, nil
+	}
+	visual, toolErr := visualConditionSession(session)
+	if toolErr != nil {
+		return errorResult(), FindOutput{Error: toolErr}, nil
+	}
+	result, err := visual.FindColor(ctx, input)
+	output := FindOutput{Result: &result}
+	if err != nil {
+		output.Error = safeToolError(err)
+		return errorResult(), output, nil
+	}
+	return nil, output, nil
+}
+
+func (s *Server) wait(ctx context.Context, _ *mcp.CallToolRequest, input agent.WaitColorRequest) (*mcp.CallToolResult, WaitOutput, error) {
+	session, toolErr := s.adapter.begin()
+	if toolErr != nil {
+		return errorResult(), WaitOutput{Error: toolErr}, nil
+	}
+	visual, toolErr := visualConditionSession(session)
+	if toolErr != nil {
+		return errorResult(), WaitOutput{Error: toolErr}, nil
+	}
+	result, err := visual.WaitColor(ctx, input)
+	output := WaitOutput{Result: &result}
+	if err != nil {
+		output.Error = safeToolError(err)
+		return errorResult(), output, nil
+	}
+	return nil, output, nil
+}
+
+func (s *Server) releaseObservation(_ context.Context, _ *mcp.CallToolRequest, input ReleaseObservationInput) (*mcp.CallToolResult, ReleaseObservationOutput, error) {
+	session, toolErr := s.adapter.begin()
+	if toolErr != nil {
+		return errorResult(), ReleaseObservationOutput{Error: toolErr}, nil
+	}
+	visual, toolErr := visualConditionSession(session)
+	if toolErr != nil {
+		return errorResult(), ReleaseObservationOutput{Error: toolErr}, nil
+	}
+	if err := visual.ReleaseObservation(input.ObservationID); err != nil {
+		return errorResult(), ReleaseObservationOutput{Error: safeToolError(err)}, nil
+	}
+	return nil, ReleaseObservationOutput{Released: true}, nil
+}
+
+func visualConditionSession(session Session) (VisualConditionSession, *ToolError) {
+	visual, ok := session.(VisualConditionSession)
+	if !ok {
+		return nil, &ToolError{Code: agent.ErrorUnsupported, Message: "RobotGo visual conditions are unavailable for this session"}
+	}
+	return visual, nil
+}

--- a/agent/mcpserver/condition_test.go
+++ b/agent/mcpserver/condition_test.go
@@ -1,0 +1,348 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marang/robotgo/agent"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestFindReturnsOnlySanitizedConditionResult(t *testing.T) {
+	request := agent.FindColorRequest{
+		ObservationID: "observation-17",
+		Condition: agent.ColorCondition{
+			Red: 19, Green: 83, Blue: 241, Tolerance: 0.123456789,
+		},
+		Confirmed: true,
+	}
+	fake := &fakeSession{findFunc: func(_ context.Context, got agent.FindColorRequest) (agent.FindColorResult, error) {
+		if got != request {
+			t.Fatalf("FindColor request = %+v, want %+v", got, request)
+		}
+		return agent.FindColorResult{
+			SchemaVersion: agent.ConditionSchemaVersion,
+			ConditionID:   "condition-11",
+			ObservationID: got.ObservationID,
+			Status:        agent.ConditionMatched,
+			Match:         &agent.VisualMatch{X: 501, Y: 702, DisplayID: 3},
+		}, nil
+	}}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+
+	result := callTool(t, client, ToolFind, request)
+	if result.IsError {
+		t.Fatalf("find returned tool error: %s", serializedResult(t, result))
+	}
+	output := decodeOutput[FindOutput](t, result)
+	if output.Result == nil || output.Result.Status != agent.ConditionMatched || output.Result.Match == nil {
+		t.Fatalf("find output = %+v", output)
+	}
+	if output.Result.Match.X != 501 || output.Result.ObservationID != request.ObservationID {
+		t.Fatalf("find result = %+v", output.Result)
+	}
+	assertNoConditionPayload(t, result)
+}
+
+func TestFindNoMatchIsARegularSanitizedResult(t *testing.T) {
+	fake := &fakeSession{findFunc: func(_ context.Context, request agent.FindColorRequest) (agent.FindColorResult, error) {
+		return agent.FindColorResult{
+			SchemaVersion: agent.ConditionSchemaVersion,
+			ConditionID:   "condition-21",
+			ObservationID: request.ObservationID,
+			Status:        agent.ConditionNotMatched,
+		}, nil
+	}}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+
+	result := callTool(t, client, ToolFind, agent.FindColorRequest{
+		ObservationID: "observation-31",
+		Condition:     agent.ColorCondition{Red: 7, Green: 71, Blue: 171, Tolerance: 0.345678912},
+	})
+	if result.IsError {
+		t.Fatalf("no-match find returned tool error: %s", serializedResult(t, result))
+	}
+	output := decodeOutput[FindOutput](t, result)
+	if output.Result == nil || output.Result.Status != agent.ConditionNotMatched || output.Result.Match != nil {
+		t.Fatalf("no-match find output = %+v", output)
+	}
+	assertNoConditionPayload(t, result)
+}
+
+func TestWaitReturnsSanitizedResultAndObservationCanBeReleased(t *testing.T) {
+	request := agent.WaitColorRequest{
+		Region: agent.CaptureRegion{X: 100, Y: 200, Width: 30, Height: 40, DisplayID: 2},
+		Condition: agent.ColorCondition{
+			Red: 37, Green: 91, Blue: 213, Tolerance: 0.234567891,
+		},
+		Confirmed: true,
+	}
+	var released []string
+	fake := &fakeSession{
+		waitFunc: func(_ context.Context, got agent.WaitColorRequest) (agent.WaitColorResult, error) {
+			if got != request {
+				t.Fatalf("WaitColor request = %+v, want %+v", got, request)
+			}
+			return agent.WaitColorResult{
+				SchemaVersion: agent.ConditionSchemaVersion,
+				ConditionID:   "condition-12",
+				Status:        agent.ConditionMatched,
+				Attempts:      3,
+				ObservationID: "observation-23",
+				Match:         &agent.VisualMatch{X: 108, Y: 209, DisplayID: 2},
+			}, nil
+		},
+		releaseFunc: func(id string) error {
+			released = append(released, id)
+			return nil
+		},
+	}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+
+	result := callTool(t, client, ToolWait, request)
+	if result.IsError {
+		t.Fatalf("wait returned tool error: %s", serializedResult(t, result))
+	}
+	output := decodeOutput[WaitOutput](t, result)
+	if output.Result == nil || output.Result.ObservationID != "observation-23" || output.Result.Attempts != 3 {
+		t.Fatalf("wait output = %+v", output)
+	}
+	assertNoConditionPayload(t, result)
+
+	for range 2 {
+		releaseResult := callTool(t, client, ToolReleaseObservation, ReleaseObservationInput{
+			ObservationID: output.Result.ObservationID,
+		})
+		if releaseResult.IsError {
+			t.Fatalf("release returned tool error: %s", serializedResult(t, releaseResult))
+		}
+		if releaseOutput := decodeOutput[ReleaseObservationOutput](t, releaseResult); !releaseOutput.Released {
+			t.Fatalf("release output = %+v", releaseOutput)
+		}
+	}
+	if len(released) != 2 || released[0] != "observation-23" || released[1] != released[0] {
+		t.Fatalf("released IDs = %v", released)
+	}
+}
+
+func TestConditionFailureKeepsSafePartialResultAndSanitizesBackendError(t *testing.T) {
+	const privateBackendError = "private pixels and backend path"
+	fake := &fakeSession{waitFunc: func(context.Context, agent.WaitColorRequest) (agent.WaitColorResult, error) {
+		return agent.WaitColorResult{
+			SchemaVersion: agent.ConditionSchemaVersion,
+			ConditionID:   "condition-13",
+			Status:        agent.ConditionNotMatched,
+			Attempts:      2,
+		}, errors.New(privateBackendError)
+	}}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+
+	result := callTool(t, client, ToolWait, agent.WaitColorRequest{
+		Region:    agent.CaptureRegion{Width: 1, Height: 1},
+		Condition: agent.ColorCondition{},
+	})
+	if !result.IsError {
+		t.Fatal("backend failure unexpectedly succeeded")
+	}
+	serialized := serializedResult(t, result)
+	if strings.Contains(serialized, privateBackendError) {
+		t.Fatal("raw condition backend error crossed MCP boundary")
+	}
+	output := decodeOutput[WaitOutput](t, result)
+	if output.Result == nil || output.Result.Attempts != 2 {
+		t.Fatalf("partial wait result = %+v", output.Result)
+	}
+	if output.Error == nil || output.Error.Code != agent.ErrorBackendFailure || output.Error.Message != errorMessageFailed {
+		t.Fatalf("safe wait error = %+v", output.Error)
+	}
+}
+
+func TestConditionStructuredErrorPreservesSafeCode(t *testing.T) {
+	fake := &fakeSession{waitFunc: func(context.Context, agent.WaitColorRequest) (agent.WaitColorResult, error) {
+		return agent.WaitColorResult{
+				SchemaVersion: agent.ConditionSchemaVersion,
+				ConditionID:   "condition-22",
+				Status:        agent.ConditionNotMatched,
+				Attempts:      4,
+			}, &agent.ActionError{
+				Code: agent.ErrorConditionNotMet, Operation: agent.OperationWaitColor,
+				Message: "visual condition was not met",
+			}
+	}}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+
+	result := callTool(t, client, ToolWait, agent.WaitColorRequest{
+		Region: agent.CaptureRegion{Width: 1, Height: 1},
+	})
+	if !result.IsError {
+		t.Fatal("condition error unexpectedly succeeded")
+	}
+	output := decodeOutput[WaitOutput](t, result)
+	if output.Error == nil || output.Error.Code != agent.ErrorConditionNotMet || output.Error.Message != "visual condition was not met" {
+		t.Fatalf("condition error = %+v", output.Error)
+	}
+	if output.Result == nil || output.Result.Attempts != 4 || output.Result.Status != agent.ConditionNotMatched {
+		t.Fatalf("condition partial result = %+v", output.Result)
+	}
+}
+
+func TestWaitErrorPreservesReleaseHandleForRetainedObservation(t *testing.T) {
+	var released string
+	fake := &fakeSession{
+		waitFunc: func(context.Context, agent.WaitColorRequest) (agent.WaitColorResult, error) {
+			return agent.WaitColorResult{
+					SchemaVersion: agent.ConditionSchemaVersion,
+					ConditionID:   "condition-23",
+					Status:        agent.ConditionMatched,
+					Attempts:      1,
+					ObservationID: "observation-41",
+					Match:         &agent.VisualMatch{X: 9, Y: 10},
+				}, &agent.ActionError{
+					Code: agent.ErrorAuditDelivery, Operation: agent.OperationWaitColor,
+					Message: "color wait completed but audit delivery failed",
+				}
+		},
+		releaseFunc: func(id string) error {
+			released = id
+			return nil
+		},
+	}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+
+	result := callTool(t, client, ToolWait, agent.WaitColorRequest{
+		Region: agent.CaptureRegion{Width: 1, Height: 1},
+	})
+	if !result.IsError {
+		t.Fatal("audit failure unexpectedly succeeded")
+	}
+	output := decodeOutput[WaitOutput](t, result)
+	if output.Error == nil || output.Error.Code != agent.ErrorAuditDelivery ||
+		output.Result == nil || output.Result.ObservationID != "observation-41" {
+		t.Fatalf("audit failure output = %+v", output)
+	}
+
+	releaseResult := callTool(t, client, ToolReleaseObservation, ReleaseObservationInput{
+		ObservationID: output.Result.ObservationID,
+	})
+	if releaseResult.IsError {
+		t.Fatalf("release after wait error failed: %s", serializedResult(t, releaseResult))
+	}
+	if released != "observation-41" {
+		t.Fatalf("released observation = %q", released)
+	}
+}
+
+func TestReleaseObservationReturnsStructuredValidationError(t *testing.T) {
+	fake := &fakeSession{releaseFunc: func(string) error {
+		return &agent.ActionError{Code: agent.ErrorInvalidInput, Message: "invalid RobotGo observation ID"}
+	}}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+
+	result := callTool(t, client, ToolReleaseObservation, ReleaseObservationInput{ObservationID: "invalid"})
+	if !result.IsError {
+		t.Fatal("invalid release unexpectedly succeeded")
+	}
+	output := decodeOutput[ReleaseObservationOutput](t, result)
+	if output.Released || output.Error == nil || output.Error.Code != agent.ErrorInvalidInput {
+		t.Fatalf("release error output = %+v", output)
+	}
+}
+
+func TestLegacySessionKeepsOriginalToolSurface(t *testing.T) {
+	legacy := struct{ Session }{Session: &fakeSession{}}
+	client := connectProtocol(t, newProtocolServer(t, legacy))
+
+	result, err := client.clientSession.ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	var names []string
+	for _, tool := range result.Tools {
+		names = append(names, tool.Name)
+	}
+	slices.Sort(names)
+	want := []string{ToolAct, ToolCapabilities, ToolClose, ToolObserve}
+	slices.Sort(want)
+	if !slices.Equal(names, want) {
+		t.Fatalf("legacy tools = %v, want %v", names, want)
+	}
+}
+
+func TestWaitCancellationReachesSessionOperation(t *testing.T) {
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	fake := &fakeSession{waitFunc: func(ctx context.Context, _ agent.WaitColorRequest) (agent.WaitColorResult, error) {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		return agent.WaitColorResult{}, ctx.Err()
+	}}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	resultDone := make(chan error, 1)
+	go func() {
+		_, err := client.clientSession.CallTool(ctx, &mcp.CallToolParams{
+			Name: ToolWait,
+			Arguments: agent.WaitColorRequest{
+				Region: agent.CaptureRegion{Width: 1, Height: 1}, Condition: agent.ColorCondition{},
+			},
+		})
+		resultDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("wait did not start")
+	}
+	cancel()
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not reach WaitColor")
+	}
+	select {
+	case err := <-resultDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("CallTool error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled wait call did not return")
+	}
+}
+
+func TestConditionSchemaRejectsUnknownInputWithoutCallingSession(t *testing.T) {
+	const privateValue = "private-condition-payload"
+	fake := &fakeSession{}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+
+	result := callTool(t, client, ToolFind, map[string]any{
+		"observation_id": "observation-1",
+		"condition":      map[string]any{"red": 1, "green": 2, "blue": 3, "tolerance": 0},
+		"unknown":        privateValue,
+	})
+	if !result.IsError {
+		t.Fatal("unknown condition field unexpectedly succeeded")
+	}
+	if strings.Contains(serializedResult(t, result), privateValue) {
+		t.Fatal("invalid condition input was echoed")
+	}
+	finds, waits, releases := fake.conditionCounts()
+	if finds != 0 || waits != 0 || releases != 0 {
+		t.Fatalf("schema-invalid input reached session: find=%d wait=%d release=%d", finds, waits, releases)
+	}
+}
+
+func assertNoConditionPayload(t *testing.T, result *mcp.CallToolResult) {
+	t.Helper()
+	serialized := strings.ToLower(serializedResult(t, result))
+	for _, forbidden := range []string{"\"red\"", "\"green\"", "\"blue\"", "\"tolerance\"", "sha256", "pixels", "image"} {
+		if strings.Contains(serialized, forbidden) {
+			t.Fatalf("condition result leaked forbidden field %q: %s", forbidden, serialized)
+		}
+	}
+}

--- a/agent/mcpserver/server.go
+++ b/agent/mcpserver/server.go
@@ -43,6 +43,17 @@ type Session interface {
 	Close() error
 }
 
+// VisualConditionSession is the additive session extension used by the visual
+// tools. Keeping it separate preserves source compatibility for existing
+// Session implementations; implementations without the extension retain the
+// original four-tool surface. *agent.Session implements VisualConditionSession.
+type VisualConditionSession interface {
+	Session
+	FindColor(context.Context, agent.FindColorRequest) (agent.FindColorResult, error)
+	WaitColor(context.Context, agent.WaitColorRequest) (agent.WaitColorResult, error)
+	ReleaseObservation(string) error
+}
+
 // Server binds one process-exclusive agent session to one MCP connection.
 type Server struct {
 	adapter    *adapter
@@ -231,6 +242,10 @@ func (s *Server) registerTools() {
 		Description: "Return sanitized runtime diagnostics and optional bounded capture metadata. Pixels and capture digests never cross MCP.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: &openWorld},
 	}, s.observe)
+
+	if _, ok := s.adapter.session.(VisualConditionSession); ok {
+		s.registerConditionTools()
+	}
 
 	mcp.AddTool(s.protocol, &mcp.Tool{
 		Name:        ToolAct,

--- a/agent/mcpserver/server_test.go
+++ b/agent/mcpserver/server_test.go
@@ -20,12 +20,18 @@ type fakeSession struct {
 	catalog     agent.OperationCatalog
 	observation *agent.Observation
 	observeFunc func(context.Context, agent.ObserveRequest) (*agent.Observation, error)
+	findFunc    func(context.Context, agent.FindColorRequest) (agent.FindColorResult, error)
+	waitFunc    func(context.Context, agent.WaitColorRequest) (agent.WaitColorResult, error)
+	releaseFunc func(string) error
 	dryRunFunc  func(context.Context, agent.ActionRequest) (agent.ActionResult, error)
 	executeFunc func(context.Context, agent.ActionRequest) (agent.ActionResult, error)
 	closeFunc   func() error
 
 	dryRuns  int
 	executes int
+	finds    int
+	waits    int
+	releases int
 	closes   int
 }
 
@@ -36,6 +42,36 @@ func (f *fakeSession) Observe(ctx context.Context, request agent.ObserveRequest)
 		return f.observeFunc(ctx, request)
 	}
 	return f.observation, nil
+}
+
+func (f *fakeSession) FindColor(ctx context.Context, request agent.FindColorRequest) (agent.FindColorResult, error) {
+	f.mu.Lock()
+	f.finds++
+	f.mu.Unlock()
+	if f.findFunc != nil {
+		return f.findFunc(ctx, request)
+	}
+	return agent.FindColorResult{}, errors.New("unused")
+}
+
+func (f *fakeSession) WaitColor(ctx context.Context, request agent.WaitColorRequest) (agent.WaitColorResult, error) {
+	f.mu.Lock()
+	f.waits++
+	f.mu.Unlock()
+	if f.waitFunc != nil {
+		return f.waitFunc(ctx, request)
+	}
+	return agent.WaitColorResult{}, errors.New("unused")
+}
+
+func (f *fakeSession) ReleaseObservation(id string) error {
+	f.mu.Lock()
+	f.releases++
+	f.mu.Unlock()
+	if f.releaseFunc != nil {
+		return f.releaseFunc(id)
+	}
+	return nil
 }
 
 func (f *fakeSession) DryRun(ctx context.Context, request agent.ActionRequest) (agent.ActionResult, error) {
@@ -72,6 +108,12 @@ func (f *fakeSession) counts() (dryRuns, executes, closes int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.dryRuns, f.executes, f.closes
+}
+
+func (f *fakeSession) conditionCounts() (finds, waits, releases int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.finds, f.waits, f.releases
 }
 
 type protocolClient struct {
@@ -140,7 +182,7 @@ func serializedResult(t *testing.T, result *mcp.CallToolResult) string {
 	return string(data)
 }
 
-func TestProtocolInitializesAndListsOnlyFourTools(t *testing.T) {
+func TestProtocolInitializesAndListsFocusedTools(t *testing.T) {
 	fake := &fakeSession{catalog: agent.OperationCatalog{SchemaVersion: agent.CatalogSchemaVersion}}
 	server := newProtocolServer(t, fake)
 	client := connectProtocol(t, server)
@@ -155,9 +197,23 @@ func TestProtocolInitializesAndListsOnlyFourTools(t *testing.T) {
 		if tool.InputSchema == nil || tool.OutputSchema == nil {
 			t.Errorf("tool %q has incomplete schemas", tool.Name)
 		}
+		switch tool.Name {
+		case ToolFind, ToolWait:
+			if tool.Annotations == nil || !tool.Annotations.ReadOnlyHint {
+				t.Errorf("tool %q is not marked read-only", tool.Name)
+			}
+		case ToolReleaseObservation:
+			if tool.Annotations == nil || !tool.Annotations.IdempotentHint ||
+				tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint {
+				t.Errorf("release annotations = %+v", tool.Annotations)
+			}
+		}
 	}
 	slices.Sort(names)
-	want := []string{ToolAct, ToolCapabilities, ToolClose, ToolObserve}
+	want := []string{
+		ToolAct, ToolCapabilities, ToolClose, ToolFind, ToolObserve,
+		ToolReleaseObservation, ToolWait,
+	}
 	slices.Sort(want)
 	if !slices.Equal(names, want) {
 		t.Fatalf("tools = %v, want %v", names, want)
@@ -380,9 +436,16 @@ func TestCloseIsIdempotentAndLaterCallsFailClosed(t *testing.T) {
 		}
 	}
 
-	for _, tool := range []string{ToolCapabilities, ToolObserve, ToolAct} {
+	for _, tool := range []string{ToolCapabilities, ToolObserve, ToolFind, ToolWait, ToolReleaseObservation, ToolAct} {
 		arguments := any(map[string]any{})
-		if tool == ToolAct {
+		switch tool {
+		case ToolFind:
+			arguments = agent.FindColorRequest{ObservationID: "observation-1"}
+		case ToolWait:
+			arguments = agent.WaitColorRequest{Region: agent.CaptureRegion{Width: 1, Height: 1}}
+		case ToolReleaseObservation:
+			arguments = ReleaseObservationInput{ObservationID: "observation-1"}
+		case ToolAct:
 			arguments = ActInput{}
 		}
 		result := callTool(t, client, tool, arguments)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@ Use the following documents as the primary entry points:
 - [Agentic desktop automation plan](plan/agentic-desktop-automation.md) for the
   session, policy, observe-act-verify, and adapter architecture.
 - [Agent adapter and evaluation plan](plan/agent-adapter-evaluation.md) for the
-  local MCP stdio boundary, default-deny policy, privacy projection, and
-  hermetic protocol evidence.
+  local MCP stdio boundary, default-deny policy, visual-query projection,
+  privacy guarantees, and hermetic protocol evidence.
 - [Safe agent visual conditions plan](plan/agent-visual-conditions.md) for
   explicit-observation color search, bounded region waits, quotas, and cleanup.
 - [Wayland status](wayland-tasks.md) for backend support and open Wayland work.

--- a/docs/plan/agent-adapter-evaluation.md
+++ b/docs/plan/agent-adapter-evaluation.md
@@ -1,12 +1,14 @@
 # Agent Adapter and Evaluation Plan
 
-Status: Completed by LAB-13
+Status: Base completed by LAB-13; visual-condition extension active in LAB-15
 
 Linear coordination:
 
 - Project: [`RobotGo | P003 | Agent Adapter and Evaluation`](https://linear.app/riotbox/project/robotgo-or-p003-or-agent-adapter-and-evaluation-7749d1ceaac3)
 - Project ID: `3643b1db-00a4-4f93-8604-3e85d0207a0c`
 - Issue: [`LAB-13 — Add safe MCP stdio adapter and hermetic protocol evaluation`](https://linear.app/riotbox/issue/LAB-13/add-safe-mcp-stdio-adapter-and-hermetic-protocol-evaluation)
+- Extension project: [`RobotGo | P004 | Safe Visual Conditions`](https://linear.app/riotbox/project/robotgo-or-p004-or-safe-visual-conditions-9eebd34245ff)
+- Extension: [`LAB-15 — Expose safe visual find and wait through MCP`](https://linear.app/riotbox/issue/LAB-15/expose-safe-visual-find-and-wait-through-mcp)
 
 ## Outcome
 
@@ -26,19 +28,23 @@ cmd/robotgo-mcp
       |
 agent/mcpserver (schema, projection, lifecycle only)
       |
-agent.Session (policy, quota, confirmation, observe/act/verify)
+agent.Session (policy, quota, confirmation, observe/find/wait/act/verify)
       |
 RobotGo platform backends
 ```
 
 The adapter uses the stable official
 `github.com/modelcontextprotocol/go-sdk` module. It provides one session per
-process and exactly four tools:
+process. LAB-13 established four tools; LAB-15 extends the same boundary to
+seven focused tools after the underlying Go contract was accepted:
 
 | Tool | Contract |
 |---|---|
 | `robotgo_capabilities` | Return the immutable policy-filtered operation catalog without desktop I/O. |
 | `robotgo_observe` | Ask the session for diagnostics or an explicitly policy-bounded capture, then return diagnostics and geometry only. Pixels and lineage digests stay in-process. |
+| `robotgo_find` | Evaluate a typed condition against one explicit live observation without implicit capture. |
+| `robotgo_wait` | Perform a finite policy-bounded wait over one explicit region and retain only a matched observation. |
+| `robotgo_release_observation` | Idempotently zero and remove one retained observation without desktop I/O. |
 | `robotgo_act` | Perform a dry-run by default. Actual input requires both `mode: "execute"` and a policy/confirmation combination that authorizes the request. |
 | `robotgo_close` | Idempotently close the process-exclusive session and zero retained capture buffers. Later calls fail with one stable sanitized error. |
 
@@ -57,22 +63,24 @@ never read from protocol stdin.
 MCP output never contains observation pixels, capture SHA-256 lineage, typed
 text, raw backend errors, clipboard data, OCR data, or file-backed desktop
 artifacts. The in-process session keeps any optional capture solely for stale
-target checks and verification, and zeroes it on close.
+target checks, visual queries, and verification. Clients can release
+observations explicitly; session close remains the final zeroing boundary.
 
 ## Evaluation evidence
 
 The blocking hermetic suite connects the official MCP client and server over
 in-memory transports. It covers initialization, exact tool listing, schemas,
-capabilities, observation projection, dry-run and explicit execution routing,
-invalid input, raw-error redaction, request cancellation, idempotent close,
-concurrent action/close, post-close rejection, and cleanup on server
-cancellation. Fakes supply all data; tests neither inspect nor mutate the real
-desktop and write no sensitive artifact.
+capabilities, observation and visual-condition projection, explicit release,
+dry-run and explicit execution routing, invalid input, target/pixel/raw-error
+redaction, request cancellation, idempotent close, concurrent action/close,
+post-close rejection, and cleanup on server cancellation. Fakes supply all
+data; tests neither inspect nor mutate the real desktop and write no sensitive
+artifact.
 
 ## Non-goals
 
 - HTTP, SSE, OAuth, remote access, or multi-tenant service hosting
-- `find`, `wait`, OCR, accessibility trees, clipboard, window, or process tools
+- OCR, accessibility trees, clipboard, window, or process tools
 - implicit portal consent or automatic policy expansion
 - duplicate validation, policy, quota, or backend logic in the adapter
 - treating MCP tool annotations as an authorization boundary
@@ -82,7 +90,7 @@ merged and evaluated.
 
 ## Exit criteria
 
-- the four-tool protocol surface and stdio lifecycle are stable and documented
+- the focused protocol surface and stdio lifecycle are stable and documented
 - default startup cannot capture the desktop or inject input
 - execution requires an explicit policy plus explicit per-call execute intent
 - sensitive values and unclassified errors cannot cross the output boundary

--- a/docs/plan/agent-visual-conditions.md
+++ b/docs/plan/agent-visual-conditions.md
@@ -1,12 +1,13 @@
 # Safe Agent Visual Conditions Plan
 
-Status: Initial Go contract active in LAB-14
+Status: Go contract completed by LAB-14; MCP projection active in LAB-15
 
 Linear coordination:
 
 - Project: [`RobotGo | P004 | Safe Visual Conditions`](https://linear.app/riotbox/project/robotgo-or-p004-or-safe-visual-conditions-9eebd34245ff)
 - Project ID: `94e14e7f-81c0-4808-b932-a8211ece1b8b`
 - Issue: [`LAB-14 — Add bounded visual find and wait conditions`](https://linear.app/riotbox/issue/LAB-14/add-bounded-visual-find-and-wait-conditions)
+- Issue: [`LAB-15 — Expose safe visual find and wait through MCP`](https://linear.app/riotbox/issue/LAB-15/expose-safe-visual-find-and-wait-through-mcp)
 
 ## Outcome
 
@@ -46,10 +47,12 @@ requires the same capture/display limits and positive bounded wait settings.
 Both share `MaxQueries`; wait attempts additionally consume the existing
 `MaxObservations` budget.
 
-The local MCP adapter remains at its accepted four-tool boundary. It may report
-the new Go operations in the session catalog, but it does not yet expose
-`robotgo_find` or `robotgo_wait`. Protocol expansion is a later P004 slice
-after this API and its privacy/cleanup evidence are accepted.
+LAB-15 projects the accepted contract through `robotgo_find` and
+`robotgo_wait`; both delegate directly to these session methods. The adapter
+does not reimplement matching, capture, authorization, confirmation, quotas,
+audit, cancellation, or cleanup. `robotgo_release_observation` provides the
+explicit zero-and-remove boundary for a matched wait observation without
+requiring the client to close the whole session.
 
 ## Privacy and safety constraints
 
@@ -69,13 +72,13 @@ observations, bounded exhaustion, timeout, payload-free audit, audit failures,
 and source/retained-buffer cleanup. The opt-in agent capture integration path
 also exercises both operations without writing a desktop artifact.
 
-## Non-goals for LAB-14
+## Non-goals
 
 - OCR or accessibility-tree queries
 - bitmap/template files or caller-supplied screenshot persistence
 - implicit full-screen capture or unbounded polling
 - window/process conditions
-- MCP tool-surface expansion
+- semantic image matching or duplicated protocol-layer condition logic
 
 ## Exit criteria
 
@@ -85,3 +88,4 @@ also exercises both operations without writing a desktop artifact.
 - default, race, non-CGO, lint, vet, tagged capture, and integration compile
   gates pass
 - GitHub CI and configured review surfaces are green with no unresolved finding
+- the MCP projection exposes only sanitized results and deterministic release

--- a/docs/plan/agentic-desktop-automation.md
+++ b/docs/plan/agentic-desktop-automation.md
@@ -1,6 +1,6 @@
 # Agentic Desktop Automation Plan
 
-Status: Initial architecture proof and MCP adapter completed; visual-condition delivery active
+Status: Initial architecture proof completed; visual-condition MCP projection active
 
 Linear coordination:
 
@@ -145,11 +145,12 @@ orthogonal tool set:
 Add redacted record/replay, a fake driver, and hermetic evaluation tasks before
 claiming reliable autonomous behavior.
 
-The first adapter boundary is now tracked separately in the
-[Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md). Its initial
-LAB-13 slice intentionally exposes only capabilities, observe, act, and close;
-`find` and `wait` remain future semantic-grounding work rather than placeholders
-in the protocol.
+The adapter boundary is tracked separately in the
+[Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md). LAB-13
+established capabilities, observe, act, and close. After the Go condition
+contract was accepted in LAB-14, LAB-15 adds thin find, bounded wait, and
+explicit observation-release projections without moving policy or capture
+ownership into the protocol layer.
 
 ## 4. First executable slices
 
@@ -207,11 +208,12 @@ surface and non-goals.
 
 ### 4.4 Safe visual conditions
 
-Delivery status: active in LAB-14.
+Delivery status: Go contract completed by LAB-14; MCP projection active in LAB-15.
 
-The next Go-first slice adds color search over an explicit retained observation
-and bounded waiting over an explicit capture region. It adds no OCR,
-accessibility, file-backed template, or MCP tool. See the
+The Go-first slice adds color search over an explicit retained observation and
+bounded waiting over an explicit capture region. Its follow-up exposes only a
+thin local MCP projection plus deterministic observation release. Neither
+slice adds OCR, accessibility, or file-backed templates. See the
 [Safe Agent Visual Conditions Plan](agent-visual-conditions.md) for its policy,
 privacy, cleanup, and validation contract.
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -47,8 +47,9 @@ reliability hardening; protected real-desktop evidence remains runner-dependent.
 The completed [Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md)
 provides a local, policy-gated MCP boundary on the agent-session proof. The
 adjacent [Safe Agent Visual Conditions Plan](agent-visual-conditions.md) now
-builds bounded `find` and `wait` semantics in Go before protocol expansion;
-neither effort broadens platform backend support or replaces phase exit gates.
+has accepted bounded `find` and `wait` semantics in Go and is adding a thin
+privacy-preserving MCP projection; neither effort broadens platform backend
+support or replaces phase exit gates.
 
 ## Delivery Order
 


### PR DESCRIPTION
## Goal

Expose the accepted LAB-14 visual-condition contract through the local MCP adapter without moving policy, capture, matching, ownership, or cleanup logic into the protocol layer.

Linear: [LAB-15](https://linear.app/riotbox/issue/LAB-15/expose-safe-visual-find-and-wait-through-mcp)

## Changes

- add `robotgo_find` for explicit live observations
- add policy-bounded `robotgo_wait` for explicit regions
- add idempotent `robotgo_release_observation` for deterministic in-memory zeroing
- preserve the original exported `mcpserver.Session` interface and conditionally expose the additive `VisualConditionSession` surface
- project only sanitized condition results and structured errors; target RGB/tolerance, pixels, digests, and raw backend errors remain private
- add official-SDK in-memory protocol tests for match/no-match, partial errors, release after success/error, schema rejection, cancellation, annotations, close behavior, legacy compatibility, and serialized redaction
- update README, TEST, and agent roadmap/plan documentation with the seven-tool flow and bounded policy example

## Safety and behavior

Find never performs implicit capture. Wait uses the immutable session policy for attempts, interval, timeout, display, query, observation, pixel, confirmation, and audit limits. A matched observation remains session-owned only until explicit release or session close. No test contacts a real desktop or persists protocol, image, clipboard, OCR, or other sensitive data.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./agent/mcpserver ./cmd/robotgo-mcp`
- `go test -race -tags wayland ./agent ./agent/mcpserver`
- `go test -tags integration ./agent -run '^$'`
- `go vet ./...`
- `golangci-lint run --timeout=5m ./...`
- 20 repeated race-enabled MCP protocol runs
- Windows amd64 and macOS arm64 non-CGO cross-builds

## Review focus

Please focus on the MCP privacy projection, matched-observation cleanup on both success and partial-error paths, cancellation/close behavior, and source compatibility for existing custom `mcpserver.Session` implementations.