### PR TITLE
chore: prepare v1.0.0-beta.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,41 @@
 # CHANGELOG
 
+## RobotGo v1.0.0-beta.2 — 2026-07-27
+
+This second pre-release adds a policy-gated agent automation layer and local
+MCP adapter, completes scoped Wayland input/capture evidence on GNOME, KDE, and
+wlroots, expands trustworthy Wayland window contracts, and hardens cleanup and
+release validation across platforms.
+
+Highlights since `v1.0.0-beta.1`:
+
+- Added `agent.Session` with typed operations, dry-run/execute separation,
+  bounded policy and quotas, audit events, in-memory observations,
+  observe-act-verify lineage, and privacy-safe visual find/wait conditions.
+- Added the local stdio `robotgo-mcp` adapter with sanitized results,
+  explicit observation release, and no network listener.
+- Added protected real-compositor evidence for native Sway and real
+  GNOME/KDE RemoteDesktop and ScreenCast portals, including multi-output
+  absolute input and per-stream capture.
+- Added truthful Wayland active-window geometry and identity APIs, bounded
+  compositor helper lifecycle, and explicit unsupported behavior where the
+  compositor cannot prove state.
+- Hardened portal screenshot decoding, external-command teardown, clipboard,
+  OCR, alerts, Windows clipboard/paste integration, pointer tests, and
+  sensitive test-artifact cleanup.
+- Replaced CircleCI with a protected GitHub Actions X11 default-suite gate.
+- Expanded exact release evidence to 25 successful checks for the candidate
+  SHA, including four release-only GNOME/KDE portal jobs, plus the six-cell
+  Linux/macOS/Windows native/Pure-Go snapshot matrix.
+
+This remains a beta release. Wayland behavior is compositor- and
+permission-dependent, the agent session is intentionally process-global, and
+the MCP adapter is a local transport rather than a remote authorization
+service.
+
+See the [complete release notes](releases/v1.0.0-beta.2.md) for installation,
+upgrade guidance, compatibility limits, and evidence verification.
+
 ## RobotGo v1.0.0-beta.1 — 2026-07-19
 
 This is the first published pre-release of the independent

