### PR TITLE
test: add hosted GNOME/KDE multi-output bounds evidence

### DIFF
--- a/.github/workflows/display-bounds-e2e.yml
+++ b/.github/workflows/display-bounds-e2e.yml
@@ -1,0 +1,162 @@
+name: Display Bounds E2E
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_call:
+    inputs:
+      desktop:
+        description: Hosted desktop lane to run
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      desktop:
+        description: Hosted desktop lane to run
+        required: true
+        default: gnome
+        type: choice
+        options:
+          - gnome
+          - kde
+          - all
+
+concurrency:
+  group: display-bounds-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  hosted-bounds:
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'release'
+    name: GitHub-hosted ${{ matrix.desktop }} multi-output Wayland bounds
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        desktop: >-
+          ${{
+            fromJSON(
+              github.event_name == 'push' && '["gnome","kde"]' ||
+              inputs.desktop == 'all' && '["gnome","kde"]' ||
+              inputs.desktop == 'kde' && '["kde"]' ||
+              '["gnome"]'
+            )
+          }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: 1.25.x
+      - name: Verify exact hosted source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain --untracked-files=all)"
+      - name: Enable hosted KVM
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -c /dev/kvm
+          sudo chmod 0666 /dev/kvm
+          test -r /dev/kvm
+          test -w /dev/kvm
+      - name: Install hosted QEMU dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -r /etc/apt/sources.list.d/ubuntu.sources
+          apt_options=(
+            -o Dir::Etc::sourcelist=sources.list.d/ubuntu.sources
+            -o Dir::Etc::sourceparts=-
+            -o APT::Get::List-Cleanup=0
+          )
+          sudo apt-get "${apt_options[@]}" update
+          sudo apt-get "${apt_options[@]}" install \
+            --no-install-recommends -y \
+            cloud-image-utils \
+            openssh-client \
+            qemu-system-gui \
+            qemu-system-x86 \
+            qemu-utils \
+            xauth \
+            xvfb
+      - name: Verify hosted capacity
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest="infrastructure/portal-runner/${{ matrix.desktop }}/manifest.json"
+          required_cpus="$(jq -r '.vm.cpus' "$manifest")"
+          required_memory_kib="$(( $(jq -r '.vm.memory_mib' "$manifest") * 1024 ))"
+          available_memory_kib="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
+          minimum_free_bytes="$(( 8 * 1024 * 1024 * 1024 ))"
+          available_bytes="$(df --output=avail -B1 "$RUNNER_TEMP" | tail -n 1)"
+          test "$(nproc)" -ge "$required_cpus"
+          test "$available_memory_kib" -ge "$required_memory_kib"
+          test "$available_bytes" -ge "$minimum_free_bytes"
+      - name: Build and test nested desktop bounds
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          state_root="$RUNNER_TEMP/robotgo-${{ matrix.desktop }}-multi-output-bounds-runner"
+          manifest="infrastructure/portal-runner/${{ matrix.desktop }}/manifest.json"
+          portal_runner="$RUNNER_TEMP/robotgo-portalrunner"
+          go build -o "$portal_runner" ./internal/cmd/portalrunner
+          test -x "$portal_runner"
+          exec timeout --preserve-status \
+            --signal=TERM --kill-after=2m 20m \
+            bash scripts/run_hosted_portal_e2e.sh \
+              "$portal_runner" "$manifest" "$GITHUB_WORKSPACE" \
+              "$state_root" "$GITHUB_SHA" display-bounds \
+              multi-output
+      - name: Reject transient runner artifacts
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          state_root="$RUNNER_TEMP/robotgo-${{ matrix.desktop }}-multi-output-bounds-runner"
+          portal_runner="$RUNNER_TEMP/robotgo-portalrunner"
+          trap 'rm -f -- "$portal_runner"' EXIT INT TERM
+          if [ -d "$state_root" ]; then
+            test "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" = "$GITHUB_SHA"
+            test -x "$portal_runner"
+            deadline=$((SECONDS + 120))
+            while :; do
+              if cleanup_error="$(
+                "$portal_runner" cleanup \
+                  -repository-root "$GITHUB_WORKSPACE" \
+                  -state-root "$state_root" 2>&1
+              )"; then
+                break
+              fi
+              if [ "$cleanup_error" != "portal runner state is already in use" ]; then
+                echo "$cleanup_error" >&2
+                exit 1
+              fi
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "timed out waiting for portal runner cleanup ownership" >&2
+                exit 1
+              fi
+              sleep 1
+            done
+            leftover="$(
+              find "$state_root" -maxdepth 1 -type d -name 'run-*' -print -quit
+            )"
+            test -z "$leftover"
+          fi
+          rm -f -- "$portal_runner"
+          trap - EXIT INT TERM
+          test ! -e "$portal_runner"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ Respect current tag split and do not collapse platform boundaries:
 - `linux && portal`: explicit portal package path (`screen/portal`)
 - `linux && wayland && test`: tagged Wayland capture/DRM test paths
 - `linux && wayland && integration`: integration suites requiring compositor setup
+- `linux && hostedboundsintegration`: consent-free hosted GNOME/KDE output
+  contract (combined with `wayland` for the native-CGO variant)
 - `cgo && linux && waylandint`: keyboard integration harness
 - `linux && !cgo && x11integration`: Pure-Go X11/XTEST input integration suite
 

--- a/README.md
+++ b/README.md
@@ -493,6 +493,10 @@ falls back to the aggregate desktop. Native
 the core-output fallback applies integer scale and all eight transforms. The
 Pure-Go query is read-only, bounded, closes its Unix connection after every
 atomic snapshot, and never opens a portal consent dialog.
+The hosted GNOME/KDE bounds workflow validates this same public contract on an
+exact two-monitor topology in both native-CGO and Pure-Go builds. Its test
+process has `DISPLAY` unset and performs no capture or input, so output
+enumeration needs neither Xwayland nor portal consent.
 Native `zwlr_virtual_pointer_v1` absolute moves use the same aggregate logical
 origin, so displays positioned left of or above the primary output do not wrap
 negative global coordinates into the protocol's unsigned absolute frame.

--- a/TEST.md
+++ b/TEST.md
@@ -425,6 +425,36 @@ Prerequisites:
 - Linux
 - Wayland runtime available
 
