### PR TITLE
feat: add truthful cross-backend window geometry APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,25 @@ Native `zwlr_virtual_pointer_v1` absolute moves use the same aggregate logical
 origin, so displays positioned left of or above the primary output do not wrap
 negative global coordinates into the protocol's unsigned absolute frame.
 
+Display geometry and window geometry are separate contracts. Use
+`GetScreenRectE`/`GetDisplayBoundsE` for outputs and the desktop. Use
+`GetBoundsE`/`GetClientE` for a window:
+
+```go
+x, y, width, height, err := robotgo.GetBoundsE(0) // active Wayland window
+```
+
+Sway exposes active-window compositor-node and client geometry. Hyprland exposes
+the active compositor-reported window box, but not a trustworthy client/frame
+distinction.
+PID/handle-specific Wayland geometry, generic wlroots, GNOME/KDE, and Wayland
+core return explicit `ErrNotSupported` until a selected compositor backend can
+prove the requested semantics. The legacy `GetBounds` and `GetClient` wrappers
+return zero geometry on those errors; they never substitute aggregate desktop
+bounds. Native and Pure-Go X11, macOS, and Windows callers can pass `-pid` or
+`-handle` to the read-only
+[`window_geometry`](examples/window_geometry/main.go) example.
+
 Capture selection is:
 
 1. Native `wlr-screencopy` using DMA-BUF when supported.
@@ -1101,11 +1120,16 @@ whose fail-closed preflight and sanitized evidence contract are implemented.
 Protected GNOME/KDE portal runner provisioning and separate Sway/wlroots native
 and portal-availability promotion remain across roadmap phases 1, 2, 3, and 5;
 those phases remain partial until their gates are green.
-Phase 4 already exposes the parity surface; Hyprland provides trustworthy
-active-window maximize query, set, and restore with provider-aware dispatch for
-legacy `hyprlang` and 0.55+ Lua configurations, while Sway and generic wlroots
-retain explicit unsupported query results where their available IPC lacks an
-equivalent state. The preceding Linux/X11 evaluation is complete: shared
+Phase 4 exposes the parity surface and now has a dedicated
+[P006 window-geometry project](https://linear.app/riotbox/project/robotgo-or-p006-or-explicit-window-geometry-4af461c427fb).
+`GetBoundsE`/`GetClientE` distinguish real window geometry from display
+geometry; Sway provides active node/client bounds and Hyprland provides its
+active compositor-reported window box, while unsupported compositor and target modes fail
+explicitly. Hyprland also provides trustworthy active-window maximize query,
+set, and restore with provider-aware dispatch for legacy `hyprlang` and 0.55+
+Lua configurations, while Sway and generic wlroots retain explicit unsupported
+query results where their available IPC lacks an equivalent state. The
+preceding Linux/X11 evaluation is complete: shared
 behavior is blocking CI, current guardian-path decision evidence is versioned,
 and native CGO remains the default while Pure-Go supports CGO-disabled builds.
 Pure-Go X11 now covers capture, input, and window introspection/control; its

--- a/TEST.md
+++ b/TEST.md
@@ -722,6 +722,10 @@ intentionally preserving a foreign replacement is not itself an error.
   - Opt-in for wlroots active-window minimize/maximize E2E integration (`MinWindowE(0)`, `MaxWindowE(0)`).
 - `ROBOTGO_SWAY_TITLE_E2E=1`
   - Opt-in for sway active-window title E2E integration (`GetTitleE`).
+    The protected hosted-Sway `native-window` cell additionally proves exact
+    `GetBoundsE`/`GetClientE` node/client geometry against a self-owned,
+    borderless fixture
+    and removes the fixture and private compositor runtime on every exit path.
 - `ROBOTGO_HYPRLAND_TITLE_E2E=1`
   - Opt-in for hyprland active-window title E2E integration (`GetTitleE`).
 - `ROBOTGO_HYPRLAND_MAXIMIZE_E2E=1`

--- a/api_contract_nocgo_test.go
+++ b/api_contract_nocgo_test.go
@@ -47,3 +47,35 @@ func TestNonCGOPortableAPIContract(t *testing.T) {
 		t.Fatalf("MinWindowE invalid argument error = %v, want validation error", err)
 	}
 }
+
+func TestNonCGOWindowGeometryErrorContract(t *testing.T) {
+	operations := []struct {
+		name string
+		call func(int, ...int) (int, int, int, int, error)
+	}{
+		{name: "GetBoundsE", call: GetBoundsE},
+		{name: "GetClientE", call: GetClientE},
+	}
+	for _, operation := range operations {
+		x, y, width, height, err := operation.call(0)
+		if err == nil {
+			t.Fatalf("%s accepted zero window target", operation.name)
+		}
+		if x != 0 || y != 0 || width != 0 || height != 0 {
+			t.Fatalf(
+				"%s failure returned geometry %d,%d %dx%d",
+				operation.name,
+				x,
+				y,
+				width,
+				height,
+			)
+		}
+	}
+	if x, y, width, height := GetBounds(0); x != 0 || y != 0 || width != 0 || height != 0 {
+		t.Fatalf("legacy GetBounds failure = %d,%d %dx%d, want zero geometry", x, y, width, height)
+	}
+	if x, y, width, height := GetClient(0); x != 0 || y != 0 || width != 0 || height != 0 {
+		t.Fatalf("legacy GetClient failure = %d,%d %dx%d, want zero geometry", x, y, width, height)
+	}
+}

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -29,7 +29,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
   Weston integration, race, vet, and native sanitizer/leak variants.
 
-## Execution Status (2026-07-21)
+## Execution Status (2026-07-23)
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
@@ -37,7 +37,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 1. Wayland input | Implementation complete; runtime validation partial | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics, protected portal harness, and isolated hosted Sway native/availability plus multi-output matrix | Register GNOME/KDE portal runners and collect their multi-output evidence |
 | 2. Capture | Hermetic implementation complete; runtime validation partial | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, sanitizer-backed native ownership gates, and isolated hosted Sway native/multi-output evidence | Real GNOME/KDE portal and multi-output evidence |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration plus Weston and hosted Sway multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected GNOME/KDE multi-output Wayland evidence, and assess further backends selectively |
-| 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, provider-aware Hyprland 0.55+ Lua window dispatch | Compositor-backed state operations and cross-platform/runtime matrix coverage |
+| 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state and window-geometry error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, Sway active node/client geometry, Hyprland active compositor-reported geometry, provider-aware Hyprland 0.55+ Lua window dispatch | Further trustworthy compositor-backed state/geometry operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, fail-closed real-compositor preflight/evidence contract, promoted six-cell hosted Sway release/branch gate, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Provision and promote dedicated GNOME/KDE portal jobs |
 
 No delivery phase is complete until all of its exit criteria are blocking and
@@ -315,10 +315,19 @@ Exit criteria:
 
 ### 4. Close API and Compositor Gaps
 
