### PR TITLE
fix: harden Wayland window helper lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,11 @@ of assuming parity with X11. Hyprland window mutations query
 older Hyprland versions without the status request keep the legacy path.
 Transport failures and successful but malformed/unknown provider responses
 fail before mutation.
+All Sway, Hyprland, and generic wlroots window-helper commands use the same
+bounded process-group runner. A stalled helper and its descendants are
+terminated, inherited command I/O has a bounded cleanup window, and callers of
+error-returning APIs can inspect `context.DeadlineExceeded` or
+`exec.ErrWaitDelay` through `errors.Is`.
 
 Use `GetActiveE` and `GetPidE` when active-window identity matters. The legacy
 `GetActive` and `GetPid` wrappers remain source-compatible but return zero when

--- a/TEST.md
+++ b/TEST.md
@@ -753,6 +753,7 @@ go test -tags "portal" ./screen/portal -v
 go test -tags "pipewire" ./screen/portal -v
 go test -tags "wayland test" ./screen -run 'TestScreencopy(BitmapStringHelper|WlShm|PortalFallback)' -v
 go test -tags "wayland integration" . ./mouse ./window -v
+go test . -run '^(TestRunBoundedWindowCommand|TestRunWindowCommandWithin|TestWindowBackendCommandErrors|TestWindowCommand)' -count=1 -v
 CGO_ENABLED=0 go test -tags "waylandoutputintegration" . \
   -run '^TestPureGoWaylandOutputEnumerationWeston$' -count=1 -timeout=30s -v
 
@@ -789,6 +790,13 @@ or protocol data is a failure rather than a skip.
 Run tag-gated suites as needed for the area you changed. Native or Pure-Go X11
 input changes must also run the required `x11integration` comparison command
 above.
+
+The focused window-helper command runs are hermetic and do not require a
+compositor. On Linux with CGO, they create test-only commands and PID records
+under `t.TempDir()`, then prove that timeouts and inherited-I/O failures remove
+the complete owned process group. Defensive `t.Cleanup` handlers repeat the
+termination on every test exit; no desktop data or command artifact survives
+the test.
 
 ## Real-Compositor Evidence
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,9 @@ Use the following documents as the primary entry points:
 - [Explicit window identity plan](plan/explicit-window-identity.md) for
   error-returning active handle/PID queries and compositor-aware Wayland
   semantics.
+- [Wayland window-helper lifecycle plan](plan/wayland-window-helper-lifecycle.md)
+  for bounded compositor commands, error-cause fidelity, and descendant
+  cleanup evidence.
 - [Wayland status](wayland-tasks.md) for backend support and open Wayland work.
 - [Upstream compatibility audit](compatibility/upstream-master.md) for
   selectively adopted and intentionally rejected upstream changes.

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -37,7 +37,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 1. Wayland input | Implementation complete; runtime validation partial | Native virtual keyboard/pointer, consent-aware RemoteDesktop fallback, shared ScreenCast stream mapping, absolute pointer/touch, restore tokens, diagnostics, protected portal harness, and isolated hosted Sway native/availability plus multi-output matrix | Register GNOME/KDE portal runners and collect their multi-output evidence |
 | 2. Capture | Hermetic implementation complete; runtime validation partial | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, integration harness, non-skipping geometry/transform CI, sanitizer-backed native ownership gates, and isolated hosted Sway native/multi-output evidence | Real GNOME/KDE portal and multi-output evidence |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration plus Weston and hosted Sway multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence, protected GNOME/KDE multi-output Wayland evidence, and assess further backends selectively |
-| 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state, geometry, and active-identity error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, Sway active node/client geometry and PID, Hyprland active compositor-reported geometry/PID, provider-aware Hyprland 0.55+ Lua window dispatch | Further trustworthy compositor-backed state/geometry operations and cross-platform/runtime matrix coverage |
+| 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state, geometry, and active-identity error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, Sway active node/client geometry and PID, Hyprland active compositor-reported geometry/PID, provider-aware Hyprland 0.55+ Lua window dispatch, bounded process-group-owned compositor helpers with lifecycle evidence | Further trustworthy compositor-backed state/geometry operations and cross-platform/runtime matrix coverage |
 | 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, fail-closed real-compositor preflight/evidence contract, promoted six-cell hosted Sway release/branch gate, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Provision and promote dedicated GNOME/KDE portal jobs |
 
 No delivery phase is complete until all of its exit criteria are blocking and
