### PR TITLE
ci: promote hosted Sway release evidence

### DIFF
--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -207,10 +207,16 @@ jobs:
               printf '%s\n' "$row" >> "$output/rows.jsonl"
             done <<'EOF'
           lint
+          native-capture
+          native-input
+          native-output
+          native-output-multi
+          native-window
           nocgo (macOS-latest)
           nocgo (ubuntu-latest)
           nocgo (windows-latest)
           ocr
+          portal-availability
           race
           release-evidence-validation
           sanitizer
@@ -326,10 +332,12 @@ jobs:
           expected_checks="$(printf '%s\n' \
             'ci/circleci: build' \
             lint \
+            native-capture native-input native-output native-output-multi \
+            native-window \
             'nocgo (macOS-latest)' \
             'nocgo (ubuntu-latest)' \
             'nocgo (windows-latest)' \
-            ocr race release-evidence-validation sanitizer \
+            ocr portal-availability race release-evidence-validation sanitizer \
             'test (macOS-latest)' \
             'test (ubuntu-latest)' \
             'test (windows-latest)' \
@@ -345,13 +353,22 @@ jobs:
           jq -e --arg commit "$commit" '
             .schema_version == "1" and
             .commit == $commit and
-            (.checks | length) == 15 and
+            (.checks | length) == 21 and
             all(.checks[];
               .conclusion == "success" and
               (.provider | type) == "string" and
               (.provider | length) > 0 and
               (.url | type) == "string" and
-              (.url | length) > 0
+              (.url | length) > 0 and
+              (if (.name == "native-capture" or
+                   .name == "native-input" or
+                   .name == "native-output" or
+                   .name == "native-output-multi" or
+                   .name == "native-window" or
+                   .name == "portal-availability")
+               then .provider == "github-actions"
+               else true
+               end)
             )
           ' required-checks/required-checks.json >/dev/null
           test_command='go test -count=1 ./...'

--- a/README.md
+++ b/README.md
@@ -1059,9 +1059,10 @@ the reported guardian is the exact child that exits and is reaped. The
 measures the guardian path and retains native CGO as the X11 default while
 Pure-Go remains the supported CGO-disabled backend. The earlier direct-path
 sample remains linked from the performance report as historical evidence.
-The stable remote checks are required by `main` branch protection. Real GNOME
-and KDE portal jobs, plus separate Sway/wlroots native and portal-availability
-jobs, remain opt-in until matching protected runners are registered.
+The stable remote checks and the six hosted Sway/wlroots native,
+single-/multi-output, and portal-availability jobs are required by `main`
+branch protection. Real GNOME and KDE portal jobs remain opt-in until matching
+protected runners and consent Environments are registered.
 
 Wayland and portal code has additional tagged suites:
 

--- a/TEST.md
+++ b/TEST.md
@@ -866,7 +866,12 @@ handoff.
 The `Release evidence` workflow validates its schema on every pull request and
 `main` push. Published releases and manual dispatches additionally run the
 default suite for native CGO and Pure-Go builds on Linux, macOS, and Windows,
-then verify and package all six evidence cells.
+then verify and package all six evidence cells. Its exact-commit protected
+manifest also requires every hosted Sway cell: native input, capture, window,
+single-output geometry, multi-output geometry, and portal availability. A
+missing, pending, skipped, neutral, cancelled, timed-out, or failed Sway check
+blocks the release bundle; GNOME/KDE portal checks remain excluded until their
+protected runner and real-consent contract exists.
 
 On a clean Linux native checkout, reproduce the generator/verifier path with:
 

--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -28,8 +28,11 @@ Each cell emits `evidence.json` and `test.log`. The JSON document records:
 The bundle also contains `required-checks.json`. It records the successful
 protected status set for the exact commit: CircleCI, lint, vet, race,
 ASan/LeakSanitizer, OCR, all three default and Pure-Go platform legs, Wayland,
-X11 evidence, and the release-evidence validator. Missing, pending, cancelled,
-or failed required checks abort snapshot publication.
+X11 evidence, the release-evidence validator, and all six hosted Sway cells
+(native input, capture, window, single-/multi-output geometry, and portal
+availability). Missing, pending, skipped, neutral, cancelled, timed-out, or
+failed required checks abort snapshot publication. The current manifest has 21
+entries.
 
 The required-check manifest in the workflow and the `main` branch-protection
 contexts are one contract. Add, rename, or remove a stable check in both places
