### PR TITLE
feat: add explicit active-window identity APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,15 @@ older Hyprland versions without the status request keep the legacy path.
 Transport failures and successful but malformed/unknown provider responses
 fail before mutation.
 
+Use `GetActiveE` and `GetPidE` when active-window identity matters. The legacy
+`GetActive` and `GetPid` wrappers remain source-compatible but return zero when
+identity is unavailable. On Sway and Hyprland, `GetPidE` validates the positive
+PID reported by the compositor. `GetActiveE` remains explicitly unsupported on
+Wayland because these compositors do not expose a stable, portable foreign
+window handle; RobotGo does not invent one. Wayland core and generic wlroots
+also return `ErrNotSupported` for active PID lookup without a trustworthy
+identity source.
+
 Pure-Go Windows builds provide window introspection and control through Win32:
 active handle/PID, title, outer/client bounds, activation, minimize/maximize,
 topmost state, and graceful close. PID lookup prefers a visible, unowned
@@ -990,6 +999,8 @@ The checked-in examples use this fork's module path and track the current API:
 - [Persistent ScreenCast/PipeWire capture](examples/screencast_capture/main.go)
 - [Bitmap-string and region color-search helpers](examples/capture_helpers/main.go)
 - [Hyprland active-window maximize state](examples/wayland_window_state/main.go)
+- [Explicit active-window handle and PID inspection](examples/window_identity/main.go)
+- [Explicit window and client geometry](examples/window_geometry/main.go)
 - [Window and process helpers](examples/window/main.go)
 - [Display scaling](examples/scale/main.go)
 

--- a/TEST.md
+++ b/TEST.md
@@ -721,13 +721,15 @@ intentionally preserving a foreign replacement is not itself an error.
 - `ROBOTGO_WLROOTS_MINMAX_E2E=1`
   - Opt-in for wlroots active-window minimize/maximize E2E integration (`MinWindowE(0)`, `MaxWindowE(0)`).
 - `ROBOTGO_SWAY_TITLE_E2E=1`
-  - Opt-in for sway active-window title E2E integration (`GetTitleE`).
+  - Opt-in for sway active-window title/PID E2E integration (`GetTitleE`,
+    `GetPidE`).
     The protected hosted-Sway `native-window` cell additionally proves exact
     `GetBoundsE`/`GetClientE` node/client geometry against a self-owned,
     borderless fixture
     and removes the fixture and private compositor runtime on every exit path.
 - `ROBOTGO_HYPRLAND_TITLE_E2E=1`
-  - Opt-in for hyprland active-window title E2E integration (`GetTitleE`).
+  - Opt-in for hyprland active-window title/PID E2E integration (`GetTitleE`,
+    `GetPidE`).
 - `ROBOTGO_HYPRLAND_MAXIMIZE_E2E=1`
   - Opt-in for Hyprland active-window maximize query/set/restore integration.
     The test refuses to alter an initially fullscreen window and restores an

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,9 @@ Use the following documents as the primary entry points:
   privacy guarantees, and hermetic protocol evidence.
 - [Safe agent visual conditions plan](plan/agent-visual-conditions.md) for
   explicit-observation color search, bounded region waits, quotas, and cleanup.
+- [Explicit window identity plan](plan/explicit-window-identity.md) for
+  error-returning active handle/PID queries and compositor-aware Wayland
+  semantics.
 - [Wayland status](wayland-tasks.md) for backend support and open Wayland work.
 - [Upstream compatibility audit](compatibility/upstream-master.md) for
   selectively adopted and intentionally rejected upstream changes.

