### PR TITLE
ci: migrate release evidence to X11 gate

### DIFF
--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -163,7 +163,6 @@ jobs:
     permissions:
       checks: read
       contents: read
-      statuses: read
     steps:
       - name: Record successful protected checks for exact commit
         shell: bash
@@ -178,9 +177,6 @@ jobs:
             gh api -H 'Accept: application/vnd.github+json' \
               "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?per_page=100" \
               > "$output/check-runs-source.json"
-            gh api -H 'Accept: application/vnd.github+json' \
-              "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status?per_page=100" \
-              > "$output/status-source.json"
             : > "$output/rows.jsonl"
             pending=0
             while IFS= read -r check_name; do
@@ -226,31 +222,8 @@ jobs:
           vet
           wayland-integration
           x11-backend-evidence
+          x11-default-suite
           EOF
-            status_row="$(jq -c '
-              [.statuses[] | select(.context == "ci/circleci: build")] |
-              sort_by(.created_at // "") |
-              last |
-              if . == null then empty else {
-                name: .context,
-                conclusion: .state,
-                provider: "circleci",
-                url: .target_url
-              } end
-            ' "$output/status-source.json")"
-            status_state="$(jq -r '.conclusion // ""' <<<"${status_row:-null}")"
-            case "$status_state" in
-              success)
-                printf '%s\n' "$status_row" >> "$output/rows.jsonl"
-                ;;
-              ""|pending)
-                pending=1
-                ;;
-              *)
-                echo "required status failed: ci/circleci: build ($status_state)" >&2
-                exit 1
-                ;;
-            esac
             if [ "$pending" -eq 0 ]; then
               break
             fi
@@ -266,8 +239,7 @@ jobs:
             commit: $commit,
             checks: sort_by(.name)
           }' "$output/rows.jsonl" > "$output/required-checks.json"
-          rm "$output/check-runs-source.json" \
-            "$output/status-source.json" "$output/rows.jsonl"
+          rm "$output/check-runs-source.json" "$output/rows.jsonl"
       - name: Upload protected-check evidence
         uses: actions/upload-artifact@v7
         with:
@@ -330,7 +302,6 @@ jobs:
             exit 1
           fi
           expected_checks="$(printf '%s\n' \
-            'ci/circleci: build' \
             lint \
             native-capture native-input native-output native-output-multi \
             native-window \
@@ -341,7 +312,8 @@ jobs:
             'test (macOS-latest)' \
             'test (ubuntu-latest)' \
             'test (windows-latest)' \
-            vet wayland-integration x11-backend-evidence | LC_ALL=C sort)"
+            vet wayland-integration x11-backend-evidence \
+            x11-default-suite | LC_ALL=C sort)"
           actual_checks="$(jq -r '.checks[].name' \
             required-checks/required-checks.json | LC_ALL=C sort)"
           if [ "$actual_checks" != "$expected_checks" ]; then
@@ -365,7 +337,8 @@ jobs:
                    .name == "native-output" or
                    .name == "native-output-multi" or
                    .name == "native-window" or
-                   .name == "portal-availability")
+                   .name == "portal-availability" or
+                   .name == "x11-default-suite")
                then .provider == "github-actions"
                else true
                end)

--- a/TEST.md
+++ b/TEST.md
@@ -263,8 +263,8 @@ operator-driven compositor jobs remain outside the default gate.
 The additive `X11 default suite` workflow runs the complete CGO default suite
 inside a private GitHub-hosted Xvfb and explicitly proves that the display-aware
 screen-size, scale, and title tests pass rather than skip. It retains no
-synthetic desktop artifact. CircleCI remains required until this replacement
-has passed on `main` and the release/branch-protection contract is migrated.
+synthetic desktop artifact. Its stable `x11-default-suite` check is required by
+`main` branch protection and the exact-commit Release Evidence contract.
 
 Pure-Go Windows input has hermetic tests for Win32 `INPUT` layout,
 foreground-layout key mapping, Unicode surrogate pairs, partial-injection

--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -26,13 +26,13 @@ Each cell emits `evidence.json` and `test.log`. The JSON document records:
 - the sanitized Runtime Diagnostics v1 report.
 
 The bundle also contains `required-checks.json`. It records the successful