+Linear delivery project:
+[`RobotGo | P006 | Explicit Window Geometry`](https://linear.app/riotbox/project/robotgo-or-p006-or-explicit-window-geometry-4af461c427fb).
+
 The compatibility surface now includes:
 
 - Error-returning window state/query APIs (`IsTopMostE`, `SetTopMostE`,
   `IsMinimizedE`, `IsMaximizedE`) with explicit unsupported behavior.
+- Error-returning window geometry APIs (`GetBoundsE`, `GetClientE`) across CGO
+  and non-CGO builds. Sway reports active node/client geometry from compositor
+  tree metadata, Hyprland reports its active compositor window box, and unavailable
+  client/frame distinctions or PID/handle modes remain explicit
+  `ErrNotSupported`. Legacy wrappers return zero geometry on failure rather
+  than substituting aggregate Wayland desktop bounds.
 - Hyprland active-window maximize query, set, and restore backed by its
   compositor-reported state. Fullscreen remains distinct from maximized;
   Sway/generic wlroots queries stay explicitly unsupported rather than
@@ -346,6 +355,8 @@ cross-platform semantics:
 
 - Extend compositor-backed state/query behavior beyond the delivered Hyprland
   maximize slice only where equally trustworthy state is exposed.
+- Collect protected Hyprland geometry evidence and add other compositor
+  geometry only where a stable active-window contract is available.
 - Add protected real-desktop capture-helper evidence beyond the delivered
   hermetic native Wayland, portal, and cross-build backend contracts.
 - Collect protected GNOME/KDE/wlroots multi-output bounds evidence beyond the

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -87,7 +87,13 @@ Current implementation baseline:
 - Window-control APIs now expose explicit Wayland NotSupported errors via
   error-returning variants (`SetActiveE`, `MinWindowE`, `MaxWindowE`,
   `CloseWindowE`, `GetTitleE`, `IsTopMostE`, `IsMinimizedE`,
-  `IsMaximizedE`, `SetTopMostE`).
+  `IsMaximizedE`, `SetTopMostE`, `GetBoundsE`, `GetClientE`).
+- Window and display geometry no longer share a misleading fallback:
+  `GetScreenRectE`/`GetDisplayBoundsE` report outputs, while
+  `GetBoundsE`/`GetClientE` report only trustworthy window geometry. Sway
+  exposes active node/client geometry, Hyprland exposes active
+  compositor-reported geometry, and unsupported target/compositor modes fail explicitly; legacy wrappers
+  return zero geometry on those failures.
 - Wayland window backend resolver is layered:
   - compositor-specific (`sway`, `hyprland`)
   - wlroots family generic backend (`wlroots-generic`)
@@ -230,8 +236,10 @@ backends.
 - Window APIs:
   - Extend compositor-backed move/resize/activate/topmost/minimize/title
     behavior while preserving explicit `ErrNotSupported` elsewhere.
-  - Validate the delivered `GetBounds`/`GetClient` `xdg-output` multi-output
-    and fractional-scale contract on protected wlroots/GNOME/KDE runners.
+  - Validate display/output geometry (`GetScreenRectE`/`GetDisplayBoundsE`)
+    independently from window geometry on protected wlroots/GNOME/KDE runners.
+    The hosted Sway window cell proves exact active node/client geometry;
+    Hyprland protected geometry evidence remains open.
   - Add resource‑leak checks for Wayland window helpers.
 - API Parity Follow-up:
   - Extend compositor-backed implementations for existing topmost/min/max

--- a/examples/window_geometry/main.go
+++ b/examples/window_geometry/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	pid := flag.Int("pid", 0, "process ID to inspect on backends that support PID resolution")
+	handle := flag.Int("handle", 0, "native window handle to inspect")
+	flag.Parse()
+
+	if *pid != 0 && *handle != 0 {
+		fmt.Fprintln(os.Stderr, "-pid and -handle are mutually exclusive")
+		os.Exit(2)
+	}
+
+	target := *pid
+	var targetMode []int
+	switch {
+	case *handle != 0:
+		target = *handle
+		targetMode = []int{1}
+	case *pid == 0:
+		fmt.Println("no target supplied; querying the active compositor window")
+	}
+
+	x, y, width, height, err := robotgo.GetBoundsE(target, targetMode...)
+	printGeometry("window", x, y, width, height, err)
+	x, y, width, height, err = robotgo.GetClientE(target, targetMode...)
+	printGeometry("client", x, y, width, height, err)
+}
+
+func printGeometry(name string, x, y, width, height int, err error) {
+	if err != nil {
+		fmt.Printf("%s geometry unavailable: %v\n", name, err)
+		return
+	}
+	fmt.Printf("%s geometry: x=%d y=%d width=%d height=%d\n", name, x, y, width, height)
+}

