### PR TITLE
docs: add protected compositor evidence plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,11 +1083,14 @@ Real Wayland input results are tracked in the
 - [Product roadmap](docs/plan/product-roadmap.md)
 - [Wayland implementation history](docs/wayland-history.md)
 
-The active product slice is Phase 5 reliability hardening. Runtime Diagnostics
+The bounded P002 reliability-hardening project is complete: Runtime Diagnostics
 v1, native sanitizer/leak gates, and a six-cell release-evidence workflow make
 support claims machine-readable and tied to exact source, test logs, and build
-identity. Published releases receive a checksummed evidence bundle. The
-remaining infrastructure blocker is protected real GNOME/KDE/wlroots evidence.
+identity. Published releases receive a checksummed evidence bundle. The active
+slice is now the
+[Protected Real-Compositor Evidence Plan](docs/plan/real-compositor-evidence.md),
+which closes shared GNOME/KDE/wlroots evidence gaps across roadmap phases 1, 2,
+3, and 5; those phases remain partial until their protected gates are green.
 Phase 4 already exposes the parity surface; Hyprland provides trustworthy
 active-window maximize query, set, and restore with provider-aware dispatch for
 legacy `hyprlang` and 0.55+ Lua configurations, while Sway and generic wlroots

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,9 @@ Use the following documents as the primary entry points:
   pull requests, CI, reviewer feedback, merges, and cleanup.
 - [Test guide](../TEST.md) for validation commands and runtime prerequisites.
 - [Product roadmap](plan/product-roadmap.md) for delivery phases.
+- [Protected real-compositor evidence plan](plan/real-compositor-evidence.md)
+  for ephemeral GNOME, KDE, and wlroots runner contracts, sanitized manifests,
+  real portal consent, and protected runtime gates.
 - [Agentic desktop automation plan](plan/agentic-desktop-automation.md) for the
   session, policy, observe-act-verify, and adapter architecture.
 - [Agent adapter and evaluation plan](plan/agent-adapter-evaluation.md) for the

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -42,8 +42,10 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
-an infrastructure blocker. The active implementation slice is Phase 5
-reliability hardening; protected real-desktop evidence remains runner-dependent.
+an infrastructure blocker. Cross-platform reliability hardening is complete;
+the active [Protected Real-Compositor Evidence Plan](real-compositor-evidence.md)
+now addresses the shared GNOME/KDE/wlroots runner-dependent exit gates across
+phases 1, 2, 3, and 5.
 The completed [Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md)
 provides a local, policy-gated MCP boundary on the agent-session proof. The
 adjacent [Safe Agent Visual Conditions Plan](agent-visual-conditions.md) now

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -42,9 +42,10 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
-an infrastructure blocker. Cross-platform reliability hardening is complete;
-the active [Protected Real-Compositor Evidence Plan](real-compositor-evidence.md)
-now addresses the shared GNOME/KDE/wlroots runner-dependent exit gates across
+an infrastructure blocker. The bounded cross-platform reliability-hardening
+project P002 is complete, while roadmap Phase 5 remains partial. The active
+[Protected Real-Compositor Evidence Plan](real-compositor-evidence.md) now
+addresses the shared GNOME/KDE/wlroots runner-dependent exit gates across
 phases 1, 2, 3, and 5.
 The completed [Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md)
 provides a local, policy-gated MCP boundary on the agent-session proof. The

--- a/docs/plan/real-compositor-evidence.md
+++ b/docs/plan/real-compositor-evidence.md
@@ -19,12 +19,14 @@ not actually demonstrate.
 
 ## Trust and runner model
 
-Each matrix job uses a clean, ephemeral Linux runner that accepts one job and
-is destroyed afterward. Persistent personal desktop sessions are not eligible.
-Runner groups and labels are restricted to this repository, and runner
-registration credentials remain outside the repository and workflow logs.
+The P005 target design requires every matrix job to use a clean, ephemeral
+Linux runner that accepts one job and is destroyed afterward. Persistent
+personal desktop sessions are not eligible. Runner groups and labels must be
+restricted to this repository, and runner registration credentials must remain
+outside the repository and workflow logs.
 
