### PR TITLE
test: acknowledge Windows paste delivery

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -292,7 +292,11 @@ The environment variable is an explicit local safety gate because the test
 temporarily changes the text clipboard; it restores the previous readable text
 value during cleanup and verifies the restoration without logging clipboard
 contents. CI repeats this test three times as a blocking Windows non-CGO check
-so focus recovery and cleanup are exercised across independent runs.
+so focus recovery, missing EDIT-control delivery acknowledgement, and cleanup
+are exercised across independent runs. A failed paste is retried at most once,
+and only after the owned window reports either focus loss or no `EN_CHANGE`
+acknowledgement at all. Any unexpected edit mutation and every persistent
+delivery failure remain blocking.
 
 Opt-in macOS runtime capture benchmark:
 

--- a/windows_paste_recovery_test.go
+++ b/windows_paste_recovery_test.go
@@ -11,11 +11,50 @@ const (
 		windowsIntegrationStatusEditFocused
 )
 
+type windowsPasteRecoveryReason uint8
+
+const (
+	windowsPasteRecoveryNone windowsPasteRecoveryReason = iota
+	windowsPasteRecoveryFocusLoss
+	windowsPasteRecoveryNoEditAcknowledgement
+)
+
+func (reason windowsPasteRecoveryReason) String() string {
+	switch reason {
+	case windowsPasteRecoveryFocusLoss:
+		return "focus_loss"
+	case windowsPasteRecoveryNoEditAcknowledgement:
+		return "no_edit_acknowledgement"
+	default:
+		return "none"
+	}
+}
+
 func windowsPasteFocusLossObserved(status, currentEvents, baselineEvents uintptr) bool {
 	return status != windowsIntegrationStatusReady || currentEvents > baselineEvents
 }
 
 func windowsPasteFocusLossDelta(currentEvents, baselineEvents uintptr) uintptr {
+	if currentEvents <= baselineEvents {
+		return 0
+	}
+	return currentEvents - baselineEvents
+}
+
+func windowsPasteRecoveryFor(
+	status, currentFocusEvents, baselineFocusEvents,
+	currentEditChanges, baselineEditChanges uintptr,
+) windowsPasteRecoveryReason {
+	if currentEditChanges > baselineEditChanges {
+		return windowsPasteRecoveryNone
+	}
+	if windowsPasteFocusLossObserved(status, currentFocusEvents, baselineFocusEvents) {
+		return windowsPasteRecoveryFocusLoss
+	}
+	return windowsPasteRecoveryNoEditAcknowledgement
+}
+
+func windowsPasteEditChangeDelta(currentEvents, baselineEvents uintptr) uintptr {
 	if currentEvents <= baselineEvents {
 		return 0
 	}
@@ -74,6 +113,85 @@ func TestWindowsPasteRecoveryRequiresObservedFocusLoss(t *testing.T) {
 			}
 			if got := windowsPasteFocusLossDelta(test.currentEvents, test.baseline); got != test.wantDelta {
 				t.Fatalf("windowsPasteFocusLossDelta() = %d, want %d", got, test.wantDelta)
+			}
+		})
+	}
+}
+
+func TestWindowsPasteRecoveryRequiresObservableTransient(t *testing.T) {
+	tests := []struct {
+		name                string
+		status              uintptr
+		currentFocusEvents  uintptr
+		baselineFocusEvents uintptr
+		currentEditChanges  uintptr
+		baselineEditChanges uintptr
+		want                windowsPasteRecoveryReason
+		wantEditChangeDelta uintptr
+	}{
+		{
+			name:                "focus loss without edit acknowledgement remains recoverable",
+			status:              windowsIntegrationStatusForeground,
+			currentFocusEvents:  2,
+			baselineFocusEvents: 1,
+			currentEditChanges:  4,
+			baselineEditChanges: 4,
+			want:                windowsPasteRecoveryFocusLoss,
+		},
+		{
+			name:                "focus loss does not excuse unexpected edit mutation",
+			status:              windowsIntegrationStatusForeground,
+			currentFocusEvents:  2,
+			baselineFocusEvents: 1,
+			currentEditChanges:  5,
+			baselineEditChanges: 4,
+			want:                windowsPasteRecoveryNone,
+			wantEditChangeDelta: 1,
+		},
+		{
+			name:                "stable target without edit acknowledgement",
+			status:              windowsIntegrationStatusReady,
+			currentFocusEvents:  3,
+			baselineFocusEvents: 3,
+			currentEditChanges:  7,
+			baselineEditChanges: 7,
+			want:                windowsPasteRecoveryNoEditAcknowledgement,
+		},
+		{
+			name:                "counter rollback is not an acknowledgement",
+			status:              windowsIntegrationStatusReady,
+			currentFocusEvents:  3,
+			baselineFocusEvents: 3,
+			currentEditChanges:  6,
+			baselineEditChanges: 7,
+			want:                windowsPasteRecoveryNoEditAcknowledgement,
+		},
+		{
+			name:                "unexpected edit mutation is not retried",
+			status:              windowsIntegrationStatusReady,
+			currentFocusEvents:  3,
+			baselineFocusEvents: 3,
+			currentEditChanges:  8,
+			baselineEditChanges: 7,
+			want:                windowsPasteRecoveryNone,
+			wantEditChangeDelta: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := windowsPasteRecoveryFor(
+				test.status,
+				test.currentFocusEvents,
+				test.baselineFocusEvents,
+				test.currentEditChanges,
+				test.baselineEditChanges,
+			)
+			if got != test.want {
+				t.Fatalf("windowsPasteRecoveryFor() = %s, want %s", got, test.want)
+			}
+			if got := windowsPasteEditChangeDelta(test.currentEditChanges, test.baselineEditChanges); got != test.wantEditChangeDelta {
+				t.Fatalf("windowsPasteEditChangeDelta() = %d, want %d", got, test.wantEditChangeDelta)
 			}
 		})
 	}