+### Hosted GNOME/KDE display bounds
+
+Purpose:
+
+- Exercise the public native-CGO and Pure-Go Wayland output APIs against the
+  same real two-output GNOME or KDE compositor session.
+- Require exact per-output bounds, aggregate desktop bounds, primary size,
+  display count/main index, invalid-index behavior, and legacy/error API parity.
+- Prove the test process is Wayland-only (`DISPLAY` unset) and does not open a
+  RemoteDesktop, ScreenCast, screenshot, input, or consent session.
+
+`.github/workflows/display-bounds-e2e.yml` runs the proof in disposable
+GitHub-hosted nested-KVM guests. The manifest-bound topology is a 1280x720
+primary at `(0,0)` and a 1024x768 secondary at `(1280,0)`. Each desktop job
+first runs the CGO native client with `wayland,hostedboundsintegration`, then
+rebuilds the same public contract with `CGO_ENABLED=0`. Missing output
+protocols, an unexpected topology, X11 exposure, a skipped test, or surviving
+runner state fails the job. The workflow is credential-free inside the guest,
+uses no portal consent marker, captures no pixels, and removes its VM, source
+archive, logs, and runner binary on every completion path.
+
+The nested guests run automatically only on trusted `main` pushes or an
+explicit workflow dispatch; pull requests do not boot them. Local compile
+coverage for the two build variants is:
+
+```bash
+go test -run '^$' -tags "wayland hostedboundsintegration" .
+CGO_ENABLED=0 go test -run '^$' -tags "hostedboundsintegration" .
+```
+
 ### RemoteDesktop portal input
 
 Purpose:
@@ -914,7 +944,8 @@ exact-tree transfer, and mandatory cleanup checks are documented in
 [GitHub-Hosted GNOME Portal Runner](infrastructure/portal-runner/gnome/README.md)
 and [GitHub-Hosted KDE Portal Runner](infrastructure/portal-runner/kde/README.md).
 `probe` remains an infrastructure diagnostic; `hosted-run` is the automated,
-credential-free portal test path.
+credential-free hosted integration path. Portal cells use the independent
+consent controller; the display-bounds cell is read-only and consent-free.
 
 wlroots is intentionally not treated as a RemoteDesktop/ScreenCast pass in
 these portal workflows. Its hosted native and explicit portal-availability

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -372,7 +372,10 @@ The compatibility surface now includes:
   transforms. Display indices are deterministic and shared with screencopy;
   display count/main-index queries no longer depend on X11. Native builds retain
   the `wayland-info` fallback for compositors where direct geometry is
-  unavailable; Pure-Go uses bounded direct protocol enumeration.
+  unavailable; Pure-Go uses bounded direct protocol enumeration. A dedicated
+  hosted GNOME/KDE two-output workflow now runs both implementations against
+  the same exact compositor topology without X11, capture, input, or portal
+  consent.
 - Hook/event capability reporting on Wayland.
 
 Remaining work must improve runtime support without inventing misleading
@@ -385,9 +388,9 @@ cross-platform semantics:
   active-window contract is available.
 - Add protected real-desktop capture-helper evidence beyond the delivered
   hermetic native Wayland, portal, and cross-build backend contracts.
-- Collect protected GNOME/KDE/wlroots multi-output bounds evidence beyond the
-  delivered hermetic geometry matrix and single-/multi-output Weston
-  integration.
+- Retain a passing exact-commit run of the new GNOME/KDE multi-output bounds
+  workflow, then decide its branch/release promotion separately from portal
+  evidence. Keep the delivered Sway/wlroots and Weston geometry gates green.
 
 Every addition needs unit tests, an applicable runtime integration test, and a
 runnable example unless the environment makes one technically impossible.

--- a/docs/plan/real-compositor-evidence.md
+++ b/docs/plan/real-compositor-evidence.md
@@ -210,6 +210,17 @@ and
 [ScreenCast](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html)
 interfaces.
 
+### Consent-free GNOME and KDE output proof
+
+The follow-up bounds cell reuses the disposable GNOME/KDE guests but does not
+use either portal interface. It configures the manifest-bound two-output
+topology, removes `DISPLAY` from the test process, and runs the same public
+geometry contract once through the native-CGO Wayland client and once through
+the Pure-Go Wayland client. It requires exact output count, deterministic
+primary-first bounds, aggregate desktop bounds, primary size, invalid-index
+errors, and legacy/error API parity. No pixels, clipboard data, window content,
+or input events are read or produced.
+
 ### Promotion to protected evidence
 
 A lane moves from `pending` to `pass` in the compatibility matrices only when:
@@ -261,6 +272,10 @@ green.
    exact release commit and in branch protection, plus the four reusable
    GNOME/KDE multi-output RemoteDesktop/ScreenCast jobs for the exact release
    commit.
+7. **Implemented, runtime evidence pending:** run the consent-free public
+   multi-output bounds contract in both native-CGO and Pure-Go builds on GNOME
+   and KDE. Retain one exact-commit run with both lanes green before deciding
+   branch or release promotion.
 
 Create Linear issues only when the next slice has concrete runner ownership and
 acceptance evidence. Do not create speculative implementation tickets for

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -224,6 +224,10 @@ backends.
     retained alongside blocking hosted wlroots/Sway and Weston
     single-/multi-output evidence. Keep the promoted multi-output portal release
     gates green.
+  - A separate consent-free hosted GNOME/KDE two-output workflow exercises
+    public native-CGO and Pure-Go bounds, count, primary, aggregate, invalid
+    index, and legacy/error parity with `DISPLAY` unset. Retain a passing
+    exact-commit run before promoting it into release evidence.
 - Portal Path:
   - Expand troubleshooting for xdg-desktop-portal backend selection and consent prompts.
   - Keep the hosted high-level RemoteDesktop input fallback validation green on
@@ -291,6 +295,9 @@ backends.
     release gates; the four GNOME/KDE multi-output portal checks are promoted
     into exact-release gates. Keep the isolated `vkms` Hyprland window cell
     green as a branch check and exact-release gate.
+  - Keep the consent-free hosted GNOME/KDE bounds workflow independent from
+    portal consent and pixel/input paths. Promote it only after both desktop
+    lanes pass for the same exact commit.
   - Keep the race/vet and native ASan/LeakSanitizer CI jobs green and protected.
     The sanitizer gate covers the default CGO suite plus hermetic screencopy
     allocation/free, bounded timeout cleanup, and FD ownership paths.