-The protected workflows retain these boundaries:
+Before the protected workflows are enabled, their implementation must enforce
+these boundaries:
 
 - trusted repository refs only; fork pull requests never run on these runners,
   and same-repository pull requests require explicit maintainer/Environment
@@ -40,9 +42,9 @@ The protected workflows retain these boundaries:
 - complete VM/session destruction after success, failure, timeout, or
   cancellation
 
-The workflows never use `pull_request_target` to check out and execute pull
-request code. Approval makes the reviewed commit eligible for an isolated
-runner; repository origin alone is not a trust decision.
+The implemented workflows must never use `pull_request_target` to check out and
+execute pull request code. Approval makes the reviewed commit eligible for an
+isolated runner; repository origin alone is not a trust decision.
 
 GitHub recommends ephemeral runners for autoscaling because one job is assigned
 before automatic deregistration. Runner logs must be retained externally, and

--- a/docs/plan/real-compositor-evidence.md
+++ b/docs/plan/real-compositor-evidence.md
@@ -8,10 +8,12 @@ Linear project:
 ## Outcome
 
 Turn RobotGo's implemented GNOME, KDE Plasma, and wlroots Wayland paths into
-reproducible, protected runtime evidence. A passing matrix cell must exercise
-the real compositor, portal backend, PipeWire service, and RobotGo integration
-harness. Missing infrastructure, skipped tests, mock services, or absent user
-consent are never runtime passes.
+reproducible, protected runtime evidence. Every passing matrix cell must
+exercise the real compositor and RobotGo integration harness. Portal cells must
+also exercise the real desktop portal backend, ScreenCast cells must exercise
+PipeWire, and wlroots-native cells must exercise their selected native
+protocols. Missing applicable infrastructure, skipped tests, mock services, or
+required but absent user consent are never runtime passes.
 
 This project closes evidence gaps shared by roadmap phases 1, 2, 3, and 5. It
 does not add new public APIs or claim compositor behavior that the runtime did

--- a/docs/plan/real-compositor-evidence.md
+++ b/docs/plan/real-compositor-evidence.md
@@ -80,8 +80,36 @@ Each session starts before runner registration and provides:
   unrelated application state
 
 Portal consent remains real. The workflow does not patch the backend to
-auto-approve requests and does not persist restore tokens between jobs. The
-protected Environment tells an operator when interactive approval is required.
+auto-approve requests and does not persist restore tokens between jobs.
+
+### Operator consent handoff
+
+Environment approval authorizes provisioning but does not satisfy a portal
+dialog. Before a GNOME or KDE portal cell can be promoted, the runner
+orchestrator must provide this out-of-band handoff:
+
+1. Provisioning creates a per-job graphical console in the infrastructure
+   control plane and places the job in a private operator queue. The console is
+   never exposed as a public runner port, and its access credential is never
+   passed to repository code or GitHub logs.
+2. A maintainer authenticated to the control plane with SSO and MFA opens the
+   console from that queue. The console shows only the fixed, disposable test
+   desktop; recording, clipboard synchronization, and file transfer are
+   disabled.
+3. The orchestrator signals console readiness before the harness makes the
+   portal request. The operator verifies the requested RemoteDesktop or
+   ScreenCast device type and accepts the real desktop dialog within a bounded
+   120-second consent window.
+4. Missing readiness, rejection, disconnect, or timeout fails the cell. The
+   workflow must not convert it to a skip or retry it with automatic consent.
+5. The orchestrator revokes console access immediately after the final dialog
+   or timeout and destroys the runner on every completion path. Audit records
+   contain operator identity, job identifier, timestamps, and outcome only;
+   they contain no console frames or desktop content.
+
+This handoff must be proven operational for the lane before its portal cells
+become required. GitHub Environment instructions may link to the private
+operator queue, but Environment approval is never reported as portal consent.
 
 ## Shared fail-closed preflight
 
@@ -96,7 +124,8 @@ before RobotGo reads frames or injects input:
 5. PipeWire development/runtime availability for persistent capture
 6. lane-specific native tools and capabilities used by window/input evidence
 7. declared output count and multi-output requirement for geometry cells