@@ -87,5 +90,6 @@ sha256sum -c robotgo-release-evidence-*.tar.gz.sha256
 
 This six-cell release bundle does not replace real-compositor evidence. GNOME
 and KDE RemoteDesktop/ScreenCast portal rows remain pending protected runners.
-The separate hosted Sway/wlroots native and explicit portal-availability rows
-must still be promoted into the release gate for the exact release commit.
+The separate hosted Sway/wlroots native, single-/multi-output, and explicit
+portal-availability rows are required by the release gate for the exact release
+commit and remain linked to their own sanitized compositor-evidence artifacts.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -36,9 +36,9 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | Current baseline | Complete in main | Native screencopy, screenshot portal fallback, bounded waits, cleanup, live capability probes, error APIs, non-CGO contract, dedicated race/vet/sanitizer jobs, protected stable CI checks | Keep required jobs green |
 | 1. Wayland input | Implementation complete; runtime validation partial | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics, protected portal harness, and isolated hosted Sway native/availability plus multi-output matrix | Register GNOME/KDE portal runners and collect their multi-output evidence |
 | 2. Capture | Hermetic implementation complete; runtime validation partial | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, sanitizer-backed native ownership gates, and isolated hosted Sway native/multi-output evidence | Real GNOME/KDE portal and multi-output evidence |
-| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration and Weston multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected GNOME/KDE/wlroots multi-output Wayland evidence, and assess further backends selectively |
+| 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration plus Weston and hosted Sway multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected GNOME/KDE multi-output Wayland evidence, and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, provider-aware Hyprland 0.55+ Lua window dispatch | Compositor-backed state operations and cross-platform/runtime matrix coverage |
-| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, fail-closed real-compositor preflight/evidence contract, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Provision and promote dedicated compositor jobs |
+| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, fail-closed real-compositor preflight/evidence contract, promoted six-cell hosted Sway release/branch gate, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Provision and promote dedicated GNOME/KDE portal jobs |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phase 1 implementation is merged; its real-compositor evidence remains
@@ -376,14 +376,15 @@ and descriptor ownership. Release Evidence v1 records exact commit/tree/ref,
 toolchain and runtime identity, sanitized diagnostics, the passed command, and
 the test-log SHA-256 for native/Pure-Go Linux, macOS, and Windows cells. It also
 requires and records the complete protected CircleCI/lint/vet/race/sanitizer/
-platform/Wayland/X11 check set for the exact commit. The first public
+platform/Wayland/X11 and six-cell hosted Sway check set for the exact commit.
+The first public
 pre-release, [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1),
 publishes that verified six-cell bundle and checksum for exact commit
 `1bab5e173f6b96f61d349473b348f839291b9a89`; manual runs remain read-only
 artifacts. Process termination rejects non-positive and platform-overflow PIDs
 before invoking the operating system, preventing Unix process-group signaling
-through `Kill(0)` or a narrowed negative PID. Dedicated GNOME/KDE/wlroots jobs
-remain open.
+through `Kill(0)` or a narrowed negative PID. Dedicated GNOME/KDE portal jobs
+remain open; the hosted wlroots jobs are promoted.
 
 Releases require:
 

--- a/docs/plan/real-compositor-evidence.md
+++ b/docs/plan/real-compositor-evidence.md
@@ -245,8 +245,9 @@ green.
 4. Provision and prove GNOME RemoteDesktop and ScreenCast when protected
    ephemeral runner ownership and operator consent are available.
 5. Provision and prove KDE RemoteDesktop and ScreenCast under the same gate.
-6. Add promoted checks to release evidence and, when operationally reliable,
-   branch protection; update the versioned compatibility matrices.
+6. **Implemented for hosted wlroots:** require all six stable Sway checks for
+   the exact release commit and in branch protection. Extend the same promotion
+   to GNOME/KDE only after their protected runner and consent paths are proven.
 
 Create Linear issues only when the next slice has concrete runner ownership and
 acceptance evidence. Do not create speculative implementation tickets for

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -265,7 +265,8 @@ backends.
     guardian-backed application-`SIGKILL` recovery in the non-skipping Xvfb
     manifest; guardian/host/X-server loss and X11 transport stalls beyond the
     cleanup deadline remain outside that scoped guarantee.
