### PR TITLE
feat: add protected compositor evidence contract

### DIFF
--- a/.github/workflows/remote-desktop-e2e.yml
+++ b/.github/workflows/remote-desktop-e2e.yml
@@ -25,51 +25,102 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        desktop: [gnome, kde, wlroots]
+        desktop: [gnome, kde]
     runs-on: [self-hosted, linux, wayland, "${{ matrix.desktop }}"]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
-      - name: Verify interactive Wayland session
+      - name: Run protected runner preflight
+        env:
+          ROBOTGO_APPROVED_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         shell: bash
         run: |
-          test -n "$WAYLAND_DISPLAY"
-          test -n "$DBUS_SESSION_BUS_ADDRESS"
-          test -n "$XDG_CURRENT_DESKTOP"
-          desktop="${XDG_CURRENT_DESKTOP,,}"
-          case "${{ matrix.desktop }}:$desktop" in
-            gnome:*gnome*|kde:*kde*|kde:*plasma*) ;;
-            wlroots:*sway*|wlroots:*hyprland*|wlroots:*wayfire*|wlroots:*river*|wlroots:*labwc*|wlroots:*dwl*|wlroots:*gamescope*) ;;
-            *) echo "runner desktop '$XDG_CURRENT_DESKTOP' does not match label '${{ matrix.desktop }}'" >&2; exit 1 ;;
-          esac
+          set -euo pipefail
+          umask 077
+          : "${ROBOTGO_COMPOSITOR_OUTPUT_COUNT:?runner must declare output count}"
+          : "${ROBOTGO_COMPOSITOR_OPERATOR_READY_FILE:?runner must provide operator readiness attestation}"
+          output="$RUNNER_TEMP/remote-desktop-report"
+          commit="$(git rev-parse HEAD)"
+          test "$commit" = "$ROBOTGO_APPROVED_COMMIT"
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            evidence_ref="refs/heads/$GITHUB_HEAD_REF"
+          else
+            evidence_ref="$GITHUB_REF"
+          fi
+          go run ./internal/cmd/compositorevidence preflight \
+            -lane "${{ matrix.desktop }}" \
+            -cell remote-desktop \
+            -runner-temp "$RUNNER_TEMP" \
+            -output-dir "$output" \
+            -commit "$commit" \
+            -expected-commit "$ROBOTGO_APPROVED_COMMIT" \
+            -ref "$evidence_ref" \
+            -workflow "$GITHUB_WORKFLOW" \
+            -run-id "$GITHUB_RUN_ID" \
+            -run-attempt "$GITHUB_RUN_ATTEMPT" \
+            -output-count "$ROBOTGO_COMPOSITOR_OUTPUT_COUNT" \
+            -operator-ready-file "$ROBOTGO_COMPOSITOR_OPERATOR_READY_FILE"
       - name: Run real RemoteDesktop portal input test
         env:
           ROBOTGO_REMOTE_DESKTOP_E2E: "1"
+          ROBOTGO_APPROVED_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         shell: bash
         run: |
-          mkdir -p "$RUNNER_TEMP/remote-desktop-report"
-          {
-            date --iso-8601=seconds
-            go version
-            uname -srm
-            printf 'desktop=%s\nwayland_display=%s\n' "$XDG_CURRENT_DESKTOP" "$WAYLAND_DISPLAY"
-            busctl --user get-property org.freedesktop.portal.Desktop \
-              /org/freedesktop/portal/desktop org.freedesktop.portal.RemoteDesktop version || true
-            busctl --user get-property org.freedesktop.portal.Desktop \
-              /org/freedesktop/portal/desktop org.freedesktop.portal.ScreenCast version || true
-          } > "$RUNNER_TEMP/remote-desktop-report/environment.txt"
-          go test -count=1 -tags "integration" ./input/portal \
-            -run '^TestRemoteDesktopPortalRuntime$' -v 2>&1 | \
-            tee "$RUNNER_TEMP/remote-desktop-report/test.log"
+          set -euo pipefail
+          umask 077
+          output="$RUNNER_TEMP/remote-desktop-report"
+          set +e
+          go test -count=1 -timeout=3m -tags=integration ./input/portal \
+            -run '^TestRemoteDesktopPortalRuntime$' -v \
+            > "$output/raw-test.log" 2>&1
+          test_status=$?
+          set -e
+          go run ./internal/cmd/compositorevidence finalize \
+            -lane "${{ matrix.desktop }}" \
+            -cell remote-desktop \
+            -runner-temp "$RUNNER_TEMP" \
+            -output-dir "$output" \
+            -expected-commit "$ROBOTGO_APPROVED_COMMIT" \
+            -workflow "$GITHUB_WORKFLOW" \
+            -run-id "$GITHUB_RUN_ID" \
+            -run-attempt "$GITHUB_RUN_ATTEMPT" \
+            -test-exit-code "$test_status"
+          go run ./internal/cmd/compositorevidence verify \
+            -lane "${{ matrix.desktop }}" \
+            -cell remote-desktop \
+            -runner-temp "$RUNNER_TEMP" \
+            -output-dir "$output" \
+            -expected-commit "$ROBOTGO_APPROVED_COMMIT" \
+            -workflow "$GITHUB_WORKFLOW" \
+            -run-id "$GITHUB_RUN_ID" \
+            -run-attempt "$GITHUB_RUN_ATTEMPT"
+          cat "$output/summary.md" >> "$GITHUB_STEP_SUMMARY"
       - name: Upload compatibility evidence
-        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: remote-desktop-${{ matrix.desktop }}
-          path: ${{ runner.temp }}/remote-desktop-report
+          path: |
+            ${{ runner.temp }}/remote-desktop-report/evidence.json
+            ${{ runner.temp }}/remote-desktop-report/test.log
+            ${{ runner.temp }}/remote-desktop-report/summary.md
+          if-no-files-found: error
+          retention-days: 90
+      - name: Remove compositor evidence workspace
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          rm -f -- \
+            "$RUNNER_TEMP/remote-desktop-report/raw-test.log" \
+            "$RUNNER_TEMP/remote-desktop-report/.preflight.json" || true
+          go run ./internal/cmd/compositorevidence cleanup \
+            -runner-temp "$RUNNER_TEMP" \
+            -output-dir "$RUNNER_TEMP/remote-desktop-report"

--- a/.github/workflows/screencast-e2e.yml
+++ b/.github/workflows/screencast-e2e.yml
@@ -25,53 +25,102 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        desktop: [gnome, kde, wlroots]
+        desktop: [gnome, kde]
     runs-on: [self-hosted, linux, wayland, "${{ matrix.desktop }}"]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
           go-version: 1.25.x
-      - name: Verify interactive Wayland session
+      - name: Run protected runner preflight
+        env:
+          ROBOTGO_APPROVED_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         shell: bash
         run: |
-          test -n "$WAYLAND_DISPLAY"
-          test -n "$DBUS_SESSION_BUS_ADDRESS"
-          test -n "$XDG_CURRENT_DESKTOP"
-          pkg-config --exists libpipewire-0.3
-          desktop="${XDG_CURRENT_DESKTOP,,}"
-          case "${{ matrix.desktop }}:$desktop" in
-            gnome:*gnome*|kde:*kde*|kde:*plasma*) ;;
-            wlroots:*sway*|wlroots:*hyprland*|wlroots:*wayfire*|wlroots:*river*|wlroots:*labwc*|wlroots:*dwl*|wlroots:*gamescope*) ;;
-            *) echo "runner desktop '$XDG_CURRENT_DESKTOP' does not match label '${{ matrix.desktop }}'" >&2; exit 1 ;;
-          esac
+          set -euo pipefail
+          umask 077
+          : "${ROBOTGO_COMPOSITOR_OUTPUT_COUNT:?runner must declare output count}"
+          : "${ROBOTGO_COMPOSITOR_OPERATOR_READY_FILE:?runner must provide operator readiness attestation}"
+          output="$RUNNER_TEMP/screencast-report"
+          commit="$(git rev-parse HEAD)"
+          test "$commit" = "$ROBOTGO_APPROVED_COMMIT"
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            evidence_ref="refs/heads/$GITHUB_HEAD_REF"
+          else
+            evidence_ref="$GITHUB_REF"
+          fi
+          go run ./internal/cmd/compositorevidence preflight \
+            -lane "${{ matrix.desktop }}" \
+            -cell screencast \
+            -runner-temp "$RUNNER_TEMP" \
+            -output-dir "$output" \
+            -commit "$commit" \
+            -expected-commit "$ROBOTGO_APPROVED_COMMIT" \
+            -ref "$evidence_ref" \
+            -workflow "$GITHUB_WORKFLOW" \
+            -run-id "$GITHUB_RUN_ID" \
+            -run-attempt "$GITHUB_RUN_ATTEMPT" \
+            -output-count "$ROBOTGO_COMPOSITOR_OUTPUT_COUNT" \
+            -operator-ready-file "$ROBOTGO_COMPOSITOR_OPERATOR_READY_FILE"
       - name: Run real persistent ScreenCast test
         env:
           ROBOTGO_SCREENCAST_E2E: "1"
+          ROBOTGO_APPROVED_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         shell: bash
         run: |
-          mkdir -p "$RUNNER_TEMP/screencast-report"
-          {
-            date --iso-8601=seconds
-            go version
-            pkg-config --modversion libpipewire-0.3
-            uname -srm
-            printf 'desktop=%s\nwayland_display=%s\n' "$XDG_CURRENT_DESKTOP" "$WAYLAND_DISPLAY"
-            busctl --user get-property org.freedesktop.portal.Desktop \
-              /org/freedesktop/portal/desktop org.freedesktop.portal.ScreenCast version || true
-            busctl --user get-property org.freedesktop.portal.Desktop \
-              /org/freedesktop/portal/desktop org.freedesktop.portal.ScreenCast AvailableSourceTypes || true
-          } > "$RUNNER_TEMP/screencast-report/environment.txt"
-          go test -count=1 -tags "pipewire integration" ./screen/portal \
-            -run '^TestPipeWireCapturePersistentSessionIntegration$' -v 2>&1 | \
-            tee "$RUNNER_TEMP/screencast-report/test.log"
+          set -euo pipefail
+          umask 077
+          output="$RUNNER_TEMP/screencast-report"
+          set +e
+          go test -count=1 -timeout=3m -tags=pipewire,integration ./screen/portal \
+            -run '^TestPipeWireCapturePersistentSessionIntegration$' -v \
+            > "$output/raw-test.log" 2>&1
+          test_status=$?
+          set -e
+          go run ./internal/cmd/compositorevidence finalize \
+            -lane "${{ matrix.desktop }}" \
+            -cell screencast \
+            -runner-temp "$RUNNER_TEMP" \
+            -output-dir "$output" \
+            -expected-commit "$ROBOTGO_APPROVED_COMMIT" \
+            -workflow "$GITHUB_WORKFLOW" \
+            -run-id "$GITHUB_RUN_ID" \
+            -run-attempt "$GITHUB_RUN_ATTEMPT" \
+            -test-exit-code "$test_status"
+          go run ./internal/cmd/compositorevidence verify \
+            -lane "${{ matrix.desktop }}" \
+            -cell screencast \
+            -runner-temp "$RUNNER_TEMP" \
+            -output-dir "$output" \
+            -expected-commit "$ROBOTGO_APPROVED_COMMIT" \
+            -workflow "$GITHUB_WORKFLOW" \
+            -run-id "$GITHUB_RUN_ID" \
+            -run-attempt "$GITHUB_RUN_ATTEMPT"
+          cat "$output/summary.md" >> "$GITHUB_STEP_SUMMARY"
       - name: Upload compatibility evidence
-        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: screencast-${{ matrix.desktop }}
-          path: ${{ runner.temp }}/screencast-report
+          path: |
+            ${{ runner.temp }}/screencast-report/evidence.json
+            ${{ runner.temp }}/screencast-report/test.log
+            ${{ runner.temp }}/screencast-report/summary.md
+          if-no-files-found: error
+          retention-days: 90
+      - name: Remove compositor evidence workspace
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          rm -f -- \
+            "$RUNNER_TEMP/screencast-report/raw-test.log" \
+            "$RUNNER_TEMP/screencast-report/.preflight.json" || true
+          go run ./internal/cmd/compositorevidence cleanup \
+            -runner-temp "$RUNNER_TEMP" \
+            -output-dir "$RUNNER_TEMP/screencast-report"

--- a/README.md
+++ b/README.md
@@ -1053,8 +1053,9 @@ the reported guardian is the exact child that exits and is reaped. The
 measures the guardian path and retains native CGO as the X11 default while
 Pure-Go remains the supported CGO-disabled backend. The earlier direct-path
 sample remains linked from the performance report as historical evidence.
-The stable remote checks are required by `main` branch protection. Real
-GNOME/KDE/wlroots jobs remain opt-in until matching runners are registered.
+The stable remote checks are required by `main` branch protection. Real GNOME
+and KDE portal jobs, plus separate Sway/wlroots native and portal-availability
+jobs, remain opt-in until matching protected runners are registered.
 
 Wayland and portal code has additional tagged suites:
 
@@ -1090,9 +1091,9 @@ identity. Published releases receive a checksummed evidence bundle. The active
 slice is now the
 [Protected Real-Compositor Evidence Plan](docs/plan/real-compositor-evidence.md),
 whose fail-closed preflight and sanitized evidence contract are implemented.
-Protected GNOME/KDE/wlroots runner provisioning and promotion remain across
-roadmap phases 1, 2, 3, and 5; those phases remain partial until their gates are
-green.
+Protected GNOME/KDE portal runner provisioning and separate Sway/wlroots native
+and portal-availability promotion remain across roadmap phases 1, 2, 3, and 5;
+those phases remain partial until their gates are green.
 Phase 4 already exposes the parity surface; Hyprland provides trustworthy
 active-window maximize query, set, and restore with provider-aware dispatch for
 legacy `hyprlang` and 0.55+ Lua configurations, while Sway and generic wlroots

--- a/README.md
+++ b/README.md
@@ -1089,8 +1089,10 @@ support claims machine-readable and tied to exact source, test logs, and build
 identity. Published releases receive a checksummed evidence bundle. The active
 slice is now the
 [Protected Real-Compositor Evidence Plan](docs/plan/real-compositor-evidence.md),
-which closes shared GNOME/KDE/wlroots evidence gaps across roadmap phases 1, 2,
-3, and 5; those phases remain partial until their protected gates are green.
+whose fail-closed preflight and sanitized evidence contract are implemented.
+Protected GNOME/KDE/wlroots runner provisioning and promotion remain across
+roadmap phases 1, 2, 3, and 5; those phases remain partial until their gates are
+green.
 Phase 4 already exposes the parity surface; Hyprland provides trustworthy
 active-window maximize query, set, and restore with provider-aware dispatch for
 legacy `hyprlang` and 0.55+ Lua configurations, while Sway and generic wlroots

--- a/TEST.md
+++ b/TEST.md
@@ -700,6 +700,19 @@ intentionally preserving a foreign replacement is not itself an error.
   - Overrides Linux capture backend selection (`auto|dmabuf|wl_shm|screencast|portal`).
 - `ROBOTGO_SCREENCAST_E2E=1`
   - Enables the real persistent ScreenCast/PipeWire integration test.
+- `ROBOTGO_COMPOSITOR_OUTPUT_COUNT`
+  - Protected-runner declaration of the fixed fixture output count. The shared
+    compositor preflight rejects missing, non-positive, or insufficient values.
+- `ROBOTGO_COMPOSITOR_OPERATOR_READY_FILE`
+  - Absolute path to the orchestrator-owned portal-consent readiness
+    attestation. The root-owned file and its root-owned parent directory must
+    not be writable by group or others. Its exact single-line value binds
+    `ready` to the approved commit, GitHub run ID/attempt, lane, and cell;
+    repository code must not create or refresh it.
+
+    ```text
+    ready commit=<approved-sha> run=<run-id> attempt=<attempt> lane=<gnome|kde> cell=<remote-desktop|screencast>
+    ```
 - `ROBOTGO_CAPTURE_DEBUG=1`
   - Enables backend/fallback diagnostic logs for capture flow.
 - `ROBOTGO_WLROOTS_MINMAX_E2E=1`
@@ -767,6 +780,43 @@ or protocol data is a failure rather than a skip.
 Run tag-gated suites as needed for the area you changed. Native or Pure-Go X11
 input changes must also run the required `x11integration` comparison command
 above.
+
+## Protected Real-Compositor Evidence
+
+The `RemoteDesktop E2E` and `ScreenCast E2E` workflows run only on protected,
+ephemeral GNOME and KDE fixture runners. They check out the explicitly approved
+pull-request head, run the shared fail-closed Go preflight, redirect raw runtime
+output into runner-temporary storage, and upload only a schema-v1 manifest,
+canonical allowlisted test log, and matching sanitized summary after repository
+validation. The raw log and private preflight report are deleted before upload;
+an `always()` cleanup step removes the complete owned workspace after success
+or failure. VM destruction remains the final cancellation/timeout cleanup
+boundary.
+
+The workflows require the runner to provide a live Wayland/user-bus session,
+the expected desktop and portal packages, the applicable portal interfaces,
+PipeWire/WirePlumber for ScreenCast, a fixed positive output count, and the
+out-of-band operator-console readiness attestation. Missing infrastructure,
+consent readiness, an exact-commit match, or a non-skipping test pass fails the
+cell. Raw output is never streamed through `tee` or uploaded on failure.
+
+wlroots is intentionally not treated as a RemoteDesktop/ScreenCast pass in
+these portal workflows. Its native and explicit portal-availability evidence is
+promoted separately under the
+[protected real-compositor plan](docs/plan/real-compositor-evidence.md).
+
+Run the hermetic contract locally without touching the live desktop:
+
+```bash
+go test -race ./internal/compositorevidence \
+  ./internal/cmd/compositorevidence
+```
+
+Default tests inject fixed command, desktop, portal, timeout, and filesystem
+fixtures and use `t.TempDir()`. Do not invoke the real workflow commands on a
+personal desktop: portal cells intentionally request real screen/input consent
+and belong only on the disposable fixture images with the protected operator
+handoff.
 
 ## Release Evidence
 