-protected status set for the exact commit: CircleCI, lint, vet, race,
-ASan/LeakSanitizer, OCR, all three default and Pure-Go platform legs, Wayland,
-X11 evidence, the release-evidence validator, and all six hosted Sway cells
-(native input, capture, window, single-/multi-output geometry, and portal
-availability). Missing, pending, skipped, neutral, cancelled, timed-out, or
-failed required checks abort snapshot publication. The current manifest has 21
-entries.
+protected status set for the exact commit: the X11 default suite, lint, vet,
+race, ASan/LeakSanitizer, OCR, all three default and Pure-Go platform legs,
+Wayland, targeted X11 evidence, the release-evidence validator, and all six
+hosted Sway cells (native input, capture, window, single-/multi-output geometry,
+and portal availability). Missing, pending, skipped, neutral, cancelled,
+timed-out, or failed required checks abort snapshot publication. The current
+manifest has 21 entries.
 
 The required-check manifest in the workflow and the `main` branch-protection
 contexts are one contract. Add, rename, or remove a stable check in both places

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -409,8 +409,9 @@ Wayland ownership-test manifest and covers allocation/free, timeout cleanup,
 and descriptor ownership. Release Evidence v1 records exact commit/tree/ref,
 toolchain and runtime identity, sanitized diagnostics, the passed command, and
 the test-log SHA-256 for native/Pure-Go Linux, macOS, and Windows cells. It also
-requires and records the complete protected CircleCI/lint/vet/race/sanitizer/
-platform/Wayland/X11 and six-cell hosted Sway check set for the exact commit.
+requires and records the complete protected `x11-default-suite`, lint, vet,
+race, sanitizer, platform, Wayland, targeted X11, and six-cell hosted Sway
+check set for the exact commit.
 The first public
 pre-release, [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1),
 publishes that verified six-cell bundle and checksum for exact commit

--- a/scripts/release_evidence_workflow_test.go
+++ b/scripts/release_evidence_workflow_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestReleaseEvidenceRequiresEveryHostedSwayCell(t *testing.T) {
+func TestReleaseEvidenceRequiresEveryPromotedHostedCheck(t *testing.T) {
 	t.Parallel()
 	workflow, err := os.ReadFile("../.github/workflows/release-evidence.yml")
 	if err != nil {
@@ -20,6 +20,7 @@ func TestReleaseEvidenceRequiresEveryHostedSwayCell(t *testing.T) {
 		"native-output-multi",
 		"native-window",
 		"portal-availability",
+		"x11-default-suite",
 	} {
 		count := 0
 		for _, field := range strings.Fields(text) {
@@ -39,6 +40,16 @@ func TestReleaseEvidenceRequiresEveryHostedSwayCell(t *testing.T) {
 		t.Fatal("release evidence does not require the expanded exact check count")
 	}
 	if !strings.Contains(text, "then .provider == \"github-actions\"") {
-		t.Fatal("release evidence does not bind hosted Sway checks to GitHub Actions")
+		t.Fatal("release evidence does not bind hosted checks to GitHub Actions")
+	}
+	for _, removed := range []string{
+		"ci/circleci: build",
+		`provider: "circleci"`,
+		"statuses: read",
+		"status-source.json",
+	} {
+		if strings.Contains(text, removed) {
+			t.Fatalf("release evidence retains CircleCI contract %q", removed)
+		}
 	}
 }


### PR DESCRIPTION
## Outcome

Replace the external CircleCI status in RobotGo Release Evidence with the proven GitHub-hosted `x11-default-suite` check while preserving the exact 21-check contract.

Linear: https://linear.app/riotbox/issue/LAB-32/replace-circleci-with-a-github-actions-x11-gate

## What changed

- collects `x11-default-suite` from exact-commit GitHub Check Runs
- removes the legacy commit-status API lookup and `statuses: read` permission
- replaces CircleCI in the package allowlist without changing the manifest count
- binds the new check to the `github-actions` provider
- adds regression assertions that the active Release Evidence workflow contains no CircleCI contract
- updates lasting test, compatibility, and roadmap documentation

## Safe transition

Branch protection currently requires both CircleCI and `x11-default-suite`. The CircleCI configuration remains in this PR solely so the old required context can complete. After this PR merges and the migrated Release Evidence workflow passes on `main`, the CircleCI required context will be removed before a final small cleanup PR deletes `.circleci`. This prevents a missing-context window.

## Exact candidate evidence

Current head: `d52cbb38ae3b35e4d5ea3d992e79ac6767e80f0f`

- all 36 applicable PR checks pass
- both transition contexts, CircleCI and `x11-default-suite`, pass
- full manual Release Evidence run: https://github.com/marang/robotgo/actions/runs/30227674532
- all six native/Pure-Go Linux, macOS, and Windows snapshots pass
- exact 21-check protected manifest passes with `x11-default-suite`
- package validation passes
- manual `publish` job skips as designed

## Local validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go test -race ./scripts ./internal/releaseevidence ./internal/cmd/releaseevidence`
- `go vet ./...`
- `golangci-lint run`
- `git diff --check`