--- a/windows_window_integration_test.go
+++ b/windows_window_integration_test.go
@@ -19,9 +19,10 @@ import (
 const envRequireWindowsWindowIntegration = "ROBOTGO_REQUIRE_WINDOWS_WINDOW_INTEGRATION"
 
 const (
-	windowsIntegrationFocusEditMessage      = win.WM_USER + 1
-	windowsIntegrationQueryStatusMessage    = win.WM_USER + 2
-	windowsIntegrationQueryFocusLossMessage = win.WM_USER + 3
+	windowsIntegrationFocusEditMessage       = win.WM_USER + 1
+	windowsIntegrationQueryStatusMessage     = win.WM_USER + 2
+	windowsIntegrationQueryFocusLossMessage  = win.WM_USER + 3
+	windowsIntegrationQueryEditChangeMessage = win.WM_USER + 4
 
 	windowsIntegrationConditionTimeout = 3 * time.Second
 	windowsIntegrationMessageTimeout   = 3 * time.Second
@@ -212,6 +213,7 @@ func startWindowsIntegrationWindow(t *testing.T) (win.HWND, win.HWND, <-chan err
 		}
 		var editHandle win.HWND
 		var focusLossEvents uintptr
+		var editChangeEvents uintptr
 		windowProc := syscall.NewCallback(func(handle uintptr, message uint32, wParam, lParam uintptr) uintptr {
 			switch message {
 			case windowsIntegrationFocusEditMessage:
@@ -228,14 +230,20 @@ func startWindowsIntegrationWindow(t *testing.T) (win.HWND, win.HWND, <-chan err
 				return status
 			case windowsIntegrationQueryFocusLossMessage:
 				return focusLossEvents
+			case windowsIntegrationQueryEditChangeMessage:
+				return editChangeEvents
 			case win.WM_ACTIVATE:
 				if win.LOWORD(uint32(wParam)) == uint16(win.WA_INACTIVE) {
 					focusLossEvents++
 				}
 			case win.WM_COMMAND:
-				if win.HWND(lParam) == editHandle &&
-					win.HIWORD(uint32(wParam)) == uint16(win.EN_KILLFOCUS) {
-					focusLossEvents++
+				if win.HWND(lParam) == editHandle {
+					switch win.HIWORD(uint32(wParam)) {
+					case uint16(win.EN_KILLFOCUS):
+						focusLossEvents++
+					case uint16(win.EN_CHANGE):
+						editChangeEvents++
+					}
 				}
 			case win.WM_DESTROY:
 				win.PostQuitMessage(0)
@@ -381,15 +389,30 @@ func exerciseWindowsPaste(t *testing.T, handle, editHandle win.HWND, text string
 	if !first.clipboardPublished {
 		t.Fatal("PasteStr returned success but its text was not present on the clipboard")
 	}
-	if !windowsPasteFocusLossObserved(first.status, first.focusLossEvents, first.focusLossBaseline) {
-		t.Fatal("PasteStr published the clipboard text and retained foreground/edit focus, but Ctrl+V was not delivered")
+	recovery := windowsPasteRecoveryFor(
+		first.status,
+		first.focusLossEvents,
+		first.focusLossBaseline,
+		first.editChangeEvents,
+		first.editChangeBaseline,
+	)
+	if recovery == windowsPasteRecoveryNone {
+		t.Fatalf(
+			"PasteStr changed the owned edit without delivering the expected fixture; refusing recovery: foreground=%t edit_focused=%t focus_loss_events=%d edit_change_events=%d",
+			first.status&windowsIntegrationStatusForeground != 0,
+			first.status&windowsIntegrationStatusEditFocused != 0,
+			windowsPasteFocusLossDelta(first.focusLossEvents, first.focusLossBaseline),
+			windowsPasteEditChangeDelta(first.editChangeEvents, first.editChangeBaseline),
+		)
 	}
 
 	t.Logf(
-		"retrying PasteStr once after observed focus loss: foreground=%t edit_focused=%t focus_loss_events=%d",
+		"retrying PasteStr once after observed transient: reason=%s foreground=%t edit_focused=%t focus_loss_events=%d edit_change_events=%d",
+		recovery,
 		first.status&windowsIntegrationStatusForeground != 0,
 		first.status&windowsIntegrationStatusEditFocused != 0,
 		windowsPasteFocusLossDelta(first.focusLossEvents, first.focusLossBaseline),
+		windowsPasteEditChangeDelta(first.editChangeEvents, first.editChangeBaseline),
 	)
 	empty, err := syscall.UTF16PtrFromString("")
 	if err != nil {
@@ -408,11 +431,12 @@ func exerciseWindowsPaste(t *testing.T, handle, editHandle win.HWND, text string
 	}
 
 	t.Fatalf(
-		"PasteStr delivery failed after one focus-loss recovery: clipboard_published=%t foreground=%t edit_focused=%t focus_loss_events=%d",
+		"PasteStr delivery failed after one bounded recovery: clipboard_published=%t foreground=%t edit_focused=%t focus_loss_events=%d edit_change_events=%d",
 		retry.clipboardPublished,
 		retry.status&windowsIntegrationStatusForeground != 0,
 		retry.status&windowsIntegrationStatusEditFocused != 0,
 		windowsPasteFocusLossDelta(retry.focusLossEvents, retry.focusLossBaseline),
+		windowsPasteEditChangeDelta(retry.editChangeEvents, retry.editChangeBaseline),
 	)
 }
 
@@ -422,6 +446,8 @@ type windowsPasteAttemptResult struct {
 	status             uintptr
 	focusLossEvents    uintptr
 	focusLossBaseline  uintptr
+	editChangeEvents   uintptr
+	editChangeBaseline uintptr
 }
 
 func runWindowsPasteAttempt(
@@ -433,6 +459,7 @@ func runWindowsPasteAttempt(
 	result := windowsPasteAttemptResult{
 		focusLossBaseline: prepareWindowsPasteTarget(t, handle, editHandle),
 	}
+	result.editChangeBaseline = queryWindowsIntegrationEditChanges(t, handle)
 	if err := PasteStr(text); err != nil {
 		return result, err
 	}
@@ -449,6 +476,7 @@ func runWindowsPasteAttempt(
 	}
 	result.status = queryWindowsIntegrationStatus(t, handle)
 	result.focusLossEvents = queryWindowsIntegrationFocusLosses(t, handle)
+	result.editChangeEvents = queryWindowsIntegrationEditChanges(t, handle)
 	return result, nil
 }
 
@@ -484,6 +512,11 @@ func queryWindowsIntegrationStatus(t *testing.T, handle win.HWND) uintptr {
 func queryWindowsIntegrationFocusLosses(t *testing.T, handle win.HWND) uintptr {
 	t.Helper()
 	return sendWindowsIntegrationMessage(t, handle, windowsIntegrationQueryFocusLossMessage)
+}
+
+func queryWindowsIntegrationEditChanges(t *testing.T, handle win.HWND) uintptr {
+	t.Helper()
+	return sendWindowsIntegrationMessage(t, handle, windowsIntegrationQueryEditChangeMessage)
 }
 
 func sendWindowsIntegrationMessage(t *testing.T, handle win.HWND, message uint32) uintptr {


### PR DESCRIPTION
## Result

Hardens the blocking Pure-Go Windows owned-window integration evidence after repeated GitHub-hosted runner flakes where `PasteStr` successfully published the clipboard text and retained foreground/edit focus, but the injected `Ctrl+V` produced no control mutation.

Closes [LAB-3](https://linear.app/riotbox/issue/LAB-3/harden-windows-clipboard-integration-timing).

## Changes

- counts `EN_CHANGE` notifications from the self-owned Win32 EDIT control for each real public `PasteStr` attempt
- distinguishes focus loss, zero delivery acknowledgement, clipboard publication failure, unexpected edit mutation, and persistent delivery failure without logging clipboard contents
- permits exactly one recovery only when the first attempt has no edit acknowledgement; focus-loss recovery remains bounded by the same rule
- refuses recovery whenever the EDIT control changed to anything other than the fixed expected fixture, even if focus was also lost
- adds hermetic classification tests and documents the strengthened Windows runtime evidence

## Contract and risk

Production RobotGo code and public APIs are unchanged. The integration test still exercises the real clipboard and `SendInput` path against a self-owned EDIT control. There is no fixed production sleep and no unbounded retry. A second failure remains blocking. Previously readable clipboard text is still restored through `t.Cleanup`, verified without content logging, and no screenshot or temporary diagnostic artifact is created.

## Local validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go vet ./...`
- `golangci-lint run --timeout=5m ./...` (`0 issues`)
- Windows amd64 non-CGO default test binary cross-build
- Windows amd64 non-CGO `windowsintegration` test binary cross-build
- `git diff --check`

Real Windows runtime validation is intentionally delegated to the blocking Windows GitHub Actions job, which executes the self-owned `PasteStr` test three times.