--- a/TEST.md
+++ b/TEST.md
@@ -460,20 +460,22 @@ deterministic close. It intentionally does not use the high-level fallback APIs,
 so an available native Wayland backend cannot mask a broken portal path. Default
 hosted CI only compile-checks this harness because it has no real desktop consent
 session. `.github/workflows/remote-desktop-e2e.yml` runs the test without skipping
-on explicitly provisioned self-hosted GNOME, KDE, and wlroots Wayland runners,
-once per desktop. The portal client is pure Go and therefore independent of the
+on explicitly provisioned protected, ephemeral GNOME and KDE Wayland runners,
+once per desktop. wlroots native and portal-availability evidence is promoted
+through the separate P005 runner path and is not a RemoteDesktop pass. The portal
+client is pure Go and therefore independent of the
 root package's CGO setting; CGO and non-CGO high-level fallback dispatch remains
 covered by the hermetic root tests. The workflow can be triggered
 manually at any time. Set the repository variable
 `ROBOTGO_REMOTE_DESKTOP_E2E=1` after those runners are provisioned to run the
 same matrix on pull requests and pushes to `main`, where it can be configured as
 a required check for branches in this repository. Fork pull requests are
-intentionally excluded because untrusted code must never execute on persistent
+intentionally excluded because untrusted code must never execute on protected
 self-hosted desktop runners. Configure the `remote-desktop-e2e` GitHub
 Environment with required reviewers and use ephemeral, network-isolated runners.
 The workflow uses read-only permissions, does not persist checkout credentials,
-and verifies that each runner's `XDG_CURRENT_DESKTOP` matches its matrix label
-before injecting input.
+and runs the shared fail-closed desktop, D-Bus, portal, operator-readiness, and
+exact-commit preflight before injecting input.
 
 Runtime outcomes and missing infrastructure are recorded in
 `docs/compatibility/wayland-input.md`; an unavailable runner is not counted as a
@@ -513,9 +515,10 @@ ROBOTGO_SCREENCAST_E2E=1 go test -tags "pipewire integration" ./screen/portal -r
 Run it from a graphical Wayland session. It displays the portal consent UI,
 captures two frames from the same session, validates non-empty output, and
 closes the PipeWire consumer before the portal session.
-`.github/workflows/screencast-e2e.yml` runs the same harness on protected
-self-hosted GNOME, KDE, and wlroots runners when the repository variable
-`ROBOTGO_SCREENCAST_E2E=1` is enabled, or by manual dispatch.
+`.github/workflows/screencast-e2e.yml` runs the same harness on protected,
+ephemeral self-hosted GNOME and KDE runners when the repository variable
+`ROBOTGO_SCREENCAST_E2E=1` is enabled, or by manual dispatch. wlroots does not
+count as a ScreenCast pass and is promoted separately under P005.
 
 ### `waylandint` (Keyboard integration harness)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,9 @@ Use the following documents as the primary entry points:
 - [Test guide](../TEST.md) for validation commands and runtime prerequisites.
 - [Product roadmap](plan/product-roadmap.md) for delivery phases.
 - [Protected real-compositor evidence plan](plan/real-compositor-evidence.md)
-  for ephemeral GNOME, KDE, and wlroots runner contracts, sanitized manifests,
-  real portal consent, and protected runtime gates.
+  for ephemeral GNOME/KDE portal and Sway/wlroots native runner contracts,
+  sanitized manifests, real portal consent where supported, and protected
+  runtime gates.
 - [Agentic desktop automation plan](plan/agentic-desktop-automation.md) for the
   session, policy, observe-act-verify, and adapter architecture.
 - [Agent adapter and evaluation plan](plan/agent-adapter-evaluation.md) for the