--- a/hosted_bounds_cgo_integration_test.go
+++ b/hosted_bounds_cgo_integration_test.go
@@ -1,0 +1,9 @@
+//go:build cgo && linux && wayland && hostedboundsintegration
+
+package robotgo
+
+import "testing"
+
+func TestHostedWaylandBoundsCGORuntime(t *testing.T) {
+	assertHostedWaylandBoundsRuntime(t)
+}

--- a/hosted_bounds_integration_test.go
+++ b/hosted_bounds_integration_test.go
@@ -1,0 +1,261 @@
+//go:build linux && hostedboundsintegration
+
+package robotgo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/marang/robotgo/internal/portalrunner"
+)
+
+const (
+	envHostedBoundsE2E         = "ROBOTGO_HOSTED_BOUNDS_E2E"
+	envHostedBoundsSessionType = "XDG_SESSION_TYPE"
+	hostedBoundsWaylandSession = "wayland"
+)
+
+func assertHostedWaylandBoundsRuntime(t *testing.T) {
+	t.Helper()
+	if os.Getenv(envHostedBoundsE2E) != "1" {
+		t.Fatalf("hosted bounds contract requires %s=1", envHostedBoundsE2E)
+	}
+	if _, exists := os.LookupEnv(envDisplay); exists {
+		t.Fatal("hosted bounds contract requires DISPLAY to be unset")
+	}
+	if os.Getenv(envWaylandDisplay) == "" {
+		t.Fatal("hosted bounds contract requires WAYLAND_DISPLAY")
+	}
+	if os.Getenv(envHostedBoundsSessionType) != hostedBoundsWaylandSession {
+		t.Fatalf(
+			"hosted bounds contract requires %s=%q",
+			envHostedBoundsSessionType,
+			hostedBoundsWaylandSession,
+		)
+	}
+	for _, forbidden := range []string{
+		"ROBOTGO_PORTAL_CONSENT_READY_FILE",
+		"ROBOTGO_PORTAL_MULTI_OUTPUT",
+		"ROBOTGO_PORTAL_EXPECTED_OUTPUTS",
+		"ROBOTGO_REMOTE_DESKTOP_E2E",
+		"ROBOTGO_SCREENCAST_E2E",
+		"ROBOTGO_FORCE_PORTAL",
+	} {
+		if _, exists := os.LookupEnv(forbidden); exists {
+			t.Fatalf("consent-free hosted bounds contract exposes %s", forbidden)
+		}
+	}
+	if DetectDisplayServer() != DisplayServerWayland {
+		t.Fatalf(
+			"hosted bounds selected %q, want %q",
+			DetectDisplayServer(),
+			DisplayServerWayland,
+		)
+	}
+	assertHostedWaylandSocket(t)
+
+	expected, err := portalrunner.ParseHostedDisplay(
+		os.Getenv(portalrunner.HostedExpectedOutputsEnvKey),
+	)
+	if err != nil {
+		t.Fatalf("parse hosted output contract: %v", err)
+	}
+	if len(expected.Outputs) != 2 {
+		t.Fatalf(
+			"hosted bounds evidence requires exactly two outputs, got %d",
+			len(expected.Outputs),
+		)
+	}
+
+	count, err := DisplaysNumE()
+	if err != nil {
+		t.Fatalf("DisplaysNumE(): %v", err)
+	}
+	if count != len(expected.Outputs) {
+		t.Fatalf("DisplaysNumE() = %d, want %d", count, len(expected.Outputs))
+	}
+	if legacy := DisplaysNum(); legacy != count {
+		t.Fatalf("DisplaysNum() = %d, error API returned %d", legacy, count)
+	}
+	if mainID := GetMainId(); mainID != 0 {
+		t.Fatalf("GetMainId() = %d, want primary output index 0", mainID)
+	}
+
+	for displayID, output := range expected.Outputs {
+		assertHostedDisplayBounds(t, displayID, output)
+	}
+	if _, _, _, _, err := GetDisplayBoundsE(count); err == nil {
+		t.Fatalf("GetDisplayBoundsE accepted inactive output index %d", count)
+	}
+	if x, y, width, height := GetDisplayBounds(count); x != 0 ||
+		y != 0 || width != 0 || height != 0 {
+		t.Fatalf(
+			"legacy invalid display bounds = %d,%d %dx%d, want empty",
+			x,
+			y,
+			width,
+			height,
+		)
+	}
+
+	aggregate := hostedAggregateRect(expected.Outputs)
+	for _, displayID := range [][]int{nil, {-1}} {
+		rect, err := GetScreenRectE(displayID...)
+		if err != nil {
+			t.Fatalf("GetScreenRectE(%v): %v", displayID, err)
+		}
+		if rect != aggregate {
+			t.Fatalf(
+				"GetScreenRectE(%v) = %+v, want %+v",
+				displayID,
+				rect,
+				aggregate,
+			)
+		}
+		if legacy := GetScreenRect(displayID...); legacy != rect {
+			t.Fatalf(
+				"GetScreenRect(%v) = %+v, error API returned %+v",
+				displayID,
+				legacy,
+				rect,
+			)
+		}
+	}
+
+	width, height, err := GetScreenSizeE()
+	if err != nil {
+		t.Fatalf("GetScreenSizeE(): %v", err)
+	}
+	primary := expected.Outputs[0]
+	if width != primary.Width || height != primary.Height {
+		t.Fatalf(
+			"GetScreenSizeE() = %dx%d, want primary %dx%d",
+			width,
+			height,
+			primary.Width,
+			primary.Height,
+		)
+	}
+	legacyWidth, legacyHeight := GetScreenSize()
+	if legacyWidth != width || legacyHeight != height {
+		t.Fatalf(
+			"GetScreenSize() = %dx%d, error API returned %dx%d",
+			legacyWidth,
+			legacyHeight,
+			width,
+			height,
+		)
+	}
+}
+
+func assertHostedWaylandSocket(t *testing.T) {
+	t.Helper()
+	runtimeDirectory := filepath.Clean(os.Getenv("XDG_RUNTIME_DIR"))
+	if !filepath.IsAbs(runtimeDirectory) ||
+		runtimeDirectory == string(filepath.Separator) {
+		t.Fatal("hosted bounds runtime directory is invalid")
+	}
+	socket := os.Getenv(envWaylandDisplay)
+	if !filepath.IsAbs(socket) {
+		socket = filepath.Join(runtimeDirectory, socket)
+	}
+	socket = filepath.Clean(socket)
+	relative, err := filepath.Rel(runtimeDirectory, socket)
+	if err != nil || relative == "." || relative == ".." ||
+		filepath.IsAbs(relative) ||
+		strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		t.Fatal("hosted bounds Wayland socket escapes its runtime directory")
+	}
+	info, err := os.Lstat(socket)
+	if err != nil || info.Mode()&os.ModeSocket == 0 {
+		t.Fatal("hosted bounds Wayland socket is unavailable")
+	}
+}
+
+func assertHostedDisplayBounds(
+	t *testing.T,
+	displayID int,
+	expected portalrunner.HostedOutput,
+) {
+	t.Helper()
+	x, y, width, height, err := GetDisplayBoundsE(displayID)
+	if err != nil {
+		t.Fatalf("GetDisplayBoundsE(%d): %v", displayID, err)
+	}
+	if x != expected.X || y != expected.Y ||
+		width != expected.Width || height != expected.Height {
+		t.Fatalf(
+			"GetDisplayBoundsE(%d) = %d,%d %dx%d, want %d,%d %dx%d",
+			displayID,
+			x,
+			y,
+			width,
+			height,
+			expected.X,
+			expected.Y,
+			expected.Width,
+			expected.Height,
+		)
+	}
+	legacyX, legacyY, legacyWidth, legacyHeight := GetDisplayBounds(displayID)
+	if legacyX != x || legacyY != y ||
+		legacyWidth != width || legacyHeight != height {
+		t.Fatalf(
+			"GetDisplayBounds(%d) = %d,%d %dx%d, error API returned %d,%d %dx%d",
+			displayID,
+			legacyX,
+			legacyY,
+			legacyWidth,
+			legacyHeight,
+			x,
+			y,
+			width,
+			height,
+		)
+	}
+	want := Rect{
+		Point: Point{X: expected.X, Y: expected.Y},
+		Size:  Size{W: expected.Width, H: expected.Height},
+	}
+	rect, err := GetScreenRectE(displayID)
+	if err != nil {
+		t.Fatalf("GetScreenRectE(%d): %v", displayID, err)
+	}
+	if rect != want {
+		t.Fatalf("GetScreenRectE(%d) = %+v, want %+v", displayID, rect, want)
+	}
+	if legacy := GetScreenRect(displayID); legacy != rect {
+		t.Fatalf(
+			"GetScreenRect(%d) = %+v, error API returned %+v",
+			displayID,
+			legacy,
+			rect,
+		)
+	}
+	if displayRect := GetDisplayRect(displayID); displayRect != rect {
+		t.Fatalf(
+			"GetDisplayRect(%d) = %+v, error API returned %+v",
+			displayID,
+			displayRect,
+			rect,
+		)
+	}
+}
+
+func hostedAggregateRect(outputs []portalrunner.HostedOutput) Rect {
+	minX, minY := outputs[0].X, outputs[0].Y
+	maxX := outputs[0].X + outputs[0].Width
+	maxY := outputs[0].Y + outputs[0].Height
+	for _, output := range outputs[1:] {
+		minX = min(minX, output.X)
+		minY = min(minY, output.Y)
+		maxX = max(maxX, output.X+output.Width)
+		maxY = max(maxY, output.Y+output.Height)
+	}
+	return Rect{
+		Point: Point{X: minX, Y: minY},
+		Size:  Size{W: maxX - minX, H: maxY - minY},
+	}
+}