--- a/docs/releases/v1.0.0-beta.2.md
+++ b/docs/releases/v1.0.0-beta.2.md
@@ -1,0 +1,151 @@
+# RobotGo v1.0.0-beta.2
+
+Published: 2026-07-27
+
+This is the second public pre-release of the independent
+`github.com/marang/robotgo` module. It advances the fork from implemented
+Wayland and Pure-Go backends to protected real-compositor evidence, and adds a
+bounded automation layer designed for local agent integrations.
+
+This is not final `v1.0.0`. The release remains a beta while broader
+compositor-specific window coverage, opt-in permission-granted macOS runtime
+evidence, and the longer-term compatibility lifecycle continue.
+
+## Install or upgrade
+
+RobotGo requires Go 1.25 or newer.
+
+```bash
+go get github.com/marang/robotgo@v1.0.0-beta.2
+```
+
+Use the explicit version shown above. The repository retains historical
+upstream stable `v1.x` tags for attribution and history, and Go module
+resolution correctly prefers a stable tag over a pre-release for `@latest`.
+Until this fork publishes a newer stable release, `@latest` therefore does not
+mean the current fork beta.
+
+Use the fork's module path:
+
+```go
+import "github.com/marang/robotgo"
+```
+
+`Version` and `GetVersion()` return `v1.0.0-beta.2`. Existing RobotGo APIs
+remain available; the agent packages and error-returning platform APIs are
+additive. Applications upgrading from beta.1 should rerun their platform and
+permission checks because Wayland backend availability is determined at
+runtime.
+
+## Highlights
+
+### Policy-gated automation for local agents
+
+- `agent.Session` provides typed move, click, text, observe, find-color, and
+  wait-color operations under an immutable allowlist and bounded quotas.
+- Dry runs execute validation, capability, policy, and confirmation preflight
+  without injecting input. Explicit execution is still required for mutation.
+- In-memory observations support stale-target preconditions and bounded
+  changed/unchanged verification. Pixel data and lineage digests stay inside
+  the process and are zeroed on release or session close.
+- Audit events contain sanitized lifecycle metadata, not typed text, pixels,
+  clipboard contents, portal identifiers, restore tokens, or backend error
+  payloads.
+- The local stdio `robotgo-mcp` command exposes focused capabilities, observe,
+  find, wait, act, observation-release, and close tools. It opens no network
+  listener and returns sanitized structured results.
+- On Wayland, agent capture prefers native screencopy and may reuse an already
+  authorized ScreenCast session; it never opens portal consent implicitly.
+
+See the [README agent section](../../README.md#policy-gated-agent-sessions) and
+the [agent architecture plan](../plan/agentic-desktop-automation.md).
+
+### Real Wayland desktop evidence
+
+- Disposable GitHub-hosted GNOME and KDE guests now prove real
+  RemoteDesktop input and persistent ScreenCast/PipeWire capture on canonical
+  single- and two-output topologies.
+- Multi-output input verifies relative movement and absolute coordinates on
+  both physical streams. Multi-output capture verifies one owned, non-empty
+  frame per unique stream.
+- Hosted Sway proves native virtual input, screencopy, supported window
+  behavior, single-/multi-output geometry, and explicit portal availability.
+- Portal consent remains real. The workflows do not substitute mocks,
+  self-hosted desktops, or implicit approval services.
+- Guest state, portal sessions, frames, raw logs, temporary disks, and host
+  runner state are rejected or destroyed after success, failure, timeout, and
+  cancellation paths.
+
+### More truthful window and compositor behavior
+
+- Error-returning active-window geometry and identity APIs expose title,
+  rectangle, client rectangle, PID, and backend handle only when the selected
+  backend can prove them.
+- Sway and Hyprland integrations use compositor-reported state; generic
+  wlroots and Wayland-core paths return explicit unsupported errors for
+  unavailable foreign-window operations.
+- External compositor helpers run with bounded process-group ownership and
+  deterministic teardown instead of leaking descendant processes.
+- Native screencopy pixel-format handling and persistent PipeWire latest-frame
+  caching received additional regression coverage.
+
+### Reliability and release integrity
+
+- Portal screenshot decoding now bounds encoded input, dimensions,
+  allocations, cancellation, and identity-verified temporary-file cleanup.
+- Unix clipboard and OCR cancellation, Linux alert errors, Windows
+  clipboard/paste recovery, exact pointer completion, and sanitizer diagnostics
+  have stronger deterministic tests.
+- CircleCI and its image are removed. A protected GitHub Actions
+  `x11-default-suite` now owns the non-skipping Xvfb/XTEST input, capture,
+  bounds, cleanup, crash-guardian, and negative contracts.
+- Release Evidence v1 records 25 successful exact-SHA checks: the 21
+  branch-protection checks plus four release-only GNOME/KDE multi-output
+  RemoteDesktop/ScreenCast jobs.
+- The release bundle also contains six independently verified native/Pure-Go
+  snapshots across Linux, macOS, and Windows.
+
+## Compatibility limits
+
+- Wayland global input, capture, and foreign-window control remain subject to
+  compositor protocols, desktop portal policy, and explicit user consent.
+- Persistent ScreenCast capture requires the `pipewire` build tag plus
+  PipeWire development and runtime libraries.
+- Only one `agent.Session` may own RobotGo's process-global desktop backends at
+  a time. Its quotas and policy are safety boundaries for that local process,
+  not multi-tenant isolation.
+- `robotgo-mcp` is a local stdio adapter. It does not provide network
+  authentication, remote transport, or an operating-system sandbox.
+- Pure-Go macOS input/window mutation requires Accessibility permission;
+  capture requires Screen Recording permission. Permission-granted mutation
+  evidence remains opt-in.
+- Compositor-specific Wayland window operations are supported only where
+  observable state and mutation contracts are trustworthy. Wayland core does
+  not provide universal foreign-window control.
+- Hook/event functionality on Wayland remains explicitly capability-reported.
+
+The current platform claims are listed in the
+[Runtime Compatibility Matrix v1](../compatibility/runtime-v1.md).
+
+## Verify release evidence
+
+Publication attaches:
+
+```text
+robotgo-release-evidence-v1.0.0-beta.2-<commit>.tar.gz
+robotgo-release-evidence-v1.0.0-beta.2-<commit>.tar.gz.sha256
+```
+
+Verify the archive before extraction:
+
+```bash
+sha256sum -c robotgo-release-evidence-v1.0.0-beta.2-*.tar.gz.sha256
+```
+
+The archive contains the exact source commit, tree, and tag ref; sanitized
+runtime diagnostics; test-log digests; platform, architecture, and CGO
+identity; and the 25-check exact-commit manifest. A missing, skipped, stale,
+cancelled, or failed required check prevents packaging and publication.
+
+See [Release Evidence v1](../compatibility/release-evidence-v1.md) for the
+schema and per-cell verification command.

--- a/docs/releases/v1.0.0-beta.2.md
+++ b/docs/releases/v1.0.0-beta.2.md
@@ -51,10 +51,12 @@ determined at runtime.
 - Dry runs execute validation, capability, policy, and confirmation preflight
   without injecting input. Explicit execution is still required for mutation.
 - In-memory observations support stale-target preconditions and bounded
-  changed/unchanged verification. Pixel buffers stay inside the process and are
-  zeroed on release or session close. SHA-256 lineage digests are non-reversible
-  metadata, not pixel payloads; they may remain in caller-held `Observation`
-  values after the backing pixels are released.
+  changed/unchanged verification. RobotGo-owned pixel buffers are zeroed on
+  release or session close. `Observation.Image()` returns a defensive image
+  copy; callers that request one own that copy and must clear or discard it
+  themselves. SHA-256 lineage digests are non-reversible metadata, not pixel
+  payloads; they may remain in caller-held `Observation` values after the
+  backing pixels are released.
 - Audit events contain sanitized lifecycle metadata, not typed text, pixels,
   clipboard contents, portal identifiers, restore tokens, or backend error
   payloads.

--- a/docs/releases/v1.0.0-beta.2.md
+++ b/docs/releases/v1.0.0-beta.2.md
@@ -155,8 +155,10 @@ The archive records the exact source commit hash, tree hash, and tag ref in its
 evidence JSON; it does not embed Git objects or a source checkout. It also
 contains sanitized runtime diagnostics, test-log digests, platform,
 architecture, and CGO identity, and the 25-check exact-commit manifest. A
-missing, skipped, stale, cancelled, or failed required check prevents packaging
-and publication.
+missing, skipped, stale, cancelled, or failed required check blocks the manual
+pre-publication decision. In the workflow triggered by an already published
+release, it prevents evidence packaging and attachment but does not
+automatically withdraw the release.
 
 See [Release Evidence v1](../compatibility/release-evidence-v1.md) for the
 schema and per-cell verification command.

--- a/docs/releases/v1.0.0-beta.2.md
+++ b/docs/releases/v1.0.0-beta.2.md
@@ -31,11 +31,16 @@ Use the fork's module path:
 import "github.com/marang/robotgo"
 ```
 
-`Version` and `GetVersion()` return `v1.0.0-beta.2`. Existing RobotGo APIs
-remain available; the agent packages and error-returning platform APIs are
-additive. Applications upgrading from beta.1 should rerun their platform and
-permission checks because Wayland backend availability is determined at
-runtime.
+`Version` and `GetVersion()` return `v1.0.0-beta.2`. The agent packages and
+error-returning platform APIs are additive. One legacy Wayland behavior changed:
+beta.1 `GetBounds(pid)` and `GetClient(pid)` returned the whole virtual desktop
+even when they could not resolve the requested window. They now delegate to the
+selected compositor backend; because their signatures cannot return an error,
+an unsupported or unresolved target produces a zero rectangle. Migrate
+Wayland callers that need actionable failure details to `GetBoundsE` and
+`GetClientE`. Applications upgrading from beta.1 should also rerun their
+platform and permission checks because Wayland backend availability is
+determined at runtime.
 
 ## Highlights
 
@@ -46,8 +51,10 @@ runtime.
 - Dry runs execute validation, capability, policy, and confirmation preflight
   without injecting input. Explicit execution is still required for mutation.
 - In-memory observations support stale-target preconditions and bounded
-  changed/unchanged verification. Pixel data and lineage digests stay inside
-  the process and are zeroed on release or session close.
+  changed/unchanged verification. Pixel buffers stay inside the process and are
+  zeroed on release or session close. SHA-256 lineage digests are non-reversible
+  metadata, not pixel payloads; they may remain in caller-held `Observation`
+  values after the backing pixels are released.
 - Audit events contain sanitized lifecycle metadata, not typed text, pixels,
   clipboard contents, portal identifiers, restore tokens, or backend error
   payloads.
@@ -142,10 +149,12 @@ Verify the archive before extraction:
 sha256sum -c robotgo-release-evidence-v1.0.0-beta.2-*.tar.gz.sha256
 ```
 
-The archive contains the exact source commit, tree, and tag ref; sanitized
-runtime diagnostics; test-log digests; platform, architecture, and CGO
-identity; and the 25-check exact-commit manifest. A missing, skipped, stale,
-cancelled, or failed required check prevents packaging and publication.
+The archive records the exact source commit hash, tree hash, and tag ref in its
+evidence JSON; it does not embed Git objects or a source checkout. It also
+contains sanitized runtime diagnostics, test-log digests, platform,
+architecture, and CGO identity, and the 25-check exact-commit manifest. A
+missing, skipped, stale, cancelled, or failed required check prevents packaging
+and publication.
 
 See [Release Evidence v1](../compatibility/release-evidence-v1.md) for the
 schema and per-cell verification command.

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package robotgo
 
 // Version is the current RobotGo module release.
-const Version = "v1.0.0-beta.1"
+const Version = "v1.0.0-beta.2"

--- a/version_test.go
+++ b/version_test.go
@@ -3,7 +3,7 @@ package robotgo
 import "testing"
 
 func TestReleaseVersion(t *testing.T) {
-	const expected = "v1.0.0-beta.1"
+	const expected = "v1.0.0-beta.2"
 	if Version != expected {
 		t.Fatalf("Version = %q, want %q", Version, expected)
 	}


### PR DESCRIPTION
## Goal

Prepare the reviewed source candidate for the second independent RobotGo pre-release, `v1.0.0-beta.2`. This PR does **not** publish final `v1.0.0` and does not create a tag or release by itself.

## Changes

- update `Version` and `GetVersion()` contract to `v1.0.0-beta.2`
- add a user-facing changelog entry for changes since beta.1
- add complete beta.2 release notes covering installation, upgrade guidance, new agent/MCP features, real Wayland evidence, reliability work, known limits, and evidence verification
- explicitly warn that inherited stable upstream `v1.x` tags mean users must request the beta tag instead of relying on `@latest`

## Local validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go vet ./...`
- `golangci-lint run`
- native and Pure-Go `TestReleaseVersion`
- documentation target/link and `git diff --check` validation

## Release sequence after merge

1. select the clean merge commit on `main`
2. run and independently verify full Release Evidence for that exact commit
3. create and push annotated tag `v1.0.0-beta.2` only after evidence is green
4. publish the prerelease using the reviewed notes
5. let the release event rerun exact-tag evidence and attach the checksummed bundle
6. independently verify tag target, assets, checksums, manifest, provenance, and cleanup

Linear: LAB-55