--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -85,6 +85,7 @@ extracting it:
 sha256sum -c robotgo-release-evidence-*.tar.gz.sha256
 ```
 
-This hosted-runner evidence does not replace the protected real GNOME, KDE, and
-wlroots RemoteDesktop/ScreenCast matrix. Those rows remain pending until the
-matching runners are provisioned.
+This hosted-runner evidence does not replace protected real-compositor evidence.
+GNOME and KDE RemoteDesktop/ScreenCast portal rows, plus separate Sway/wlroots
+native and explicit portal-availability rows, remain pending until the matching
+runners are provisioned.

--- a/docs/compatibility/wayland-capture.md
+++ b/docs/compatibility/wayland-capture.md
@@ -10,8 +10,11 @@ passing result.
 | 2026-07-11 | Hermetic Linux | ScreenCast/PipeWire | `cgo,pipewire` | pass | Session/request cleanup, FD duplication, repeated consumer lifecycle, crop/fractional scaling, eight transforms, pixel buffer validation, race and lint gates |
 | pending | GNOME | ScreenCast/PipeWire | `cgo,pipewire,integration` | no runner | Protected runner label `gnome`; workflow artifact `screencast-gnome` |
 | pending | KDE Plasma | ScreenCast/PipeWire | `cgo,pipewire,integration` | no runner | Protected runner label `kde`; workflow artifact `screencast-kde` |
-| pending | wlroots portal backend | ScreenCast/PipeWire | `cgo,pipewire,integration` | no runner | Protected runner label `wlroots`; workflow artifact `screencast-wlroots` |
 
-The protected matrix is defined in `.github/workflows/screencast-e2e.yml`. It
-captures two frames through one consent session and uploads the desktop,
-PipeWire, portal version, and test log as compatibility evidence.
+The protected GNOME/KDE matrix is defined in
+`.github/workflows/screencast-e2e.yml`. It captures two frames through one
+consent session and uploads only the schema-v1 evidence manifest, canonical
+sanitized test log, and summary. Sway/wlroots native capture and explicit portal
+availability are separate P005 evidence lanes; a wlroots environment is not
+counted as a ScreenCast portal pass unless a compatible portal backend is
+independently preflighted and promoted in a future workflow change.

--- a/docs/compatibility/wayland-input.md
+++ b/docs/compatibility/wayland-input.md
@@ -11,15 +11,14 @@ pass.
 | 2026-07-11 | Sway (wlroots) | RemoteDesktop portal | CGO/default | unavailable, actionable | Local portal exposes ScreenCast v4/source mask 3 but no `org.freedesktop.portal.RemoteDesktop`; diagnostics return an explicit unavailable error |
 | pending | GNOME | RemoteDesktop + ScreenCast mapping | Pure-Go portal client | no runner | Requires self-hosted runner label `gnome` |
 | pending | KDE Plasma | RemoteDesktop + ScreenCast mapping | Pure-Go portal client | no runner | Requires self-hosted runner label `kde` |
-| pending | wlroots portal backend | RemoteDesktop + ScreenCast mapping | Pure-Go portal client | no runner | Requires a backend implementing RemoteDesktop and runner label `wlroots` |
 
 ## Evidence workflow
 
 `.github/workflows/remote-desktop-e2e.yml` validates the CGO-independent pure-Go
-portal client once per desktop:
+portal client on protected, ephemeral GNOME and KDE runners:
 
 The harness calls the lower-level portal session methods directly, ensuring a
-native wlroots input backend cannot satisfy the checks instead of RemoteDesktop.
+native input backend cannot satisfy the checks instead of RemoteDesktop.
 
 - RemoteDesktop and ScreenCast capability discovery
 - explicit consent and granted keyboard/pointer devices
@@ -29,7 +28,9 @@ native wlroots input backend cannot satisfy the checks instead of RemoteDesktop.
 - touchscreen down/up when advertised
 - deterministic close
 
-The workflow uploads sanitized environment, portal-version, and test logs. Set
-the repository variable `ROBOTGO_REMOTE_DESKTOP_E2E=1` only after protected,
-ephemeral GNOME/KDE/wlroots runners are registered. Fork pull requests are
-excluded from self-hosted execution.
+The workflow uploads only the schema-v1 evidence manifest, canonical sanitized
+test log, and summary. Set the repository variable
+`ROBOTGO_REMOTE_DESKTOP_E2E=1` only after protected, ephemeral GNOME and KDE
+runners are registered. Fork pull requests are excluded from self-hosted
+execution. Sway/wlroots native input and explicit portal-unavailability evidence
+use separate P005 lanes; they are not counted as RemoteDesktop portal passes.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -38,15 +38,16 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE/wlroots evidence |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration and Weston multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected GNOME/KDE/wlroots multi-output Wayland evidence, and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, provider-aware Hyprland 0.55+ Lua window dispatch | Compositor-backed state operations and cross-platform/runtime matrix coverage |
-| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Dedicated compositor jobs |
+| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, fail-closed real-compositor preflight/evidence contract, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Provision and promote dedicated compositor jobs |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
 an infrastructure blocker. The bounded cross-platform reliability-hardening
 project P002 is complete, while roadmap Phase 5 remains partial. The active
 [Protected Real-Compositor Evidence Plan](real-compositor-evidence.md) now
-addresses the shared GNOME/KDE/wlroots runner-dependent exit gates across
-phases 1, 2, 3, and 5.
+provides the shared preflight and sanitized evidence contract; protected runner
+provisioning and promotion now remain for the GNOME/KDE/wlroots exit gates
+across phases 1, 2, 3, and 5.
 The completed [Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md)
 provides a local, policy-gated MCP boundary on the agent-session proof. The
 adjacent [Safe Agent Visual Conditions Plan](agent-visual-conditions.md) now

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -34,8 +34,8 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet/sanitizer jobs, protected stable CI checks | Keep required jobs green |
-| 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE/wlroots runners and collect green CGO/non-CGO evidence |
-| 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE/wlroots evidence |
+| 1. Wayland input | Implementation complete; runtime validation blocked | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics and E2E harness | Register GNOME/KDE portal and Sway/wlroots native runners; collect green behavior or explicit-unavailability evidence |
+| 2. Capture | Hermetic implementation complete | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, and sanitizer-backed native ownership gates | Real GNOME/KDE portal plus Sway/wlroots native and portal-availability evidence |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration and Weston multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected GNOME/KDE/wlroots multi-output Wayland evidence, and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, provider-aware Hyprland 0.55+ Lua window dispatch | Compositor-backed state operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, fail-closed real-compositor preflight/evidence contract, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Provision and promote dedicated compositor jobs |
@@ -46,8 +46,8 @@ an infrastructure blocker. The bounded cross-platform reliability-hardening
 project P002 is complete, while roadmap Phase 5 remains partial. The active
 [Protected Real-Compositor Evidence Plan](real-compositor-evidence.md) now
 provides the shared preflight and sanitized evidence contract; protected runner
-provisioning and promotion now remain for the GNOME/KDE/wlroots exit gates
-across phases 1, 2, 3, and 5.
+provisioning and promotion now remain for GNOME/KDE portal gates and separate
+Sway/wlroots native and portal-availability gates across phases 1, 2, 3, and 5.
 The completed [Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md)
 provides a local, policy-gated MCP boundary on the agent-session proof. The
 adjacent [Safe Agent Visual Conditions Plan](agent-visual-conditions.md) now
@@ -78,8 +78,9 @@ and expose persistence restore-token availability. Runtime capability and
 permission diagnostics, including explicit cancellation and timeout states, are
 available without opening a consent dialog. Portal-backed mouse timing is
 consistent in CGO and non-CGO builds. The
-remaining Phase 1 blocker is real GNOME/KDE/wlroots evidence; this repository
-currently has no registered self-hosted runners for that matrix.
+remaining Phase 1 blocker is real GNOME/KDE portal plus Sway/wlroots native and
+explicit portal-availability evidence; this repository currently has no
+registered self-hosted runners for those lanes.
 
 Exit criteria:
 

--- a/docs/plan/real-compositor-evidence.md
+++ b/docs/plan/real-compositor-evidence.md
@@ -1,6 +1,6 @@
 # Protected Real-Compositor Evidence Plan
 
-Status: Accepted direction; runner-contract implementation is next
+Status: Delivery slice 1 implemented; protected runner provisioning is next
 
 Linear project:
 [RobotGo | P005 | Protected Compositor Evidence](https://linear.app/riotbox/project/robotgo-or-p005-or-protected-compositor-evidence-d66467e3b5ee)
@@ -224,8 +224,8 @@ green.
 
 ## Ordered delivery slices
 
-1. Implement the shared preflight, schema-v1 manifest, hermetic tests, and both
-   workflow integrations.
+1. **Implemented:** shared preflight, schema-v1 manifest, hermetic tests, and
+   both portal-workflow integrations.
 2. Provision and prove the ephemeral Sway/wlroots image and promote its native
    rows.
 3. Provision and prove GNOME RemoteDesktop and ScreenCast.

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -144,14 +144,17 @@ PID/handle-specific control remains unsupported for all listed Wayland
 backends.
 
 - Priority Backlog (1-7):
-  - 1. Register protected GNOME/KDE/wlroots runners and validate the complete
-    RemoteDesktop high-level matrix in hermetic CGO and non-CGO builds. Shared ScreenCast
+  - 1. Register protected GNOME/KDE portal runners and validate the complete
+    RemoteDesktop high-level matrix in hermetic CGO and non-CGO builds. Track
+    Sway/wlroots native input and explicit portal availability in separate lanes.
+    Shared ScreenCast
     mapping, absolute pointer/touch, consent, denial, cancellation, timeout,
     restore metadata, teardown, and high-level dispatch have hermetic coverage.
     `[new vs robotgo-pro]`
   - 2. Validate the reusable ScreenCast/PipeWire backend on protected real
-    GNOME/KDE/wlroots runners and promote its leak/timeout tests to release
-    gates. The implementation and opt-in integration harness are present.
+    GNOME/KDE portal runners and promote its leak/timeout tests to release
+    gates. Validate Sway/wlroots native capture and portal availability
+    separately. The implementation and opt-in integration harness are present.
     `[new vs robotgo-pro]`
   - 3. Continue window state/query operations beyond the delivered Hyprland
     maximize slice where a compositor exposes equally trustworthy state.
@@ -211,7 +214,9 @@ backends.
   - Expand troubleshooting for xdg-desktop-portal backend selection and consent prompts.
   - Validate the existing high-level RemoteDesktop input fallback on GNOME/KDE.
   - Validate the persistent ScreenCast/PipeWire stream path and repeated-frame
-    behavior across GNOME/KDE/wlroots portal backends.
+    behavior across GNOME/KDE portal backends. Keep Sway/wlroots native capture
+    and portal-availability evidence separate unless a compatible portal backend
+    is explicitly promoted.
 - Keyboard Input:
   - Keep the delivered native Wayland exact-Unicode keysym path covered,
     including whole-text preflight and explicit unsupported/fallback behavior

--- a/internal/cmd/compositorevidence/main.go
+++ b/internal/cmd/compositorevidence/main.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/marang/robotgo/internal/compositorevidence"
+)
+
+const (
+	envCurrentDesktop    = "XDG_CURRENT_DESKTOP"
+	envWaylandDisplay    = "WAYLAND_DISPLAY"
+	envRuntimeDir        = "XDG_RUNTIME_DIR"
+	envSessionBusAddress = "DBUS_SESSION_BUS_ADDRESS"
+	envHome              = "HOME"
+	envUser              = "USER"
+	envLogName           = "LOGNAME"
+	envRunnerName        = "RUNNER_NAME"
+)
+
+type getenvFunc func(string) string
+
+func main() {
+	if err := run(context.Background(), os.Args[1:], os.Stdout, os.Stderr, os.Getenv); err != nil {
+		fmt.Fprintf(os.Stderr, "compositorevidence: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(
+	ctx context.Context,
+	arguments []string,
+	stdout io.Writer,
+	stderr io.Writer,
+	getenv getenvFunc,
+) error {
+	if len(arguments) == 0 {
+		return errors.New("expected preflight, finalize, verify, or cleanup subcommand")
+	}
+	switch arguments[0] {
+	case "preflight":
+		return runPreflight(ctx, arguments[1:], stdout, stderr, getenv)
+	case "finalize":
+		return runFinalize(arguments[1:], stdout, stderr, getenv)
+	case "verify":
+		return runVerify(arguments[1:], stdout, stderr)
+	case "cleanup":
+		return runCleanup(arguments[1:], stderr)
+	default:
+		return fmt.Errorf("unknown subcommand %q", arguments[0])
+	}
+}
+
+type identityFlags struct {
+	laneValue       string
+	cellValue       string
+	runnerTemp      string
+	outputDirectory string
+	expectedCommit  string
+}
+
+func (identity *identityFlags) register(flags *flag.FlagSet) {
+	flags.StringVar(&identity.laneValue, "lane", "", "protected desktop lane")
+	flags.StringVar(&identity.cellValue, "cell", "", "protected evidence cell")
+	flags.StringVar(&identity.runnerTemp, "runner-temp", "", "runner temporary directory")
+	flags.StringVar(&identity.outputDirectory, "output-dir", "", "owned evidence output directory")
+	flags.StringVar(&identity.expectedCommit, "expected-commit", "", "approved exact Git commit")
+}
+
+func (identity identityFlags) parse() (compositorevidence.Lane, compositorevidence.Cell, error) {
+	lane, err := compositorevidence.ParseLane(identity.laneValue)
+	if err != nil {
+		return "", "", err
+	}
+	cell, err := compositorevidence.ParseCell(identity.cellValue)
+	if err != nil {
+		return "", "", err
+	}
+	return lane, cell, nil
+}
+
+func runPreflight(
+	ctx context.Context,
+	arguments []string,
+	stdout io.Writer,
+	stderr io.Writer,
+	getenv getenvFunc,
+) (retErr error) {
+	flags := flag.NewFlagSet("compositorevidence preflight", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var identity identityFlags
+	identity.register(flags)
+	var (
+		checkoutCommit    string
+		ref               string
+		workflow          string
+		runID             string
+		runAttempt        int
+		operatorReadyPath string
+		outputCount       int
+		minimumOutputs    int
+		probeTimeout      time.Duration
+	)
+	flags.StringVar(&checkoutCommit, "commit", "", "checked-out Git commit")
+	flags.StringVar(&ref, "ref", "", "checked-out full Git ref")
+	flags.StringVar(&workflow, "workflow", "", "GitHub Actions workflow name")
+	flags.StringVar(&runID, "run-id", "", "GitHub Actions run ID")
+	flags.IntVar(&runAttempt, "run-attempt", 0, "GitHub Actions run attempt")
+	flags.StringVar(&operatorReadyPath, "operator-ready-file", "", "orchestrator-owned consent readiness file")
+	flags.IntVar(&outputCount, "output-count", 0, "declared compositor output count")
+	flags.IntVar(&minimumOutputs, "minimum-outputs", 1, "minimum required output count")
+	flags.DurationVar(&probeTimeout, "probe-timeout", 5*time.Second, "per-probe timeout")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+	lane, cell, err := identity.parse()
+	if err != nil {
+		return err
+	}
+	if err := compositorevidence.PrepareOutputDirectory(
+		identity.runnerTemp,
+		identity.outputDirectory,
+	); err != nil {
+		return err
+	}
+	prepared := true
+	defer func() {
+		if !prepared || retErr == nil {
+			return
+		}
+		cleanupErr := compositorevidence.Cleanup(identity.runnerTemp, identity.outputDirectory)
+		if cleanupErr != nil {
+			retErr = errors.Join(retErr, cleanupErr)
+		}
+	}()
+	report, err := compositorevidence.Preflight(ctx, compositorevidence.PreflightConfig{
+		Lane:               lane,
+		Cell:               cell,
+		CheckoutCommit:     checkoutCommit,
+		ExpectedCommit:     identity.expectedCommit,
+		Ref:                ref,
+		Workflow:           workflow,
+		RunID:              runID,
+		RunAttempt:         runAttempt,
+		CurrentDesktop:     getenv(envCurrentDesktop),
+		WaylandDisplay:     getenv(envWaylandDisplay),
+		RuntimeDir:         getenv(envRuntimeDir),
+		SessionBusAddress:  getenv(envSessionBusAddress),
+		OperatorReadyPath:  operatorReadyPath,
+		OutputCount:        outputCount,
+		MinimumOutputCount: minimumOutputs,
+		ProbeTimeout:       probeTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	if err := compositorevidence.WritePreflight(identity.outputDirectory, report); err != nil {
+		return err
+	}
+	prepared = false
+	if _, err := fmt.Fprintf(
+		stdout,
+		"preflight passed lane=%s cell=%s outputs=%d\n",
+		lane,
+		cell,
+		outputCount,
+	); err != nil {
+		return fmt.Errorf("write preflight summary: %w", err)
+	}
+	return nil
+}
+
+func runFinalize(
+	arguments []string,
+	stdout io.Writer,
+	stderr io.Writer,
+	getenv getenvFunc,
+) error {
+	flags := flag.NewFlagSet("compositorevidence finalize", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var identity identityFlags
+	identity.register(flags)
+	var (
+		workflow     string
+		runID        string
+		runAttempt   int
+		testExitCode int
+	)
+	flags.StringVar(&workflow, "workflow", "", "GitHub Actions workflow name")
+	flags.StringVar(&runID, "run-id", "", "GitHub Actions run ID")
+	flags.IntVar(&runAttempt, "run-attempt", 0, "GitHub Actions run attempt")
+	flags.IntVar(&testExitCode, "test-exit-code", -1, "integration test exit code")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+	lane, cell, err := identity.parse()
+	if err != nil {
+		return err
+	}
+	manifest, err := compositorevidence.Finalize(compositorevidence.FinalizeConfig{
+		RunnerTemp:      identity.runnerTemp,
+		OutputDirectory: identity.outputDirectory,
+		ExpectedCommit:  identity.expectedCommit,
+		ExpectedLane:    lane,
+		ExpectedCell:    cell,
+		Workflow:        workflow,
+		RunID:           runID,
+		RunAttempt:      runAttempt,
+		TestExitCode:    testExitCode,
+		SensitiveValues: sensitiveValues(getenv),
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(
+		stdout,
+		"evidence validated schema=%s lane=%s cell=%s commit=%s\n",
+		manifest.SchemaVersion,
+		manifest.Desktop.Lane,
+		manifest.Desktop.Cell,
+		manifest.Commit,
+	); err != nil {
+		return fmt.Errorf("write finalization summary: %w", err)
+	}
+	return nil
+}
+
+func runVerify(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("compositorevidence verify", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var identity identityFlags
+	identity.register(flags)
+	var (
+		workflow   string
+		runID      string
+		runAttempt int
+	)
+	flags.StringVar(&workflow, "workflow", "", "expected GitHub Actions workflow")
+	flags.StringVar(&runID, "run-id", "", "expected GitHub Actions run ID")
+	flags.IntVar(&runAttempt, "run-attempt", 0, "expected GitHub Actions run attempt")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+	lane, cell, err := identity.parse()
+	if err != nil {
+		return err
+	}
+	manifest, err := compositorevidence.VerifyDirectory(
+		identity.outputDirectory,
+		compositorevidence.VerifyExpectations{
+			Commit:     identity.expectedCommit,
+			Lane:       lane,
+			Cell:       cell,
+			Workflow:   workflow,
+			RunID:      runID,
+			RunAttempt: runAttempt,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(
+		stdout,
+		"verified evidence schema=%s lane=%s cell=%s commit=%s\n",
+		manifest.SchemaVersion,
+		manifest.Desktop.Lane,
+		manifest.Desktop.Cell,
+		manifest.Commit,
+	); err != nil {
+		return fmt.Errorf("write verification summary: %w", err)
+	}
+	return nil
+}
+
+func runCleanup(arguments []string, stderr io.Writer) error {
+	flags := flag.NewFlagSet("compositorevidence cleanup", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var runnerTemp, outputDirectory string
+	flags.StringVar(&runnerTemp, "runner-temp", "", "runner temporary directory")
+	flags.StringVar(&outputDirectory, "output-dir", "", "owned evidence output directory")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+	return compositorevidence.Cleanup(runnerTemp, outputDirectory)
+}
+
+func sensitiveValues(getenv getenvFunc) []string {
+	values := make([]string, 0, 8)
+	for _, name := range []string{
+		envWaylandDisplay,
+		envRuntimeDir,
+		envSessionBusAddress,
+		envHome,
+		envUser,
+		envLogName,
+		envRunnerName,
+	} {
+		values = append(values, getenv(name))
+	}
+	if hostname, err := os.Hostname(); err == nil {
+		values = append(values, hostname)
+	}
+	return values
+}

--- a/internal/cmd/compositorevidence/main_test.go
+++ b/internal/cmd/compositorevidence/main_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/marang/robotgo/internal/compositorevidence"
+)
+
+func emptyEnvironment(string) string { return "" }
+
+func TestRunRejectsMissingAndUnknownSubcommands(t *testing.T) {
+	t.Parallel()
+	for _, arguments := range [][]string{nil, {"unknown"}} {
+		var stdout, stderr bytes.Buffer
+		err := run(context.Background(), arguments, &stdout, &stderr, emptyEnvironment)
+		if err == nil {
+			t.Fatalf("run(%v) succeeded", arguments)
+		}
+	}
+}
+
+func TestRunPreflightRejectsInvalidIdentityBeforeCreatingOutput(t *testing.T) {
+	t.Parallel()
+	runnerTemp := t.TempDir()
+	outputDirectory := filepath.Join(runnerTemp, "report")
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"preflight",
+		"-lane", "invalid",
+		"-cell", "remote-desktop",
+		"-runner-temp", runnerTemp,
+		"-output-dir", outputDirectory,
+	}, &stdout, &stderr, emptyEnvironment)
+	if err == nil || !strings.Contains(err.Error(), "lane") {
+		t.Fatalf("run error = %v, want lane validation", err)
+	}
+	if _, err := os.Lstat(outputDirectory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid identity created output: %v", err)
+	}
+}
+
+func TestRunPreflightCleansPreparedDirectoryOnValidationFailure(t *testing.T) {
+	t.Parallel()
+	runnerTemp := t.TempDir()
+	outputDirectory := filepath.Join(runnerTemp, "report")
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"preflight",
+		"-lane", "gnome",
+		"-cell", "remote-desktop",
+		"-runner-temp", runnerTemp,
+		"-output-dir", outputDirectory,
+		"-commit", "invalid",
+		"-expected-commit", "invalid",
+		"-ref", "refs/heads/test",
+		"-output-count", "1",
+	}, &stdout, &stderr, emptyEnvironment)
+	if err == nil || !strings.Contains(err.Error(), "commit") {
+		t.Fatalf("run error = %v, want commit validation", err)
+	}
+	if _, err := os.Lstat(outputDirectory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed preflight left output directory: %v", err)
+	}
+}
+
+func TestRunCleanupRemovesOnlyOwnedOutput(t *testing.T) {
+	t.Parallel()
+	runnerTemp := t.TempDir()
+	outputDirectory := filepath.Join(runnerTemp, "report")
+	if err := compositorevidence.PrepareOutputDirectory(runnerTemp, outputDirectory); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		compositorevidence.RawTestLogPath(outputDirectory),
+		[]byte("private"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	err := run(context.Background(), []string{
+		"cleanup",
+		"-runner-temp", runnerTemp,
+		"-output-dir", outputDirectory,
+	}, &stdout, &stderr, emptyEnvironment)
+	if err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+	if _, err := os.Lstat(outputDirectory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cleanup left output directory: %v", err)
+	}
+}
+
+func TestSensitiveValuesIgnoreEmptyAndShortEnvironmentValues(t *testing.T) {
+	t.Parallel()
+	values := sensitiveValues(func(name string) string {
+		if name == envWaylandDisplay {
+			return "w0"
+		}
+		return ""
+	})
+	if len(values) == 0 {
+		t.Fatal("sensitiveValues omitted host result")
+	}
+}

--- a/internal/compositorevidence/contract.go
+++ b/internal/compositorevidence/contract.go
@@ -1,0 +1,230 @@
+// Package compositorevidence creates privacy-safe evidence for protected
+// real-compositor integration jobs.
+package compositorevidence
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	// SchemaVersion identifies the compositor-evidence JSON contract.
+	SchemaVersion = "1"
+
+	preflightSchemaVersion = "1"
+	evidenceProvider       = "github-actions"
+	maxTextLength          = 256
+	maxLogBytes            = 1024 * 1024
+	maxEvidenceBytes       = 1024 * 1024
+	defaultProbeTimeout    = 5 * time.Second
+)
+
+// Lane identifies a protected desktop image family.
+type Lane string
+
+const (
+	LaneGNOME   Lane = "gnome"
+	LaneKDE     Lane = "kde"
+	LaneWlroots Lane = "wlroots"
+)
+
+// Cell identifies the runtime behavior proven by one matrix cell.
+type Cell string
+
+const (
+	CellRemoteDesktop      Cell = "remote-desktop"
+	CellScreenCast         Cell = "screencast"
+	CellNativeInput        Cell = "native-input"
+	CellNativeCapture      Cell = "native-capture"
+	CellNativeWindow       Cell = "native-window"
+	CellNativeOutput       Cell = "native-output"
+	CellPortalAvailability Cell = "portal-availability"
+)
+
+const (
+	remoteDesktopTestName = "TestRemoteDesktopPortalRuntime"
+	remoteDesktopPackage  = "github.com/marang/robotgo/input/portal"
+	remoteDesktopCommand  = "go test -count=1 -timeout=3m -tags=integration ./input/portal -run ^TestRemoteDesktopPortalRuntime$ -v"
+	screenCastTestName    = "TestPipeWireCapturePersistentSessionIntegration"
+	screenCastPackage     = "github.com/marang/robotgo/screen/portal"
+	screenCastCommand     = "go test -count=1 -timeout=3m -tags=pipewire,integration ./screen/portal -run ^TestPipeWireCapturePersistentSessionIntegration$ -v"
+)
+
+var (
+	gitObjectPattern = regexp.MustCompile(`^(?:[0-9a-f]{40}|[0-9a-f]{64})$`)
+	labelPattern     = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	versionPattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9.+:~_-]{0,127}$`)
+	kernelPattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9.+_-]{0,127}$`)
+	digestPattern    = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+// TestSpec describes the single integration test represented by a portal
+// evidence cell.
+type TestSpec struct {
+	Package string
+	Name    string
+	Command string
+}
+
+// ParseLane validates a desktop lane name.
+func ParseLane(value string) (Lane, error) {
+	lane := Lane(strings.ToLower(strings.TrimSpace(value)))
+	switch lane {
+	case LaneGNOME, LaneKDE, LaneWlroots:
+		return lane, nil
+	default:
+		return "", fmt.Errorf("unsupported compositor lane %q", value)
+	}
+}
+
+// ParseCell validates an evidence cell name.
+func ParseCell(value string) (Cell, error) {
+	cell := Cell(strings.ToLower(strings.TrimSpace(value)))
+	switch cell {
+	case CellRemoteDesktop, CellScreenCast, CellNativeInput,
+		CellNativeCapture, CellNativeWindow, CellNativeOutput,
+		CellPortalAvailability:
+		return cell, nil
+	default:
+		return "", fmt.Errorf("unsupported compositor evidence cell %q", value)
+	}
+}
+
+// PortalRequired reports whether the cell must expose a real desktop portal
+// interface.
+func (cell Cell) PortalRequired() bool {
+	return cell == CellRemoteDesktop || cell == CellScreenCast
+}
+
+// PortalObserved reports whether the cell records portal capability even when
+// the selected wlroots image explicitly proves that it is unavailable.
+func (cell Cell) PortalObserved() bool {
+	return cell.PortalRequired() || cell == CellPortalAvailability
+}
+
+// PipeWireRequired reports whether the cell must expose a persistent PipeWire
+// capture runtime.
+func (cell Cell) PipeWireRequired() bool {
+	return cell == CellScreenCast
+}
+
+// ConsentRequired reports whether the cell starts an interactive portal
+// request that requires the protected operator handoff.
+func (cell Cell) ConsentRequired() bool {
+	return cell == CellRemoteDesktop || cell == CellScreenCast
+}
+
+// NativeRequired reports whether the cell proves wlroots-native behavior.
+func (cell Cell) NativeRequired() bool {
+	switch cell {
+	case CellNativeInput, CellNativeCapture, CellNativeWindow, CellNativeOutput:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestSpec returns the fixed test represented by a runnable portal cell.
+func (cell Cell) TestSpec() (TestSpec, error) {
+	switch cell {
+	case CellRemoteDesktop:
+		return TestSpec{
+			Package: remoteDesktopPackage,
+			Name:    remoteDesktopTestName,
+			Command: remoteDesktopCommand,
+		}, nil
+	case CellScreenCast:
+		return TestSpec{
+			Package: screenCastPackage,
+			Name:    screenCastTestName,
+			Command: screenCastCommand,
+		}, nil
+	default:
+		return TestSpec{}, fmt.Errorf("cell %q has no portal integration test", cell)
+	}
+}
+
+func (cell Cell) expectedWorkflow() string {
+	switch cell {
+	case CellRemoteDesktop:
+		return "RemoteDesktop E2E"
+	case CellScreenCast:
+		return "ScreenCast E2E"
+	default:
+		return ""
+	}
+}
+
+func validateWorkflow(cell Cell, workflow string) error {
+	if err := validateText("workflow", workflow); err != nil {
+		return err
+	}
+	if expected := cell.expectedWorkflow(); expected != "" && workflow != expected {
+		return errors.New("workflow does not match compositor evidence cell")
+	}
+	return nil
+}
+
+func validateLaneCell(lane Lane, cell Cell) error {
+	if _, err := ParseLane(string(lane)); err != nil {
+		return err
+	}
+	if _, err := ParseCell(string(cell)); err != nil {
+		return err
+	}
+	if cell.NativeRequired() && lane != LaneWlroots {
+		return fmt.Errorf("native cell %q requires the wlroots lane", cell)
+	}
+	if lane == LaneWlroots && cell.ConsentRequired() {
+		return errors.New("wlroots portal behavior must use the portal-availability cell until a protected consent backend is promoted")
+	}
+	return nil
+}
+
+func validateGitIdentity(commit, ref string) error {
+	if !gitObjectPattern.MatchString(commit) {
+		return errors.New("commit must be a lowercase 40- or 64-character Git object ID")
+	}
+	if err := validateText("ref", ref); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(ref, "refs/") {
+		return errors.New("ref must start with refs/")
+	}
+	return nil
+}
+
+func validateText(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", name)
+	}
+	if len(value) > maxTextLength {
+		return fmt.Errorf("%s exceeds %d bytes", name, maxTextLength)
+	}
+	for _, char := range value {
+		if char < 0x20 || char == 0x7f {
+			return fmt.Errorf("%s contains control characters", name)
+		}
+	}
+	return nil
+}
+
+func validateLabel(name, value string) error {
+	if len(value) > 128 || !labelPattern.MatchString(value) {
+		return fmt.Errorf("%s must contain only letters, digits, dot, underscore, or hyphen", name)
+	}
+	return nil
+}
+
+func validateVersion(name, value string, required bool) error {
+	if value == "" && !required {
+		return nil
+	}
+	if !versionPattern.MatchString(value) {
+		return fmt.Errorf("%s is not a sanitized version", name)
+	}
+	return nil
+}

--- a/internal/compositorevidence/evidence.go
+++ b/internal/compositorevidence/evidence.go
@@ -1,0 +1,828 @@
+package compositorevidence
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	outputSentinelName    = ".robotgo-compositor-evidence"
+	outputSentinelContent = "robotgo-compositor-evidence-v1\n"
+	validatedMarkerName   = ".validated"
+	preflightFileName     = ".preflight.json"
+	rawTestLogFileName    = "raw-test.log"
+	testLogFileName       = "test.log"
+	evidenceFileName      = "evidence.json"
+	summaryFileName       = "summary.md"
+	canonicalLogSchema    = "robotgo-compositor-test-log-v1"
+)
+
+var (
+	runIDPattern            = regexp.MustCompile(`^[1-9][0-9]*$`)
+	staticSensitivePatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)(password|credential|secret|restore[ _-]?token)`),
+		regexp.MustCompile(`(?i)(session[ _-]?handle|request[ _-]?handle|node[ _-]?id)`),
+		regexp.MustCompile(`(?i)(wayland_display|dbus_session_bus_address)`),
+		regexp.MustCompile(`(?i)(clipboard contents?|screen[ _-]?shot|frame pixels?)`),
+		regexp.MustCompile(`(?:^|[[:space:]"'])/(?:home|Users)/`),
+	}
+)
+
+// CI identifies the protected GitHub Actions execution.
+type CI struct {
+	Provider   string `json:"provider"`
+	Workflow   string `json:"workflow"`
+	RunID      string `json:"run_id"`
+	RunAttempt int    `json:"run_attempt"`
+}
+
+// EvidenceTest records the canonical, privacy-safe integration result.
+type EvidenceTest struct {
+	Package        string `json:"package"`
+	Name           string `json:"name"`
+	Command        string `json:"command"`
+	Result         string `json:"result"`
+	DurationMillis int64  `json:"duration_ms"`
+	LogFile        string `json:"log_file"`
+	LogSHA256      string `json:"log_sha256"`
+}
+
+// Manifest is the schema-v1 protected compositor evidence document.
+type Manifest struct {
+	SchemaVersion string       `json:"schema_version"`
+	CompletedAt   string       `json:"completed_at"`
+	Commit        string       `json:"commit"`
+	Ref           string       `json:"ref"`
+	CI            CI           `json:"ci"`
+	Platform      Platform     `json:"platform"`
+	Desktop       Desktop      `json:"desktop"`
+	Test          EvidenceTest `json:"test"`
+}
+
+// FinalizeConfig binds a passed raw integration test to its protected workflow
+// identity. SensitiveValues are checked but never persisted.
+type FinalizeConfig struct {
+	RunnerTemp      string
+	OutputDirectory string
+	ExpectedCommit  string
+	ExpectedLane    Lane
+	ExpectedCell    Cell
+	Workflow        string
+	RunID           string
+	RunAttempt      int
+	TestExitCode    int
+	CompletedAt     time.Time
+	SensitiveValues []string
+}
+
+// VerifyExpectations bind existing evidence to an exact protected job.
+type VerifyExpectations struct {
+	Commit     string
+	Lane       Lane
+	Cell       Cell
+	Workflow   string
+	RunID      string
+	RunAttempt int
+}
+
+// PrepareOutputDirectory creates a new evidence directory inside runnerTemp.
+// The ownership sentinel lets Cleanup reject unrelated paths.
+func PrepareOutputDirectory(runnerTemp, outputDirectory string) error {
+	if err := validateOutputPath(runnerTemp, outputDirectory); err != nil {
+		return err
+	}
+	if err := os.Mkdir(outputDirectory, 0o700); err != nil {
+		return fmt.Errorf("create compositor evidence directory: %w", err)
+	}
+	created := true
+	defer func() {
+		if created {
+			_ = os.RemoveAll(outputDirectory)
+		}
+	}()
+	if err := atomicWrite(
+		filepath.Join(outputDirectory, outputSentinelName),
+		[]byte(outputSentinelContent),
+		0o600,
+	); err != nil {
+		return err
+	}
+	created = false
+	return nil
+}
+
+// RawTestLogPath returns the fixed private log path owned by an evidence
+// directory. The file is removed during finalization or cleanup.
+func RawTestLogPath(outputDirectory string) string {
+	return filepath.Join(outputDirectory, rawTestLogFileName)
+}
+
+// WritePreflight stores a validated intermediate report transactionally.
+func WritePreflight(outputDirectory string, report PreflightReport) error {
+	if err := requireOwnedOutput(outputDirectory); err != nil {
+		return err
+	}
+	if err := validatePreflightReport(report); err != nil {
+		return err
+	}
+	data, err := marshalDocument(report)
+	if err != nil {
+		return fmt.Errorf("marshal compositor preflight: %w", err)
+	}
+	return atomicWrite(filepath.Join(outputDirectory, preflightFileName), data, 0o600)
+}
+
+// Finalize converts a passed raw Go test log into canonical sanitized evidence,
+// verifies the complete directory, and writes the validated marker last.
+func Finalize(config FinalizeConfig) (_ Manifest, retErr error) {
+	if err := validateFinalizeConfig(config); err != nil {
+		return Manifest{}, err
+	}
+	if err := requireOwnedOutput(config.OutputDirectory); err != nil {
+		return Manifest{}, err
+	}
+	rawPath := RawTestLogPath(config.OutputDirectory)
+	defer func() {
+		if removeErr := os.Remove(rawPath); removeErr != nil &&
+			!errors.Is(removeErr, os.ErrNotExist) && retErr == nil {
+			retErr = fmt.Errorf("remove private raw test log: %w", removeErr)
+		}
+	}()
+	if config.TestExitCode != 0 {
+		return Manifest{}, errors.New("protected integration test failed")
+	}
+
+	report, err := readPreflight(config.OutputDirectory)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if report.Commit != config.ExpectedCommit ||
+		report.Desktop.Lane != config.ExpectedLane ||
+		report.Desktop.Cell != config.ExpectedCell ||
+		report.Workflow != config.Workflow ||
+		report.RunID != config.RunID ||
+		report.RunAttempt != config.RunAttempt {
+		return Manifest{}, errors.New("preflight identity does not match finalization request")
+	}
+	spec, err := config.ExpectedCell.TestSpec()
+	if err != nil {
+		return Manifest{}, err
+	}
+	rawLog, err := readRegularFile(rawPath, maxLogBytes)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("private test log: %w", err)
+	}
+	if err := rejectSensitive(rawLog, config.SensitiveValues); err != nil {
+		return Manifest{}, err
+	}
+	duration, err := parsePassedGoTest(rawLog, spec)
+	if err != nil {
+		return Manifest{}, err
+	}
+	canonicalLog := canonicalTestLog(spec, duration)
+	if err := rejectSensitive(canonicalLog, nil); err != nil {
+		return Manifest{}, err
+	}
+	logDigest := sha256Hex(canonicalLog)
+
+	completedAt := config.CompletedAt
+	if completedAt.IsZero() {
+		completedAt = time.Now()
+	}
+	manifest := Manifest{
+		SchemaVersion: SchemaVersion,
+		CompletedAt:   completedAt.UTC().Format(time.RFC3339),
+		Commit:        report.Commit,
+		Ref:           report.Ref,
+		CI: CI{
+			Provider:   evidenceProvider,
+			Workflow:   report.Workflow,
+			RunID:      report.RunID,
+			RunAttempt: report.RunAttempt,
+		},
+		Platform: report.Platform,
+		Desktop:  report.Desktop,
+		Test: EvidenceTest{
+			Package:        spec.Package,
+			Name:           spec.Name,
+			Command:        spec.Command,
+			Result:         "pass",
+			DurationMillis: durationMilliseconds(duration),
+			LogFile:        testLogFileName,
+			LogSHA256:      logDigest,
+		},
+	}
+	if err := validateManifest(manifest); err != nil {
+		return Manifest{}, err
+	}
+	manifestData, err := marshalDocument(manifest)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("marshal compositor evidence: %w", err)
+	}
+	if err := rejectSensitive(manifestData, config.SensitiveValues); err != nil {
+		return Manifest{}, err
+	}
+	summary := renderSummary(manifest)
+	if err := rejectSensitive(summary, config.SensitiveValues); err != nil {
+		return Manifest{}, err
+	}
+
+	created := []string{}
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		for _, path := range created {
+			_ = os.Remove(path)
+		}
+	}()
+	for _, output := range []struct {
+		name string
+		data []byte
+	}{
+		{name: testLogFileName, data: canonicalLog},
+		{name: evidenceFileName, data: manifestData},
+		{name: summaryFileName, data: summary},
+	} {
+		path := filepath.Join(config.OutputDirectory, output.name)
+		if err := atomicWrite(path, output.data, 0o600); err != nil {
+			return Manifest{}, err
+		}
+		created = append(created, path)
+	}
+	if err := os.Remove(filepath.Join(config.OutputDirectory, preflightFileName)); err != nil {
+		return Manifest{}, fmt.Errorf("remove private preflight report: %w", err)
+	}
+	if err := os.Remove(rawPath); err != nil {
+		return Manifest{}, fmt.Errorf("remove private raw test log: %w", err)
+	}
+	if _, err := verifyDirectory(config.OutputDirectory, VerifyExpectations{
+		Commit:     config.ExpectedCommit,
+		Lane:       config.ExpectedLane,
+		Cell:       config.ExpectedCell,
+		Workflow:   config.Workflow,
+		RunID:      config.RunID,
+		RunAttempt: config.RunAttempt,
+	}, false); err != nil {
+		return Manifest{}, err
+	}
+	marker := []byte("sha256=" + sha256Hex(manifestData) + "\n")
+	markerPath := filepath.Join(config.OutputDirectory, validatedMarkerName)
+	if err := atomicWrite(markerPath, marker, 0o600); err != nil {
+		return Manifest{}, err
+	}
+	created = append(created, markerPath)
+	if _, err := verifyDirectory(config.OutputDirectory, VerifyExpectations{
+		Commit:     config.ExpectedCommit,
+		Lane:       config.ExpectedLane,
+		Cell:       config.ExpectedCell,
+		Workflow:   config.Workflow,
+		RunID:      config.RunID,
+		RunAttempt: config.RunAttempt,
+	}, true); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+// VerifyDirectory validates the schema, exact identity, canonical log digest,
+// sensitive-data denylist, summary, marker, and directory file allowlist.
+func VerifyDirectory(
+	outputDirectory string,
+	expected VerifyExpectations,
+) (Manifest, error) {
+	return verifyDirectory(outputDirectory, expected, true)
+}
+
+func verifyDirectory(
+	outputDirectory string,
+	expected VerifyExpectations,
+	requireMarker bool,
+) (Manifest, error) {
+	if err := requireOwnedOutput(outputDirectory); err != nil {
+		return Manifest{}, err
+	}
+	if err := validateVerifyExpectations(expected); err != nil {
+		return Manifest{}, err
+	}
+	allowed := map[string]bool{
+		outputSentinelName:  true,
+		testLogFileName:     true,
+		evidenceFileName:    true,
+		summaryFileName:     true,
+		validatedMarkerName: requireMarker,
+	}
+	entries, err := os.ReadDir(outputDirectory)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("read evidence directory: %w", err)
+	}
+	for _, entry := range entries {
+		if !allowed[entry.Name()] || entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			return Manifest{}, errors.New("evidence directory contains an unexpected file")
+		}
+	}
+	for name, required := range allowed {
+		if !required {
+			continue
+		}
+		if _, err := os.Lstat(filepath.Join(outputDirectory, name)); err != nil {
+			return Manifest{}, fmt.Errorf("required evidence file %q is unavailable", name)
+		}
+	}
+
+	manifestData, err := readRegularFile(
+		filepath.Join(outputDirectory, evidenceFileName),
+		maxEvidenceBytes,
+	)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if err := rejectSensitive(manifestData, nil); err != nil {
+		return Manifest{}, err
+	}
+	var manifest Manifest
+	if err := decodeStrict(manifestData, &manifest); err != nil {
+		return Manifest{}, fmt.Errorf("decode compositor evidence: %w", err)
+	}
+	if err := validateManifest(manifest); err != nil {
+		return Manifest{}, err
+	}
+	if err := matchExpectations(manifest, expected); err != nil {
+		return Manifest{}, err
+	}
+	testLog, err := readRegularFile(filepath.Join(outputDirectory, testLogFileName), maxLogBytes)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if err := rejectSensitive(testLog, nil); err != nil {
+		return Manifest{}, err
+	}
+	if sha256Hex(testLog) != manifest.Test.LogSHA256 {
+		return Manifest{}, errors.New("canonical test log digest does not match evidence")
+	}
+	if !bytes.Equal(testLog, canonicalTestLog(TestSpec{
+		Package: manifest.Test.Package,
+		Name:    manifest.Test.Name,
+		Command: manifest.Test.Command,
+	}, time.Duration(manifest.Test.DurationMillis)*time.Millisecond)) {
+		return Manifest{}, errors.New("test log is not canonical")
+	}
+	summary, err := readRegularFile(filepath.Join(outputDirectory, summaryFileName), maxLogBytes)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if err := rejectSensitive(summary, nil); err != nil {
+		return Manifest{}, err
+	}
+	if !bytes.Equal(summary, renderSummary(manifest)) {
+		return Manifest{}, errors.New("evidence summary does not match manifest")
+	}
+	if requireMarker {
+		marker, err := readRegularFile(filepath.Join(outputDirectory, validatedMarkerName), 128)
+		if err != nil {
+			return Manifest{}, err
+		}
+		wantMarker := "sha256=" + sha256Hex(manifestData) + "\n"
+		if string(marker) != wantMarker {
+			return Manifest{}, errors.New("validated marker does not match evidence")
+		}
+	}
+	return manifest, nil
+}
+
+// Cleanup removes an owned evidence directory and refuses paths without the
+// repository sentinel or outside runnerTemp.
+func Cleanup(runnerTemp, outputDirectory string) error {
+	if err := validateOutputPath(runnerTemp, outputDirectory); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(outputDirectory); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("inspect evidence directory: %w", err)
+	}
+	if err := requireOwnedOutput(outputDirectory); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(outputDirectory); err != nil {
+		return fmt.Errorf("remove compositor evidence directory: %w", err)
+	}
+	if _, err := os.Lstat(outputDirectory); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return errors.New("compositor evidence directory survived cleanup")
+		}
+		return fmt.Errorf("verify compositor evidence cleanup: %w", err)
+	}
+	return nil
+}
+
+func validateOutputPath(runnerTemp, outputDirectory string) error {
+	if !filepath.IsAbs(runnerTemp) || filepath.Clean(runnerTemp) != runnerTemp {
+		return errors.New("runner temporary directory must be a clean absolute path")
+	}
+	if !filepath.IsAbs(outputDirectory) || filepath.Clean(outputDirectory) != outputDirectory {
+		return errors.New("evidence output directory must be a clean absolute path")
+	}
+	if filepath.Dir(outputDirectory) != runnerTemp {
+		return errors.New("evidence output directory must be a direct child of runner temporary storage")
+	}
+	info, err := os.Lstat(runnerTemp)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("runner temporary directory is unavailable")
+	}
+	return nil
+}
+
+func requireOwnedOutput(outputDirectory string) error {
+	info, err := os.Lstat(outputDirectory)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("compositor evidence directory is unavailable")
+	}
+	sentinel, err := readRegularFile(
+		filepath.Join(outputDirectory, outputSentinelName),
+		len(outputSentinelContent),
+	)
+	if err != nil || string(sentinel) != outputSentinelContent {
+		return errors.New("compositor evidence ownership sentinel is invalid")
+	}
+	return nil
+}
+
+func readPreflight(outputDirectory string) (PreflightReport, error) {
+	data, err := readRegularFile(
+		filepath.Join(outputDirectory, preflightFileName),
+		maxEvidenceBytes,
+	)
+	if err != nil {
+		return PreflightReport{}, fmt.Errorf("read compositor preflight: %w", err)
+	}
+	var report PreflightReport
+	if err := decodeStrict(data, &report); err != nil {
+		return PreflightReport{}, fmt.Errorf("decode compositor preflight: %w", err)
+	}
+	if err := validatePreflightReport(report); err != nil {
+		return PreflightReport{}, err
+	}
+	return report, nil
+}
+
+func validateFinalizeConfig(config FinalizeConfig) error {
+	if err := validateOutputPath(config.RunnerTemp, config.OutputDirectory); err != nil {
+		return err
+	}
+	if !gitObjectPattern.MatchString(config.ExpectedCommit) {
+		return errors.New("expected commit is invalid")
+	}
+	if err := validateLaneCell(config.ExpectedLane, config.ExpectedCell); err != nil {
+		return err
+	}
+	if _, err := config.ExpectedCell.TestSpec(); err != nil {
+		return err
+	}
+	if err := validateWorkflow(config.ExpectedCell, config.Workflow); err != nil {
+		return err
+	}
+	if !runIDPattern.MatchString(config.RunID) {
+		return errors.New("run ID must be a positive decimal integer")
+	}
+	if config.RunAttempt <= 0 {
+		return errors.New("run attempt must be positive")
+	}
+	if config.TestExitCode < 0 {
+		return errors.New("test exit code must not be negative")
+	}
+	return nil
+}
+
+func validateVerifyExpectations(expected VerifyExpectations) error {
+	if !gitObjectPattern.MatchString(expected.Commit) {
+		return errors.New("expected commit is invalid")
+	}
+	if err := validateLaneCell(expected.Lane, expected.Cell); err != nil {
+		return err
+	}
+	if err := validateWorkflow(expected.Cell, expected.Workflow); err != nil {
+		return err
+	}
+	if !runIDPattern.MatchString(expected.RunID) {
+		return errors.New("expected run ID must be a positive decimal integer")
+	}
+	if expected.RunAttempt <= 0 {
+		return errors.New("expected run attempt must be positive")
+	}
+	return nil
+}
+
+func validateManifest(manifest Manifest) error {
+	if manifest.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("compositor evidence schema %q, want %q", manifest.SchemaVersion, SchemaVersion)
+	}
+	if _, err := time.Parse(time.RFC3339, manifest.CompletedAt); err != nil {
+		return errors.New("completed timestamp must be RFC3339 UTC")
+	}
+	if !strings.HasSuffix(manifest.CompletedAt, "Z") {
+		return errors.New("completed timestamp must use UTC")
+	}
+	if err := validateGitIdentity(manifest.Commit, manifest.Ref); err != nil {
+		return err
+	}
+	if manifest.CI.Provider != evidenceProvider {
+		return errors.New("unsupported compositor evidence provider")
+	}
+	if err := validateText("workflow", manifest.CI.Workflow); err != nil {
+		return err
+	}
+	if !runIDPattern.MatchString(manifest.CI.RunID) || manifest.CI.RunAttempt <= 0 {
+		return errors.New("invalid compositor evidence run identity")
+	}
+	if err := validatePreflightReport(PreflightReport{
+		SchemaVersion: preflightSchemaVersion,
+		Commit:        manifest.Commit,
+		Ref:           manifest.Ref,
+		Workflow:      manifest.CI.Workflow,
+		RunID:         manifest.CI.RunID,
+		RunAttempt:    manifest.CI.RunAttempt,
+		Platform:      manifest.Platform,
+		Desktop:       manifest.Desktop,
+	}); err != nil {
+		return err
+	}
+	spec, err := manifest.Desktop.Cell.TestSpec()
+	if err != nil {
+		return err
+	}
+	if manifest.Test.Package != spec.Package || manifest.Test.Name != spec.Name ||
+		manifest.Test.Command != spec.Command {
+		return errors.New("test identity does not match evidence cell")
+	}
+	if manifest.Test.Result != "pass" || manifest.Test.DurationMillis < 0 {
+		return errors.New("compositor evidence test did not pass")
+	}
+	if manifest.Test.LogFile != testLogFileName {
+		return errors.New("compositor evidence test log name is invalid")
+	}
+	if !digestPattern.MatchString(manifest.Test.LogSHA256) {
+		return errors.New("test log SHA-256 is invalid")
+	}
+	return nil
+}
+
+func matchExpectations(manifest Manifest, expected VerifyExpectations) error {
+	comparisons := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "commit", got: manifest.Commit, want: expected.Commit},
+		{name: "lane", got: string(manifest.Desktop.Lane), want: string(expected.Lane)},
+		{name: "cell", got: string(manifest.Desktop.Cell), want: string(expected.Cell)},
+		{name: "workflow", got: manifest.CI.Workflow, want: expected.Workflow},
+		{name: "run ID", got: manifest.CI.RunID, want: expected.RunID},
+	}
+	for _, comparison := range comparisons {
+		if comparison.got != comparison.want {
+			return fmt.Errorf("%s does not match expected protected job", comparison.name)
+		}
+	}
+	if manifest.CI.RunAttempt != expected.RunAttempt {
+		return errors.New("run attempt does not match expected protected job")
+	}
+	return nil
+}
+
+func parsePassedGoTest(data []byte, spec TestSpec) (time.Duration, error) {
+	if !utf8Safe(data) {
+		return 0, errors.New("private test log is not valid bounded text")
+	}
+	runLine := "=== RUN   " + spec.Name
+	passPattern := regexp.MustCompile(`^--- PASS: ` + regexp.QuoteMeta(spec.Name) + ` \(([^)]+)\)$`)
+	packagePattern := regexp.MustCompile(
+		`^ok  \t` + regexp.QuoteMeta(spec.Package) + `\t([0-9]+(?:\.[0-9]+)?s)$`,
+	)
+	const (
+		awaitRun = iota
+		awaitTestPass
+		awaitOverallPass
+		awaitPackagePass
+		complete
+	)
+	state := awaitRun
+	var duration time.Duration
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if state == complete && line != "" {
+			return 0, errors.New("private test log contains trailing output")
+		}
+		switch {
+		case line == runLine:
+			if state != awaitRun {
+				return 0, errors.New("integration test run marker is out of order or duplicated")
+			}
+			state = awaitTestPass
+		case strings.HasPrefix(line, "=== RUN"):
+			return 0, errors.New("private test log contains an unexpected test run")
+		case passPattern.MatchString(line):
+			if state != awaitTestPass {
+				return 0, errors.New("integration test pass marker is out of order or duplicated")
+			}
+			match := passPattern.FindStringSubmatch(line)
+			parsed, err := time.ParseDuration(match[1])
+			if err != nil || parsed < 0 {
+				return 0, errors.New("integration test duration is malformed")
+			}
+			duration = parsed
+			state = awaitOverallPass
+		case strings.HasPrefix(line, "--- PASS:"):
+			return 0, errors.New("private test log contains an unexpected passing test")
+		case line == "PASS":
+			if state != awaitOverallPass {
+				return 0, errors.New("overall pass marker is out of order or duplicated")
+			}
+			state = awaitPackagePass
+		case packagePattern.MatchString(line):
+			if state != awaitPackagePass {
+				return 0, errors.New("package pass marker is out of order or duplicated")
+			}
+			match := packagePattern.FindStringSubmatch(line)
+			if _, err := time.ParseDuration(match[1]); err != nil {
+				return 0, errors.New("package pass duration is malformed")
+			}
+			state = complete
+		case strings.HasPrefix(line, "ok  \t"):
+			return 0, errors.New("private test log contains an unexpected package result")
+		case strings.HasPrefix(line, "--- FAIL:") ||
+			strings.HasPrefix(line, "--- SKIP:") || line == "FAIL":
+			return 0, errors.New("integration test did not produce a non-skipping pass")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, errors.New("scan private test log")
+	}
+	if state != complete {
+		return 0, errors.New("integration test pass evidence is incomplete")
+	}
+	return duration, nil
+}
+
+func canonicalTestLog(spec TestSpec, duration time.Duration) []byte {
+	return []byte(fmt.Sprintf(
+		"schema=%s\npackage=%s\ntest=%s\nresult=pass\nduration_ms=%d\n",
+		canonicalLogSchema,
+		spec.Package,
+		spec.Name,
+		durationMilliseconds(duration),
+	))
+}
+
+func durationMilliseconds(duration time.Duration) int64 {
+	milliseconds := duration.Milliseconds()
+	if duration > 0 && milliseconds == 0 {
+		return 1
+	}
+	return milliseconds
+}
+
+func renderSummary(manifest Manifest) []byte {
+	return []byte(fmt.Sprintf(
+		"### Protected compositor evidence\n\n- Status: validated\n- Lane: `%s`\n- Cell: `%s`\n- Commit: `%s`\n- Outputs: `%d`\n- Test: `%s`\n",
+		manifest.Desktop.Lane,
+		manifest.Desktop.Cell,
+		manifest.Commit,
+		manifest.Desktop.OutputCount,
+		manifest.Test.Name,
+	))
+}
+
+func rejectSensitive(data []byte, sensitiveValues []string) error {
+	for _, pattern := range staticSensitivePatterns {
+		if pattern.FindIndex(data) != nil {
+			return errors.New("evidence contains a sensitive-data denylist match")
+		}
+	}
+	for _, value := range sensitiveValues {
+		value = strings.TrimSpace(value)
+		if len(value) >= 4 && bytes.Contains(data, []byte(value)) {
+			return errors.New("evidence contains private runtime identity")
+		}
+	}
+	return nil
+}
+
+func marshalDocument(value any) ([]byte, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func decodeStrict(data []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func readRegularFile(path string, maximum int) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("evidence input is not a regular file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	openedInfo, err := file.Stat()
+	if err != nil || !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		return nil, errors.New("evidence input changed during validation")
+	}
+	if openedInfo.Size() > int64(maximum) {
+		return nil, fmt.Errorf("evidence input exceeds %d bytes", maximum)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, int64(maximum)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maximum {
+		return nil, fmt.Errorf("evidence input exceeds %d bytes", maximum)
+	}
+	return data, nil
+}
+
+func atomicWrite(path string, data []byte, mode os.FileMode) (retErr error) {
+	if _, err := os.Lstat(path); err == nil {
+		return errors.New("evidence output already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect evidence output: %w", err)
+	}
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, ".robotgo-evidence-*")
+	if err != nil {
+		return fmt.Errorf("create transactional evidence output: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		_ = temporary.Close()
+		_ = os.Remove(temporaryPath)
+	}()
+	if err := temporary.Chmod(mode); err != nil {
+		return fmt.Errorf("set evidence output permissions: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		return fmt.Errorf("write transactional evidence output: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync transactional evidence output: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close transactional evidence output: %w", err)
+	}
+	if err := os.Link(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish transactional evidence output: %w", err)
+	}
+	return nil
+}
+
+func sha256Hex(data []byte) string {
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}
+
+func utf8Safe(data []byte) bool {
+	if !bytes.Equal(bytes.ToValidUTF8(data, nil), data) {
+		return false
+	}
+	for _, char := range string(data) {
+		if (char < 0x20 && char != '\n' && char != '\t') || char == 0x7f {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/compositorevidence/evidence_test.go
+++ b/internal/compositorevidence/evidence_test.go
@@ -1,0 +1,381 @@
+package compositorevidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func validReport(lane Lane, cell Cell) PreflightReport {
+	portal := Portal{}
+	operatorReady := false
+	pipeWire := PipeWire{Required: cell.PipeWireRequired()}
+	if cell.PortalObserved() {
+		portal = Portal{
+			Observed:             true,
+			Available:            true,
+			FrontendVersion:      "1.20.0",
+			Backend:              string(lane),
+			BackendVersion:       "1.20.0",
+			RemoteDesktopVersion: 2,
+			ScreenCastVersion:    5,
+			AvailableSources:     1,
+		}
+	}
+	if cell.ConsentRequired() {
+		operatorReady = true
+	}
+	if cell.PipeWireRequired() {
+		pipeWire.Version = "1.2.3"
+	}
+	compositor := string(lane)
+	workflow := "RemoteDesktop E2E"
+	if lane == LaneWlroots {
+		compositor = "sway"
+	}
+	if cell == CellScreenCast {
+		workflow = "ScreenCast E2E"
+	}
+	return PreflightReport{
+		SchemaVersion: preflightSchemaVersion,
+		Commit:        testCommit,
+		Ref:           testRef,
+		Workflow:      workflow,
+		RunID:         "12345",
+		RunAttempt:    2,
+		Platform: Platform{
+			OSID:          "ubuntu",
+			OSVersion:     "24.04",
+			KernelName:    "Linux",
+			KernelRelease: "6.12.4-test",
+			Architecture:  "amd64",
+			GoVersion:     "go1.25.0",
+		},
+		Desktop: Desktop{
+			Lane:              lane,
+			Cell:              cell,
+			Compositor:        compositor,
+			CompositorVersion: "1.2.3",
+			OutputCount:       2,
+			OperatorReady:     operatorReady,
+			Portal:            portal,
+			PipeWire:          pipeWire,
+		},
+	}
+}
+
+func passedRawLog(spec TestSpec) []byte {
+	return []byte(
+		"=== RUN   " + spec.Name + "\n" +
+			"--- PASS: " + spec.Name + " (1.25s)\n" +
+			"PASS\n" +
+			"ok  \t" + spec.Package + "\t1.250s\n",
+	)
+}
+
+func prepareFinalization(t *testing.T, lane Lane, cell Cell) (string, FinalizeConfig) {
+	t.Helper()
+	runnerTemp := t.TempDir()
+	outputDirectory := filepath.Join(runnerTemp, "compositor-report")
+	if err := PrepareOutputDirectory(runnerTemp, outputDirectory); err != nil {
+		t.Fatal(err)
+	}
+	if err := WritePreflight(outputDirectory, validReport(lane, cell)); err != nil {
+		t.Fatal(err)
+	}
+	spec, err := cell.TestSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(RawTestLogPath(outputDirectory), passedRawLog(spec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	report := validReport(lane, cell)
+	return outputDirectory, FinalizeConfig{
+		RunnerTemp:      runnerTemp,
+		OutputDirectory: outputDirectory,
+		ExpectedCommit:  testCommit,
+		ExpectedLane:    lane,
+		ExpectedCell:    cell,
+		Workflow:        report.Workflow,
+		RunID:           "12345",
+		RunAttempt:      2,
+		TestExitCode:    0,
+		CompletedAt:     time.Date(2026, time.July, 21, 12, 30, 0, 0, time.UTC),
+		SensitiveValues: []string{"wayland-private-9", "/private/home"},
+	}
+}
+
+func TestFinalizeAndVerifyCreateOnlySanitizedEvidence(t *testing.T) {
+	t.Parallel()
+	outputDirectory, config := prepareFinalization(t, LaneGNOME, CellRemoteDesktop)
+	manifest, err := Finalize(config)
+	if err != nil {
+		t.Fatalf("Finalize failed: %v", err)
+	}
+	if manifest.Test.DurationMillis != 1250 {
+		t.Fatalf("duration = %dms, want 1250ms", manifest.Test.DurationMillis)
+	}
+	verified, err := VerifyDirectory(outputDirectory, VerifyExpectations{
+		Commit:     testCommit,
+		Lane:       LaneGNOME,
+		Cell:       CellRemoteDesktop,
+		Workflow:   config.Workflow,
+		RunID:      config.RunID,
+		RunAttempt: config.RunAttempt,
+	})
+	if err != nil {
+		t.Fatalf("VerifyDirectory failed: %v", err)
+	}
+	if verified.Test.LogSHA256 != manifest.Test.LogSHA256 {
+		t.Fatal("verified test-log digest changed")
+	}
+	for _, privateName := range []string{rawTestLogFileName, preflightFileName} {
+		if _, err := os.Lstat(filepath.Join(outputDirectory, privateName)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("private intermediate %q survived: %v", privateName, err)
+		}
+	}
+	entries, err := os.ReadDir(outputDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		outputSentinelName,
+		validatedMarkerName,
+		evidenceFileName,
+		summaryFileName,
+		testLogFileName,
+	}
+	if len(entries) != len(want) {
+		t.Fatalf("evidence files = %v, want %v", entries, want)
+	}
+	for index, entry := range entries {
+		if entry.Name() != want[index] {
+			t.Fatalf("evidence file %d = %q, want %q", index, entry.Name(), want[index])
+		}
+	}
+	canonical, err := os.ReadFile(filepath.Join(outputDirectory, testLogFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(canonical, []byte("=== RUN")) ||
+		bytes.Contains(canonical, []byte("ok  \t")) {
+		t.Fatalf("canonical log retained raw Go output: %q", canonical)
+	}
+}
+
+func TestFinalizeRejectsSensitiveRawLogAndRemovesIt(t *testing.T) {
+	t.Parallel()
+	outputDirectory, config := prepareFinalization(t, LaneGNOME, CellRemoteDesktop)
+	rawPath := RawTestLogPath(outputDirectory)
+	data, err := os.ReadFile(rawPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append([]byte("WAYLAND_DISPLAY=wayland-private-9\n"), data...)
+	if err := os.WriteFile(rawPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Finalize(config); err == nil || !strings.Contains(err.Error(), "denylist") {
+		t.Fatalf("Finalize error = %v, want denylist rejection", err)
+	}
+	if _, err := os.Lstat(rawPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("private raw log survived rejection: %v", err)
+	}
+	for _, name := range []string{testLogFileName, evidenceFileName, summaryFileName, validatedMarkerName} {
+		if _, err := os.Lstat(filepath.Join(outputDirectory, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("artifact %q survived failed finalization: %v", name, err)
+		}
+	}
+}
+
+func TestFinalizeFailureAndPartialWriteCleanup(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		configure func(string, *FinalizeConfig) error
+	}{
+		{
+			name: "test failure",
+			configure: func(_ string, config *FinalizeConfig) error {
+				config.TestExitCode = 1
+				return nil
+			},
+		},
+		{
+			name: "late output collision",
+			configure: func(outputDirectory string, _ *FinalizeConfig) error {
+				return os.WriteFile(filepath.Join(outputDirectory, summaryFileName), []byte("collision"), 0o600)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			outputDirectory, config := prepareFinalization(t, LaneGNOME, CellRemoteDesktop)
+			if err := tc.configure(outputDirectory, &config); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Finalize(config); err == nil {
+				t.Fatal("Finalize succeeded")
+			}
+			if _, err := os.Lstat(RawTestLogPath(outputDirectory)); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("raw log survived: %v", err)
+			}
+			for _, name := range []string{testLogFileName, evidenceFileName, validatedMarkerName} {
+				if _, err := os.Lstat(filepath.Join(outputDirectory, name)); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("partial artifact %q survived: %v", name, err)
+				}
+			}
+		})
+	}
+}
+
+func TestVerifyRejectsUnknownManifestFieldAndTamperedLog(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		tamper func(string) error
+		want   string
+	}{
+		{
+			name: "unknown field",
+			tamper: func(outputDirectory string) error {
+				path := filepath.Join(outputDirectory, evidenceFileName)
+				data, err := os.ReadFile(path)
+				if err != nil {
+					return err
+				}
+				var document map[string]any
+				if err := json.Unmarshal(data, &document); err != nil {
+					return err
+				}
+				document["unexpected"] = true
+				data, err = json.Marshal(document)
+				if err != nil {
+					return err
+				}
+				return os.WriteFile(path, data, 0o600)
+			},
+			want: "unknown field",
+		},
+		{
+			name: "test log",
+			tamper: func(outputDirectory string) error {
+				return os.WriteFile(
+					filepath.Join(outputDirectory, testLogFileName),
+					[]byte("schema=tampered\n"),
+					0o600,
+				)
+			},
+			want: "digest",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			outputDirectory, config := prepareFinalization(t, LaneGNOME, CellRemoteDesktop)
+			if _, err := Finalize(config); err != nil {
+				t.Fatal(err)
+			}
+			if err := tc.tamper(outputDirectory); err != nil {
+				t.Fatal(err)
+			}
+			_, err := VerifyDirectory(outputDirectory, VerifyExpectations{
+				Commit:     testCommit,
+				Lane:       LaneGNOME,
+				Cell:       CellRemoteDesktop,
+				Workflow:   config.Workflow,
+				RunID:      config.RunID,
+				RunAttempt: config.RunAttempt,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("VerifyDirectory error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParsePassedGoTestRejectsSkipAndIncompleteOutput(t *testing.T) {
+	t.Parallel()
+	spec, err := CellRemoteDesktop.TestSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, log := range []string{
+		"=== RUN   " + spec.Name + "\n--- SKIP: " + spec.Name + " (0.00s)\nPASS\n",
+		"PASS\nok  \t" + spec.Package + "\t0.1s\n",
+		"=== RUN   TestUnexpected\n--- PASS: TestUnexpected (0.01s)\n" + string(passedRawLog(spec)),
+		"--- PASS: " + spec.Name + " (0.01s)\n=== RUN   " + spec.Name + "\nPASS\nok  \t" + spec.Package + "\t0.1s\n",
+		"=== RUN   " + spec.Name + "\n--- PASS: " + spec.Name + " (0.01s)\nok  \t" + spec.Package + "\t0.1s\nPASS\n",
+		string(passedRawLog(spec)) + "unexpected trailing output\n",
+		"=== RUN   " + spec.Name + "\n--- PASS: " + spec.Name + " (1.25s)\nPASS\nok  \t" + spec.Package + "\tnot-a-duration\n",
+	} {
+		if _, err := parsePassedGoTest([]byte(log), spec); err == nil {
+			t.Fatalf("parsePassedGoTest(%q) succeeded", log)
+		}
+	}
+}
+
+func TestFinalizeRejectsPreflightRunIdentityMismatch(t *testing.T) {
+	t.Parallel()
+	outputDirectory, config := prepareFinalization(t, LaneGNOME, CellRemoteDesktop)
+	config.RunID = "54321"
+	if _, err := Finalize(config); err == nil || !strings.Contains(err.Error(), "identity") {
+		t.Fatalf("Finalize error = %v, want preflight identity rejection", err)
+	}
+	if _, err := os.Lstat(RawTestLogPath(outputDirectory)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("private raw log survived identity rejection: %v", err)
+	}
+}
+
+func TestCleanupRequiresSentinelAndRemovesPrivateIntermediates(t *testing.T) {
+	t.Parallel()
+	runnerTemp := t.TempDir()
+	unrelated := filepath.Join(runnerTemp, "unrelated")
+	if err := os.Mkdir(unrelated, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := Cleanup(runnerTemp, unrelated); err == nil || !strings.Contains(err.Error(), "sentinel") {
+		t.Fatalf("Cleanup unrelated error = %v", err)
+	}
+
+	owned := filepath.Join(runnerTemp, "owned")
+	if err := PrepareOutputDirectory(runnerTemp, owned); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(RawTestLogPath(owned), []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Cleanup(runnerTemp, owned); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(owned); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("owned evidence survived cleanup: %v", err)
+	}
+}
+
+func TestPrepareOutputDirectoryRejectsEscapeAndExistingDirectory(t *testing.T) {
+	t.Parallel()
+	runnerTemp := t.TempDir()
+	if err := PrepareOutputDirectory(runnerTemp, filepath.Join(runnerTemp, "..", "escape")); err == nil {
+		t.Fatal("PrepareOutputDirectory accepted escape")
+	}
+	nestedParent := filepath.Join(runnerTemp, "nested")
+	if err := os.Mkdir(nestedParent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := PrepareOutputDirectory(runnerTemp, filepath.Join(nestedParent, "report")); err == nil {
+		t.Fatal("PrepareOutputDirectory accepted nested output path")
+	}
+	existing := filepath.Join(runnerTemp, "existing")
+	if err := os.Mkdir(existing, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := PrepareOutputDirectory(runnerTemp, existing); err == nil {
+		t.Fatal("PrepareOutputDirectory accepted existing directory")
+	}
+}

--- a/internal/compositorevidence/operator_owner_linux.go
+++ b/internal/compositorevidence/operator_owner_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package compositorevidence
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func validateOperatorReadyOwner(info os.FileInfo) error {
+	status, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || status.Uid != 0 {
+		return errors.New("operator readiness attestation is not owned by root")
+	}
+	return nil
+}

--- a/internal/compositorevidence/operator_owner_other.go
+++ b/internal/compositorevidence/operator_owner_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package compositorevidence
+
+import (
+	"errors"
+	"os"
+)
+
+func validateOperatorReadyOwner(os.FileInfo) error {
+	return errors.New("operator readiness attestation is supported only on Linux")
+}

--- a/internal/compositorevidence/preflight.go
+++ b/internal/compositorevidence/preflight.go
@@ -1,0 +1,751 @@
+package compositorevidence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/marang/robotgo/internal/command"
+)
+
+const (
+	portalBusName            = "org.freedesktop.portal.Desktop"
+	portalObjectPath         = "/org/freedesktop/portal/desktop"
+	remoteDesktopInterface   = "org.freedesktop.portal.RemoteDesktop"
+	screenCastInterface      = "org.freedesktop.portal.ScreenCast"
+	portalVersionProperty    = "version"
+	availableSourcesProperty = "AvailableSourceTypes"
+	pipeWirePackage          = "libpipewire-0.3"
+	operatorReadyContent     = "ready"
+	defaultOSReleasePath     = "/etc/os-release"
+	maxProbeOutputBytes      = 4096
+)
+
+// PreflightConfig contains trusted workflow inputs and private session values.
+// Private values are validated but never copied into the report.
+type PreflightConfig struct {
+	Lane               Lane
+	Cell               Cell
+	CheckoutCommit     string
+	ExpectedCommit     string
+	Ref                string
+	Workflow           string
+	RunID              string
+	RunAttempt         int
+	CurrentDesktop     string
+	WaylandDisplay     string
+	RuntimeDir         string
+	SessionBusAddress  string
+	OperatorReadyPath  string
+	OutputCount        int
+	MinimumOutputCount int
+	ProbeTimeout       time.Duration
+}
+
+// Platform identifies a sanitized runner software platform.
+type Platform struct {
+	OSID          string `json:"os_id"`
+	OSVersion     string `json:"os_version"`
+	KernelName    string `json:"kernel_name"`
+	KernelRelease string `json:"kernel_release"`
+	Architecture  string `json:"architecture"`
+	GoVersion     string `json:"go_version"`
+}
+
+// Portal identifies the selected real desktop portal contract. Empty versions
+// are allowed only for an explicit portal-availability cell.
+type Portal struct {
+	Observed             bool   `json:"observed"`
+	Available            bool   `json:"available"`
+	FrontendVersion      string `json:"frontend_version"`
+	Backend              string `json:"backend"`
+	BackendVersion       string `json:"backend_version"`
+	RemoteDesktopVersion uint64 `json:"remote_desktop_version"`
+	ScreenCastVersion    uint64 `json:"screencast_version"`
+	AvailableSources     uint64 `json:"available_sources"`
+}
+
+// PipeWire identifies the persistent capture runtime required by ScreenCast.
+type PipeWire struct {
+	Required bool   `json:"required"`
+	Version  string `json:"version"`
+}
+
+// Desktop identifies only allowlisted compositor facts required by evidence.
+type Desktop struct {
+	Lane              Lane     `json:"lane"`
+	Cell              Cell     `json:"cell"`
+	Compositor        string   `json:"compositor"`
+	CompositorVersion string   `json:"compositor_version"`
+	OutputCount       int      `json:"output_count"`
+	OperatorReady     bool     `json:"operator_ready"`
+	Portal            Portal   `json:"portal"`
+	PipeWire          PipeWire `json:"pipewire"`
+}
+
+// PreflightReport is the private intermediate document consumed by finalization.
+type PreflightReport struct {
+	SchemaVersion string   `json:"schema_version"`
+	Commit        string   `json:"commit"`
+	Ref           string   `json:"ref"`
+	Workflow      string   `json:"workflow"`
+	RunID         string   `json:"run_id"`
+	RunAttempt    int      `json:"run_attempt"`
+	Platform      Platform `json:"platform"`
+	Desktop       Desktop  `json:"desktop"`
+}
+
+type preflightDependencies struct {
+	output        func(context.Context, string, ...string) ([]byte, error)
+	socketReady   func(string, string) error
+	operatorReady func(string, string) error
+	readFile      func(string) ([]byte, error)
+}
+
+// Preflight validates the selected runner cell and returns a sanitized report.
+func Preflight(ctx context.Context, config PreflightConfig) (PreflightReport, error) {
+	return preflight(ctx, config, preflightDependencies{
+		output:        command.Output,
+		socketReady:   validateWaylandSocket,
+		operatorReady: validateOperatorReady,
+		readFile:      os.ReadFile,
+	})
+}
+
+func preflight(
+	ctx context.Context,
+	config PreflightConfig,
+	dependencies preflightDependencies,
+) (PreflightReport, error) {
+	if err := validatePreflightConfig(config); err != nil {
+		return PreflightReport{}, err
+	}
+	if dependencies.output == nil || dependencies.socketReady == nil ||
+		dependencies.operatorReady == nil || dependencies.readFile == nil {
+		return PreflightReport{}, errors.New("preflight dependencies are incomplete")
+	}
+	if err := dependencies.socketReady(config.RuntimeDir, config.WaylandDisplay); err != nil {
+		return PreflightReport{}, fmt.Errorf("wayland socket check failed: %w", err)
+	}
+	if strings.TrimSpace(config.SessionBusAddress) == "" {
+		return PreflightReport{}, errors.New("session bus check failed")
+	}
+
+	compositor, err := matchDesktop(config.Lane, config.CurrentDesktop)
+	if err != nil {
+		return PreflightReport{}, err
+	}
+	if config.Cell.NativeRequired() && compositor != "sway" {
+		return PreflightReport{}, errors.New("protected native wlroots cells currently require the pinned Sway image")
+	}
+
+	probe := commandProbe{
+		output:  dependencies.output,
+		timeout: config.ProbeTimeout,
+	}
+	if err := probeBusName(ctx, probe, "org.freedesktop.DBus"); err != nil {
+		return PreflightReport{}, fmt.Errorf("session bus check failed: %w", err)
+	}
+	platform, err := probePlatform(ctx, dependencies.readFile, probe)
+	if err != nil {
+		return PreflightReport{}, err
+	}
+	compositorVersion, err := probe.packageVersion(ctx, compositorPackage(config.Lane))
+	if err != nil {
+		return PreflightReport{}, fmt.Errorf("compositor version check failed: %w", err)
+	}
+
+	desktop := Desktop{
+		Lane:              config.Lane,
+		Cell:              config.Cell,
+		Compositor:        compositor,
+		CompositorVersion: compositorVersion,
+		OutputCount:       config.OutputCount,
+		PipeWire: PipeWire{
+			Required: config.Cell.PipeWireRequired(),
+		},
+	}
+	if config.Cell.NativeRequired() {
+		if err := probeSway(ctx, probe); err != nil {
+			return PreflightReport{}, err
+		}
+	}
+	if config.Cell.PortalObserved() {
+		desktop.Portal, err = probePortal(ctx, probe, config.Lane, config.Cell)
+		if err != nil {
+			return PreflightReport{}, err
+		}
+	}
+	if config.Cell.PipeWireRequired() {
+		desktop.PipeWire.Version, err = probePipeWire(ctx, probe)
+		if err != nil {
+			return PreflightReport{}, err
+		}
+	}
+	if config.Cell.ConsentRequired() {
+		if err := dependencies.operatorReady(
+			config.OperatorReadyPath,
+			operatorAttestation(config),
+		); err != nil {
+			return PreflightReport{}, fmt.Errorf("operator console readiness check failed: %w", err)
+		}
+		desktop.OperatorReady = true
+	}
+
+	report := PreflightReport{
+		SchemaVersion: preflightSchemaVersion,
+		Commit:        config.CheckoutCommit,
+		Ref:           config.Ref,
+		Workflow:      config.Workflow,
+		RunID:         config.RunID,
+		RunAttempt:    config.RunAttempt,
+		Platform:      platform,
+		Desktop:       desktop,
+	}
+	if err := validatePreflightReport(report); err != nil {
+		return PreflightReport{}, err
+	}
+	return report, nil
+}
+
+func validatePreflightConfig(config PreflightConfig) error {
+	if err := validateLaneCell(config.Lane, config.Cell); err != nil {
+		return err
+	}
+	if err := validateGitIdentity(config.CheckoutCommit, config.Ref); err != nil {
+		return err
+	}
+	if !gitObjectPattern.MatchString(config.ExpectedCommit) {
+		return errors.New("expected commit must be a lowercase 40- or 64-character Git object ID")
+	}
+	if config.CheckoutCommit != config.ExpectedCommit {
+		return errors.New("checked-out commit does not match the approved commit")
+	}
+	if err := validateWorkflow(config.Cell, config.Workflow); err != nil {
+		return err
+	}
+	if !runIDPattern.MatchString(config.RunID) || config.RunAttempt <= 0 {
+		return errors.New("preflight run identity is invalid")
+	}
+	if config.OutputCount <= 0 {
+		return errors.New("declared output count must be positive")
+	}
+	if config.MinimumOutputCount <= 0 {
+		return errors.New("minimum output count must be positive")
+	}
+	if config.OutputCount < config.MinimumOutputCount {
+		return fmt.Errorf("declared output count is below the required minimum %d", config.MinimumOutputCount)
+	}
+	return nil
+}
+
+func matchDesktop(lane Lane, current string) (string, error) {
+	tokens := strings.FieldsFunc(strings.ToLower(current), func(char rune) bool {
+		switch char {
+		case ':', ';', ',', ' ', '\t':
+			return true
+		default:
+			return false
+		}
+	})
+	contains := func(values ...string) bool {
+		for _, token := range tokens {
+			for _, value := range values {
+				if token == value {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	switch lane {
+	case LaneGNOME:
+		if contains("gnome", "gnome-classic") {
+			return "gnome", nil
+		}
+	case LaneKDE:
+		if contains("kde", "plasma") {
+			return "kde", nil
+		}
+	case LaneWlroots:
+		for _, compositor := range []string{
+			"sway", "hyprland", "wayfire", "river", "labwc", "dwl", "gamescope",
+		} {
+			if contains(compositor) {
+				return compositor, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("desktop identity does not match protected lane %q", lane)
+}
+
+func validateWaylandSocket(runtimeDir, display string) error {
+	if !filepath.IsAbs(runtimeDir) || filepath.Clean(runtimeDir) != runtimeDir {
+		return errors.New("runtime directory must be a clean absolute path")
+	}
+	if display == "" || filepath.Base(display) != display ||
+		strings.ContainsAny(display, `/\\`) {
+		return errors.New("wayland display must be a base name")
+	}
+	info, err := os.Lstat(filepath.Join(runtimeDir, display))
+	if err != nil {
+		return errors.New("wayland display is unavailable")
+	}
+	if info.Mode()&os.ModeSymlink != 0 || info.Mode()&os.ModeSocket == 0 {
+		return errors.New("wayland display is not a socket")
+	}
+	return nil
+}
+
+func validateOperatorReady(path, expected string) error {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return errors.New("readiness path must be a clean absolute path")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return errors.New("operator console is not ready")
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() > maxTextLength {
+		return errors.New("operator readiness attestation is invalid")
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return errors.New("operator readiness attestation is writable by group or others")
+	}
+	if err := validateOperatorReadyOwner(info); err != nil {
+		return err
+	}
+	parentInfo, err := os.Lstat(filepath.Dir(path))
+	if err != nil || !parentInfo.IsDir() || parentInfo.Mode()&os.ModeSymlink != 0 {
+		return errors.New("operator readiness directory is invalid")
+	}
+	if parentInfo.Mode().Perm()&0o022 != 0 {
+		return errors.New("operator readiness directory is writable by group or others")
+	}
+	if err := validateOperatorReadyOwner(parentInfo); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || !validOperatorAttestation(data, expected) {
+		return errors.New("operator readiness attestation is invalid")
+	}
+	return nil
+}
+
+func validOperatorAttestation(data []byte, expected string) bool {
+	return string(data) == expected || string(data) == expected+"\n"
+}
+
+func operatorAttestation(config PreflightConfig) string {
+	return fmt.Sprintf(
+		"%s commit=%s run=%s attempt=%d lane=%s cell=%s",
+		operatorReadyContent,
+		config.ExpectedCommit,
+		config.RunID,
+		config.RunAttempt,
+		config.Lane,
+		config.Cell,
+	)
+}
+
+type commandProbe struct {
+	output  func(context.Context, string, ...string) ([]byte, error)
+	timeout time.Duration
+}
+
+type probeFailure uint8
+
+const (
+	probeFailureInfrastructure probeFailure = iota
+	probeFailureExecutableMissing
+	probeFailureUnavailable
+)
+
+type probeError struct {
+	failure probeFailure
+}
+
+func (err *probeError) Error() string {
+	switch err.failure {
+	case probeFailureExecutableMissing:
+		return "probe executable is unavailable"
+	case probeFailureUnavailable:
+		return "probed capability is unavailable"
+	default:
+		return "probe command failed"
+	}
+}
+
+func probeFailureIs(err error, failure probeFailure) bool {
+	var classified *probeError
+	return errors.As(err, &classified) && classified.failure == failure
+}
+
+func (probe commandProbe) run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	timeout := probe.timeout
+	if timeout <= 0 {
+		timeout = defaultProbeTimeout
+	}
+	probeContext, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	output, err := probe.output(probeContext, name, args...)
+	if err != nil {
+		if errors.Is(probeContext.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("probe timed out: %w", &probeError{failure: probeFailureInfrastructure})
+		}
+		var classified *probeError
+		if errors.As(err, &classified) {
+			return nil, classified
+		}
+		var executableError *exec.Error
+		if errors.As(err, &executableError) {
+			return nil, &probeError{failure: probeFailureExecutableMissing}
+		}
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			return nil, &probeError{failure: probeFailureUnavailable}
+		}
+		return nil, &probeError{failure: probeFailureInfrastructure}
+	}
+	if len(output) > maxProbeOutputBytes {
+		return nil, errors.New("probe output exceeds safety limit")
+	}
+	return output, nil
+}
+
+func (probe commandProbe) packageVersion(ctx context.Context, packageName string) (string, error) {
+	output, err := probe.run(ctx, "dpkg-query", "-W", "-f=${Version}", packageName)
+	if err != nil && probeFailureIs(err, probeFailureUnavailable) {
+		return "", fmt.Errorf("package version is unavailable: %w", err)
+	}
+	if err != nil && !probeFailureIs(err, probeFailureExecutableMissing) {
+		return "", fmt.Errorf("package version probe failed: %w", err)
+	}
+	if err != nil {
+		output, err = probe.run(
+			ctx,
+			"rpm",
+			"-q",
+			"--qf",
+			"%{VERSION}-%{RELEASE}",
+			packageName,
+		)
+	}
+	if err != nil {
+		if probeFailureIs(err, probeFailureUnavailable) {
+			return "", fmt.Errorf("package version is unavailable: %w", err)
+		}
+		return "", fmt.Errorf("package version probe failed: %w", err)
+	}
+	version := strings.TrimSpace(string(output))
+	if err := validateVersion("package version", version, true); err != nil {
+		return "", err
+	}
+	return version, nil
+}
+
+func compositorPackage(lane Lane) string {
+	switch lane {
+	case LaneGNOME:
+		return "gnome-shell"
+	case LaneKDE:
+		return "kwin-wayland"
+	default:
+		return "sway"
+	}
+}
+
+func portalBackend(lane Lane) (string, string, string) {
+	switch lane {
+	case LaneGNOME:
+		return "gnome", "xdg-desktop-portal-gnome", "org.freedesktop.impl.portal.desktop.gnome"
+	case LaneKDE:
+		return "kde", "xdg-desktop-portal-kde", "org.freedesktop.impl.portal.desktop.kde"
+	default:
+		return "wlr", "xdg-desktop-portal-wlr", "org.freedesktop.impl.portal.desktop.wlr"
+	}
+}
+
+func probePlatform(
+	ctx context.Context,
+	readFile func(string) ([]byte, error),
+	probe commandProbe,
+) (Platform, error) {
+	osData, err := readFile(defaultOSReleasePath)
+	if err != nil {
+		return Platform{}, errors.New("operating-system identity check failed")
+	}
+	osID, osVersion, err := parseOSRelease(osData)
+	if err != nil {
+		return Platform{}, err
+	}
+	kernelName, err := probe.run(ctx, "uname", "-s")
+	if err != nil {
+		return Platform{}, fmt.Errorf("kernel name check failed: %w", err)
+	}
+	kernelRelease, err := probe.run(ctx, "uname", "-r")
+	if err != nil {
+		return Platform{}, fmt.Errorf("kernel release check failed: %w", err)
+	}
+	platform := Platform{
+		OSID:          osID,
+		OSVersion:     osVersion,
+		KernelName:    strings.TrimSpace(string(kernelName)),
+		KernelRelease: strings.TrimSpace(string(kernelRelease)),
+		Architecture:  runtime.GOARCH,
+		GoVersion:     runtime.Version(),
+	}
+	if !kernelPattern.MatchString(platform.KernelName) ||
+		!kernelPattern.MatchString(platform.KernelRelease) {
+		return Platform{}, errors.New("kernel identity is not sanitized")
+	}
+	return platform, nil
+}
+
+func parseOSRelease(data []byte) (string, string, error) {
+	values := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		name, value, found := strings.Cut(line, "=")
+		if !found || (name != "ID" && name != "VERSION_ID") {
+			continue
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
+		values[name] = value
+	}
+	if err := validateLabel("operating-system ID", values["ID"]); err != nil {
+		return "", "", err
+	}
+	if err := validateVersion("operating-system version", values["VERSION_ID"], true); err != nil {
+		return "", "", err
+	}
+	return values["ID"], values["VERSION_ID"], nil
+}
+
+func probeSway(ctx context.Context, probe commandProbe) error {
+	output, err := probe.run(ctx, "swaymsg", "-t", "get_version", "-r")
+	if err != nil || !json.Valid(output) {
+		return errors.New("native Sway capability check failed")
+	}
+	return nil
+}
+
+func probeBusName(ctx context.Context, probe commandProbe, busName string) error {
+	output, err := probe.run(
+		ctx,
+		"busctl",
+		"--user",
+		"--no-pager",
+		"--no-legend",
+		"list",
+		busName,
+	)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) == 0 || fields[0] != busName {
+		return &probeError{failure: probeFailureUnavailable}
+	}
+	return nil
+}
+
+func probePortal(ctx context.Context, probe commandProbe, lane Lane, cell Cell) (Portal, error) {
+	backend, backendPackage, backendBusName := portalBackend(lane)
+	portal := Portal{Observed: true, Backend: backend}
+	frontendVersion, frontendErr := probe.packageVersion(ctx, "xdg-desktop-portal")
+	backendVersion, backendErr := probe.packageVersion(ctx, backendPackage)
+	remoteVersion, remoteErr := probePortalUint(ctx, probe, remoteDesktopInterface, portalVersionProperty)
+	screenVersion, screenErr := probePortalUint(ctx, probe, screenCastInterface, portalVersionProperty)
+	sources, sourcesErr := probePortalUint(ctx, probe, screenCastInterface, availableSourcesProperty)
+	ownerErr := probeBusName(ctx, probe, portalBusName)
+	backendOwnerErr := probeBusName(ctx, probe, backendBusName)
+	probeErrors := []error{
+		ownerErr,
+		backendOwnerErr,
+		frontendErr,
+		backendErr,
+		remoteErr,
+		screenErr,
+	}
+	if cell == CellRemoteDesktop || cell == CellScreenCast {
+		probeErrors = append(probeErrors, sourcesErr)
+	}
+	for _, probeErr := range probeErrors {
+		if probeErr != nil && !probeFailureIs(probeErr, probeFailureUnavailable) {
+			return Portal{}, errors.New("portal probe infrastructure failed")
+		}
+	}
+
+	portalAvailable := ownerErr == nil && backendOwnerErr == nil &&
+		frontendErr == nil && backendErr == nil && remoteErr == nil && screenErr == nil
+	if cell.PortalRequired() && !portalAvailable {
+		return Portal{}, errors.New("required portal interface check failed")
+	}
+	if (cell == CellRemoteDesktop || cell == CellScreenCast) &&
+		(sourcesErr != nil || sources == 0) {
+		return Portal{}, errors.New("ScreenCast source capability check failed")
+	}
+	if !portalAvailable {
+		return portal, nil
+	}
+	portal.Available = true
+	portal.FrontendVersion = frontendVersion
+	portal.BackendVersion = backendVersion
+	portal.RemoteDesktopVersion = remoteVersion
+	portal.ScreenCastVersion = screenVersion
+	if sourcesErr == nil {
+		portal.AvailableSources = sources
+	}
+	return portal, nil
+}
+
+func probePortalUint(
+	ctx context.Context,
+	probe commandProbe,
+	interfaceName string,
+	property string,
+) (uint64, error) {
+	output, err := probe.run(
+		ctx,
+		"busctl",
+		"--user",
+		"get-property",
+		portalBusName,
+		portalObjectPath,
+		interfaceName,
+		property,
+	)
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) != 2 || fields[0] != "u" {
+		return 0, errors.New("portal property is malformed")
+	}
+	value, err := strconv.ParseUint(fields[1], 10, 32)
+	if err != nil {
+		return 0, errors.New("portal property is malformed")
+	}
+	if value == 0 {
+		return 0, &probeError{failure: probeFailureUnavailable}
+	}
+	return value, nil
+}
+
+func probePipeWire(ctx context.Context, probe commandProbe) (string, error) {
+	versionOutput, err := probe.run(ctx, "pkg-config", "--modversion", pipeWirePackage)
+	if err != nil {
+		return "", errors.New("PipeWire package check failed")
+	}
+	version := strings.TrimSpace(string(versionOutput))
+	if err := validateVersion("PipeWire version", version, true); err != nil {
+		return "", err
+	}
+	for _, service := range []string{"pipewire.service", "wireplumber.service"} {
+		output, err := probe.run(ctx, "systemctl", "--user", "is-active", service)
+		if err != nil || strings.TrimSpace(string(output)) != "active" {
+			return "", errors.New("PipeWire user service check failed")
+		}
+	}
+	return version, nil
+}
+
+func validatePreflightReport(report PreflightReport) error {
+	if report.SchemaVersion != preflightSchemaVersion {
+		return errors.New("invalid preflight schema version")
+	}
+	if err := validateGitIdentity(report.Commit, report.Ref); err != nil {
+		return err
+	}
+	if err := validateWorkflow(report.Desktop.Cell, report.Workflow); err != nil {
+		return err
+	}
+	if !runIDPattern.MatchString(report.RunID) || report.RunAttempt <= 0 {
+		return errors.New("preflight run identity is invalid")
+	}
+	if err := validateLaneCell(report.Desktop.Lane, report.Desktop.Cell); err != nil {
+		return err
+	}
+	if err := validateLabel("operating-system ID", report.Platform.OSID); err != nil {
+		return err
+	}
+	for name, value := range map[string]string{
+		"operating-system version": report.Platform.OSVersion,
+		"Go version":               report.Platform.GoVersion,
+		"compositor version":       report.Desktop.CompositorVersion,
+	} {
+		if err := validateVersion(name, value, true); err != nil {
+			return err
+		}
+	}
+	if !kernelPattern.MatchString(report.Platform.KernelName) ||
+		!kernelPattern.MatchString(report.Platform.KernelRelease) {
+		return errors.New("kernel identity is not sanitized")
+	}
+	if err := validateLabel("architecture", report.Platform.Architecture); err != nil {
+		return err
+	}
+	if err := validateLabel("compositor", report.Desktop.Compositor); err != nil {
+		return err
+	}
+	if report.Desktop.OutputCount <= 0 {
+		return errors.New("output count must be positive")
+	}
+	if report.Desktop.Cell.ConsentRequired() && !report.Desktop.OperatorReady {
+		return errors.New("interactive portal cell lacks operator readiness")
+	}
+	if err := validatePortal(report.Desktop.Portal, report.Desktop.Cell); err != nil {
+		return err
+	}
+	if report.Desktop.PipeWire.Required != report.Desktop.Cell.PipeWireRequired() {
+		return errors.New("PipeWire requirement does not match evidence cell")
+	}
+	return validateVersion(
+		"PipeWire version",
+		report.Desktop.PipeWire.Version,
+		report.Desktop.PipeWire.Required,
+	)
+}
+
+func validatePortal(portal Portal, cell Cell) error {
+	if portal.Observed != cell.PortalObserved() {
+		return errors.New("portal observation does not match evidence cell")
+	}
+	if !portal.Observed {
+		return nil
+	}
+	if err := validateLabel("portal backend", portal.Backend); err != nil {
+		return err
+	}
+	if !portal.Available {
+		if cell.PortalRequired() {
+			return errors.New("required portal is unavailable")
+		}
+		if portal.FrontendVersion != "" || portal.BackendVersion != "" ||
+			portal.RemoteDesktopVersion != 0 || portal.ScreenCastVersion != 0 ||
+			portal.AvailableSources != 0 {
+			return errors.New("unavailable portal contains capability values")
+		}
+		return nil
+	}
+	if err := validateVersion("portal frontend version", portal.FrontendVersion, true); err != nil {
+		return err
+	}
+	if err := validateVersion("portal backend version", portal.BackendVersion, true); err != nil {
+		return err
+	}
+	if portal.RemoteDesktopVersion == 0 || portal.ScreenCastVersion == 0 {
+		return errors.New("available portal lacks interface versions")
+	}
+	if cell == CellScreenCast && portal.AvailableSources == 0 {
+		return errors.New("ScreenCast cell lacks available source types")
+	}
+	return nil
+}

--- a/internal/compositorevidence/preflight.go
+++ b/internal/compositorevidence/preflight.go
@@ -541,17 +541,21 @@ func probeBusName(ctx context.Context, probe commandProbe, busName string) error
 		ctx,
 		"busctl",
 		"--user",
-		"--no-pager",
-		"--no-legend",
-		"list",
+		"call",
+		"org.freedesktop.DBus",
+		"/org/freedesktop/DBus",
+		"org.freedesktop.DBus",
+		"GetNameOwner",
+		"s",
 		busName,
 	)
 	if err != nil {
 		return err
 	}
 	fields := strings.Fields(string(output))
-	if len(fields) == 0 || fields[0] != busName {
-		return &probeError{failure: probeFailureUnavailable}
+	if len(fields) != 2 || fields[0] != "s" ||
+		len(fields[1]) < 3 || fields[1][0] != '"' || fields[1][len(fields[1])-1] != '"' {
+		return errors.New("D-Bus name owner response is malformed")
 	}
 	return nil
 }

--- a/internal/compositorevidence/preflight_test.go
+++ b/internal/compositorevidence/preflight_test.go
@@ -47,8 +47,8 @@ func (probe *fakeProbe) output(
 	case "rpm":
 		return []byte("1.2.3-1\n"), nil
 	case "busctl":
-		if len(args) >= 2 && args[len(args)-2] == "list" {
-			return []byte(args[len(args)-1] + " 123 portal-user :1.42 session - -\n"), nil
+		if len(args) >= 2 && args[1] == "call" {
+			return []byte("s \":1.42\"\n"), nil
 		}
 		if args[len(args)-1] == availableSourcesProperty {
 			return []byte("u 3\n"), nil
@@ -232,10 +232,10 @@ func TestPreflightWlrootsRecordsPortalWithoutNameOwnerAsUnavailable(t *testing.T
 	probe := &fakeProbe{}
 	dependencies := validDependencies(probe)
 	dependencies.output = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-		if name == "busctl" && args[len(args)-2] == "list" && args[len(args)-1] == portalBusName {
-			return nil, nil
+		if name == "busctl" && args[1] == "call" && args[len(args)-1] == portalBusName {
+			return nil, &probeError{failure: probeFailureUnavailable}
 		}
-		if name == "busctl" && args[len(args)-2] != "list" {
+		if name == "busctl" && args[1] == "get-property" {
 			return nil, &probeError{failure: probeFailureUnavailable}
 		}
 		return probe.output(ctx, name, args...)
@@ -273,7 +273,7 @@ func TestPreflightWlrootsPortalAvailabilityRejectsProbeFailure(t *testing.T) {
 	probe := &fakeProbe{}
 	dependencies := validDependencies(probe)
 	dependencies.output = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-		if name == "busctl" && args[len(args)-2] != "list" {
+		if name == "busctl" && args[1] == "get-property" {
 			return nil, errors.New("probe transport failed")
 		}
 		return probe.output(ctx, name, args...)
@@ -355,7 +355,7 @@ func TestPreflightRejectsUnavailableSessionBus(t *testing.T) {
 	probe := &fakeProbe{}
 	dependencies := validDependencies(probe)
 	dependencies.output = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-		if name == "busctl" && args[len(args)-1] == "org.freedesktop.DBus" {
+		if name == "busctl" && args[1] == "call" && args[len(args)-1] == "org.freedesktop.DBus" {
 			return nil, errors.New("private bus failure")
 		}
 		return probe.output(ctx, name, args...)
@@ -375,7 +375,7 @@ func TestProbePortalRejectsMalformedRequiredProperty(t *testing.T) {
 	probe := &fakeProbe{}
 	dependencies := validDependencies(probe)
 	dependencies.output = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-		if name == "busctl" && args[len(args)-2] != "list" {
+		if name == "busctl" && args[1] == "get-property" {
 			return []byte("not-a-variant\n"), nil
 		}
 		return probe.output(ctx, name, args...)

--- a/internal/compositorevidence/preflight_test.go
+++ b/internal/compositorevidence/preflight_test.go
@@ -1,0 +1,403 @@
+package compositorevidence
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	testCommit = "0123456789abcdef0123456789abcdef01234567"
+	testRef    = "refs/heads/feature/lab-16-evidence"
+)
+
+type fakeProbe struct {
+	mu       sync.Mutex
+	calls    []string
+	failName string
+	block    bool
+}
+
+func (probe *fakeProbe) output(
+	ctx context.Context,
+	name string,
+	args ...string,
+) ([]byte, error) {
+	probe.mu.Lock()
+	probe.calls = append(probe.calls, name+" "+strings.Join(args, " "))
+	probe.mu.Unlock()
+	if probe.block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if name == probe.failName {
+		return nil, errors.New("private backend failure")
+	}
+	switch name {
+	case "uname":
+		if len(args) == 1 && args[0] == "-s" {
+			return []byte("Linux\n"), nil
+		}
+		return []byte("6.12.4-test\n"), nil
+	case "dpkg-query":
+		return []byte("1.2.3-1ubuntu1\n"), nil
+	case "rpm":
+		return []byte("1.2.3-1\n"), nil
+	case "busctl":
+		if len(args) >= 2 && args[len(args)-2] == "list" {
+			return []byte(args[len(args)-1] + " 123 portal-user :1.42 session - -\n"), nil
+		}
+		if args[len(args)-1] == availableSourcesProperty {
+			return []byte("u 3\n"), nil
+		}
+		return []byte("u 6\n"), nil
+	case "pkg-config":
+		return []byte("1.2.3\n"), nil
+	case "systemctl":
+		return []byte("active\n"), nil
+	case "swaymsg":
+		return []byte(`{"human_readable":"sway version 1.10"}`), nil
+	default:
+		return nil, errors.New("unexpected command")
+	}
+}
+
+func (probe *fakeProbe) called(name string) bool {
+	probe.mu.Lock()
+	defer probe.mu.Unlock()
+	for _, call := range probe.calls {
+		if strings.HasPrefix(call, name+" ") {
+			return true
+		}
+	}
+	return false
+}
+
+func validPreflightConfig(lane Lane, cell Cell) PreflightConfig {
+	desktop := "GNOME"
+	workflow := "RemoteDesktop E2E"
+	if lane == LaneKDE {
+		desktop = "KDE:Plasma"
+	}
+	if lane == LaneWlroots {
+		desktop = "sway"
+	}
+	if cell == CellScreenCast {
+		workflow = "ScreenCast E2E"
+	}
+	return PreflightConfig{
+		Lane:               lane,
+		Cell:               cell,
+		CheckoutCommit:     testCommit,
+		ExpectedCommit:     testCommit,
+		Ref:                testRef,
+		Workflow:           workflow,
+		RunID:              "12345",
+		RunAttempt:         2,
+		CurrentDesktop:     desktop,
+		WaylandDisplay:     "wayland-1",
+		RuntimeDir:         "/run/user/1000",
+		SessionBusAddress:  "unix:path=/run/private-bus",
+		OperatorReadyPath:  "/run/robotgo-evidence/operator-ready",
+		OutputCount:        2,
+		MinimumOutputCount: 2,
+		ProbeTimeout:       time.Second,
+	}
+}
+
+func validDependencies(probe *fakeProbe) preflightDependencies {
+	return preflightDependencies{
+		output: probe.output,
+		socketReady: func(runtimeDir, display string) error {
+			if runtimeDir != "/run/user/1000" || display != "wayland-1" {
+				return errors.New("unexpected private socket identity")
+			}
+			return nil
+		},
+		operatorReady: func(path, expected string) error {
+			if path != "/run/robotgo-evidence/operator-ready" {
+				return errors.New("unexpected readiness path")
+			}
+			if !strings.HasPrefix(expected, operatorReadyContent+" commit="+testCommit+" run=12345 attempt=2 lane=") {
+				return errors.New("unexpected readiness attestation")
+			}
+			return nil
+		},
+		readFile: func(path string) ([]byte, error) {
+			if path != defaultOSReleasePath {
+				return nil, errors.New("unexpected OS identity path")
+			}
+			return []byte("ID=ubuntu\nVERSION_ID=24.04\n"), nil
+		},
+	}
+}
+
+func TestPreflightPortalCellsSelectApplicableRequirements(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name         string
+		lane         Lane
+		cell         Cell
+		wantPipeWire bool
+	}{
+		{name: "remote desktop", lane: LaneGNOME, cell: CellRemoteDesktop},
+		{name: "screen cast", lane: LaneKDE, cell: CellScreenCast, wantPipeWire: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			probe := &fakeProbe{}
+			report, err := preflight(
+				context.Background(),
+				validPreflightConfig(tc.lane, tc.cell),
+				validDependencies(probe),
+			)
+			if err != nil {
+				t.Fatalf("preflight failed: %v", err)
+			}
+			if !report.Desktop.Portal.Available ||
+				report.Desktop.Portal.RemoteDesktopVersion != 6 ||
+				report.Desktop.Portal.ScreenCastVersion != 6 {
+				t.Fatalf("portal report = %+v", report.Desktop.Portal)
+			}
+			if report.Desktop.PipeWire.Required != tc.wantPipeWire {
+				t.Fatalf("PipeWire required = %t, want %t", report.Desktop.PipeWire.Required, tc.wantPipeWire)
+			}
+			if probe.called("pkg-config") != tc.wantPipeWire {
+				t.Fatalf("pkg-config called = %t, want %t", probe.called("pkg-config"), tc.wantPipeWire)
+			}
+			if !report.Desktop.OperatorReady {
+				t.Fatal("interactive portal cell lacks operator readiness")
+			}
+			if report.Workflow != validPreflightConfig(tc.lane, tc.cell).Workflow ||
+				report.RunID != "12345" || report.RunAttempt != 2 {
+				t.Fatalf("protected run identity = %q/%q/%d", report.Workflow, report.RunID, report.RunAttempt)
+			}
+		})
+	}
+}
+
+func TestPreflightNativeSwayDoesNotRequirePortalOrPipeWire(t *testing.T) {
+	t.Parallel()
+	probe := &fakeProbe{}
+	report, err := preflight(
+		context.Background(),
+		validPreflightConfig(LaneWlroots, CellNativeInput),
+		validDependencies(probe),
+	)
+	if err != nil {
+		t.Fatalf("preflight failed: %v", err)
+	}
+	if report.Desktop.Portal.Observed || report.Desktop.PipeWire.Required ||
+		report.Desktop.OperatorReady {
+		t.Fatalf("native report contains inapplicable requirements: %+v", report.Desktop)
+	}
+	if !probe.called("swaymsg") {
+		t.Fatal("native Sway capability was not probed")
+	}
+	calls := strings.Join(probe.calls, "\n")
+	if strings.Contains(calls, portalBusName) || probe.called("pkg-config") || probe.called("systemctl") {
+		t.Fatalf("native cell ran portal/PipeWire probes: %v", probe.calls)
+	}
+}
+
+func TestPreflightWlrootsPortalAvailabilityRecordsUnavailable(t *testing.T) {
+	t.Parallel()
+	probe := &fakeProbe{}
+	dependencies := validDependencies(probe)
+	dependencies.output = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if (name == "dpkg-query" || name == "rpm") &&
+			strings.HasPrefix(args[len(args)-1], "xdg-desktop-portal") {
+			return nil, &probeError{failure: probeFailureUnavailable}
+		}
+		return probe.output(ctx, name, args...)
+	}
+	report, err := preflight(
+		context.Background(),
+		validPreflightConfig(LaneWlroots, CellPortalAvailability),
+		dependencies,
+	)
+	if err != nil {
+		t.Fatalf("preflight failed: %v", err)
+	}
+	if !report.Desktop.Portal.Observed || report.Desktop.Portal.Available {
+		t.Fatalf("portal availability report = %+v", report.Desktop.Portal)
+	}
+}
+
+func TestPreflightWlrootsRecordsPortalWithoutNameOwnerAsUnavailable(t *testing.T) {
+	t.Parallel()
+	probe := &fakeProbe{}
+	dependencies := validDependencies(probe)
+	dependencies.output = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if name == "busctl" && args[len(args)-2] == "list" && args[len(args)-1] == portalBusName {
+			return nil, nil
+		}
+		if name == "busctl" && args[len(args)-2] != "list" {
+			return nil, &probeError{failure: probeFailureUnavailable}
+		}
+		return probe.output(ctx, name, args...)
+	}
+	report, err := preflight(
+		context.Background(),
+		validPreflightConfig(LaneWlroots, CellPortalAvailability),
+		dependencies,
+	)
+	if err != nil {
+		t.Fatalf("preflight failed: %v", err)
+	}
+	if report.Desktop.Portal.Available {
+		t.Fatalf("portal availability report = %+v", report.Desktop.Portal)
+	}
+}
+
+func TestValidOperatorAttestationRequiresExactBoundLine(t *testing.T) {
+	t.Parallel()
+	expected := operatorAttestation(validPreflightConfig(LaneGNOME, CellRemoteDesktop))
+	for _, data := range []string{expected, expected + "\n"} {
+		if !validOperatorAttestation([]byte(data), expected) {
+			t.Fatalf("validOperatorAttestation rejected %q", data)
+		}
+	}
+	for _, data := range []string{"ready", " " + expected, expected + "\n\n", expected + " stale"} {
+		if validOperatorAttestation([]byte(data), expected) {
+			t.Fatalf("validOperatorAttestation accepted %q", data)
+		}
+	}
+}
+
+func TestPreflightWlrootsPortalAvailabilityRejectsProbeFailure(t *testing.T) {
+	t.Parallel()
+	probe := &fakeProbe{}
+	dependencies := validDependencies(probe)
+	dependencies.output = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if name == "busctl" && args[len(args)-2] != "list" {
+			return nil, errors.New("probe transport failed")
+		}
+		return probe.output(ctx, name, args...)
+	}
+	_, err := preflight(
+		context.Background(),
+		validPreflightConfig(LaneWlroots, CellPortalAvailability),
+		dependencies,
+	)
+	if err == nil || !strings.Contains(err.Error(), "infrastructure") {
+		t.Fatalf("preflight error = %v, want infrastructure failure", err)
+	}
+}
+
+func TestPreflightRejectsIdentityAndTopologyMismatch(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		configure func(*PreflightConfig)
+		want      string
+	}{
+		{
+			name: "commit",
+			configure: func(config *PreflightConfig) {
+				config.ExpectedCommit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+			want: "approved commit",
+		},
+		{
+			name: "workflow",
+			configure: func(config *PreflightConfig) {
+				config.Workflow = "ScreenCast E2E"
+			},
+			want: "workflow",
+		},
+		{
+			name: "desktop",
+			configure: func(config *PreflightConfig) {
+				config.CurrentDesktop = "KDE"
+			},
+			want: "desktop identity",
+		},
+		{
+			name: "outputs",
+			configure: func(config *PreflightConfig) {
+				config.OutputCount = 1
+			},
+			want: "required minimum",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			config := validPreflightConfig(LaneGNOME, CellRemoteDesktop)
+			tc.configure(&config)
+			_, err := preflight(context.Background(), config, validDependencies(&fakeProbe{}))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("preflight error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestPreflightBoundsProbeTimeoutWithoutPrivateOutput(t *testing.T) {
+	t.Parallel()
+	probe := &fakeProbe{block: true}
+	config := validPreflightConfig(LaneGNOME, CellRemoteDesktop)
+	config.ProbeTimeout = 10 * time.Millisecond
+	_, err := preflight(context.Background(), config, validDependencies(probe))
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("preflight error = %v, want bounded timeout", err)
+	}
+	if strings.Contains(err.Error(), config.SessionBusAddress) {
+		t.Fatalf("preflight error leaked private session identity: %v", err)
+	}
+}
+
+func TestPreflightRejectsUnavailableSessionBus(t *testing.T) {
+	t.Parallel()
+	probe := &fakeProbe{}
+	dependencies := validDependencies(probe)
+	dependencies.output = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if name == "busctl" && args[len(args)-1] == "org.freedesktop.DBus" {
+			return nil, errors.New("private bus failure")
+		}
+		return probe.output(ctx, name, args...)
+	}
+	_, err := preflight(
+		context.Background(),
+		validPreflightConfig(LaneWlroots, CellNativeInput),
+		dependencies,
+	)
+	if err == nil || !strings.Contains(err.Error(), "session bus") {
+		t.Fatalf("preflight error = %v, want live session-bus rejection", err)
+	}
+}
+
+func TestProbePortalRejectsMalformedRequiredProperty(t *testing.T) {
+	t.Parallel()
+	probe := &fakeProbe{}
+	dependencies := validDependencies(probe)
+	dependencies.output = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if name == "busctl" && args[len(args)-2] != "list" {
+			return []byte("not-a-variant\n"), nil
+		}
+		return probe.output(ctx, name, args...)
+	}
+	_, err := preflight(
+		context.Background(),
+		validPreflightConfig(LaneGNOME, CellRemoteDesktop),
+		dependencies,
+	)
+	if err == nil || !strings.Contains(err.Error(), "portal") {
+		t.Fatalf("preflight error = %v, want malformed portal rejection", err)
+	}
+}
+
+func TestParseOSReleaseRejectsMissingOrUnsafeIdentity(t *testing.T) {
+	t.Parallel()
+	for _, data := range []string{
+		"ID=ubuntu\n",
+		"ID=../../private\nVERSION_ID=24.04\n",
+	} {
+		if _, _, err := parseOSRelease([]byte(data)); err == nil {
+			t.Fatalf("parseOSRelease(%q) succeeded", data)
+		}
+	}
+}


### PR DESCRIPTION
## Outcome

Adds a shared fail-closed preflight and schema-v1 evidence pipeline for the protected GNOME/KDE RemoteDesktop and ScreenCast jobs.

Linear: [LAB-16](https://linear.app/riotbox/issue/LAB-16/add-fail-closed-compositor-preflight-and-evidence-manifest)

## Behavior

- validates the exact checkout, ref, workflow/run identity, desktop lane, Wayland socket, live session bus, portal frontend/backend owners and versions, output declaration, PipeWire/WirePlumber, and operator readiness where applicable
- binds the root-owned operator attestation to commit, run ID/attempt, lane, and cell
- distinguishes confirmed portal unavailability from broken probe infrastructure
- accepts only one exact, non-skipping integration-test pass and emits a canonical allowlisted log
- writes strict schema-v1 evidence transactionally, verifies digests and identity, uploads only three sanitized files, and removes private intermediates on success and failure
- removes wlroots from portal-pass matrices; wlroots native and portal-availability evidence remains a separate P005 slice
- updates the roadmap and test/operator contract

## Risk and compatibility

No public RobotGo API changes. The workflows remain opt-in/protected and now intentionally fail closed if the runner contract or out-of-band operator handoff is missing. X11, non-Linux, and non-CGO runtime behavior is unchanged. The helper packages compile on Linux, macOS, and Windows; the root-owned interactive attestation is Linux-only by design.

## Privacy and cleanup

Raw runtime output stays in a mode-0700 runner-temp directory, is never streamed with `tee`, and is deleted before upload. Only `evidence.json`, canonical `test.log`, and `summary.md` are uploaded after strict validation. An `always()` step removes private intermediates and the owned workspace; ephemeral VM destruction remains the cancellation/timeout boundary.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=1 golangci-lint run --timeout=5m ./...`
- `CGO_ENABLED=0 golangci-lint run --timeout=5m ./...`
- `go test -race ./internal/compositorevidence ./internal/cmd/compositorevidence`
- `go test -tags portal ./screen/portal -v`
- `go test -tags pipewire ./screen/portal -v`
- integration-tag compile checks for RemoteDesktop and PipeWire
- non-CGO Windows and macOS cross-compile checks
- actionlint v1.7.12 for both changed workflows

## Runtime evidence intentionally omitted

Real GNOME/KDE consent runs require the protected ephemeral runners and out-of-band operator console described by P005. This PR implements and validates the contract; runner provisioning and promotion are the next slice.