--- a/hosted_bounds_nocgo_integration_test.go
+++ b/hosted_bounds_nocgo_integration_test.go
@@ -1,0 +1,9 @@
+//go:build !cgo && linux && hostedboundsintegration
+
+package robotgo
+
+import "testing"
+
+func TestHostedWaylandBoundsPureGoRuntime(t *testing.T) {
+	assertHostedWaylandBoundsRuntime(t)
+}

--- a/infrastructure/portal-runner/gnome/README.md
+++ b/infrastructure/portal-runner/gnome/README.md
@@ -1,7 +1,8 @@
 # GitHub-Hosted GNOME Portal Runner
 
 This directory defines RobotGo's disposable GNOME Wayland guest for real
-RemoteDesktop and ScreenCast tests. The primary execution path is nested
+RemoteDesktop, ScreenCast, and read-only display-bounds tests. The primary
+execution path is nested
 QEMU/KVM on a fresh GitHub-hosted Ubuntu runner; it does not use a developer
 workstation or register a self-hosted Actions runner.
 
@@ -43,7 +44,9 @@ go run ./internal/cmd/portalrunner hosted-run \
   -commit "$GITHUB_SHA" -cell remote-desktop
 ```
 
-Use `-cell screencast` for the persistent PipeWire cell.
+Use `-cell screencast` for the persistent PipeWire cell. The separate
+`display-bounds` cell requires `-topology multi-output`; it runs native-CGO and
+Pure-Go public output APIs with `DISPLAY` unset and creates no portal session.
 
 `build` verifies every downloaded artifact against the pinned SHA-256 digest.
 The image identity also covers the manifest, provisioning implementation, guest
@@ -52,15 +55,16 @@ silently reuse an older image.
 
 `hosted-run` refuses a dirty or different checkout, creates a bounded source
 archive for the exact lowercase commit, and starts the test as the unprivileged
-`robotgo` guest user. Immediately before requesting portal consent, the test
-creates a private non-sensitive readiness marker. A separate host-side QMP
-client sends GNOME's real dialog mnemonics through the VM's virtual keyboard
-for RemoteDesktop. For the pinned two-output ScreenCast dialog, it selects both
-manifest-declared monitor buttons through the VM's virtual pointer. The target
-coordinates are derived from the validated output manifest and pinned dialog
-contract; no pixels, accessibility data, or window contents leave the guest.
-RobotGo does not patch or auto-approve the portal backend and is not the
-consent-input actor.
+`robotgo` guest user. For portal cells, the test creates a private
+non-sensitive readiness marker immediately before requesting consent. A
+separate host-side QMP client sends GNOME's real dialog mnemonics through the
+VM's virtual keyboard for RemoteDesktop. For the pinned two-output ScreenCast
+dialog, it selects both manifest-declared monitor buttons through the VM's
+virtual pointer. The target coordinates are derived from the validated output
+manifest and pinned dialog contract; no pixels, accessibility data, or window
+contents leave the guest. RobotGo does not patch or auto-approve the portal
+backend and is not the consent-input actor. The display-bounds cell never
+creates the marker or enters this consent path.
 
 Build and runtime logs, serial output, SSH keys, cloud-init inputs, seed disks,
 and overlays remain inside a private per-run directory. The command removes

--- a/infrastructure/portal-runner/kde/README.md
+++ b/infrastructure/portal-runner/kde/README.md
@@ -1,9 +1,9 @@
 # GitHub-Hosted KDE Portal Runner
 
 This directory defines RobotGo's disposable KDE Plasma Wayland guest for real
-RemoteDesktop and ScreenCast tests. It runs through nested QEMU/KVM on a fresh
-GitHub-hosted Ubuntu runner and never uses a developer workstation or registers
-a self-hosted Actions runner.
+RemoteDesktop, ScreenCast, and read-only display-bounds tests. It runs through
+nested QEMU/KVM on a fresh GitHub-hosted Ubuntu runner and never uses a
+developer workstation or registers a self-hosted Actions runner.
 
 The host builds an immutable, digest-addressed Ubuntu image from
 `manifest.json`. Every run boots a private copy-on-write overlay, starts a real
@@ -35,7 +35,9 @@ go run ./internal/cmd/portalrunner hosted-run \
   -commit "$GITHUB_SHA" -cell remote-desktop
 ```
 