-  - Provision the existing dedicated GNOME, KDE, and wlroots runtime workflow.
+  - Provision the existing dedicated GNOME and KDE portal workflows. The six
+    hosted wlroots/Sway checks are promoted into branch and release gates.
   - Keep the race/vet and native ASan/LeakSanitizer CI jobs green and protected.
     The sanitizer gate covers the default CGO suite plus hermetic screencopy
     allocation/free, bounded timeout cleanup, and FD ownership paths.

--- a/scripts/release_evidence_workflow_test.go
+++ b/scripts/release_evidence_workflow_test.go
@@ -1,0 +1,44 @@
+package scripts
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestReleaseEvidenceRequiresEveryHostedSwayCell(t *testing.T) {
+	t.Parallel()
+	workflow, err := os.ReadFile("../.github/workflows/release-evidence.yml")
+	if err != nil {
+		t.Fatalf("read release-evidence workflow: %v", err)
+	}
+	text := string(workflow)
+	for _, check := range []string{
+		"native-capture",
+		"native-input",
+		"native-output",
+		"native-output-multi",
+		"native-window",
+		"portal-availability",
+	} {
+		count := 0
+		for _, field := range strings.Fields(text) {
+			if strings.Trim(field, "'\"\\()") == check {
+				count++
+			}
+		}
+		if count != 3 {
+			t.Fatalf(
+				"release evidence contains %q %d times, want collector, package allowlist, and provider binding",
+				check,
+				count,
+			)
+		}
+	}
+	if !strings.Contains(text, "(.checks | length) == 21") {
+		t.Fatal("release evidence does not require the expanded exact check count")
+	}
+	if !strings.Contains(text, "then .provider == \"github-actions\"") {
+		t.Fatal("release evidence does not bind hosted Sway checks to GitHub Actions")
+	}
+}


### PR DESCRIPTION
## Outcome

Promotes all six stable hosted Sway checks into RobotGo's exact-commit release-evidence contract. A release or manual bundle can no longer be packaged unless native input, capture, window, single-output geometry, multi-output geometry, and portal availability all succeeded for the release commit.

Linear: https://linear.app/riotbox/issue/LAB-19/promote-hosted-sway-matrix-into-release-evidence

## Behavior and architecture

- Expands `required-checks.json` from 15 to 21 exact-commit entries.
- Adds `native-input`, `native-capture`, `native-window`, `native-output`, `native-output-multi`, and `portal-availability` to both the bounded collector and the package allowlist.
- Requires every Sway entry to come from the `github-actions` provider in addition to a `success` conclusion and non-empty URL.
- Preserves the existing 600-second bounded wait and fail-closed handling for missing, pending, skipped, neutral, cancelled, timed-out, or failed checks.
- Adds a hermetic regression test that detects drift among the collector, package allowlist, provider binding, and exact count.
- Updates user, testing, compatibility, roadmap, and P005 documentation.
- Synchronizes the same six contexts into `main` branch protection with GitHub Actions app ID `15368`; the existing 15 contexts and strict up-to-date requirement remain intact.

## Risk and privacy

The collector still does not check out or execute repository code. It reads only GitHub check/status metadata for the exact `GITHUB_SHA`. No compositor artifacts are copied into the release bundle: only each check's sanitized name, conclusion, provider, and URL enter `required-checks.json`. Raw Sway logs, pixels, sockets, and private runtime data remain excluded.

GNOME/KDE RemoteDesktop and ScreenCast are intentionally not promoted because their protected ephemeral runners, Environments, variables, and real-consent handoff do not yet exist.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./internal/releaseevidence ./internal/cmd/releaseevidence ./scripts`
- `go vet ./...`
- `golangci-lint run`
- `go test ./scripts -run '^TestReleaseEvidenceRequiresEveryHostedSwayCell$' -count=1 -v`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release-evidence.yml .github/workflows/sway-e2e.yml`
- hosted [Sway E2E run 29862130392](https://github.com/marang/robotgo/actions/runs/29862130392): all six exact-head cells passed
- read-only manual [Release evidence run 29862212054](https://github.com/marang/robotgo/actions/runs/29862212054): six platform snapshots, release validation, protected-check collection, and package verification passed; publish was correctly skipped
- downloaded `required-checks.json`: exact commit `f9946a4`, exactly 21 successes, all six Sway providers equal `github-actions`
- branch protection readback: `strict=true`, exactly 21 app-bound contexts, six new Sway contexts use app ID `15368`