-8. writable runner-temporary evidence directory with cleanup registered
+8. operator-console readiness for interactive GNOME/KDE portal cells
+9. writable runner-temporary evidence directory with cleanup registered
 
 The preflight returns a non-zero status for missing or mismatched requirements.
 It distinguishes unavailable infrastructure from a RobotGo test failure, but

--- a/docs/plan/real-compositor-evidence.md
+++ b/docs/plan/real-compositor-evidence.md
@@ -1,0 +1,228 @@
+# Protected Real-Compositor Evidence Plan
+
+Status: Accepted direction; runner-contract implementation is next
+
+Linear project:
+[RobotGo | P005 | Protected Compositor Evidence](https://linear.app/riotbox/project/robotgo-or-p005-or-protected-compositor-evidence-d66467e3b5ee)
+
+## Outcome
+
+Turn RobotGo's implemented GNOME, KDE Plasma, and wlroots Wayland paths into
+reproducible, protected runtime evidence. A passing matrix cell must exercise
+the real compositor, portal backend, PipeWire service, and RobotGo integration
+harness. Missing infrastructure, skipped tests, mock services, or absent user
+consent are never runtime passes.
+
+This project closes evidence gaps shared by roadmap phases 1, 2, 3, and 5. It
+does not add new public APIs or claim compositor behavior that the runtime did
+not actually demonstrate.
+
+## Trust and runner model
+
+Each matrix job uses a clean, ephemeral Linux runner that accepts one job and
+is destroyed afterward. Persistent personal desktop sessions are not eligible.
+Runner groups and labels are restricted to this repository, and runner
+registration credentials remain outside the repository and workflow logs.
+
+The protected workflows retain these boundaries:
+
+- trusted repository refs only; fork pull requests never run on these runners,
+  and same-repository pull requests require explicit maintainer/Environment
+  approval of the exact head commit
+- read-only GitHub permissions and checkout credentials disabled
+- a protected GitHub Environment with a maintainer approval boundary
+- no long-lived repository, cloud, or personal credentials inside the desktop
+  session; the unavoidable job-scoped `GITHUB_TOKEN` remains read-only
+- outbound network access limited to GitHub endpoints and pinned package/image
+  sources required to run the job
+- runner application and system logs forwarded outside the disposable VM for
+  infrastructure diagnosis, without captured desktop content
+- complete VM/session destruction after success, failure, timeout, or
+  cancellation
+
+The workflows never use `pull_request_target` to check out and execute pull
+request code. Approval makes the reviewed commit eligible for an isolated
+runner; repository origin alone is not a trust decision.
+
+GitHub recommends ephemeral runners for autoscaling because one job is assigned
+before automatic deregistration. Runner logs must be retained externally, and
+runner images must stay within GitHub's supported update window. The normative
+platform reference is the
+[GitHub self-hosted runner documentation](https://docs.github.com/en/actions/reference/runners/self-hosted-runners).
+
+## Desktop image contract
+
+P005 maintains three independently versioned images or VM definitions:
+
+| Lane | Required session | Primary evidence |
+|---|---|---|
+| GNOME | Mutter Wayland plus `xdg-desktop-portal-gnome` | RemoteDesktop, persistent ScreenCast, output geometry |
+| KDE | KWin Wayland plus `xdg-desktop-portal-kde` | RemoteDesktop, persistent ScreenCast, output geometry |
+| wlroots | Sway first, with the matching portal backend where available | Native input/window behavior, output geometry, explicit portal availability |
+
+Images pin the operating-system release and package source. The evidence
+manifest records exact installed versions, so an image may be rebuilt for
+security updates without pretending that it is the previous runtime. Software
+rendering is acceptable when the compositor and PipeWire path behave normally;
+a mock compositor or portal backend is not.
+
+Each session starts before runner registration and provides:
+
+- a real Wayland socket and user D-Bus session
+- the expected compositor and `XDG_CURRENT_DESKTOP`
+- `xdg-desktop-portal` plus the desktop-specific backend
+- a running PipeWire/WirePlumber user session for ScreenCast cells
+- an operator-visible consent surface for portal cells
+- a deterministic test application/window and declared output topology; the
+  desktop image contains no personal files, accounts, browser sessions, or
+  unrelated application state
+
+Portal consent remains real. The workflow does not patch the backend to
+auto-approve requests and does not persist restore tokens between jobs. The
+protected Environment tells an operator when interactive approval is required.
+
+## Shared fail-closed preflight
+
+The first implementation slice replaces duplicated shell probes in the two E2E
+workflows with one repository-owned command. It validates all prerequisites
+before RobotGo reads frames or injects input:
+
+1. expected lane and desktop/compositor identity
+2. live Wayland socket under `XDG_RUNTIME_DIR`, without printing its address
+3. live user session bus and `org.freedesktop.portal.Desktop` owner
+4. required RemoteDesktop and/or ScreenCast interfaces and advertised versions
+5. PipeWire development/runtime availability for persistent capture
+6. lane-specific native tools and capabilities used by window/input evidence
+7. declared output count and multi-output requirement for geometry cells
+8. writable runner-temporary evidence directory with cleanup registered
+
+The preflight returns a non-zero status for missing or mismatched requirements.
+It distinguishes unavailable infrastructure from a RobotGo test failure, but
+both block the matrix cell. It never converts either result into a successful
+skip.
+
+Hermetic tests cover desktop matching, required capability selection, malformed
+probe output, command failure, sanitization, bounded execution, and partial-file
+cleanup. Tests use fixed fixtures and `t.TempDir`; they never inspect the
+developer's live desktop, portal, or display environment.
+
+## Versioned evidence manifest
+
+Every cell uploads a schema-versioned manifest and test log. Allowed manifest
+fields are deliberately narrow:
+
+- schema version, UTC timestamp, exact Git commit and workflow/run identity
+- operating-system ID/version, kernel name/release, architecture, Go version
+- desktop lane, compositor name/version, portal frontend/backend package
+  versions, PipeWire version, and advertised portal interface versions
+- renderer class (`hardware` or `software`) without device serials
+- sanitized output count and geometry/scale/transform values required by the
+  assertion
+- exact test command, outcome category, duration, and SHA-256 of the test log
+
+The manifest and logs must not contain screenshots, frame pixels, window
+titles, clipboard contents, injected text, restore tokens, PipeWire node IDs,
+portal handles, display/socket addresses, hostnames, usernames, home paths,
+runner registration tokens, environment dumps, or credentials. Captured frames
+stay in memory and are released before session teardown.
+
+Before artifact upload, a repository-owned validator checks the manifest schema,
+required commit binding, allowed fields, and a denylist over both manifest and
+test log. Validation failure blocks the cell and suppresses the unsafe artifact;
+infrastructure-only diagnosis then uses the separately protected runner logs.
+Manifest creation is transactional so a cancellation cannot promote a partial
+file as evidence. Workflows capture raw runtime output only inside the
+disposable runner; they do not stream it through `tee` into GitHub logs before
+validation. After validation they publish a bounded sanitized summary plus the
+approved evidence files.
+
+## Runtime evidence matrix
+
+### wlroots first proof
+
+Sway is the first protected lane because RobotGo already has native
+virtual-input, screencopy, output, and compositor-window integration harnesses.
+The proof includes:
+
+- native pointer and keyboard round trips with deterministic release
+- Sway title/close and supported state operations against a self-owned window
+- single- and multi-output bounds with scale/transform coverage
+- native screencopy selection and buffer cleanup
+- explicit RemoteDesktop/ScreenCast portal availability or unsupported result
+
+Input is injected only into the isolated fixture session. Tests restore pointer,
+key, button, window, and output state on success and through registered failure,
+timeout, and cancellation cleanup paths.
+
+An unavailable wlroots RemoteDesktop backend is valid capability evidence, not
+a portal pass.
+
+### GNOME and KDE portal proof
+
+Each lane runs the lower-level RemoteDesktop harness directly so a different
+native backend cannot satisfy the test. It validates granted device types,
+relative and absolute pointer input, keyboard modifier release, optional touch,
+stream mapping, and deterministic session close.
+
+The ScreenCast cell opens one real consent session, obtains two non-empty frames
+from the same PipeWire stream, validates geometry and ownership, releases all
+buffers/file descriptors, and closes PipeWire before the portal session. The
+contracts follow the official
+[RemoteDesktop](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html)
+and
+[ScreenCast](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html)
+interfaces.
+
+### Promotion to protected evidence
+
+A lane moves from `pending` to `pass` in the compatibility matrices only when:
+
+- its pinned runner definition is reviewable and reproducible
+- preflight and every selected real-runtime test pass without skips
+- cleanup assertions pass on success and deliberately induced failure
+- the sanitized manifest and log checksum are retained
+- the evidence applies to the exact commit recorded by the manifest
+
+The release-evidence workflow must require the promoted compositor checks for
+the exact release commit. PR branch protection may require them only after the
+runner capacity and consent process can reliably service every trusted PR;
+until then, absence remains visible and release-blocking rather than reported as
+green.
+
+## Ordered delivery slices
+
+1. Implement the shared preflight, schema-v1 manifest, hermetic tests, and both
+   workflow integrations.
+2. Provision and prove the ephemeral Sway/wlroots image and promote its native
+   rows.
+3. Provision and prove GNOME RemoteDesktop and ScreenCast.
+4. Provision and prove KDE RemoteDesktop and ScreenCast.
+5. Add promoted checks to release evidence and, when operationally reliable,
+   branch protection; update the versioned compatibility matrices.
+
+Create Linear issues only when the next slice has concrete runner ownership and
+acceptance evidence. Do not create speculative implementation tickets for
+unfunded or unavailable infrastructure.
+
+## Exit criteria
+
+P005 is complete only when:
+
+- GNOME, KDE, and wlroots runner definitions are reproducible and ephemeral
+- every configured job fails closed on missing infrastructure or consent
+- real RemoteDesktop and ScreenCast pass on GNOME and KDE
+- wlroots native input, capture, output, and supported window behavior pass
+- multi-output geometry evidence exists for all three lanes
+- manifests are schema-validated, sanitized, checksummed, and commit-bound
+- failure, cancellation, and timeout paths leave no private desktop artifacts
+- promoted checks block release evidence for the exact commit
+- `docs/compatibility/wayland-input.md`, `wayland-capture.md`, and
+  `runtime-v1.md` link the retained evidence
+
+## Non-goals
+
+- Running untrusted fork code on self-hosted infrastructure
+- Replacing real portal consent with an auto-accepting mock
+- Treating Weston, compile-only, or hermetic portal tests as GNOME/KDE evidence
+- Persisting captured frames, clipboard data, input payloads, or restore tokens
+- Claiming unsupported compositor-wide window control through Wayland core


### PR DESCRIPTION
## Result

Creates the durable technical plan for [RobotGo P005 — Protected Compositor Evidence](https://linear.app/riotbox/project/robotgo-or-p005-or-protected-compositor-evidence-d66467e3b5ee) and makes it the active runner-dependent roadmap slice.

## Plan contract

- ephemeral single-job GNOME, KDE Plasma, and wlroots runners instead of persistent personal desktops
- exact-head maintainer/Environment approval, fork exclusion, read-only permissions, and no `pull_request_target` execution of PR code
- pinned desktop images and real compositor/portal/PipeWire behavior; mocks, skips, missing consent, and unavailable runners never become passes
- a shared fail-closed runner preflight as the first implementation slice
- schema-versioned, commit-bound, checksummed evidence with a strict field allowlist and sensitive-data denylist
- raw runtime output retained only inside the disposable runner until validation; no pre-validation `tee` into GitHub logs
- real portal consent without auto-approval or persisted restore tokens
- ordered promotion from wlroots proof through GNOME/KDE portal proof to protected release evidence

## Repository impact

Documentation only. No production API, backend, workflow, test, or branch-protection behavior changes in this PR. Implementation begins in a separate LAB issue after this plan is accepted.

## Validation

- `go test ./...`
- `git diff --check`
- structured review of runner trust, job-scoped credentials, consent, artifact privacy, cleanup, and release-gate feasibility