--- a/robotgo_linux.go
+++ b/robotgo_linux.go
@@ -38,53 +38,92 @@ import (
 // GetBounds returns the window bounds and dispatches to the appropriate
 // Wayland or X11 implementation based on DetectDisplayServer.
 func GetBounds(pid int, args ...int) (int, int, int, int) {
+	x, y, width, height, _ := GetBoundsE(pid, args...)
+	return x, y, width, height
+}
+
+// GetBoundsE returns the target window bounds or an explicit backend error.
+func GetBoundsE(pid int, args ...int) (int, int, int, int, error) {
 	if base.DetectDisplayServer() == base.Wayland {
-		rect := GetScreenRect(-1)
-		return rect.X, rect.Y, rect.W, rect.H
+		return waylandWindowGeometryE(pid, len(args) > 0 || currentTreatAsHandle(), false)
 	}
-	if !nativeX11BackendCompiled() {
-		return 0, 0, 0, 0
-	}
-
-	var isPid int
-	if len(args) > 0 || currentTreatAsHandle() {
-		isPid = 1
-		return internalGetBounds(pid, isPid)
-	}
-
-	xid, err := GetXid(nil, pid)
-	if err != nil {
-		log.Println("Get Xid from Pid errors is: ", err)
-		return 0, 0, 0, 0
-	}
-
-	return internalGetBounds(int(xid), isPid)
+	return nativeX11WindowGeometryE(pid, len(args) > 0 || currentTreatAsHandle(), false)
 }
 
 // GetClient returns the client bounds of the window and dispatches to the
 // Wayland or X11 implementation based on DetectDisplayServer.
 func GetClient(pid int, args ...int) (int, int, int, int) {
+	x, y, width, height, _ := GetClientE(pid, args...)
+	return x, y, width, height
+}
+
+// GetClientE returns the target window client bounds or an explicit backend error.
+func GetClientE(pid int, args ...int) (int, int, int, int, error) {
 	if base.DetectDisplayServer() == base.Wayland {
-		rect := GetScreenRect(-1)
-		return rect.X, rect.Y, rect.W, rect.H
+		return waylandWindowGeometryE(pid, len(args) > 0 || currentTreatAsHandle(), true)
 	}
-	if !nativeX11BackendCompiled() {
-		return 0, 0, 0, 0
-	}
+	return nativeX11WindowGeometryE(pid, len(args) > 0 || currentTreatAsHandle(), true)
+}
 
-	var isPid int
-	if len(args) > 0 || currentTreatAsHandle() {
-		isPid = 1
-		return internalGetClient(pid, isPid)
-	}
-
-	xid, err := GetXid(nil, pid)
+func waylandWindowGeometryE(
+	target int,
+	isHandle bool,
+	client bool,
+) (int, int, int, int, error) {
+	rect, err := resolveWindowBackend().Bounds(target, isHandle, client)
 	if err != nil {
-		log.Println("Get Xid from Pid errors is: ", err)
-		return 0, 0, 0, 0
+		return 0, 0, 0, 0, err
 	}
+	return rect.X, rect.Y, rect.W, rect.H, nil
+}
 
-	return internalGetClient(int(xid), isPid)
+func nativeX11WindowGeometryE(
+	target int,
+	isHandle bool,
+	client bool,
+) (int, int, int, int, error) {
+	if !nativeX11BackendCompiled() {
+		return 0, 0, 0, 0, fmt.Errorf(
+			"%w: native X11 window backend is not compiled",
+			ErrNotSupported,
+		)
+	}
+	if target <= 0 {
+		return 0, 0, 0, 0, fmt.Errorf(
+			"%w: invalid window target %d",
+			errWindowGeometryUnavailable,
+			target,
+		)
+	}
+	resolved := target
+	flag := 0
+	if isHandle {
+		flag = 1
+	} else {
+		xid, err := GetXid(nil, target)
+		if err != nil {
+			return 0, 0, 0, 0, fmt.Errorf(
+				"%w: resolve X11 window: %w",
+				errWindowGeometryUnavailable,
+				err,
+			)
+		}
+		resolved = int(xid)
+	}
+	var x, y, width, height int
+	if client {
+		x, y, width, height = internalGetClient(resolved, flag)
+	} else {
+		x, y, width, height = internalGetBounds(resolved, flag)
+	}
+	rect, err := validateWindowRect("native X11 window geometry", Rect{
+		Point: Point{X: x, Y: y},
+		Size:  Size{W: width, H: height},
+	})
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	return rect.X, rect.Y, rect.W, rect.H, nil
 }
 
 // internalGetTitle get the window title

--- a/robotgo_linux_x11.go
+++ b/robotgo_linux_x11.go
@@ -35,48 +35,85 @@ func configuredX11DisplayName() string {
 
 // GetBounds returns the window bounds using X11.
 func GetBounds(pid int, args ...int) (int, int, int, int) {
-	var isPid int
-	if len(args) > 0 || currentTreatAsHandle() {
-		isPid = 1
-		return internalGetBounds(pid, isPid)
-	}
-	unlock := lockNativeX11Display()
-	defer unlock()
-	xu, err := newX11XUtilForDisplay(getXDisplayNameLocked())
-	if err != nil {
-		log.Println("Open configured X11 target errors is: ", err)
-		return 0, 0, 0, 0
-	}
-	defer xu.Conn().Close()
-	xid, err := GetXidFromPid(xu, pid)
-	if err != nil {
-		log.Println("Get Xid from Pid errors is: ", err)
-		return 0, 0, 0, 0
-	}
-	return internalGetBoundsLocked(int(xid), isPid)
+	x, y, width, height, _ := GetBoundsE(pid, args...)
+	return x, y, width, height
+}
+
+// GetBoundsE returns the target window bounds or an explicit backend error.
+func GetBoundsE(pid int, args ...int) (int, int, int, int, error) {
+	return nativeX11WindowGeometryE(pid, len(args) > 0 || currentTreatAsHandle(), false)
 }
 
 // GetClient returns the client bounds using X11.
 func GetClient(pid int, args ...int) (int, int, int, int) {
-	var isPid int
-	if len(args) > 0 || currentTreatAsHandle() {
-		isPid = 1
-		return internalGetClient(pid, isPid)
+	x, y, width, height, _ := GetClientE(pid, args...)
+	return x, y, width, height
+}
+
+// GetClientE returns the target window client bounds or an explicit backend error.
+func GetClientE(pid int, args ...int) (int, int, int, int, error) {
+	return nativeX11WindowGeometryE(pid, len(args) > 0 || currentTreatAsHandle(), true)
+}
+
+func nativeX11WindowGeometryE(
+	target int,
+	isHandle bool,
+	client bool,
+) (int, int, int, int, error) {
+	if target <= 0 {
+		return 0, 0, 0, 0, fmt.Errorf(
+			"%w: invalid window target %d",
+			errWindowGeometryUnavailable,
+			target,
+		)
 	}
+	if isHandle {
+		var x, y, width, height int
+		if client {
+			x, y, width, height = internalGetClient(target, 1)
+		} else {
+			x, y, width, height = internalGetBounds(target, 1)
+		}
+		return checkedNativeWindowGeometry(x, y, width, height)
+	}
+
 	unlock := lockNativeX11Display()
 	defer unlock()
 	xu, err := newX11XUtilForDisplay(getXDisplayNameLocked())
 	if err != nil {
-		log.Println("Open configured X11 target errors is: ", err)
-		return 0, 0, 0, 0
+		return 0, 0, 0, 0, fmt.Errorf(
+			"%w: open configured X11 target: %w",
+			errWindowGeometryUnavailable,
+			err,
+		)
 	}
 	defer xu.Conn().Close()
-	xid, err := GetXidFromPid(xu, pid)
+	xid, err := GetXidFromPid(xu, target)
 	if err != nil {
-		log.Println("Get Xid from Pid errors is: ", err)
-		return 0, 0, 0, 0
+		return 0, 0, 0, 0, fmt.Errorf(
+			"%w: resolve X11 window: %w",
+			errWindowGeometryUnavailable,
+			err,
+		)
 	}
-	return internalGetClientLocked(int(xid), isPid)
+	var x, y, width, height int
+	if client {
+		x, y, width, height = internalGetClientLocked(int(xid), 0)
+	} else {
+		x, y, width, height = internalGetBoundsLocked(int(xid), 0)
+	}
+	return checkedNativeWindowGeometry(x, y, width, height)
+}
+
+func checkedNativeWindowGeometry(x, y, width, height int) (int, int, int, int, error) {
+	rect, err := validateWindowRect("native X11 window geometry", Rect{
+		Point: Point{X: x, Y: y},
+		Size:  Size{W: width, H: height},
+	})
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	return rect.X, rect.Y, rect.W, rect.H, nil
 }
 
 // internalGetTitle gets the window title using X11.

--- a/robotgo_mac_win.go
+++ b/robotgo_mac_win.go
@@ -24,22 +24,47 @@ import "unsafe"
 
 // GetBounds get the window bounds
 func GetBounds(pid int, args ...int) (int, int, int, int) {
+	x, y, width, height, _ := GetBoundsE(pid, args...)
+	return x, y, width, height
+}
+
+// GetBoundsE returns the target window bounds or an explicit backend error.
+func GetBoundsE(pid int, args ...int) (int, int, int, int, error) {
 	var isPid int
 	if len(args) > 0 || currentTreatAsHandle() {
 		isPid = 1
 	}
 
-	return internalGetBounds(pid, isPid)
+	x, y, width, height := internalGetBounds(pid, isPid)
+	return checkedPlatformWindowGeometry(x, y, width, height)
 }
 
 // GetClient get the window client bounds
 func GetClient(pid int, args ...int) (int, int, int, int) {
+	x, y, width, height, _ := GetClientE(pid, args...)
+	return x, y, width, height
+}
+
+// GetClientE returns the target window client bounds or an explicit backend error.
+func GetClientE(pid int, args ...int) (int, int, int, int, error) {
 	var isPid int
 	if len(args) > 0 || currentTreatAsHandle() {
 		isPid = 1
 	}
 
-	return internalGetClient(pid, isPid)
+	x, y, width, height := internalGetClient(pid, isPid)
+	return checkedPlatformWindowGeometry(x, y, width, height)
+}
+
+func checkedPlatformWindowGeometry(x, y, width, height int) (int, int, int, int, error) {
+	rect, err := validateWindowRect("native window geometry", Rect{
+		Point: Point{X: x, Y: y},
+		Size:  Size{W: width, H: height},
+	})
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	return rect.X, rect.Y, rect.W, rect.H, nil
 }
 
 // internalGetTitle get the window title

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -360,10 +360,31 @@ func pureGoSysScale(
 }
 
 func GetBounds(target int, args ...int) (int, int, int, int) {
-	return pureGoWindowBounds(target, len(args) > 0 || currentTreatAsHandle(), false)
+	x, y, width, height, _ := GetBoundsE(target, args...)
+	return x, y, width, height
 }
+
+// GetBoundsE returns the target window bounds or an explicit backend error.
+func GetBoundsE(target int, args ...int) (int, int, int, int, error) {
+	return pureGoWindowBoundsE(
+		target,
+		len(args) > 0 || currentTreatAsHandle(),
+		false,
+	)
+}
+
 func GetClient(target int, args ...int) (int, int, int, int) {
-	return pureGoWindowBounds(target, len(args) > 0 || currentTreatAsHandle(), true)
+	x, y, width, height, _ := GetClientE(target, args...)
+	return x, y, width, height
+}
+
+// GetClientE returns the target window client bounds or an explicit backend error.
+func GetClientE(target int, args ...int) (int, int, int, int, error) {
+	return pureGoWindowBoundsE(
+		target,
+		len(args) > 0 || currentTreatAsHandle(),
+		true,
+	)
 }
 func GetTitle(args ...int) string {
 	title, _ := GetTitleE(args...)

--- a/sway_native_integration_test.go
+++ b/sway_native_integration_test.go
@@ -35,6 +35,7 @@ const (
 	swayFixtureY       = 80
 	swayFixtureWidth   = 480
 	swayFixtureHeight  = 320
+	swayConfigureEvent = "xdg_surface] configure:"
 	swayOutputWidth    = 1280
 	swayOutputHeight   = 720
 	swaySecondOutputX  = -600
@@ -82,9 +83,20 @@ type swayInputIdentity struct {
 type swayFixtureNode struct {
 	AppID         string            `json:"app_id"`
 	Name          string            `json:"name"`
+	Type          string            `json:"type"`
 	Focused       bool              `json:"focused"`
+	Rect          swayFixtureRect   `json:"rect"`
+	WindowRect    swayFixtureRect   `json:"window_rect"`
+	Geometry      swayFixtureRect   `json:"geometry"`
 	Nodes         []swayFixtureNode `json:"nodes"`
 	FloatingNodes []swayFixtureNode `json:"floating_nodes"`
+}
+
+type swayFixtureRect struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
 }
 
 type lockedBoundedBuffer struct {
@@ -210,7 +222,7 @@ func TestSwayNativeCaptureRuntime(t *testing.T) {
 func TestSwayNativeWindowRuntime(t *testing.T) {
 	requireIsolatedSway(t, swaySingleOutput)
 	fixture := startSwayFixture(t)
-	configureSwayFixtureGeometry(t)
+	configureSwayFixtureGeometry(t, fixture.log)
 	waitForSwayFixtureGeometry(t)
 	title, err := GetTitleE()
 	if err != nil {
@@ -235,33 +247,117 @@ func TestSwayNativeWindowRuntime(t *testing.T) {
 	fixture.close(t, true)
 }
 
-func configureSwayFixtureGeometry(t *testing.T) {
+func configureSwayFixtureGeometry(t *testing.T, log *lockedBoundedBuffer) {
 	t.Helper()
 	criterion := `[app_id="` + swayFixtureAppID + `"]`
-	commands := [][]string{
-		{criterion, "border", "none"},
-		{criterion, "floating", "enable"},
-		{
-			criterion,
-			"resize", "set",
-			"width", strconv.Itoa(swayFixtureWidth), "px",
-			"height", strconv.Itoa(swayFixtureHeight), "px",
-		},
-		{
-			criterion,
-			"move", "position",
-			strconv.Itoa(swayFixtureX), "px",
-			strconv.Itoa(swayFixtureY), "px",
-		},
-	}
-	for _, args := range commands {
-		ctx, cancel := context.WithTimeout(context.Background(), swayCommandTimeout)
-		output, err := exec.CommandContext(ctx, cmdSwayMsg, args...).CombinedOutput()
-		cancel()
-		if err != nil {
-			t.Fatalf("configure self-owned Sway fixture geometry: %v: %s", err, output)
+	configureCount := waitForSwayConfigureSettled(t, log, 0)
+	runSwayFixtureCommand(t, criterion, "border", "none")
+	configureCount = waitForSwayConfigureSettled(t, log, configureCount)
+	runSwayFixtureCommand(t, criterion, "floating", "enable")
+	configureCount = waitForSwayConfigureSettled(t, log, configureCount)
+	waitForSwayFixtureState(t, "confirmed floating mode", func(node swayFixtureNode) bool {
+		return node.Type == swayNodeTypeFloatingContainer &&
+			node.Geometry.Width > 0 &&
+			node.Geometry.Height > 0 &&
+			node.Rect.Width == node.Geometry.Width &&
+			node.Rect.Height == node.Geometry.Height &&
+			node.WindowRect.Width == node.Geometry.Width &&
+			node.WindowRect.Height == node.Geometry.Height
+	})
+	runSwayFixtureCommand(
+		t,
+		criterion,
+		"resize", "set",
+		"width", strconv.Itoa(swayFixtureWidth), "px",
+		"height", strconv.Itoa(swayFixtureHeight), "px",
+	)
+	_ = waitForSwayConfigureSettled(t, log, configureCount)
+	waitForSwayFixtureState(t, "confirmed size", func(node swayFixtureNode) bool {
+		return node.Rect.Width == swayFixtureWidth &&
+			node.Rect.Height == swayFixtureHeight &&
+			node.WindowRect.Width == swayFixtureWidth &&
+			node.WindowRect.Height == swayFixtureHeight
+	})
+	runSwayFixtureCommand(
+		t,
+		criterion,
+		"move", "position",
+		strconv.Itoa(swayFixtureX), "px",
+		strconv.Itoa(swayFixtureY), "px",
+	)
+}
+
+func waitForSwayConfigureSettled(
+	t *testing.T,
+	log *lockedBoundedBuffer,
+	previous int,
+) int {
+	t.Helper()
+	deadline := time.Now().Add(swayFixtureTimeout)
+	last := previous
+	stable := 0
+	for time.Now().Before(deadline) {
+		count := strings.Count(log.String(), swayConfigureEvent)
+		if count > previous && count == last {
+			stable++
+			if stable >= 3 {
+				return count
+			}
+		} else {
+			stable = 0
 		}
+		last = count
+		time.Sleep(25 * time.Millisecond)
 	}
+	t.Fatalf(
+		"self-owned Sway fixture configure count did not advance past %d (last %d)",
+		previous,
+		last,
+	)
+	return 0
+}
+
+func runSwayFixtureCommand(t *testing.T, args ...string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), swayCommandTimeout)
+	output, err := exec.CommandContext(ctx, cmdSwayMsg, args...).CombinedOutput()
+	cancel()
+	if err != nil {
+		t.Fatalf("configure self-owned Sway fixture geometry: %v: %s", err, output)
+	}
+}
+
+func waitForSwayFixtureState(
+	t *testing.T,
+	description string,
+	ready func(swayFixtureNode) bool,
+) {
+	t.Helper()
+	deadline := time.Now().Add(swayFixtureTimeout)
+	var last *swayFixtureNode
+	for time.Now().Before(deadline) {
+		var tree swayFixtureNode
+		runSwayJSON(t, &tree, "get_tree")
+		if node := findSwayFixture(tree); node != nil {
+			snapshot := *node
+			last = &snapshot
+			if ready(snapshot) {
+				return
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if last == nil {
+		t.Fatalf("self-owned Sway fixture disappeared before reaching %s", description)
+	}
+	t.Fatalf(
+		"self-owned Sway fixture did not reach %s: type=%q rect=%+v window_rect=%+v geometry=%+v",
+		description,
+		last.Type,
+		last.Rect,
+		last.WindowRect,
+		last.Geometry,
+	)
 }
 
 func waitForSwayFixtureGeometry(t *testing.T) {
@@ -534,7 +630,10 @@ func startSwayFixture(t *testing.T) *swayFixture {
 	command := exec.CommandContext(
 		ctx,
 		"stdbuf", "-oL", "-eL",
-		"wev", "-f", "wl_pointer", "-f", "wl_keyboard",
+		"wev",
+		"-f", "wl_pointer",
+		"-f", "wl_keyboard",
+		"-f", "xdg_surface",
 	)
 	command.Stdout = log
 	command.Stderr = log

--- a/sway_native_integration_test.go
+++ b/sway_native_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -30,6 +31,10 @@ const (
 	envSwayRuntimeDir  = "XDG_RUNTIME_DIR"
 	swayFixtureAppID   = "wev"
 	swayFixtureTitle   = "wev"
+	swayFixtureX       = 120
+	swayFixtureY       = 80
+	swayFixtureWidth   = 480
+	swayFixtureHeight  = 320
 	swayOutputWidth    = 1280
 	swayOutputHeight   = 720
 	swaySecondOutputX  = -600
@@ -205,6 +210,8 @@ func TestSwayNativeCaptureRuntime(t *testing.T) {
 func TestSwayNativeWindowRuntime(t *testing.T) {
 	requireIsolatedSway(t, swaySingleOutput)
 	fixture := startSwayFixture(t)
+	configureSwayFixtureGeometry(t)
+	waitForSwayFixtureGeometry(t)
 	title, err := GetTitleE()
 	if err != nil {
 		t.Fatalf("query Sway fixture title: %v", err)
@@ -216,10 +223,103 @@ func TestSwayNativeWindowRuntime(t *testing.T) {
 	if !capability.Available || capability.Backend != windowBackendSway {
 		t.Fatalf("Sway window capability = %+v", capability)
 	}
+	if _, _, _, _, err := GetBoundsE(os.Getpid()); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("pid-specific Sway bounds error = %v, want ErrNotSupported", err)
+	}
+	if _, _, _, _, err := GetClientE(1, 1); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("handle-specific Sway client error = %v, want ErrNotSupported", err)
+	}
 	if err := CloseWindowE(); err != nil {
 		t.Fatalf("close self-owned Sway fixture: %v", err)
 	}
 	fixture.close(t, true)
+}
+
+func configureSwayFixtureGeometry(t *testing.T) {
+	t.Helper()
+	criterion := `[app_id="` + swayFixtureAppID + `"]`
+	commands := [][]string{
+		{criterion, "border", "none"},
+		{criterion, "floating", "enable"},
+		{
+			criterion,
+			"resize", "set",
+			"width", strconv.Itoa(swayFixtureWidth), "px",
+			"height", strconv.Itoa(swayFixtureHeight), "px",
+		},
+		{
+			criterion,
+			"move", "position",
+			strconv.Itoa(swayFixtureX), "px",
+			strconv.Itoa(swayFixtureY), "px",
+		},
+	}
+	for _, args := range commands {
+		ctx, cancel := context.WithTimeout(context.Background(), swayCommandTimeout)
+		output, err := exec.CommandContext(ctx, cmdSwayMsg, args...).CombinedOutput()
+		cancel()
+		if err != nil {
+			t.Fatalf("configure self-owned Sway fixture geometry: %v: %s", err, output)
+		}
+	}
+}
+
+func waitForSwayFixtureGeometry(t *testing.T) {
+	t.Helper()
+	assertGeometry := func(name string, client bool) bool {
+		t.Helper()
+		var x, y, width, height int
+		var err error
+		if client {
+			x, y, width, height, err = GetClientE(0)
+		} else {
+			x, y, width, height, err = GetBoundsE(0)
+		}
+		if err != nil {
+			return false
+		}
+		if x != swayFixtureX || y != swayFixtureY ||
+			width != swayFixtureWidth || height != swayFixtureHeight {
+			return false
+		}
+		var legacyX, legacyY, legacyWidth, legacyHeight int
+		if client {
+			legacyX, legacyY, legacyWidth, legacyHeight = GetClient(0)
+		} else {
+			legacyX, legacyY, legacyWidth, legacyHeight = GetBounds(0)
+		}
+		if legacyX != x || legacyY != y ||
+			legacyWidth != width || legacyHeight != height {
+			t.Fatalf(
+				"legacy %s geometry = %d,%d %dx%d, error API = %d,%d %dx%d",
+				name,
+				legacyX,
+				legacyY,
+				legacyWidth,
+				legacyHeight,
+				x,
+				y,
+				width,
+				height,
+			)
+		}
+		return true
+	}
+
+	deadline := time.Now().Add(swayFixtureTimeout)
+	for time.Now().Before(deadline) {
+		if assertGeometry("outer", false) && assertGeometry("client", true) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf(
+		"self-owned Sway fixture did not reach exact geometry %d,%d %dx%d",
+		swayFixtureX,
+		swayFixtureY,
+		swayFixtureWidth,
+		swayFixtureHeight,
+	)
 }
 
 func TestSwayNativeOutputRuntime(t *testing.T) {

--- a/window/wayland_test.go
+++ b/window/wayland_test.go
@@ -3,6 +3,7 @@
 package window
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,11 +36,18 @@ func startHeadlessWeston(t *testing.T) func() {
 
 	// Wait for socket file to appear indicating compositor is ready.
 	sockPath := filepath.Join(runtimeDir, socket)
+	ready := false
 	for i := 0; i < 50; i++ {
 		if _, err := os.Stat(sockPath); err == nil {
+			ready = true
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
+	}
+	if !ready {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatal("headless Weston did not create its Wayland socket before timeout")
 	}
 	// Allow compositor time to finish startup.
 	time.Sleep(200 * time.Millisecond)
@@ -47,6 +55,12 @@ func startHeadlessWeston(t *testing.T) func() {
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 	t.Setenv("WAYLAND_DISPLAY", socket)
 	t.Setenv("DISPLAY", "")
+	t.Setenv("XDG_CURRENT_DESKTOP", "")
+	t.Setenv("XDG_SESSION_DESKTOP", "")
+	t.Setenv("DESKTOP_SESSION", "")
+	t.Setenv("XDG_SESSION_TYPE", "wayland")
+	t.Setenv("SWAYSOCK", "")
+	t.Setenv("HYPRLAND_INSTANCE_SIGNATURE", "")
 
 	return func() {
 		_ = cmd.Process.Kill()
@@ -54,8 +68,7 @@ func startHeadlessWeston(t *testing.T) func() {
 	}
 }
 
-func TestGetBoundsWayland(t *testing.T) {
-	requireDisplay(t)
+func TestWindowBoundsDoNotMasqueradeAsWaylandDesktopBounds(t *testing.T) {
 	cleanup := startHeadlessWeston(t)
 	defer cleanup()
 
@@ -65,23 +78,19 @@ func TestGetBoundsWayland(t *testing.T) {
 
 	rect := robotgo.GetScreenRect()
 	if rect.W == 0 || rect.H == 0 {
-		t.Skip("wayland compositor did not provide bounds")
+		t.Fatal("headless Weston did not provide display bounds")
 	}
-	x, y, w, h := robotgo.GetBounds(0)
-	if x != rect.X || y != rect.Y || w != rect.W || h != rect.H {
-		t.Fatalf("GetBounds = (%d,%d %dx%d), screen rect = %+v", x, y, w, h, rect)
+	if _, _, _, _, err := robotgo.GetBoundsE(0); !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("GetBoundsE error = %v, want ErrNotSupported", err)
 	}
-	clientX, clientY, clientW, clientH := robotgo.GetClient(0)
-	if clientX != rect.X || clientY != rect.Y ||
-		clientW != rect.W || clientH != rect.H {
-		t.Fatalf(
-			"GetClient = (%d,%d %dx%d), screen rect = %+v",
-			clientX,
-			clientY,
-			clientW,
-			clientH,
-			rect,
-		)
+	if x, y, w, h := robotgo.GetBounds(0); x != 0 || y != 0 || w != 0 || h != 0 {
+		t.Fatalf("legacy GetBounds = (%d,%d %dx%d), want zero geometry", x, y, w, h)
+	}
+	if _, _, _, _, err := robotgo.GetClientE(0); !errors.Is(err, robotgo.ErrNotSupported) {
+		t.Fatalf("GetClientE error = %v, want ErrNotSupported", err)
+	}
+	if x, y, w, h := robotgo.GetClient(0); x != 0 || y != 0 || w != 0 || h != 0 {
+		t.Fatalf("legacy GetClient = (%d,%d %dx%d), want zero geometry", x, y, w, h)
 	}
 	if count := robotgo.DisplaysNum(); count != 1 {
 		t.Fatalf("DisplaysNum = %d, want 1", count)
@@ -107,7 +116,6 @@ func countFDs(t *testing.T) int {
 }
 
 func TestWaylandBoundsResourceRelease(t *testing.T) {
-	requireDisplay(t)
 	cleanup := startHeadlessWeston(t)
 	defer cleanup()
 
@@ -117,13 +125,11 @@ func TestWaylandBoundsResourceRelease(t *testing.T) {
 
 	before := countFDs(t)
 	for i := 0; i < 5; i++ {
-		_, _, w, h := robotgo.GetBounds(0)
-		if w == 0 || h == 0 {
-			t.Skip("wayland compositor did not provide bounds")
+		if _, _, _, _, err := robotgo.GetBoundsE(0); !errors.Is(err, robotgo.ErrNotSupported) {
+			t.Fatalf("GetBoundsE error = %v, want ErrNotSupported", err)
 		}
-		_, _, w, h = robotgo.GetClient(0)
-		if w == 0 || h == 0 {
-			t.Skip("wayland compositor did not provide client bounds")
+		if _, _, _, _, err := robotgo.GetClientE(0); !errors.Is(err, robotgo.ErrNotSupported) {
+			t.Fatalf("GetClientE error = %v, want ErrNotSupported", err)
 		}
 		if count := robotgo.DisplaysNum(); count != 1 {
 			t.Fatalf("DisplaysNum = %d, want 1", count)

--- a/window_backend.go
+++ b/window_backend.go
@@ -22,8 +22,8 @@ const (
 	reasonWaylandGlobalUnsupported = "global foreign-window operations are not universally available in Wayland core protocols"
 	notesWlrootsBackend            = "wlroots generic backend selected; operation support to be implemented via wlroots-compatible paths"
 	reasonCompositorSpecific       = "compositor-specific backend selected with partial operation support"
-	notesSwayPartialSupport        = "supports active-window title retrieval and close; active minimize/maximize available when wlrctl is present"
-	notesHyprPartialSupport        = "supports active-window title, close, and reliable maximize query/set/restore across Hyprland hyprlang/Lua config providers; active minimize requires wlrctl"
+	notesSwayPartialSupport        = "supports active-window title, compositor-node/client geometry, and close; active minimize/maximize available when wlrctl is present"
+	notesHyprPartialSupport        = "supports active-window title, compositor-reported window geometry, close, and reliable maximize query/set/restore across Hyprland hyprlang/Lua config providers; active minimize requires wlrctl"
 	cmdSwayMsg                     = "swaymsg"
 	cmdHyprCtl                     = "hyprctl"
 	cmdWlrCtl                      = "wlrctl"
@@ -58,6 +58,7 @@ const (
 
 var (
 	errWindowTitleUnavailable    = errors.New("window title unavailable from compositor backend")
+	errWindowGeometryUnavailable = errors.New("window geometry unavailable from compositor backend")
 	errWindowStateUnavailable    = errors.New("window state unavailable from compositor backend")
 	errWindowOperationFailed     = errors.New("window operation failed for compositor backend")
 	errHyprlandStatusUnavailable = errors.New("hyprland status request unavailable")
@@ -73,6 +74,7 @@ type windowBackend interface {
 	Minimize(pid int, state bool, isPid bool) error
 	Maximize(pid int, state bool, isPid bool) error
 	Maximized() (bool, error)
+	Bounds(target int, isHandle, client bool) (Rect, error)
 	Close(args ...int) error
 	Title(args ...int) (string, error)
 }
@@ -178,6 +180,14 @@ func (nativeWindowBackend) Maximized() (bool, error) {
 	return false, linuxWindowStateNotSupported("query maximized state")
 }
 
+func (nativeWindowBackend) Bounds(target int, isHandle, client bool) (Rect, error) {
+	_, _, _ = target, isHandle, client
+	return Rect{}, fmt.Errorf(
+		"%w: native window geometry is dispatched by the platform API",
+		ErrNotSupported,
+	)
+}
+
 func (nativeWindowBackend) Close(args ...int) error {
 	if err := nativeX11WindowReady(); err != nil {
 		return err
@@ -271,6 +281,11 @@ func (b waylandCoreWindowBackend) Maximized() (bool, error) {
 	return false, b.unsupported("query maximized state")
 }
 
+func (b waylandCoreWindowBackend) Bounds(target int, isHandle, client bool) (Rect, error) {
+	_, _, _ = target, isHandle, client
+	return Rect{}, b.unsupported("get window geometry")
+}
+
 func (b waylandCoreWindowBackend) Close(args ...int) error {
 	_ = args
 	return b.unsupported("close window")
@@ -336,6 +351,35 @@ func (swayWindowBackend) Maximize(pid int, state bool, isPid bool) error {
 }
 func (swayWindowBackend) Maximized() (bool, error) {
 	return false, waylandWindowNotSupported("query maximized state")
+}
+func (swayWindowBackend) Bounds(target int, isHandle, client bool) (Rect, error) {
+	if target != 0 || isHandle {
+		return Rect{}, waylandWindowNotSupported("get window geometry by pid/handle")
+	}
+	node, err := getSwayActiveWindow()
+	if err != nil {
+		return Rect{}, fmt.Errorf("%w: %w", errWindowGeometryUnavailable, err)
+	}
+	nodeRect := node.Rect.publicRect()
+	if !client {
+		return validateWindowRect("sway active-window bounds", nodeRect)
+	}
+	windowRect := node.WindowRect.publicRect()
+	if _, err := validateWindowRect("sway active-window client metadata", windowRect); err != nil {
+		return Rect{}, err
+	}
+	x, err := checkedWindowCoordinate(nodeRect.X, windowRect.X)
+	if err != nil {
+		return Rect{}, fmt.Errorf("%w: sway client x coordinate: %w", errWindowGeometryUnavailable, err)
+	}
+	y, err := checkedWindowCoordinate(nodeRect.Y, windowRect.Y)
+	if err != nil {
+		return Rect{}, fmt.Errorf("%w: sway client y coordinate: %w", errWindowGeometryUnavailable, err)
+	}
+	return validateWindowRect("sway active-window client bounds", Rect{
+		Point: Point{X: x, Y: y},
+		Size:  Size{W: windowRect.W, H: windowRect.H},
+	})
 }
 func (swayWindowBackend) Close(args ...int) error {
 	if len(args) > 0 {
@@ -472,6 +516,33 @@ func (hyprlandWindowBackend) Maximized() (bool, error) {
 	}
 	return hyprlandFullscreenModeIsMaximized(*info.Fullscreen), nil
 }
+func (hyprlandWindowBackend) Bounds(target int, isHandle, client bool) (Rect, error) {
+	if target != 0 || isHandle {
+		return Rect{}, waylandWindowNotSupported("get window geometry by pid/handle")
+	}
+	if client {
+		return Rect{}, waylandWindowNotSupported(
+			"get client geometry (hyprland does not expose a trustworthy client/frame distinction)",
+		)
+	}
+	if !hasCommand(cmdHyprCtl) {
+		return Rect{}, waylandWindowNotSupported("get window geometry (hyprctl unavailable)")
+	}
+	info, err := getHyprlandActiveWindow()
+	if err != nil {
+		return Rect{}, fmt.Errorf("%w: %w", errWindowGeometryUnavailable, err)
+	}
+	if len(info.At) != 2 || len(info.Size) != 2 {
+		return Rect{}, fmt.Errorf(
+			"%w: hyprland response omitted active-window position or size",
+			errWindowGeometryUnavailable,
+		)
+	}
+	return validateWindowRect("hyprland active-window bounds", Rect{
+		Point: Point{X: info.At[0], Y: info.At[1]},
+		Size:  Size{W: info.Size[0], H: info.Size[1]},
+	})
+}
 func (hyprlandWindowBackend) Close(args ...int) error {
 	if len(args) > 0 {
 		return waylandWindowNotSupported("close window by pid/handle")
@@ -549,6 +620,11 @@ func (wlrootsGenericWindowBackend) Maximized() (bool, error) {
 	return false, waylandWindowNotSupported("query maximized state")
 }
 
+func (wlrootsGenericWindowBackend) Bounds(target int, isHandle, client bool) (Rect, error) {
+	_, _, _ = target, isHandle, client
+	return Rect{}, waylandWindowNotSupported("get window geometry")
+}
+
 func runWlrctlActiveWindowAction(op, action string) error {
 	if !hasCommand(cmdWlrCtl) {
 		return waylandWindowNotSupported(op + " (wlrctl unavailable)")
@@ -569,54 +645,6 @@ func (wlrootsGenericWindowBackend) Close(args ...int) error {
 func (wlrootsGenericWindowBackend) Title(args ...int) (string, error) {
 	_ = args
 	return "", waylandWindowNotSupported("get window title")
-}
-
-type swayTreeNode struct {
-	Name          string         `json:"name"`
-	Focused       bool           `json:"focused"`
-	Nodes         []swayTreeNode `json:"nodes"`
-	FloatingNodes []swayTreeNode `json:"floating_nodes"`
-}
-
-func findFocusedSwayTitle(n swayTreeNode) (string, bool) {
-	if n.Focused && n.Name != "" {
-		return n.Name, true
-	}
-	for _, c := range n.Nodes {
-		if title, ok := findFocusedSwayTitle(c); ok {
-			return title, true
-		}
-	}
-	for _, c := range n.FloatingNodes {
-		if title, ok := findFocusedSwayTitle(c); ok {
-			return title, true
-		}
-	}
-	return "", false
-}
-
-func getSwayActiveWindowTitle() (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
-	defer cancel()
-	out, err := runWindowCommand(ctx, cmdSwayMsg, argType, argGetTree, argRawJSON)
-	if err != nil {
-		return "", fmt.Errorf("%w: %v", errWindowTitleUnavailable, err)
-	}
-	var root swayTreeNode
-	if err := json.Unmarshal(out, &root); err != nil {
-		return "", fmt.Errorf("%w: invalid sway tree json: %v", errWindowTitleUnavailable, err)
-	}
-	title, ok := findFocusedSwayTitle(root)
-	if !ok || strings.TrimSpace(title) == "" {
-		return "", errWindowTitleUnavailable
-	}
-	return title, nil
-}
-
-type hyprlandActiveWindow struct {
-	Title            string `json:"title"`
-	Fullscreen       *int   `json:"fullscreen"`
-	FullscreenClient *int   `json:"fullscreenClient"`
 }
 
 type hyprlandStatus struct {

--- a/window_backend_nocgo.go
+++ b/window_backend_nocgo.go
@@ -147,18 +147,26 @@ func pureGoWindowTitle(args ...int) (string, error) {
 	return backend.Title(handle)
 }
 
-func pureGoWindowBounds(target int, isHandle, client bool) (int, int, int, int) {
+func pureGoWindowBoundsE(target int, isHandle, client bool) (int, int, int, int, error) {
 	backend, err := pureGoWindowBackend()
 	if err != nil {
-		return 0, 0, 0, 0
+		return 0, 0, 0, 0, err
 	}
 	handle, err := backend.Resolve(target, isHandle)
 	if err != nil {
-		return 0, 0, 0, 0
+		return 0, 0, 0, 0, err
 	}
 	rect, err := backend.Bounds(handle, client)
 	if err != nil {
-		return 0, 0, 0, 0
+		return 0, 0, 0, 0, err
 	}
-	return rect.X, rect.Y, rect.Width, rect.Height
+	if rect.Width <= 0 || rect.Height <= 0 {
+		return 0, 0, 0, 0, fmt.Errorf(
+			"%w: Pure-Go window backend returned invalid size %dx%d",
+			windowbackend.ErrInvalidWindow,
+			rect.Width,
+			rect.Height,
+		)
+	}
+	return rect.X, rect.Y, rect.Width, rect.Height, nil
 }

--- a/window_backend_test.go
+++ b/window_backend_test.go
@@ -265,7 +265,7 @@ func TestSwayWindowBackendTitle(t *testing.T) {
 		if name != cmdSwayMsg {
 			t.Fatalf("expected %q, got %q", cmdSwayMsg, name)
 		}
-		return []byte(`{"focused":false,"name":"","nodes":[{"focused":true,"name":"Terminal","nodes":[],"floating_nodes":[]}],"floating_nodes":[]}`), nil
+		return []byte(`{"focused":false,"name":"","nodes":[{"type":"con","focused":true,"name":"Terminal","nodes":[],"floating_nodes":[]}],"floating_nodes":[]}`), nil
 	}
 
 	b := newSwayWindowBackend()

--- a/window_geometry_backend.go
+++ b/window_geometry_backend.go
@@ -1,0 +1,120 @@
+//go:build cgo
+
+package robotgo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+)
+
+const (
+	swayNodeTypeContainer         = "con"
+	swayNodeTypeFloatingContainer = "floating_con"
+)
+
+type compositorWindowRect struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+	W int `json:"width"`
+	H int `json:"height"`
+}
+
+func (rect compositorWindowRect) publicRect() Rect {
+	return Rect{
+		Point: Point{X: rect.X, Y: rect.Y},
+		Size:  Size{W: rect.W, H: rect.H},
+	}
+}
+
+type swayTreeNode struct {
+	Name          string               `json:"name"`
+	Type          string               `json:"type"`
+	Focused       bool                 `json:"focused"`
+	Rect          compositorWindowRect `json:"rect"`
+	WindowRect    compositorWindowRect `json:"window_rect"`
+	Nodes         []swayTreeNode       `json:"nodes"`
+	FloatingNodes []swayTreeNode       `json:"floating_nodes"`
+}
+
+func findFocusedSwayWindow(node swayTreeNode) (swayTreeNode, bool) {
+	if node.Focused &&
+		(node.Type == swayNodeTypeContainer ||
+			node.Type == swayNodeTypeFloatingContainer) {
+		return node, true
+	}
+	for _, child := range node.Nodes {
+		if focused, ok := findFocusedSwayWindow(child); ok {
+			return focused, true
+		}
+	}
+	for _, child := range node.FloatingNodes {
+		if focused, ok := findFocusedSwayWindow(child); ok {
+			return focused, true
+		}
+	}
+	return swayTreeNode{}, false
+}
+
+func getSwayActiveWindow() (swayTreeNode, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
+	defer cancel()
+	out, err := runWindowCommand(ctx, cmdSwayMsg, argType, argGetTree, argRawJSON)
+	if err != nil {
+		return swayTreeNode{}, fmt.Errorf("query sway tree: %w", err)
+	}
+	var root swayTreeNode
+	if err := json.Unmarshal(out, &root); err != nil {
+		return swayTreeNode{}, fmt.Errorf("invalid sway tree json: %w", err)
+	}
+	node, ok := findFocusedSwayWindow(root)
+	if !ok {
+		return swayTreeNode{}, errors.New("sway tree has no focused window")
+	}
+	return node, nil
+}
+
+func getSwayActiveWindowTitle() (string, error) {
+	node, err := getSwayActiveWindow()
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", errWindowTitleUnavailable, err)
+	}
+	if strings.TrimSpace(node.Name) == "" {
+		return "", errWindowTitleUnavailable
+	}
+	return node.Name, nil
+}
+
+type hyprlandActiveWindow struct {
+	Title            string `json:"title"`
+	At               []int  `json:"at"`
+	Size             []int  `json:"size"`
+	Fullscreen       *int   `json:"fullscreen"`
+	FullscreenClient *int   `json:"fullscreenClient"`
+}
+
+func validateWindowRect(operation string, rect Rect) (Rect, error) {
+	if rect.W <= 0 || rect.H <= 0 {
+		return Rect{}, fmt.Errorf(
+			"%w: %s returned invalid size %dx%d",
+			errWindowGeometryUnavailable,
+			operation,
+			rect.W,
+			rect.H,
+		)
+	}
+	return rect, nil
+}
+
+func checkedWindowCoordinate(base, relative int) (int, error) {
+	if relative > 0 && base > math.MaxInt-relative {
+		return 0, errors.New("integer overflow")
+	}
+	if relative < 0 && base < math.MinInt-relative {
+		return 0, errors.New("integer underflow")
+	}
+	return base + relative, nil
+}

--- a/window_geometry_backend_test.go
+++ b/window_geometry_backend_test.go
@@ -1,0 +1,235 @@
+//go:build cgo
+
+package robotgo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestSwayWindowBackendGeometry(t *testing.T) {
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdSwayMsg {
+			t.Fatalf("expected %q, got %q", cmdSwayMsg, name)
+		}
+		if want := []string{argType, argGetTree, argRawJSON}; fmt.Sprint(args) != fmt.Sprint(want) {
+			t.Fatalf("unexpected args: %#v", args)
+		}
+		return []byte(`{
+			"focused":false,
+			"nodes":[{
+				"type":"con",
+				"focused":true,
+				"name":"Terminal",
+				"rect":{"x":-400,"y":25,"width":800,"height":600},
+				"window_rect":{"x":2,"y":30,"width":796,"height":568}
+			}]
+		}`), nil
+	}
+
+	backend := newSwayWindowBackend()
+	bounds, err := backend.Bounds(0, false, false)
+	if err != nil {
+		t.Fatalf("node bounds: %v", err)
+	}
+	if want := (Rect{Point: Point{X: -400, Y: 25}, Size: Size{W: 800, H: 600}}); bounds != want {
+		t.Fatalf("node bounds = %+v, want %+v", bounds, want)
+	}
+	client, err := backend.Bounds(0, false, true)
+	if err != nil {
+		t.Fatalf("client bounds: %v", err)
+	}
+	if want := (Rect{Point: Point{X: -398, Y: 55}, Size: Size{W: 796, H: 568}}); client != want {
+		t.Fatalf("client bounds = %+v, want %+v", client, want)
+	}
+
+	for _, call := range []struct {
+		name     string
+		target   int
+		isHandle bool
+	}{
+		{name: "pid", target: 1234},
+		{name: "handle", isHandle: true},
+	} {
+		t.Run(call.name, func(t *testing.T) {
+			if _, err := backend.Bounds(call.target, call.isHandle, false); !errors.Is(err, ErrNotSupported) {
+				t.Fatalf("Bounds error = %v, want ErrNotSupported", err)
+			}
+		})
+	}
+}
+
+func TestSwayWindowBackendGeometryRejectsInvalidResponses(t *testing.T) {
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	tests := []struct {
+		name   string
+		json   string
+		client bool
+	}{
+		{name: "malformed", json: `{"focused":`},
+		{name: "no focused window", json: `{"focused":false,"nodes":[]}`},
+		{
+			name: "focused workspace is not a window",
+			json: `{
+				"type":"workspace",
+				"focused":true,
+				"rect":{"x":0,"y":0,"width":800,"height":600}
+			}`,
+		},
+		{
+			name: "invalid node size",
+			json: `{
+				"type":"con",
+				"focused":true,
+				"rect":{"x":0,"y":0,"width":0,"height":600},
+				"window_rect":{"x":0,"y":0,"width":800,"height":600}
+			}`,
+		},
+		{
+			name:   "invalid client size",
+			client: true,
+			json: `{
+				"type":"con",
+				"focused":true,
+				"rect":{"x":0,"y":0,"width":800,"height":600},
+				"window_rect":{"x":0,"y":0,"width":800,"height":0}
+			}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runWindowCommand = func(context.Context, string, ...string) ([]byte, error) {
+				return []byte(test.json), nil
+			}
+			if _, err := newSwayWindowBackend().Bounds(0, false, test.client); !errors.Is(err, errWindowGeometryUnavailable) {
+				t.Fatalf("Bounds error = %v, want errWindowGeometryUnavailable", err)
+			}
+		})
+	}
+}
+
+func TestSwayWindowBoundsDoNotRequireClientMetadata(t *testing.T) {
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+	runWindowCommand = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte(`{
+			"type":"con",
+			"focused":true,
+			"rect":{"x":10,"y":20,"width":800,"height":600}
+		}`), nil
+	}
+
+	bounds, err := newSwayWindowBackend().Bounds(0, false, false)
+	if err != nil {
+		t.Fatalf("Bounds: %v", err)
+	}
+	if want := (Rect{Point: Point{X: 10, Y: 20}, Size: Size{W: 800, H: 600}}); bounds != want {
+		t.Fatalf("Bounds = %+v, want %+v", bounds, want)
+	}
+}
+
+func TestCheckedWindowCoordinateRejectsOverflow(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		base     int
+		relative int
+	}{
+		{name: "positive overflow", base: math.MaxInt, relative: 1},
+		{name: "negative overflow", base: math.MinInt, relative: -1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := checkedWindowCoordinate(test.base, test.relative); err == nil {
+				t.Fatal("checkedWindowCoordinate accepted overflowing sum")
+			}
+		})
+	}
+}
+
+func TestHyprlandWindowBackendGeometry(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdHyprCtl {
+			t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
+		}
+		if want := []string{argActiveWindow, argJSON}; fmt.Sprint(args) != fmt.Sprint(want) {
+			t.Fatalf("unexpected args: %#v", args)
+		}
+		return []byte(`{"at":[-1280,40],"size":[1200,700]}`), nil
+	}
+
+	backend := newHyprlandWindowBackend()
+	bounds, err := backend.Bounds(0, false, false)
+	if err != nil {
+		t.Fatalf("Bounds: %v", err)
+	}
+	if want := (Rect{Point: Point{X: -1280, Y: 40}, Size: Size{W: 1200, H: 700}}); bounds != want {
+		t.Fatalf("Bounds = %+v, want %+v", bounds, want)
+	}
+	if _, err := backend.Bounds(0, false, true); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("client Bounds error = %v, want ErrNotSupported", err)
+	}
+	if _, err := backend.Bounds(1234, false, false); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("pid Bounds error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestHyprlandWindowBackendGeometryRejectsInvalidResponses(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+	for _, test := range []struct {
+		name string
+		json string
+	}{
+		{name: "malformed", json: `{"at":`},
+		{name: "missing size", json: `{"at":[0,0]}`},
+		{name: "short position", json: `{"at":[0],"size":[800,600]}`},
+		{name: "invalid size", json: `{"at":[0,0],"size":[800,0]}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runWindowCommand = func(context.Context, string, ...string) ([]byte, error) {
+				return []byte(test.json), nil
+			}
+			if _, err := newHyprlandWindowBackend().Bounds(0, false, false); !errors.Is(err, errWindowGeometryUnavailable) {
+				t.Fatalf("Bounds error = %v, want errWindowGeometryUnavailable", err)
+			}
+		})
+	}
+}
+
+func TestWaylandBackendsWithoutGeometryReturnUnsupported(t *testing.T) {
+	backends := []windowBackend{
+		waylandCoreWindowBackend{compositor: compositorMutter},
+		newWlrootsGenericWindowBackend(),
+	}
+	for _, backend := range backends {
+		for _, client := range []bool{false, true} {
+			if _, err := backend.Bounds(0, false, client); !errors.Is(err, ErrNotSupported) {
+				t.Fatalf(
+					"%s Bounds(client=%v) error = %v, want ErrNotSupported",
+					backend.Name(),
+					client,
+					err,
+				)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Result

Adds source-compatible `GetBoundsE` and `GetClientE` APIs and stops legacy Wayland geometry calls from returning aggregate desktop bounds as fake window bounds.

- Sway reports active compositor-node and client geometry from `get_tree`.
- Hyprland reports its active compositor-provided window box.
- Wayland core, generic wlroots, GNOME/KDE, unsupported client/frame distinctions, and unsupported PID/handle modes return explicit `ErrNotSupported`.
- Native X11, macOS, Windows, and Pure-Go backends retain their existing targeting behavior while the new APIs expose real failures.
- Legacy `GetBounds`/`GetClient` remain source-compatible and return zero geometry on failure.
- Adds a read-only example and updates the Phase 4 roadmap/backend documentation.

## Why

The CGO Wayland path previously returned `GetScreenRect(-1)` for both window APIs. That silently mislabeled desktop geometry as window geometry and made valid-looking zero-error results impossible to trust.

## Runtime and compatibility consequences

The behavior change is intentional only where the previous result was false: unsupported Wayland window-geometry calls now fail explicitly through the E APIs and yield zeroes through legacy wrappers. Sway active-window geometry and Hyprland active window-box geometry are additive. No X11 fallback is introduced into Wayland-primary paths.

Sway rejects focused non-window nodes, validates positive geometry, and uses overflow-checked relative client coordinates. `GetBoundsE` does not depend on client metadata unless client geometry is requested.

## Resource, privacy, and fallback risk

The Sway runtime test uses a self-owned borderless `wev` fixture inside an isolated private compositor runtime. Cleanup closes the fixture and removes the private runtime on all test exit paths. The change captures no screen, clipboard, title artifact, restore token, or other private desktop data.

No geometry is fabricated when a backend cannot prove the requested semantics; the fallback is an explicit error.

## Validation

Locally:

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -tags wayland ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run` (0 issues)
- Windows/macOS Pure-Go cross-builds
- tagged Weston/Sway integration compilation
- private headless-Sway execution of `TestSwayNativeWindowRuntime` and `TestSwayNativeInputRuntime`

GitHub Actions on head `76c5ad1`:

- Linux/macOS/Windows tests and non-CGO builds pass
- lint, vet, race, sanitizer, OCR, Wayland integration, X11 evidence, and CircleCI pass
- all six hosted Sway cells pass
- `native-window` proves exact 120,80 / 480x320 self-owned node/client geometry and uploads sanitized evidence

The first Sway attempt exposed a fixture race: resize commands could precede acknowledgement of an earlier `xdg_surface.configure`. Commit `76c5ad1` synchronizes Border/Floating/Resize transitions against bounded in-memory configure events and confirmed synthetic tree state. The exact runtime test then passed locally and in hosted CI. Two unrelated runner package-install timeouts were retried without code changes and passed.

Protected Hyprland geometry evidence remains a bounded follow-up and is not claimed here.

Linear: [LAB-20](https://linear.app/riotbox/issue/LAB-20/add-truthful-cross-backend-window-geometry-apis)