### PR TITLE
docs: synchronize roadmap after v1.0.0-beta.2

### DIFF
--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -63,7 +63,19 @@ repository code; it only verifies the already packaged SHA-256 and uploads the
 two assets. Manual runs retain the bundle as a GitHub Actions artifact for 90
 days and do not modify a release.
 
-The first published bundle is attached to
+The latest published bundle is attached to
+[`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2):
+
+- [`robotgo-release-evidence-v1.0.0-beta.2-f3530594f30b.tar.gz`](https://github.com/marang/robotgo/releases/download/v1.0.0-beta.2/robotgo-release-evidence-v1.0.0-beta.2-f3530594f30b.tar.gz)
+- [`robotgo-release-evidence-v1.0.0-beta.2-f3530594f30b.tar.gz.sha256`](https://github.com/marang/robotgo/releases/download/v1.0.0-beta.2/robotgo-release-evidence-v1.0.0-beta.2-f3530594f30b.tar.gz.sha256)
+
+It records exact source commit
+`f3530594f30baa29fd61828c77b2b5c0140f3d15`; all six snapshot cells and all 25
+protected checks passed, including the four real GNOME/KDE multi-output portal
+checks. The archive digest is
+`5d21e7da7b2f8d8745dfa9a48b14e301ac7d97763d453fbe789f6355fe01efe0`.
+
+The first published bundle remains attached to
 [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1):
 
 - [`robotgo-release-evidence-v1.0.0-beta.1-1bab5e173f6b.tar.gz`](https://github.com/marang/robotgo/releases/download/v1.0.0-beta.1/robotgo-release-evidence-v1.0.0-beta.1-1bab5e173f6b.tar.gz)

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -29,7 +29,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 - CI covers lint, default tests on Linux/macOS/Windows, non-CGO, Wayland, portal,
   Weston integration, race, vet, and native sanitizer/leak variants.
 
-## Execution Status (2026-07-26)
+## Execution Status (2026-07-27)
 
 | Area | Status | Delivered | Exit criteria still open |
 |---|---|---|---|
@@ -38,7 +38,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 2. Capture | Complete for the scoped production and evidence contract | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames with static-desktop reuse, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, hosted GNOME/KDE single- and multi-output persistent-capture execution, non-skipping geometry/transform CI, sanitizer-backed native ownership gates, isolated hosted Sway native/multi-output evidence, and exact-release promotion | Keep runtime and release gates green; extend only for newly scoped formats/backends |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration plus Weston, hosted Sway, and hosted GNOME/KDE multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state, geometry, and active-identity error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, Sway active node/client geometry and PID, Hyprland active compositor-reported geometry/PID, provider-aware Hyprland 0.55+ Lua window dispatch, bounded process-group-owned compositor helpers with lifecycle evidence | Further trustworthy compositor-backed state/geometry operations and cross-platform/runtime matrix coverage |
-| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release-evidence pipeline, fail-closed real-compositor contracts, promoted six-cell hosted Sway gate, promoted GNOME/KDE multi-output portal release gates, and the published [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1) evidence bundle | Complete the remaining release-readiness and ongoing compatibility lifecycle |
+| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release snapshots, fail-closed real-compositor contracts, promoted six-cell hosted Sway gate, promoted GNOME/KDE multi-output portal release gates, and published exact-tag [`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2) evidence with a 25-check manifest | Continue the compatibility lifecycle and final `v1.0.0` readiness; keep open Phase 3/4 runtime gaps explicit |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phases 1 and 2 now have implementation, real-compositor validation, and
@@ -57,8 +57,8 @@ Ubuntu 24.04 with retained exact-commit evidence;
 the separate hosted Sway multi-output cell is passing with retained
 [exact-commit evidence](https://github.com/marang/robotgo/actions/runs/29861058126).
 The GNOME/KDE evidence and release-promotion gap across phases 1, 2, and 3 is
-closed; Phase 5 continues with release readiness and compatibility lifecycle
-work.
+closed; Phase 5 continues with compatibility lifecycle work and final
+`v1.0.0` readiness.
 The completed [Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md)
 provides a local, policy-gated MCP boundary on the agent-session proof. The
 adjacent [Safe Agent Visual Conditions Plan](agent-visual-conditions.md) now
@@ -418,7 +418,14 @@ The first public
 pre-release, [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1),
 publishes that verified six-cell bundle and checksum for exact commit
 `1bab5e173f6b96f61d349473b348f839291b9a89`; manual runs remain read-only
-artifacts. Process termination rejects non-positive and platform-overflow PIDs
+artifacts. The latest pre-release,
+[`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2),
+publishes exact-tag
+[release evidence](https://github.com/marang/robotgo/actions/runs/30244107872)
+for commit `f3530594f30baa29fd61828c77b2b5c0140f3d15`: six platform
+snapshots, the protected 25-check manifest, and real GNOME/KDE multi-output
+RemoteDesktop and ScreenCast execution all passed before the checksummed bundle
+was attached. Process termination rejects non-positive and platform-overflow PIDs
 before invoking the operating system, preventing Unix process-group signaling
 through `Kill(0)` or a narrowed negative PID. Dedicated GNOME/KDE portal jobs
 are hosted; their multi-output cells are promoted into exact-release evidence

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -198,10 +198,12 @@ backends.
     versioned. Schema v1 now reports negotiated protocol versions, permission
     state, and actionable remediation without sensitive session data. Release
     Evidence v1 binds that report and test-log digests to exact source across
-    the six native/Pure-Go hosted platform cells.
+    the six native/Pure-Go hosted platform cells; `v1.0.0-beta.2` additionally
+    records the protected 25-check manifest.
   - 7. Keep race/vet and the manifest-checked native ASan/LeakSanitizer ownership
     suites blocking. Hosted Sway and GNOME/KDE single-/multi-output jobs are
-    defined and evidenced; provision their remaining release-promotion gates.
+    defined and evidenced. The six hosted Sway checks and four GNOME/KDE
+    multi-output portal checks remain required by exact-release evidence.
 
 - Recently completed parity work:
   - Window state/query APIs expose `IsTopMostE`, `IsMinimizedE`,
@@ -220,10 +222,12 @@ backends.
     GNOME, and KDE sessions.
   - Protected GNOME/KDE portal multi-output selection and stream evidence is
     retained alongside blocking hosted wlroots/Sway and Weston
-    single-/multi-output evidence. Promote the portal checks into release gates.
+    single-/multi-output evidence. Keep the promoted multi-output portal release
+    gates green.
 - Portal Path:
   - Expand troubleshooting for xdg-desktop-portal backend selection and consent prompts.
-  - Validate the existing high-level RemoteDesktop input fallback on GNOME/KDE.
+  - Keep the hosted high-level RemoteDesktop input fallback validation green on
+    GNOME and KDE.
   - GNOME/KDE single-output repeated-frame behavior and multi-output
     per-stream ScreenCast/PipeWire capture are validated in hosted guests. Keep
     Sway/wlroots native capture and
@@ -298,4 +302,5 @@ backends.
     `-text`, `-paste`, or `-color` flags.
   - Keep the explicitly gated real Windows input-desktop pointer probe blocking
     in the non-CGO Windows CI leg; it must restore the original cursor position.
-  - Publish a versioned support matrix and troubleshooting guide.
+  - Keep the published versioned support matrix and troubleshooting guidance
+    current.


### PR DESCRIPTION
## Goal
Synchronize the product and Wayland roadmaps with the published `v1.0.0-beta.2` release evidence while keeping the remaining Phase 3/4 and final-v1.0 gaps explicit.

Linear: [LAB-58](https://linear.app/riotbox/issue/LAB-58/synchronize-robotgo-roadmap-after-v100-beta2)

## Changes
- record Beta.2 as the latest published exact-tag evidence bundle
- document its six platform snapshots, protected 25-check manifest, and real GNOME/KDE multi-output portal evidence
- replace stale future promotion tasks with ongoing gate-maintenance wording
- retain Beta.1 as historical first-bundle evidence and preserve genuinely open runtime gaps

## Validation
- `git diff --check`
- `go test ./...`
- verified the published Beta.2 release asset names against GitHub

## Risk
Documentation-only. The main risk is overstating completion; wording intentionally distinguishes the completed Beta.2 release contract from open Phase 3/4 runtime coverage and final `v1.0.0` readiness.