@@ -319,6 +319,8 @@ Linear delivery project:
 [`RobotGo | P006 | Explicit Window Geometry`](https://linear.app/riotbox/project/robotgo-or-p006-or-explicit-window-geometry-4af461c427fb).
 The adjacent active-identity contract is tracked by
 [`RobotGo | P007 | Explicit Window Identity`](https://linear.app/riotbox/project/robotgo-or-p007-or-explicit-window-identity-78b4d2482f79).
+Compositor helper timeout and descendant ownership are tracked by
+[`RobotGo | P008 | Wayland Window Helper Lifecycle`](https://linear.app/riotbox/project/robotgo-or-p008-or-wayland-window-helper-lifecycle-e009305b14f5).
 
 The compatibility surface now includes:
 
@@ -342,6 +344,11 @@ The compatibility surface now includes:
   inferring state. Mutating close/maximize operations select the active
   `hyprlang` or Hyprland 0.55+ Lua dispatcher syntax and fail closed on
   provider-query transport failures or malformed successful detection.
+- Sway, Hyprland, and generic wlroots window commands share one bounded runner
+  backed by process-group cleanup. Hermetic tests prove that timeout and
+  inherited-I/O failures leave neither direct helpers nor descendants running,
+  while the exact deadline and cleanup causes remain available through
+  `errors.Is`.
 - Bitmap string helpers (`CaptureBitmapStr`, `FindBitmapStr`, `BitmapFromStr`,
   `ToStrBitmap`).
 - Region/tolerance color search through `FindColorCS`/`FindcolorCS`.

--- a/docs/plan/wayland-window-helper-lifecycle.md
+++ b/docs/plan/wayland-window-helper-lifecycle.md
@@ -1,0 +1,49 @@
+# Wayland Window Helper Lifecycle Plan
+
+Status: Initial delivery implemented by LAB-22
+
+Linear coordination:
+
+- Team: `Lab` (`LAB`)
+- Project: [`RobotGo | P008 | Wayland Window Helper Lifecycle`](https://linear.app/riotbox/project/robotgo-or-p008-or-wayland-window-helper-lifecycle-e009305b14f5)
+- Project ID: `89db5b55-8795-413a-9b43-653be5d6bbc3`
+- Initial issue: [`LAB-22`](https://linear.app/riotbox/issue/LAB-22/harden-wayland-window-helper-command-lifecycle)
+
+## Outcome
+
+Make one-shot Sway, Hyprland, and generic wlroots window helpers uniformly
+bounded and prove that failure cannot leave a helper or its descendants
+running. Public APIs retain their signatures and compositor-specific support
+contracts.
+
+## Contract
+
+- Every compositor window command uses one internal two-second bounded runner.
+- Unix commands retain the shared process-group ownership and 250-millisecond
+  inherited-I/O cleanup bound from `internal/command`.
+- Deadline and cleanup causes remain discoverable through backend error
+  wrapping with `errors.Is`.
+- Invalid internal timeout values fail before starting a command.
+- Timeout and inherited-I/O failures never become successful window
+  operations.
+
+## Privacy and ownership
+
+Lifecycle tests create private shell helpers and PID records only under
+`t.TempDir()`. They never contact a compositor, inspect a desktop, capture
+pixels, or persist command output. Test cleanup kills the recorded process
+group and child defensively on every exit path; temporary files are removed by
+the test framework.
+
+## Validation
+
+Hermetic Linux/CGO tests exercise a blocked helper with a spawned descendant
+and a successful parent whose descendant retains stdout. They verify bounded
+return, exact timeout/`exec.ErrWaitDelay` causes, and the absence of surviving
+processes. Cross-platform unit tests cover the production deadline, normal
+output, invalid bounds, and cause preservation through Sway, Hyprland, and
+wlroots backend errors.
+
+No runnable example is added because this project changes internal ownership
+and error fidelity rather than adding a user-invoked operation. Existing
+window examples continue to exercise the unchanged public API.

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -246,7 +246,11 @@ backends.
     independently from window geometry on protected wlroots/GNOME/KDE runners.
     The hosted Sway window cell proves exact active node/client geometry;
     Hyprland protected geometry evidence remains open.
-  - Add resource‑leak checks for Wayland window helpers.
+  - Keep the delivered bounded Wayland window-helper lifecycle contract green.
+    Sway, Hyprland, and generic wlroots commands share one two-second runner;
+    hermetic Linux/CGO tests prove process-group and inherited-I/O cleanup with
+    no surviving descendants, and backend errors preserve timeout/cleanup
+    causes.
 - API Parity Follow-up:
   - Extend compositor-backed implementations for existing topmost/min/max
     status APIs where Wayland protocols or helpers make the state observable.

--- a/window_backend.go
+++ b/window_backend.go
@@ -63,10 +63,35 @@ var (
 	errWindowStateUnavailable    = errors.New("window state unavailable from compositor backend")
 	errWindowOperationFailed     = errors.New("window operation failed for compositor backend")
 	errHyprlandStatusUnavailable = errors.New("hyprland status request unavailable")
+	errInvalidWindowCommandBound = errors.New("invalid window command timeout")
 	runWindowCommand             = func(ctx context.Context, name string, args ...string) ([]byte, error) {
 		return commandpkg.Output(ctx, name, args...)
 	}
 )
+
+func runBoundedWindowCommand(name string, args ...string) ([]byte, error) {
+	return runWindowCommandWithin(windowCommandTimeout, name, args...)
+}
+
+func runWindowCommandWithin(
+	timeout time.Duration,
+	name string,
+	args ...string,
+) ([]byte, error) {
+	if timeout <= 0 {
+		return nil, fmt.Errorf("%w: %s", errInvalidWindowCommandBound, timeout)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	output, err := runWindowCommand(ctx, name, args...)
+	if err == nil {
+		return output, nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil && !errors.Is(err, ctxErr) {
+		err = errors.Join(err, ctxErr)
+	}
+	return output, err
+}
 
 type windowBackend interface {
 	Name() string
@@ -444,10 +469,8 @@ func (swayWindowBackend) Close(args ...int) error {
 	if len(args) > 0 {
 		return waylandWindowNotSupported("close window by pid/handle")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
-	defer cancel()
-	if _, err := runWindowCommand(ctx, cmdSwayMsg, argKill); err != nil {
-		return fmt.Errorf("%w: %v", errWindowOperationFailed, err)
+	if _, err := runBoundedWindowCommand(cmdSwayMsg, argKill); err != nil {
+		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
 	}
 	return nil
 }
@@ -565,10 +588,7 @@ func (hyprlandWindowBackend) Maximize(pid int, state bool, isPid bool) error {
 	if err != nil {
 		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
-	defer cancel()
-	if _, err := runWindowCommand(
-		ctx,
+	if _, err := runBoundedWindowCommand(
 		cmdHyprCtl,
 		args...,
 	); err != nil {
@@ -634,9 +654,7 @@ func (hyprlandWindowBackend) Close(args ...int) error {
 	if err != nil {
 		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
-	defer cancel()
-	if _, err := runWindowCommand(ctx, cmdHyprCtl, dispatchArgs...); err != nil {
+	if _, err := runBoundedWindowCommand(cmdHyprCtl, dispatchArgs...); err != nil {
 		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
 	}
 	return nil
@@ -717,10 +735,13 @@ func runWlrctlActiveWindowAction(op, action string) error {
 	if !hasCommand(cmdWlrCtl) {
 		return waylandWindowNotSupported(op + " (wlrctl unavailable)")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
-	defer cancel()
-	if _, err := runWindowCommand(ctx, cmdWlrCtl, argWindow, action, argStateActive); err != nil {
-		return fmt.Errorf("%w: %v", errWindowOperationFailed, err)
+	if _, err := runBoundedWindowCommand(
+		cmdWlrCtl,
+		argWindow,
+		action,
+		argStateActive,
+	); err != nil {
+		return fmt.Errorf("%w: %w", errWindowOperationFailed, err)
 	}
 	return nil
 }
@@ -764,9 +785,7 @@ func resolveHyprlandDispatchArgs(legacy []string, luaExpression string) ([]strin
 }
 
 func getHyprlandConfigProvider() (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
-	defer cancel()
-	out, err := runWindowCommand(ctx, cmdHyprCtl, argStatus, argJSON)
+	out, err := runBoundedWindowCommand(cmdHyprCtl, argStatus, argJSON)
 	if err != nil {
 		return "", fmt.Errorf("query hyprland status: %w", err)
 	}
@@ -797,9 +816,7 @@ func hyprlandFullscreenModeIsMaximized(mode int) bool {
 }
 
 func getHyprlandActiveWindow() (hyprlandActiveWindow, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
-	defer cancel()
-	out, err := runWindowCommand(ctx, cmdHyprCtl, argActiveWindow, argJSON)
+	out, err := runBoundedWindowCommand(cmdHyprCtl, argActiveWindow, argJSON)
 	if err != nil {
 		return hyprlandActiveWindow{}, err
 	}
@@ -813,7 +830,7 @@ func getHyprlandActiveWindow() (hyprlandActiveWindow, error) {
 func getHyprlandActiveWindowTitle() (string, error) {
 	info, err := getHyprlandActiveWindow()
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", errWindowTitleUnavailable, err)
+		return "", fmt.Errorf("%w: %w", errWindowTitleUnavailable, err)
 	}
 	if strings.TrimSpace(info.Title) == "" {
 		return "", errWindowTitleUnavailable

--- a/window_backend_test.go
+++ b/window_backend_test.go
@@ -7,10 +7,105 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
+
+func TestRunBoundedWindowCommandUsesProductionDeadline(t *testing.T) {
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	runWindowCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		if name != cmdSwayMsg || len(args) != 1 || args[0] != argKill {
+			t.Fatalf("unexpected command: %s %#v", name, args)
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("window command context has no deadline")
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > windowCommandTimeout {
+			t.Fatalf("window command deadline remaining = %s", remaining)
+		}
+		return []byte("ok"), nil
+	}
+
+	output, err := runBoundedWindowCommand(cmdSwayMsg, argKill)
+	if err != nil {
+		t.Fatalf("runBoundedWindowCommand error = %v", err)
+	}
+	if string(output) != "ok" {
+		t.Fatalf("runBoundedWindowCommand output = %q, want ok", output)
+	}
+}
+
+func TestRunWindowCommandWithinRejectsInvalidBound(t *testing.T) {
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+
+	called := false
+	runWindowCommand = func(context.Context, string, ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	}
+
+	for _, timeout := range []time.Duration{0, -time.Nanosecond} {
+		output, err := runWindowCommandWithin(timeout, cmdSwayMsg, argKill)
+		if output != nil || !errors.Is(err, errInvalidWindowCommandBound) {
+			t.Errorf(
+				"runWindowCommandWithin(%s) = %q, %v; want nil and invalid-bound error",
+				timeout,
+				output,
+				err,
+			)
+		}
+	}
+	if called {
+		t.Fatal("invalid timeout invoked external window command")
+	}
+}
+
+func TestWindowBackendCommandErrorsPreserveCleanupCause(t *testing.T) {
+	tmp := t.TempDir()
+	for _, command := range []string{cmdSwayMsg, cmdHyprCtl, cmdWlrCtl} {
+		writeStubCommand(t, tmp, command)
+	}
+	t.Setenv(envPath, tmp)
+
+	old := runWindowCommand
+	t.Cleanup(func() { runWindowCommand = old })
+	runWindowCommand = func(context.Context, string, ...string) ([]byte, error) {
+		return nil, exec.ErrWaitDelay
+	}
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "sway close", run: func() error { return newSwayWindowBackend().Close() }},
+		{name: "sway title", run: func() error {
+			_, err := newSwayWindowBackend().Title()
+			return err
+		}},
+		{name: "hyprland title", run: func() error {
+			_, err := newHyprlandWindowBackend().Title()
+			return err
+		}},
+		{name: "wlrctl action", run: func() error {
+			return newWlrootsGenericWindowBackend().Maximize(0, true, false)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.run(); !errors.Is(err, exec.ErrWaitDelay) {
+				t.Fatalf("error = %v, want exec.ErrWaitDelay in error chain", err)
+			}
+		})
+	}
+}
 
 func writeStubCommand(t *testing.T, dir, name string) {
 	t.Helper()

--- a/window_command_lifecycle_linux_test.go
+++ b/window_command_lifecycle_linux_test.go
@@ -1,0 +1,195 @@
+//go:build cgo && linux
+
+package robotgo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	commandpkg "github.com/marang/robotgo/internal/command"
+)
+
+const (
+	windowHelperStartTimeout = 2 * time.Second
+	windowHelperTestTimeout  = 500 * time.Millisecond
+)
+
+type windowHelperProcesses struct {
+	group int
+	child int
+}
+
+func writeWindowHelperTestCommand(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "compositor-helper")
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatalf("write compositor helper: %v", err)
+	}
+	return path
+}
+
+func readWindowHelperProcesses(t *testing.T, path string) windowHelperProcesses {
+	t.Helper()
+	deadline := time.Now().Add(windowHelperStartTimeout)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			fields := strings.Fields(string(data))
+			if len(fields) != 2 {
+				t.Fatalf("process record = %q, want process group and child PID", data)
+			}
+			group, groupErr := strconv.Atoi(fields[0])
+			child, childErr := strconv.Atoi(fields[1])
+			if groupErr != nil || childErr != nil || group <= 0 || child <= 0 {
+				t.Fatalf(
+					"invalid process record %q: group error=%v child error=%v",
+					data,
+					groupErr,
+					childErr,
+				)
+			}
+			return windowHelperProcesses{group: group, child: child}
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("read process record: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for compositor helper process record")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func cleanupWindowHelperProcesses(t *testing.T, processes *windowHelperProcesses) {
+	t.Helper()
+	t.Cleanup(func() {
+		if processes.group > 0 {
+			_ = syscall.Kill(-processes.group, syscall.SIGKILL)
+		}
+		if processes.child > 0 {
+			_ = syscall.Kill(processes.child, syscall.SIGKILL)
+		}
+	})
+}
+
+func windowHelperProcessTerminated(pid int) (bool, error) {
+	err := syscall.Kill(pid, 0)
+	if errors.Is(err, syscall.ESRCH) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ESRCH) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	closingParen := strings.LastIndexByte(string(data), ')')
+	if closingParen < 0 || closingParen+2 >= len(data) {
+		return false, fmt.Errorf("parse /proc status for process %d", pid)
+	}
+	state := data[closingParen+2]
+	return state == 'Z' || state == 'X', nil
+}
+
+func requireWindowHelperProcessGone(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(windowHelperStartTimeout)
+	for {
+		terminated, err := windowHelperProcessTerminated(pid)
+		if terminated {
+			return
+		}
+		if err != nil {
+			t.Fatalf("probe compositor helper process %d: %v", pid, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("compositor helper process %d survived bounded cleanup", pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func useRealWindowCommandRunner(t *testing.T) {
+	t.Helper()
+	old := runWindowCommand
+	runWindowCommand = commandpkg.Output
+	t.Cleanup(func() { runWindowCommand = old })
+}
+
+func TestWindowCommandTimeoutTerminatesProcessGroup(t *testing.T) {
+	useRealWindowCommandRunner(t)
+	pidPath := filepath.Join(t.TempDir(), "processes")
+	t.Setenv("ROBOTGO_WINDOW_HELPER_TEST_PIDS", pidPath)
+	helper := writeWindowHelperTestCommand(t, `#!/bin/sh
+/bin/sleep 30 &
+child=$!
+printf '%s %s' "$$" "$child" > "$ROBOTGO_WINDOW_HELPER_TEST_PIDS"
+wait
+`)
+
+	processes := windowHelperProcesses{}
+	cleanupWindowHelperProcesses(t, &processes)
+
+	started := time.Now()
+	output, err := runWindowCommandWithin(windowHelperTestTimeout, helper)
+	elapsed := time.Since(started)
+	if len(output) != 0 || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf(
+			"timed window command = %q, %v; want empty output and deadline exceeded",
+			output,
+			err,
+		)
+	}
+	if elapsed >= windowHelperStartTimeout {
+		t.Fatalf("timed window command returned after %s", elapsed)
+	}
+
+	processes = readWindowHelperProcesses(t, pidPath)
+	requireWindowHelperProcessGone(t, processes.group)
+	requireWindowHelperProcessGone(t, processes.child)
+}
+
+func TestWindowCommandInheritedOutputTerminatesDescendant(t *testing.T) {
+	useRealWindowCommandRunner(t)
+	pidPath := filepath.Join(t.TempDir(), "processes")
+	t.Setenv("ROBOTGO_WINDOW_HELPER_TEST_PIDS", pidPath)
+	helper := writeWindowHelperTestCommand(t, `#!/bin/sh
+/bin/sleep 30 &
+child=$!
+printf '%s %s' "$$" "$child" > "$ROBOTGO_WINDOW_HELPER_TEST_PIDS"
+printf ready
+`)
+
+	processes := windowHelperProcesses{}
+	cleanupWindowHelperProcesses(t, &processes)
+
+	started := time.Now()
+	output, err := runWindowCommandWithin(windowHelperStartTimeout, helper)
+	elapsed := time.Since(started)
+	if string(output) != "ready" || !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf(
+			"window command = %q, %v; want ready and exec.ErrWaitDelay",
+			output,
+			err,
+		)
+	}
+	if elapsed >= windowHelperStartTimeout {
+		t.Fatalf("inherited-output window command returned after %s", elapsed)
+	}
+
+	processes = readWindowHelperProcesses(t, pidPath)
+	requireWindowHelperProcessGone(t, processes.child)
+}

--- a/window_geometry_backend.go
+++ b/window_geometry_backend.go
@@ -3,7 +3,6 @@
 package robotgo
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -61,9 +60,7 @@ func findFocusedSwayWindow(node swayTreeNode) (swayTreeNode, bool) {
 }
 
 func getSwayActiveWindow() (swayTreeNode, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), windowCommandTimeout)
-	defer cancel()
-	out, err := runWindowCommand(ctx, cmdSwayMsg, argType, argGetTree, argRawJSON)
+	out, err := runBoundedWindowCommand(cmdSwayMsg, argType, argGetTree, argRawJSON)
 	if err != nil {
 		return swayTreeNode{}, fmt.Errorf("query sway tree: %w", err)
 	}


### PR DESCRIPTION
## Outcome

Makes every Sway, Hyprland, and generic wlroots one-shot window helper use one auditable bounded runner and adds window-specific proof that misbehaving helpers cannot leave owned descendants behind.

- centralizes the existing two-second compositor command deadline
- retains the shared Unix process-group and inherited-I/O cleanup contract
- preserves `context.DeadlineExceeded` and `exec.ErrWaitDelay` through backend error chains
- rejects invalid internal timeout values before process creation
- adds hermetic Linux/CGO timeout and inherited-stdout lifecycle tests
- updates README, TEST, Wayland status, product roadmap, docs index, and the P008 plan

## Root cause

The shared external-command package already owned whole Unix process groups, but the window layer duplicated timeout contexts across seven call sites, several `%v` wrappers discarded machine-readable cleanup causes, and no window-specific end-to-end test proved parent/descendant cleanup.

## Compatibility, safety, and privacy

Public API signatures and compositor support semantics are unchanged. The tests use only private `t.TempDir()` shell helpers and PID records, never contact a compositor or inspect/capture a desktop, defensively terminate recorded processes on every exit path, and leave no repository artifacts.

No new runnable example is included because this changes internal ownership and error fidelity rather than adding a user-invoked operation; existing window examples remain applicable.

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `golangci-lint run` (`0 issues`)
- `go test -tags wayland . -count=1`
- `go test -tags "wayland integration" . ./mouse ./window -count=1`
- Sway integration-tag compile
- `go test -asan -count=1 ./...`
- `scripts/run-wayland-sanitizer-tests.sh`
- focused lifecycle suite repeated ten times

Hosted push CI is green on exact head `fac22c7e82fdc224d93ef76d26a534b267fa0517` across Linux, macOS, Windows, non-CGO, race, vet, lint, sanitizer, Wayland integration, X11 evidence, and OCR.

Linear: [LAB-22](https://linear.app/riotbox/issue/LAB-22/harden-wayland-window-helper-command-lifecycle)
Project: [RobotGo | P008 | Wayland Window Helper Lifecycle](https://linear.app/riotbox/project/robotgo-or-p008-or-wayland-window-helper-lifecycle-e009305b14f5)