--- a/docs/plan/explicit-window-identity.md
+++ b/docs/plan/explicit-window-identity.md
@@ -1,0 +1,48 @@
+# Explicit Window Identity Plan
+
+Status: Initial delivery implemented by LAB-21
+
+Linear coordination:
+
+- Team: `Lab` (`LAB`)
+- Project: [`RobotGo | P007 | Explicit Window Identity`](https://linear.app/riotbox/project/robotgo-or-p007-or-explicit-window-identity-78b4d2482f79)
+- Project ID: `83b19143-14a5-40f9-bacc-096b1eee8b12`
+- Initial issue: [`LAB-21`](https://linear.app/riotbox/issue/LAB-21/add-explicit-active-window-and-pid-identity-apis)
+
+## Outcome
+
+Make active-window identity truthful across native, Pure-Go, X11, and Wayland
+backends. New error-returning APIs expose unsupported, permission, and backend
+failures; existing wrappers remain source-compatible and return their
+historical zero values on failure.
+
+## Contract
+
+- `GetActiveE` returns a native active-window handle only when the selected
+  backend provides a stable handle.
+- `GetPidE` returns a validated positive process ID for the active window.
+- `GetActive` and `GetPid` delegate to their error-returning equivalents.
+- CGO Wayland sessions use the compositor-aware window resolver and never call
+  X11-only identity helpers.
+- Sway and Hyprland may report the active PID from compositor metadata.
+- Wayland core and generic wlroots keep active PID lookup unsupported when no
+  trustworthy identity source exists.
+- Wayland backends do not synthesize a cross-compositor window handle.
+
+## Compatibility boundaries
+
+The work does not add PID/handle targeting to compositor operations and does
+not change the meaning of native handles on X11, Windows, or macOS. Missing,
+zero, negative, malformed, or transport-failed compositor identity is an error,
+not a plausible PID.
+
+## Validation
+
+Hermetic tests cover Sway and Hyprland success, missing or invalid PID,
+malformed output, command failure, unavailable helpers, and unsupported
+Wayland handles. Existing protected Sway and opt-in Sway/Hyprland runtime tests
+also exercise active PID lookup. Cross-build tests preserve native and Pure-Go
+behavior.
+
+Protected Hyprland geometry evidence and GNOME/KDE runner provisioning remain
+separate infrastructure work.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -37,7 +37,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 1. Wayland input | Implementation complete; runtime validation partial | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics, protected portal harness, and isolated hosted Sway native/availability plus multi-output matrix | Register GNOME/KDE portal runners and collect their multi-output evidence |
 | 2. Capture | Hermetic implementation complete; runtime validation partial | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, sanitizer-backed native ownership gates, and isolated hosted Sway native/multi-output evidence | Real GNOME/KDE portal and multi-output evidence |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration plus Weston and hosted Sway multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected GNOME/KDE multi-output Wayland evidence, and assess further backends selectively |
-| 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state and window-geometry error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, Sway active node/client geometry, Hyprland active compositor-reported geometry, provider-aware Hyprland 0.55+ Lua window dispatch | Further trustworthy compositor-backed state/geometry operations and cross-platform/runtime matrix coverage |
+| 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state, geometry, and active-identity error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, Sway active node/client geometry and PID, Hyprland active compositor-reported geometry/PID, provider-aware Hyprland 0.55+ Lua window dispatch | Further trustworthy compositor-backed state/geometry operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, fail-closed real-compositor preflight/evidence contract, promoted six-cell hosted Sway release/branch gate, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Provision and promote dedicated GNOME/KDE portal jobs |
 
 No delivery phase is complete until all of its exit criteria are blocking and
@@ -317,6 +317,8 @@ Exit criteria:
 
 Linear delivery project:
 [`RobotGo | P006 | Explicit Window Geometry`](https://linear.app/riotbox/project/robotgo-or-p006-or-explicit-window-geometry-4af461c427fb).
+The adjacent active-identity contract is tracked by
+[`RobotGo | P007 | Explicit Window Identity`](https://linear.app/riotbox/project/robotgo-or-p007-or-explicit-window-identity-78b4d2482f79).
 
 The compatibility surface now includes:
 
@@ -328,6 +330,12 @@ The compatibility surface now includes:
   client/frame distinctions or PID/handle modes remain explicit
   `ErrNotSupported`. Legacy wrappers return zero geometry on failure rather
   than substituting aggregate Wayland desktop bounds.
+- Error-returning active-window identity APIs (`GetActiveE`, `GetPidE`) across
+  CGO and non-CGO builds. CGO Wayland identity uses the selected compositor
+  backend instead of X11 helpers. Sway and Hyprland expose only a validated
+  positive active PID; Wayland active handles and identity without a stable
+  compositor source remain explicitly unsupported. Legacy wrappers return
+  zero on failure.
 - Hyprland active-window maximize query, set, and restore backed by its
   compositor-reported state. Fullscreen remains distinct from maximized;
   Sway/generic wlroots queries stay explicitly unsupported rather than

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -55,6 +55,10 @@ Current implementation baseline:
 - Error-returning mouse and typing variants are available (`MoveE`,
   `MoveRelativeE`, `ClickE`, `ScrollE`, `LocationE`, `TypeStrE`,
   `UnicodeTypeE`) while legacy APIs remain source-compatible.
+- Error-returning active-window identity variants (`GetActiveE`, `GetPidE`)
+  keep CGO Wayland sessions out of X11 helpers. Sway and Hyprland return only
+  validated compositor-reported active PIDs; stable Wayland handles and generic
+  identity without a trustworthy source remain explicitly unsupported.
 - Native screencopy has bounded event dispatch, deterministic FD/resource
   cleanup and hermetic regression coverage for compositor stalls and DMABUF failures.
 - Fallback output bounds use short success/failure TTLs and can be refreshed
@@ -236,6 +240,8 @@ backends.
 - Window APIs:
   - Extend compositor-backed move/resize/activate/topmost/minimize/title
     behavior while preserving explicit `ErrNotSupported` elsewhere.
+  - Keep the delivered active-identity contract covered: Sway/Hyprland may
+    report active PIDs, while Wayland backends must not invent portable handles.
   - Validate display/output geometry (`GetScreenRectE`/`GetDisplayBoundsE`)
     independently from window geometry on protected wlroots/GNOME/KDE runners.
     The hosted Sway window cell proves exact active node/client geometry;

--- a/examples/window_identity/main.go
+++ b/examples/window_identity/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/marang/robotgo"
+)
+
+func main() {
+	pid, err := robotgo.GetPidE()
+	if err != nil {
+		fmt.Println("active window PID unavailable:", err)
+	} else {
+		fmt.Println("active window PID:", pid)
+	}
+
+	handle, err := robotgo.GetActiveE()
+	if err != nil {
+		if errors.Is(err, robotgo.ErrNotSupported) {
+			fmt.Println("active window handle unsupported by this backend")
+			return
+		}
+		fmt.Println("active window handle unavailable:", err)
+		return
+	}
+	fmt.Printf("active window handle: %v\n", handle)
+}

--- a/robotgo.go
+++ b/robotgo.go
@@ -2734,16 +2734,27 @@ func nativeGetInternalTitle(pid int, isPid int) string {
 
 // GetActive get the active window
 func GetActive() Handle {
-	return Handle(GetActiveC())
+	handle, _ := GetActiveE()
+	return handle
+}
+
+// GetActiveE gets the active window or returns an explicit backend error.
+// Wayland backends return ErrNotSupported unless the compositor exposes a
+// stable foreign-window handle contract.
+func GetActiveE() (Handle, error) {
+	return resolveWindowBackend().Active()
 }
 
 // GetActiveC get the active window
 func GetActiveC() C.MData {
+	handle, _ := GetActiveE()
+	return C.MData(handle)
+}
+
+func nativeGetActiveC() C.MData {
 	unlock := lockNativeX11Display()
 	defer unlock()
-	mdata := C.get_active()
-	// fmt.Println("active----", mdata)
-	return mdata
+	return C.get_active()
 }
 
 // MinWindow set the window min
@@ -2972,10 +2983,20 @@ func GetTitleE(args ...int) (string, error) {
 
 // GetPid get the process id return int32
 func GetPid() int {
+	pid, _ := GetPidE()
+	return pid
+}
+
+// GetPidE gets the active window process ID or returns an explicit backend
+// error.
+func GetPidE() (int, error) {
+	return resolveWindowBackend().PID()
+}
+
+func nativeGetActivePID() int {
 	unlock := lockNativeX11Display()
 	defer unlock()
-	pid := C.get_PID()
-	return int(pid)
+	return int(C.get_PID())
 }
 
 // internalGetBounds get the window bounds

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -971,21 +971,60 @@ func U8ToHex(rgb *uint8) uint32 {
 	)
 }
 func GetActive() Handle {
-	handle, _ := pureGoWindowActive()
-	return Handle(handle)
+	handle, _ := GetActiveE()
+	return handle
 }
 func GetHandle() int { return int(GetActive()) }
 func GetPid() int {
+	pid, _ := GetPidE()
+	return pid
+}
+
+// GetActiveE gets the active window or returns an explicit backend error.
+func GetActiveE() (Handle, error) {
+	handle, err := pureGoWindowActive()
+	return validatePureGoActiveWindow(handle, err)
+}
+
+func validatePureGoActiveWindow(
+	handle windowbackend.Handle,
+	err error,
+) (Handle, error) {
+	if err != nil {
+		return 0, err
+	}
+	if handle == 0 {
+		return 0, fmt.Errorf(
+			"%w: Pure-Go window backend returned an invalid active-window handle",
+			windowbackend.ErrInvalidWindow,
+		)
+	}
+	return Handle(handle), nil
+}
+
+// GetPidE gets the active window process ID or returns an explicit backend
+// error.
+func GetPidE() (int, error) {
 	backend, err := pureGoWindowBackend()
 	if err != nil {
-		return 0
+		return 0, err
 	}
 	handle, err := backend.Active()
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	pid, _ := backend.PID(handle)
-	return pid
+	pid, err := backend.PID(handle)
+	if err != nil {
+		return 0, err
+	}
+	if pid <= 0 {
+		return 0, fmt.Errorf(
+			"%w: Pure-Go window backend returned invalid active-window pid %d",
+			windowbackend.ErrInvalidWindow,
+			pid,
+		)
+	}
+	return pid, nil
 }
 func MinWindow(target int, args ...interface{}) { _ = MinWindowE(target, args...) }
 func MaxWindow(target int, args ...interface{}) { _ = MaxWindowE(target, args...) }

--- a/robotgo_wayland_window_policy_test.go
+++ b/robotgo_wayland_window_policy_test.go
@@ -42,6 +42,22 @@ func TestWaylandWindowOpsReturnNotSupported(t *testing.T) {
 	if _, err := GetTitleE(1234); !errors.Is(err, ErrNotSupported) {
 		t.Fatalf("GetTitleE expected ErrNotSupported, got: %v", err)
 	}
+	var zero Handle
+	if handle, err := GetActiveE(); handle != zero || !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("GetActiveE = %#v, %v; want zero and ErrNotSupported", handle, err)
+	}
+	if handle := GetActive(); handle != zero {
+		t.Fatalf("GetActive = %#v, want zero unsupported result", handle)
+	}
+	if handle := Handle(GetActiveC()); handle != zero {
+		t.Fatalf("GetActiveC = %#v, want zero unsupported result", handle)
+	}
+	if pid, err := GetPidE(); pid != 0 || !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("GetPidE = %d, %v; want zero and ErrNotSupported", pid, err)
+	}
+	if pid := GetPid(); pid != 0 {
+		t.Fatalf("GetPid = %d, want zero unsupported result", pid)
+	}
 }
 
 func TestWaylandWlrootsMinMaxWindowSupportedForActiveWindow(t *testing.T) {

--- a/robotgo_wayland_wlroots_integration_test.go
+++ b/robotgo_wayland_wlroots_integration_test.go
@@ -147,6 +147,13 @@ func TestSwayTitleE2EOptIn(t *testing.T) {
 	if title == "" {
 		t.Fatalf("GetTitleE returned empty title in sway e2e mode")
 	}
+	pid, err := GetPidE()
+	if err != nil {
+		t.Fatalf("GetPidE failed in sway e2e mode: %v", err)
+	}
+	if pid <= 0 {
+		t.Fatalf("GetPidE returned invalid pid %d in sway e2e mode", pid)
+	}
 }
 
 func TestHyprlandTitleE2EOptIn(t *testing.T) {
@@ -174,6 +181,13 @@ func TestHyprlandTitleE2EOptIn(t *testing.T) {
 	}
 	if title == "" {
 		t.Fatalf("GetTitleE returned empty title in hyprland e2e mode")
+	}
+	pid, err := GetPidE()
+	if err != nil {
+		t.Fatalf("GetPidE failed in hyprland e2e mode: %v", err)
+	}
+	if pid <= 0 {
+		t.Fatalf("GetPidE returned invalid pid %d in hyprland e2e mode", pid)
 	}
 }
 

--- a/sway_native_integration_test.go
+++ b/sway_native_integration_test.go
@@ -235,8 +235,12 @@ func TestSwayNativeWindowRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query Sway fixture pid: %v", err)
 	}
-	if pid != fixture.cmd.Process.Pid {
-		t.Fatalf("active Sway pid = %d, want fixture pid %d", pid, fixture.cmd.Process.Pid)
+	if pid != fixture.command.Process.Pid {
+		t.Fatalf(
+			"active Sway pid = %d, want fixture pid %d",
+			pid,
+			fixture.command.Process.Pid,
+		)
 	}
 	var zero Handle
 	if handle, activeErr := GetActiveE(); handle != zero ||

--- a/sway_native_integration_test.go
+++ b/sway_native_integration_test.go
@@ -231,6 +231,22 @@ func TestSwayNativeWindowRuntime(t *testing.T) {
 	if title != swayFixtureTitle {
 		t.Fatalf("active Sway title = %q, want %q", title, swayFixtureTitle)
 	}
+	pid, err := GetPidE()
+	if err != nil {
+		t.Fatalf("query Sway fixture pid: %v", err)
+	}
+	if pid != fixture.cmd.Process.Pid {
+		t.Fatalf("active Sway pid = %d, want fixture pid %d", pid, fixture.cmd.Process.Pid)
+	}
+	var zero Handle
+	if handle, activeErr := GetActiveE(); handle != zero ||
+		!errors.Is(activeErr, ErrNotSupported) {
+		t.Fatalf(
+			"active Sway handle = %#v, %v; want zero and ErrNotSupported",
+			handle,
+			activeErr,
+		)
+	}
 	capability := GetLinuxCapabilities().Window
 	if !capability.Available || capability.Backend != windowBackendSway {
 		t.Fatalf("Sway window capability = %+v", capability)

--- a/window_backend.go
+++ b/window_backend.go
@@ -22,8 +22,8 @@ const (
 	reasonWaylandGlobalUnsupported = "global foreign-window operations are not universally available in Wayland core protocols"
 	notesWlrootsBackend            = "wlroots generic backend selected; operation support to be implemented via wlroots-compatible paths"
 	reasonCompositorSpecific       = "compositor-specific backend selected with partial operation support"
-	notesSwayPartialSupport        = "supports active-window title, compositor-node/client geometry, and close; active minimize/maximize available when wlrctl is present"
-	notesHyprPartialSupport        = "supports active-window title, compositor-reported window geometry, close, and reliable maximize query/set/restore across Hyprland hyprlang/Lua config providers; active minimize requires wlrctl"
+	notesSwayPartialSupport        = "supports active-window title/PID, compositor-node/client geometry, and close; stable active handles remain unsupported; active minimize/maximize available when wlrctl is present"
+	notesHyprPartialSupport        = "supports active-window title/PID, compositor-reported window geometry, close, and reliable maximize query/set/restore across Hyprland hyprlang/Lua config providers; stable active handles remain unsupported; active minimize requires wlrctl"
 	cmdSwayMsg                     = "swaymsg"
 	cmdHyprCtl                     = "hyprctl"
 	cmdWlrCtl                      = "wlrctl"
@@ -59,6 +59,7 @@ const (
 var (
 	errWindowTitleUnavailable    = errors.New("window title unavailable from compositor backend")
 	errWindowGeometryUnavailable = errors.New("window geometry unavailable from compositor backend")
+	errWindowIdentityUnavailable = errors.New("window identity unavailable from selected backend")
 	errWindowStateUnavailable    = errors.New("window state unavailable from compositor backend")
 	errWindowOperationFailed     = errors.New("window operation failed for compositor backend")
 	errHyprlandStatusUnavailable = errors.New("hyprland status request unavailable")
@@ -70,6 +71,8 @@ var (
 type windowBackend interface {
 	Name() string
 	Capability() FeatureCapability
+	Active() (Handle, error)
+	PID() (int, error)
 	SetActive(win Handle) error
 	Minimize(pid int, state bool, isPid bool) error
 	Maximize(pid int, state bool, isPid bool) error
@@ -128,6 +131,33 @@ func nativeX11WindowReady() error {
 	unlock := lockNativeX11Display()
 	defer unlock()
 	return nativeX11DisplayReadyLocked()
+}
+
+func (nativeWindowBackend) Active() (Handle, error) {
+	if err := nativeX11WindowReady(); err != nil {
+		return Handle{}, err
+	}
+	handle := Handle(nativeGetActiveC())
+	var zero Handle
+	if handle == zero {
+		return Handle{}, errWindowIdentityUnavailable
+	}
+	return handle, nil
+}
+
+func (nativeWindowBackend) PID() (int, error) {
+	if err := nativeX11WindowReady(); err != nil {
+		return 0, err
+	}
+	pid := nativeGetActivePID()
+	if pid <= 0 {
+		return 0, fmt.Errorf(
+			"%w: native backend returned invalid active-window pid %d",
+			errWindowIdentityUnavailable,
+			pid,
+		)
+	}
+	return pid, nil
 }
 
 func (nativeWindowBackend) SetActive(win Handle) error {
@@ -262,6 +292,14 @@ func (b waylandCoreWindowBackend) unsupported(op string) error {
 	return fmt.Errorf("%w (compositor=%s)", waylandWindowNotSupported(op), b.compositor)
 }
 
+func (b waylandCoreWindowBackend) Active() (Handle, error) {
+	return Handle{}, b.unsupported("get active window handle")
+}
+
+func (b waylandCoreWindowBackend) PID() (int, error) {
+	return 0, b.unsupported("get active window pid")
+}
+
 func (b waylandCoreWindowBackend) SetActive(win Handle) error {
 	_ = win
 	return b.unsupported("set active window")
@@ -326,6 +364,27 @@ func (swayWindowBackend) Capability() FeatureCapability {
 		Reason:    reason,
 		Notes:     notes,
 	}
+}
+func (swayWindowBackend) Active() (Handle, error) {
+	return Handle{}, waylandWindowNotSupported(
+		"get active window handle (sway does not expose a stable cross-process handle)",
+	)
+}
+func (swayWindowBackend) PID() (int, error) {
+	if !hasCommand(cmdSwayMsg) {
+		return 0, waylandWindowNotSupported("get active window pid (swaymsg unavailable)")
+	}
+	node, err := getSwayActiveWindow()
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", errWindowIdentityUnavailable, err)
+	}
+	if node.PID == nil || *node.PID <= 0 {
+		return 0, fmt.Errorf(
+			"%w: sway response omitted a valid active-window pid",
+			errWindowIdentityUnavailable,
+		)
+	}
+	return *node.PID, nil
 }
 func (swayWindowBackend) SetActive(win Handle) error {
 	_ = win
@@ -417,6 +476,27 @@ func (hyprlandWindowBackend) Capability() FeatureCapability {
 		Reason:    reason,
 		Notes:     notes,
 	}
+}
+func (hyprlandWindowBackend) Active() (Handle, error) {
+	return Handle{}, waylandWindowNotSupported(
+		"get active window handle (hyprland does not expose a stable cross-process handle)",
+	)
+}
+func (hyprlandWindowBackend) PID() (int, error) {
+	if !hasCommand(cmdHyprCtl) {
+		return 0, waylandWindowNotSupported("get active window pid (hyprctl unavailable)")
+	}
+	info, err := getHyprlandActiveWindow()
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", errWindowIdentityUnavailable, err)
+	}
+	if info.PID == nil || *info.PID <= 0 {
+		return 0, fmt.Errorf(
+			"%w: hyprland response omitted a valid active-window pid",
+			errWindowIdentityUnavailable,
+		)
+	}
+	return *info.PID, nil
 }
 func (hyprlandWindowBackend) SetActive(win Handle) error {
 	_ = win
@@ -578,7 +658,7 @@ func (wlrootsGenericWindowBackend) Capability() FeatureCapability {
 	notes := notesWlrootsBackend
 	if available {
 		reason = "wlroots generic backend can minimize/maximize active window via wlrctl"
-		notes = "supports active-window minimize/maximize (state=true only); close/title and pid/handle-specific operations remain unsupported"
+		notes = "supports active-window minimize/maximize (state=true only); close/title, active identity, and pid/handle-specific operations remain unsupported"
 	} else {
 		notes += "; install wlrctl to enable active-window minimize/maximize operations"
 	}
@@ -589,6 +669,14 @@ func (wlrootsGenericWindowBackend) Capability() FeatureCapability {
 		Reason:    reason,
 		Notes:     notes,
 	}
+}
+
+func (wlrootsGenericWindowBackend) Active() (Handle, error) {
+	return Handle{}, waylandWindowNotSupported("get active window handle")
+}
+
+func (wlrootsGenericWindowBackend) PID() (int, error) {
+	return 0, waylandWindowNotSupported("get active window pid")
 }
 
 func (wlrootsGenericWindowBackend) SetActive(win Handle) error {

--- a/window_backend_nocgo_test.go
+++ b/window_backend_nocgo_test.go
@@ -79,3 +79,26 @@ func TestPublicPureGoWindowBackendTranslatesPermissionForEveryOperation(t *testi
 	assertPermission("SetTopMost", backend.SetTopMost(1, true))
 	assertPermission("Close", backend.Close(1))
 }
+
+func TestGetActiveERejectsBackendZeroHandle(t *testing.T) {
+	handle, err := validatePureGoActiveWindow(0, nil)
+	if handle != 0 || err == nil {
+		t.Fatalf(
+			"validatePureGoActiveWindow() = %d, %v; want zero and explicit error",
+			handle,
+			err,
+		)
+	}
+}
+
+func TestGetActiveEPreservesBackendFailure(t *testing.T) {
+	permission := errors.New("active window denied")
+	handle, err := validatePureGoActiveWindow(42, permission)
+	if handle != 0 || !errors.Is(err, permission) {
+		t.Fatalf(
+			"validatePureGoActiveWindow() = %d, %v; want zero and backend error",
+			handle,
+			err,
+		)
+	}
+}

--- a/window_backend_test.go
+++ b/window_backend_test.go
@@ -278,6 +278,77 @@ func TestSwayWindowBackendTitle(t *testing.T) {
 	}
 }
 
+func TestSwayWindowBackendPID(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdSwayMsg)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdSwayMsg {
+			t.Fatalf("expected %q, got %q", cmdSwayMsg, name)
+		}
+		return []byte(`{"nodes":[{"type":"con","focused":true,"pid":4242}]}`), nil
+	}
+
+	pid, err := newSwayWindowBackend().PID()
+	if err != nil {
+		t.Fatalf("PID() error = %v", err)
+	}
+	if pid != 4242 {
+		t.Fatalf("PID() = %d, want 4242", pid)
+	}
+}
+
+func TestSwayWindowBackendPIDRejectsUnreliableIdentity(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdSwayMsg)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	tests := []struct {
+		name       string
+		response   string
+		commandErr error
+	}{
+		{name: "missing pid", response: `{"nodes":[{"type":"con","focused":true}]}`},
+		{name: "zero pid", response: `{"nodes":[{"type":"con","focused":true,"pid":0}]}`},
+		{name: "negative pid", response: `{"nodes":[{"type":"con","focused":true,"pid":-1}]}`},
+		{name: "malformed response", response: `{"nodes":`},
+		{name: "transport failure", commandErr: errors.New("sway transport failed")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runWindowCommand = func(context.Context, string, ...string) ([]byte, error) {
+				return []byte(test.response), test.commandErr
+			}
+			pid, err := newSwayWindowBackend().PID()
+			if pid != 0 || !errors.Is(err, errWindowIdentityUnavailable) {
+				t.Fatalf(
+					"PID() = %d, %v; want zero and errWindowIdentityUnavailable",
+					pid,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestSwayWindowBackendPIDRequiresSwaymsg(t *testing.T) {
+	t.Setenv(envPath, t.TempDir())
+
+	pid, err := newSwayWindowBackend().PID()
+	if pid != 0 || !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("PID() = %d, %v; want zero and ErrNotSupported", pid, err)
+	}
+}
+
 func TestHyprlandWindowBackendTitle(t *testing.T) {
 	old := runWindowCommand
 	t.Cleanup(func() { runWindowCommand = old })
@@ -297,6 +368,100 @@ func TestHyprlandWindowBackendTitle(t *testing.T) {
 	}
 	if title != "Editor" {
 		t.Fatalf("unexpected title: %q", title)
+	}
+}
+
+func TestHyprlandWindowBackendPID(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != cmdHyprCtl {
+			t.Fatalf("expected %q, got %q", cmdHyprCtl, name)
+		}
+		if len(args) != 2 || args[0] != argActiveWindow || args[1] != argJSON {
+			t.Fatalf("unexpected args: %#v", args)
+		}
+		return []byte(`{"pid":5252}`), nil
+	}
+
+	pid, err := newHyprlandWindowBackend().PID()
+	if err != nil {
+		t.Fatalf("PID() error = %v", err)
+	}
+	if pid != 5252 {
+		t.Fatalf("PID() = %d, want 5252", pid)
+	}
+}
+
+func TestHyprlandWindowBackendPIDRejectsUnreliableIdentity(t *testing.T) {
+	tmp := t.TempDir()
+	writeStubCommand(t, tmp, cmdHyprCtl)
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	tests := []struct {
+		name       string
+		response   string
+		commandErr error
+	}{
+		{name: "missing pid", response: `{"title":"Editor"}`},
+		{name: "zero pid", response: `{"pid":0}`},
+		{name: "negative pid", response: `{"pid":-1}`},
+		{name: "malformed response", response: `{"pid":`},
+		{name: "transport failure", commandErr: errors.New("hyprland transport failed")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runWindowCommand = func(context.Context, string, ...string) ([]byte, error) {
+				return []byte(test.response), test.commandErr
+			}
+			pid, err := newHyprlandWindowBackend().PID()
+			if pid != 0 || !errors.Is(err, errWindowIdentityUnavailable) {
+				t.Fatalf(
+					"PID() = %d, %v; want zero and errWindowIdentityUnavailable",
+					pid,
+					err,
+				)
+			}
+		})
+	}
+}
+
+func TestHyprlandWindowBackendPIDRequiresHyprctl(t *testing.T) {
+	t.Setenv(envPath, t.TempDir())
+
+	pid, err := newHyprlandWindowBackend().PID()
+	if pid != 0 || !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("PID() = %d, %v; want zero and ErrNotSupported", pid, err)
+	}
+}
+
+func TestWaylandBackendsDoNotInventActiveHandles(t *testing.T) {
+	backends := []windowBackend{
+		waylandCoreWindowBackend{},
+		newSwayWindowBackend(),
+		newHyprlandWindowBackend(),
+		newWlrootsGenericWindowBackend(),
+	}
+	for _, backend := range backends {
+		handle, err := backend.Active()
+		var zero Handle
+		if handle != zero || !errors.Is(err, ErrNotSupported) {
+			t.Errorf(
+				"%s Active() = %#v, %v; want zero and ErrNotSupported",
+				backend.Name(),
+				handle,
+				err,
+			)
+		}
 	}
 }
 

--- a/window_geometry_backend.go
+++ b/window_geometry_backend.go
@@ -34,6 +34,7 @@ type swayTreeNode struct {
 	Name          string               `json:"name"`
 	Type          string               `json:"type"`
 	Focused       bool                 `json:"focused"`
+	PID           *int                 `json:"pid"`
 	Rect          compositorWindowRect `json:"rect"`
 	WindowRect    compositorWindowRect `json:"window_rect"`
 	Nodes         []swayTreeNode       `json:"nodes"`
@@ -90,6 +91,7 @@ func getSwayActiveWindowTitle() (string, error) {
 
 type hyprlandActiveWindow struct {
 	Title            string `json:"title"`
+	PID              *int   `json:"pid"`
 	At               []int  `json:"at"`
 	Size             []int  `json:"size"`
 	Fullscreen       *int   `json:"fullscreen"`

--- a/window_native_backend_linux_test.go
+++ b/window_native_backend_linux_test.go
@@ -54,6 +54,13 @@ func TestNativeWindowBackendReportsUnavailableDisplay(t *testing.T) {
 	if err := backend.Close(1); !errors.Is(err, ErrNotSupported) {
 		t.Fatalf("Close(1) error = %v, want ErrNotSupported", err)
 	}
+	if handle, err := backend.Active(); handle != (Handle{}) ||
+		!errors.Is(err, ErrNotSupported) {
+		t.Fatalf("Active() = %#v, %v; want zero and ErrNotSupported", handle, err)
+	}
+	if pid, err := backend.PID(); pid != 0 || !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("PID() = %d, %v; want zero and ErrNotSupported", pid, err)
+	}
 }
 
 func TestWaylandBuildCannotReportX11WindowStubSuccess(t *testing.T) {
@@ -93,6 +100,13 @@ func TestWaylandBuildCannotReportX11WindowStubSuccess(t *testing.T) {
 	}
 	if _, err := GetTitleE(1, 1); !errors.Is(err, ErrNotSupported) {
 		t.Errorf("public title error = %v, want ErrNotSupported", err)
+	}
+	if handle, err := GetActiveE(); handle != (Handle{}) ||
+		!errors.Is(err, ErrNotSupported) {
+		t.Errorf("public active = %#v, %v; want zero and ErrNotSupported", handle, err)
+	}
+	if pid, err := GetPidE(); pid != 0 || !errors.Is(err, ErrNotSupported) {
+		t.Errorf("public pid = %d, %v; want zero and ErrNotSupported", pid, err)
 	}
 	if x, y, width, height := GetBounds(1, 1); x != 0 || y != 0 || width != 0 || height != 0 {
 		t.Errorf("wayland-build X11 GetBounds = (%d,%d %dx%d), want zero unsupported result", x, y, width, height)

--- a/windows_window_integration_test.go
+++ b/windows_window_integration_test.go
@@ -122,8 +122,11 @@ func TestPureGoWindowsWindowRuntime(t *testing.T) {
 	waitForWindowsCondition(t, "window to become foreground", func() bool {
 		return GetActive() == Handle(handle)
 	})
-	if got := GetPid(); got != pid {
-		t.Fatalf("GetPid() = %d, want %d", got, pid)
+	if got, err := GetActiveE(); err != nil || got != Handle(handle) {
+		t.Fatalf("GetActiveE() = %#x, %v; want %#x, nil", got, err, handle)
+	}
+	if got, err := GetPidE(); err != nil || got != pid {
+		t.Fatalf("GetPidE() = %d, %v; want %d, nil", got, err, pid)
 	}
 
 	previousClipboard, clipboardErr := ReadAll()

--- a/x11_window_native_integration_test.go
+++ b/x11_window_native_integration_test.go
@@ -116,6 +116,14 @@ func TestNativeX11ConfiguredTargetAppliesToWindowAndScale(t *testing.T) {
 	if err != nil || title != "robotgo-x11-target" {
 		t.Fatalf("GetTitleE on configured X11 target = %q, %v", title, err)
 	}
+	active, err := robotgo.GetActiveE()
+	if err != nil || active == (robotgo.Handle{}) {
+		t.Fatalf("GetActiveE on configured X11 target = %#v, %v", active, err)
+	}
+	pid, err := robotgo.GetPidE()
+	if err != nil || pid != os.Getpid() {
+		t.Fatalf("GetPidE on configured X11 target = %d, %v; want %d, nil", pid, err, os.Getpid())
+	}
 
 	// DetectDisplayServer intentionally remains environment-only, while backend
 	// selection must continue to honor an explicit SetXDisplayName target.

--- a/x11_window_nocgo_integration_test.go
+++ b/x11_window_nocgo_integration_test.go
@@ -347,8 +347,17 @@ func TestPureGoX11WindowIntrospectionAndControl(t *testing.T) {
 	if err := ewmh.ActiveWindowSet(manager.xu, harness.window); err != nil {
 		t.Fatalf("restore EWMH active window: %v", err)
 	}
-	if pid := robotgo.GetPid(); pid != os.Getpid() {
-		t.Fatalf("GetPid() = %d, want %d", pid, os.Getpid())
+	if handle, err := robotgo.GetActiveE(); err != nil ||
+		handle != robotgo.Handle(harness.window) {
+		t.Fatalf(
+			"GetActiveE() = %#x, %v; want %#x, nil",
+			handle,
+			err,
+			harness.window,
+		)
+	}
+	if pid, err := robotgo.GetPidE(); err != nil || pid != os.Getpid() {
+		t.Fatalf("GetPidE() = %d, %v; want %d, nil", pid, err, os.Getpid())
 	}
 	if handle := robotgo.GetHWNDByPid(os.Getpid()); handle != int(harness.window) {
 		t.Fatalf("GetHWNDByPid() = %#x, want %#x", handle, harness.window)


### PR DESCRIPTION
## Outcome

Adds truthful, source-compatible active-window identity across CGO and Pure-Go builds.

- introduces `GetActiveE()` and `GetPidE()`
- makes legacy `GetActive()`, `GetActiveC()`, and `GetPid()` delegate to the explicit APIs and return zero on failure
- routes CGO Linux identity through the selected Wayland/X11 window backend
- reads validated positive active PIDs from Sway and Hyprland compositor metadata
- keeps stable Wayland handles and generic identity without a trustworthy source explicitly unsupported
- adds a runnable inspection-only example and synchronizes README, TEST, roadmap, and Wayland status documentation

## Why

The geometry and state APIs already expose backend failures, but active handle/PID lookup could still return plausible zero values and CGO Wayland sessions could reach legacy native/X11-oriented helpers. That violated the Wayland-first and explicit-error contracts.

## Compatibility and risk

Existing exported signatures remain unchanged. X11, Windows, and macOS keep their native/Pure-Go handle and PID behavior. RobotGo does not synthesize Wayland window handles. Missing, malformed, zero, negative, or transport-failed compositor identity fails closed. The change creates no files containing desktop data and the example performs no mutation.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run` (`0 issues`)
- focused and full `-tags wayland` tests
- `-tags "wayland integration"` mouse/window packages
- non-CGO X11 integration test compile
- non-CGO Windows `windowsintegration` test compile
- non-CGO macOS test compile

The local host does not provide `xvfb-run`, so the real X11 integration execution is intentionally left to the protected CI job. Protected Sway runtime coverage exercises the self-owned active PID; opt-in Sway/Hyprland title cells now include PID lookup.

Linear: [LAB-21](https://linear.app/riotbox/issue/LAB-21/add-explicit-active-window-and-pid-identity-apis)
Project: [RobotGo | P007 | Explicit Window Identity](https://linear.app/riotbox/project/robotgo-or-p007-or-explicit-window-identity-78b4d2482f79)