-Use `-cell screencast` for persistent PipeWire capture.
+Use `-cell screencast` for persistent PipeWire capture. The separate
+`display-bounds` cell requires `-topology multi-output`; it runs native-CGO and
+Pure-Go public output APIs with `DISPLAY` unset and creates no portal session.
 
 The host transfers the exact clean tree without credentials and enforces an
 active nftables output chain with `policy drop` before the transfer. A private

--- a/internal/cmd/portalrunner/main.go
+++ b/internal/cmd/portalrunner/main.go
@@ -149,7 +149,7 @@ func runHosted(arguments []string, stdout, stderr io.Writer) error {
 	cell := flags.String(
 		"cell",
 		"",
-		"hosted test cell: remote-desktop or screencast",
+		"hosted test cell: remote-desktop, screencast, or display-bounds",
 	)
 	topology := flags.String(
 		"topology",
@@ -202,7 +202,7 @@ func runHosted(arguments []string, stdout, stderr io.Writer) error {
 		syscall.SIGTERM,
 	)
 	defer cancel()
-	return portalrunner.RunHostedPortal(
+	return portalrunner.RunHosted(
 		ctx,
 		portalrunner.HostedRuntimeOptions{
 			ManifestPath:   absoluteManifest,

--- a/internal/portalrunner/hosted_linux.go
+++ b/internal/portalrunner/hosted_linux.go
@@ -30,6 +30,16 @@ const (
 	maximumPortalGeometry   = 256
 	hostedXvfbEnvKey        = "ROBOTGO_HOSTED_XVFB"
 
+	// HostedCellRemoteDesktop exercises portal-backed pointer and keyboard
+	// input in a disposable desktop guest.
+	HostedCellRemoteDesktop = "remote-desktop"
+	// HostedCellScreenCast exercises persistent portal-backed capture in a
+	// disposable desktop guest.
+	HostedCellScreenCast = "screencast"
+	// HostedCellDisplayBounds exercises read-only public display geometry
+	// without opening a portal session or exposing X11 to the test process.
+	HostedCellDisplayBounds = "display-bounds"
+
 	// HostedTopologySingle preserves the established one-output portal run.
 	HostedTopologySingle = "single-output"
 	// HostedTopologyMulti enables the manifest-bound two-output experiment.
@@ -59,7 +69,7 @@ var kdeLocatorFailureStages = map[string]struct{}{
 	"window-unavailable":     {},
 }
 
-// HostedRuntimeOptions identifies one credential-free portal test in a
+// HostedRuntimeOptions identifies one credential-free integration test in a
 // disposable desktop guest running inside a GitHub-hosted Linux runner.
 type HostedRuntimeOptions struct {
 	ManifestPath   string
@@ -95,10 +105,11 @@ type hostedPortalPoint struct {
 	y int
 }
 
-// RunHostedPortal transfers the exact clean commit into a disposable guest,
-// runs one portal integration cell, and drives desktop consent independently
-// through QMP. It does not register a GitHub Actions runner or consume tokens.
-func RunHostedPortal(
+// RunHosted transfers the exact clean commit into a disposable guest and runs
+// one integration cell. Portal cells drive desktop consent independently
+// through QMP; read-only cells do not create a portal session. The runner does
+// not register a GitHub Actions runner or consume tokens.
+func RunHosted(
 	ctx context.Context,
 	options HostedRuntimeOptions,
 ) (returnError error) {
@@ -417,9 +428,12 @@ func RunHostedPortal(
 		}
 	}
 
-	marker := "/run/user/1100/robotgo-portal-consent-" +
-		options.Cell + ".ready"
-	testLogPath := filepath.Join(runDirectory, "portal-test.log")
+	marker := ""
+	if hostedCellUsesPortal(options.Cell) {
+		marker = "/run/user/1100/robotgo-portal-consent-" +
+			options.Cell + ".ready"
+	}
+	testLogPath := filepath.Join(runDirectory, "hosted-test.log")
 	testLog, err := os.OpenFile(
 		testLogPath,
 		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
@@ -457,7 +471,7 @@ func RunHostedPortal(
 	testCommand.Stderr = testOutput
 	configureHostedProcess(testCommand)
 	if err := testCommand.Start(); err != nil {
-		return errors.New("start hosted portal integration test")
+		return errors.New("start hosted integration test")
 	}
 	testResult := &hostedProcessResult{done: make(chan struct{})}
 	go func() {
@@ -515,21 +529,32 @@ func RunHostedPortal(
 	}
 	<-testResult.done
 	testError := testResult.err
-	cleanupError := assertConsentMarkerRemoved(
-		guestContext,
-		options.Commands,
-		sshArguments,
-		marker,
-		logWriter,
-	)
+	var cleanupError error
+	if marker != "" {
+		cleanupError = assertConsentMarkerRemoved(
+			guestContext,
+			options.Commands,
+			sshArguments,
+			marker,
+			logWriter,
+		)
+	}
 	if testError != nil {
-		stage := readPortalFailureStage(testLogPath)
-		if stage == "" {
-			testError = errors.New("hosted portal integration test failed")
+		if hostedCellUsesPortal(options.Cell) {
+			stage := readPortalFailureStage(testLogPath)
+			if stage == "" {
+				testError = errors.New(
+					"hosted portal integration test failed",
+				)
+			} else {
+				testError = fmt.Errorf(
+					"hosted portal integration test failed at stage %q",
+					stage,
+				)
+			}
 		} else {
-			testError = fmt.Errorf(
-				"hosted portal integration test failed at stage %q",
-				stage,
+			testError = errors.New(
+				"hosted display-bounds integration test failed",
 			)
 		}
 	}
@@ -552,11 +577,11 @@ func RunHostedPortal(
 			return fmt.Errorf("hosted %s VM exited unsuccessfully", manifest.Lane)
 		}
 	case <-runtimeContext.Done():
-		return fmt.Errorf("hosted portal lifetime ended: %w", runtimeContext.Err())
+		return fmt.Errorf("hosted integration lifetime ended: %w", runtimeContext.Err())
 	}
 	return writeStatus(
 		options.Output,
-		"hosted portal test complete cell=%s commit=%s\n",
+		"hosted test complete cell=%s commit=%s\n",
 		options.Cell,
 		options.Commit,
 	)
@@ -686,12 +711,19 @@ func validateHostedIdentity(commit, cell, topology string) error {
 		commit != strings.ToLower(commit) {
 		return errors.New("hosted portal commit is invalid")
 	}
-	if cell != "remote-desktop" && cell != "screencast" {
+	if cell != HostedCellRemoteDesktop &&
+		cell != HostedCellScreenCast &&
+		cell != HostedCellDisplayBounds {
 		return errors.New("hosted portal cell is invalid")
 	}
 	if topology != HostedTopologySingle &&
 		topology != HostedTopologyMulti {
 		return errors.New("hosted portal topology is invalid")
+	}
+	if cell == HostedCellDisplayBounds && topology != HostedTopologyMulti {
+		return errors.New(
+			"hosted display-bounds evidence requires multi-output topology",
+		)
 	}
 	return nil
 }
@@ -962,7 +994,25 @@ func hostedPortalTestCommandForTopology(
 		topology != HostedTopologyMulti {
 		return "", errors.New("hosted portal topology is invalid")
 	}
-	environment := strings.Join([]string{
+	if !hostedCellUsesPortal(cell) && cell != HostedCellDisplayBounds {
+		return "", errors.New("hosted portal cell is invalid")
+	}
+	if hostedCellUsesPortal(cell) && marker == "" {
+		return "", errors.New("hosted portal cell requires a consent marker")
+	}
+	if cell == HostedCellDisplayBounds {
+		if marker != "" {
+			return "", errors.New(
+				"hosted display-bounds cell must not receive a consent marker",
+			)
+		}
+		if topology != HostedTopologyMulti {
+			return "", errors.New(
+				"hosted display-bounds evidence requires multi-output topology",
+			)
+		}
+	}
+	environmentParts := []string{
 		"HOME=/home/robotgo",
 		"XDG_RUNTIME_DIR=/run/user/1100",
 		"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1100/bus",
@@ -970,39 +1020,66 @@ func hostedPortalTestCommandForTopology(
 		"XDG_CURRENT_DESKTOP=" + currentDesktop,
 		"XDG_SESSION_DESKTOP=" + sessionDesktop,
 		"XDG_SESSION_TYPE=wayland",
-		"DISPLAY=:0",
 		"HTTP_PROXY=http://10.0.2.2:3128",
 		"HTTPS_PROXY=http://10.0.2.2:3128",
 		"http_proxy=http://10.0.2.2:3128",
 		"https_proxy=http://10.0.2.2:3128",
 		"NO_PROXY=localhost,127.0.0.1",
 		"no_proxy=localhost,127.0.0.1",
-		"ROBOTGO_PORTAL_CONSENT_READY_FILE=" + marker,
-	}, " ")
+	}
+	if hostedCellUsesPortal(cell) {
+		environmentParts = append(
+			environmentParts,
+			"DISPLAY=:0",
+			"ROBOTGO_PORTAL_CONSENT_READY_FILE="+marker,
+		)
+	}
+	environment := strings.Join(environmentParts, " ")
 	if topology == HostedTopologyMulti {
 		encoded, err := display.Encode()
 		if err != nil {
 			return "", err
 		}
-		environment += " " + PortalMultiOutputEnvKey + "=1" +
-			" " + PortalExpectedOutputsEnvKey + "=" + shellQuote(encoded)
+		if cell == HostedCellDisplayBounds {
+			environment += " " + HostedExpectedOutputsEnvKey + "=" +
+				shellQuote(encoded)
+		} else {
+			environment += " " + PortalMultiOutputEnvKey + "=1" +
+				" " + PortalExpectedOutputsEnvKey + "=" + shellQuote(encoded)
+		}
 	}
 	var test string
-	if cell == "screencast" {
+	switch cell {
+	case HostedCellScreenCast:
 		environment += " ROBOTGO_SCREENCAST_E2E=1" +
 			" ROBOTGO_SCREENCAST_REQUIRE_MONITOR=1"
 		test = "go test -count=1 -timeout=3m -tags=pipewire,integration " +
 			"./screen/portal " +
 			"-run '^TestPipeWireCapturePersistentSessionIntegration$' -v"
-	} else {
+	case HostedCellRemoteDesktop:
 		environment += " ROBOTGO_REMOTE_DESKTOP_E2E=1"
 		test = "go test -count=1 -timeout=3m -tags=integration " +
 			"./input/portal " +
 			"-run '^TestRemoteDesktopPortalRuntime$' -v"
+	case HostedCellDisplayBounds:
+		environment += " ROBOTGO_HOSTED_BOUNDS_E2E=1"
+		boundsTests := strings.Join([]string{
+			"go test -count=1 -timeout=3m " +
+				"-tags=wayland,hostedboundsintegration . " +
+				"-run '^TestHostedWaylandBoundsCGORuntime$' -v",
+			"CGO_ENABLED=0 go test -count=1 -timeout=3m " +
+				"-tags=hostedboundsintegration . " +
+				"-run '^TestHostedWaylandBoundsPureGoRuntime$' -v",
+		}, " && ")
+		test = "bash -c " + shellQuote(boundsTests)
 	}
 	guestCommand := "cd /home/robotgo/robotgo; exec " + test
-	return "set -euo pipefail; exec runuser -u robotgo -- env " +
+	return "set -euo pipefail; exec runuser -u robotgo -- env -u DISPLAY " +
 		environment + " bash -c " + shellQuote(guestCommand), nil
+}
+
+func hostedCellUsesPortal(cell string) bool {
+	return cell == HostedCellRemoteDesktop || cell == HostedCellScreenCast
 }
 
 func hostedDesktopEnvironment(lane string) (current, session string, err error) {
@@ -1017,8 +1094,9 @@ func hostedDesktopEnvironment(lane string) (current, session string, err error) 
 }
 
 func hostedPortalApprovalRequired(lane, cell, topology string) bool {
-	return lane == portalLaneGNOME ||
-		(lane == portalLaneKDE && cell == "screencast")
+	return hostedCellUsesPortal(cell) &&
+		(lane == portalLaneGNOME ||
+			(lane == portalLaneKDE && cell == HostedCellScreenCast))
 }
 
 func approveHostedPortal(

--- a/internal/portalrunner/hosted_linux_test.go
+++ b/internal/portalrunner/hosted_linux_test.go
@@ -15,7 +15,10 @@ import (
 func TestHostedIdentityIsExact(t *testing.T) {
 	t.Parallel()
 	commit := strings.Repeat("a", 40)
-	for _, cell := range []string{"remote-desktop", "screencast"} {
+	for _, cell := range []string{
+		HostedCellRemoteDesktop,
+		HostedCellScreenCast,
+	} {
 		for _, topology := range []string{
 			HostedTopologySingle,
 			HostedTopologyMulti,
@@ -33,6 +36,13 @@ func TestHostedIdentityIsExact(t *testing.T) {
 				)
 			}
 		}
+	}
+	if err := validateHostedIdentity(
+		commit,
+		HostedCellDisplayBounds,
+		HostedTopologyMulti,
+	); err != nil {
+		t.Fatalf("validate display-bounds identity: %v", err)
 	}
 	for _, invalid := range []struct {
 		commit   string
@@ -58,6 +68,10 @@ func TestHostedIdentityIsExact(t *testing.T) {
 		{
 			commit: commit, cell: "remote-desktop",
 			topology: "other",
+		},
+		{
+			commit: commit, cell: HostedCellDisplayBounds,
+			topology: HostedTopologySingle,
 		},
 	} {
 		if err := validateHostedIdentity(
@@ -270,6 +284,66 @@ func TestHostedPortalMultiOutputCommandBindsCanonicalTopology(
 	}
 }
 
+func TestHostedDisplayBoundsCommandIsWaylandOnlyAndConsentFree(t *testing.T) {
+	t.Parallel()
+	command, err := hostedPortalTestCommandForTopology(
+		portalLaneGNOME,
+		HostedCellDisplayBounds,
+		"",
+		HostedTopologyMulti,
+		validManifest().HostedDisplay,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"runuser -u robotgo",
+		"env -u DISPLAY",
+		"WAYLAND_DISPLAY=wayland-0",
+		"XDG_SESSION_TYPE=wayland",
+		"ROBOTGO_HOSTED_BOUNDS_E2E=1",
+		HostedExpectedOutputsEnvKey +
+			"='0,0,1280,720;1280,0,1024,768'",
+		"TestHostedWaylandBoundsCGORuntime",
+		"CGO_ENABLED=0",
+		"TestHostedWaylandBoundsPureGoRuntime",
+	} {
+		if !strings.Contains(command, required) {
+			t.Errorf("display-bounds command omits %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"DISPLAY=:",
+		"ROBOTGO_PORTAL_",
+		"ROBOTGO_REMOTE_DESKTOP_E2E",
+		"ROBOTGO_SCREENCAST_E2E",
+		"TestRemoteDesktopPortalRuntime",
+		"TestPipeWireCapturePersistentSessionIntegration",
+	} {
+		if strings.Contains(command, forbidden) {
+			t.Errorf("display-bounds command contains %q", forbidden)
+		}
+	}
+	if _, err := hostedPortalTestCommandForTopology(
+		portalLaneGNOME,
+		HostedCellDisplayBounds,
+		"/run/user/1100/unexpected.ready",
+		HostedTopologyMulti,
+		validManifest().HostedDisplay,
+	); err == nil {
+		t.Fatal("display-bounds command accepted a consent marker")
+	}
+	if _, err := hostedPortalTestCommandForTopology(
+		portalLaneGNOME,
+		HostedCellDisplayBounds,
+		"",
+		HostedTopologySingle,
+		validManifest().HostedDisplay,
+	); err == nil {
+		t.Fatal("display-bounds command accepted single-output topology")
+	}
+}
+
 func TestHostedDisplayConfigurationIsGuestRestrictedAndCredentialFree(
 	t *testing.T,
 ) {
@@ -423,6 +497,14 @@ func TestHostedPortalApprovalPolicyMatchesDesktopBackend(t *testing.T) {
 		{
 			lane: portalLaneKDE, cell: "screencast",
 			topology: HostedTopologyMulti, want: true,
+		},
+		{
+			lane: portalLaneGNOME, cell: HostedCellDisplayBounds,
+			topology: HostedTopologyMulti, want: false,
+		},
+		{
+			lane: portalLaneKDE, cell: HostedCellDisplayBounds,
+			topology: HostedTopologyMulti, want: false,
 		},
 	} {
 		if got := hostedPortalApprovalRequired(

--- a/internal/portalrunner/manifest.go
+++ b/internal/portalrunner/manifest.go
@@ -26,6 +26,9 @@ const (
 	// HostedGuestEnvKey gates commands that may reconfigure the disposable
 	// hosted guest desktop.
 	HostedGuestEnvKey = "ROBOTGO_HOSTED_GUEST"
+	// HostedExpectedOutputsEnvKey carries the encoded logical topology for
+	// consent-free hosted display-bounds evidence.
+	HostedExpectedOutputsEnvKey = "ROBOTGO_HOSTED_EXPECTED_OUTPUTS"
 	// PortalMultiOutputEnvKey enables the hosted multi-output portal contract.
 	PortalMultiOutputEnvKey = "ROBOTGO_PORTAL_MULTI_OUTPUT"
 	// PortalExpectedOutputsEnvKey carries the encoded hosted output topology.

--- a/scripts/portal_runner_hosted_workflow_test.go
+++ b/scripts/portal_runner_hosted_workflow_test.go
@@ -118,6 +118,92 @@ func TestHostedPortalProofUsesEphemeralGitHubKVM(t *testing.T) {
 	}
 }
 
+func TestHostedBoundsProofIsMultiOutputWaylandOnly(t *testing.T) {
+	t.Parallel()
+	workflowData, err := os.ReadFile(
+		"../.github/workflows/display-bounds-e2e.yml",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scriptData, err := os.ReadFile("run_hosted_portal_e2e.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := normalizeWorkflowText(workflowData)
+	script := normalizeWorkflowText(scriptData)
+	start := strings.Index(workflow, "  hosted-bounds:")
+	if start < 0 {
+		t.Fatal("display bounds workflow does not isolate its hosted job")
+	}
+	hostedJob := workflow[start:]
+	contract := hostedJob + "\n" + script
+	for _, required := range []string{
+		"github.event_name == 'release'",
+		"github.event_name == 'push'",
+		`'["gnome","kde"]'`,
+		"inputs.desktop == 'kde'",
+		"inputs.desktop == 'all'",
+		"runs-on: ubuntu-24.04",
+		"actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+		"actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
+		"persist-credentials: false",
+		`ref: ${{ github.sha }}`,
+		`test "$(git rev-parse HEAD)" = "$GITHUB_SHA"`,
+		"test -c /dev/kvm",
+		"sudo chmod 0666 /dev/kvm",
+		"qemu-system-gui",
+		"qemu-system-x86",
+		"xauth",
+		"xvfb",
+		`go build -o "$portal_runner" ./internal/cmd/portalrunner`,
+		"exec timeout --preserve-status",
+		"--signal=TERM --kill-after=2m 20m",
+		"scripts/run_hosted_portal_e2e.sh",
+		"display-bounds",
+		"multi-output",
+		"xvfb-run -a",
+		`env ROBOTGO_HOSTED_XVFB=1 "${hosted_run[@]}"`,
+		`manifest="infrastructure/portal-runner/${{ matrix.desktop }}/manifest.json"`,
+		`state_root="$RUNNER_TEMP/robotgo-${{ matrix.desktop }}-multi-output-bounds-runner"`,
+		`-cell "$cell"`,
+		`-topology "$topology"`,
+		"Reject transient runner artifacts",
+		`"$portal_runner" cleanup`,
+		`trap 'rm -f -- "$portal_runner"' EXIT INT TERM`,
+		`find "$state_root" -maxdepth 1 -type d -name 'run-*'`,
+	} {
+		if !strings.Contains(contract, required) {
+			t.Errorf("display bounds hosted contract omits %q", required)
+		}
+	}
+	if !strings.Contains(workflow, "permissions:\n  contents: read") {
+		t.Error("display bounds workflow omits read-only permissions")
+	}
+	if !strings.Contains(workflow, "  workflow_call:\n") {
+		t.Error("display bounds workflow cannot be reused as release evidence")
+	}
+	for _, forbidden := range []string{
+		"self-hosted",
+		"environment:",
+		"generate-jitconfig",
+		"registration-token",
+		"ROBOTGO_PORTAL_CONSENT_READY_FILE",
+		"ROBOTGO_REMOTE_DESKTOP_E2E",
+		"ROBOTGO_SCREENCAST_E2E",
+		"actions/checkout@v",
+		"actions/setup-go@v",
+		"persist-credentials: true",
+	} {
+		if strings.Contains(hostedJob, forbidden) {
+			t.Errorf(
+				"display bounds hosted job contains unsafe token %q",
+				forbidden,
+			)
+		}
+	}
+}
+
 func TestNormalizeWorkflowTextHandlesWindowsCheckout(t *testing.T) {
 	t.Parallel()
 	got := normalizeWorkflowText([]byte("permissions:\r\n  contents: read\r\n"))

--- a/scripts/run_hosted_portal_e2e.sh
+++ b/scripts/run_hosted_portal_e2e.sh
@@ -16,7 +16,7 @@ cell="$6"
 topology="$7"
 
 case "$cell" in
-  remote-desktop|screencast) ;;
+  remote-desktop|screencast|display-bounds) ;;
   *) echo "unsupported hosted portal cell" >&2; exit 2 ;;
 esac
 case "$topology" in


### PR DESCRIPTION
## Result

Add a dedicated consent-free hosted GNOME/KDE evidence lane for RobotGo's public Wayland display-bounds contract.

The new workflow configures the manifest-bound 1280x720 + 1024x768 topology and runs the same assertions twice in each disposable guest:

- native CGO Wayland (`wayland,hostedboundsintegration`)
- Pure-Go Wayland (`CGO_ENABLED=0`)

It verifies exact per-output bounds, aggregate desktop bounds, primary size, display count/main index, invalid-index behavior, and legacy/error API parity.

## Safety and backend contract

- `DISPLAY` is removed and asserted absent, so the test cannot silently use Xwayland.
- The bounds cell receives no portal consent marker or portal/input/capture environment.
- It reads no pixels, clipboard data, window content, or input events.
- It reuses the exact-clean-commit nested-KVM runner and its mandatory VM/source/log/process cleanup.
- No public API or fallback order changes.

## Runtime evidence boundary

GitHub cannot dispatch a brand-new workflow until its file exists on the default branch. Therefore this PR intentionally delivers and hermetically validates the lane, while the first exact GNOME+KDE runtime result will be produced automatically by the post-merge `main` push. Promotion into release evidence is a separate decision after both jobs pass for that exact commit.

## Local validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `go test -run '^$' -tags='wayland,hostedboundsintegration' .`
- `CGO_ENABLED=0 go test -run '^$' -tags=hostedboundsintegration .`
- `go test ./internal/portalrunner ./internal/cmd/portalrunner ./scripts`
- `golangci-lint run ./internal/portalrunner ./internal/cmd/portalrunner ./scripts ./...` (0 issues)
- `git diff --check`

Linear: [LAB-61](https://linear.app/riotbox/issue/LAB-61/add-hosted-gnomekde-multi-output-bounds-evidence)