### PR TITLE
fix: expose safe hosted bounds failure stages

### DIFF
--- a/hosted_bounds_integration_test.go
+++ b/hosted_bounds_integration_test.go
@@ -15,10 +15,27 @@ const (
 	envHostedBoundsE2E         = "ROBOTGO_HOSTED_BOUNDS_E2E"
 	envHostedBoundsSessionType = "XDG_SESSION_TYPE"
 	hostedBoundsWaylandSession = "wayland"
+
+	hostedBoundsStageEnvironment  = "environment"
+	hostedBoundsStageTopology     = "topology"
+	hostedBoundsStageDisplayCount = "display-count"
+	hostedBoundsStageMainDisplay  = "main-display"
+	hostedBoundsStageDisplayZero  = "display-zero"
+	hostedBoundsStageDisplayOne   = "display-one"
+	hostedBoundsStageInvalidIndex = "invalid-index"
+	hostedBoundsStageAggregate    = "aggregate"
+	hostedBoundsStagePrimarySize  = "primary-size"
+	hostedBoundsStageComplete     = "complete"
 )
 
 func assertHostedWaylandBoundsRuntime(t *testing.T) {
 	t.Helper()
+	variant := os.Getenv(portalrunner.HostedBoundsVariantEnvKey)
+	if variant != portalrunner.HostedBoundsVariantNativeCGO &&
+		variant != portalrunner.HostedBoundsVariantPureGo {
+		t.Fatal("hosted bounds implementation variant is invalid")
+	}
+	reportHostedBoundsStage(t, variant, hostedBoundsStageEnvironment)
 	if os.Getenv(envHostedBoundsE2E) != "1" {
 		t.Fatalf("hosted bounds contract requires %s=1", envHostedBoundsE2E)
 	}
@@ -56,6 +73,7 @@ func assertHostedWaylandBoundsRuntime(t *testing.T) {
 	}
 	assertHostedWaylandSocket(t)
 
+	reportHostedBoundsStage(t, variant, hostedBoundsStageTopology)
 	expected, err := portalrunner.ParseHostedDisplay(
 		os.Getenv(portalrunner.HostedExpectedOutputsEnvKey),
 	)
@@ -69,6 +87,7 @@ func assertHostedWaylandBoundsRuntime(t *testing.T) {
 		)
 	}
 
+	reportHostedBoundsStage(t, variant, hostedBoundsStageDisplayCount)
 	count, err := DisplaysNumE()
 	if err != nil {
 		t.Fatalf("DisplaysNumE(): %v", err)
@@ -79,13 +98,20 @@ func assertHostedWaylandBoundsRuntime(t *testing.T) {
 	if legacy := DisplaysNum(); legacy != count {
 		t.Fatalf("DisplaysNum() = %d, error API returned %d", legacy, count)
 	}
+	reportHostedBoundsStage(t, variant, hostedBoundsStageMainDisplay)
 	if mainID := GetMainId(); mainID != 0 {
 		t.Fatalf("GetMainId() = %d, want primary output index 0", mainID)
 	}
 
 	for displayID, output := range expected.Outputs {
+		stage := hostedBoundsStageDisplayZero
+		if displayID == 1 {
+			stage = hostedBoundsStageDisplayOne
+		}
+		reportHostedBoundsStage(t, variant, stage)
 		assertHostedDisplayBounds(t, displayID, output)
 	}
+	reportHostedBoundsStage(t, variant, hostedBoundsStageInvalidIndex)
 	if _, _, _, _, err := GetDisplayBoundsE(count); err == nil {
 		t.Fatalf("GetDisplayBoundsE accepted inactive output index %d", count)
 	}
@@ -100,6 +126,7 @@ func assertHostedWaylandBoundsRuntime(t *testing.T) {
 		)
 	}
 
+	reportHostedBoundsStage(t, variant, hostedBoundsStageAggregate)
 	aggregate := hostedAggregateRect(expected.Outputs)
 	for _, displayID := range [][]int{nil, {-1}} {
 		rect, err := GetScreenRectE(displayID...)
@@ -124,6 +151,7 @@ func assertHostedWaylandBoundsRuntime(t *testing.T) {
 		}
 	}
 
+	reportHostedBoundsStage(t, variant, hostedBoundsStagePrimarySize)
 	width, height, err := GetScreenSizeE()
 	if err != nil {
 		t.Fatalf("GetScreenSizeE(): %v", err)
@@ -148,6 +176,12 @@ func assertHostedWaylandBoundsRuntime(t *testing.T) {
 			height,
 		)
 	}
+	reportHostedBoundsStage(t, variant, hostedBoundsStageComplete)
+}
+
+func reportHostedBoundsStage(t *testing.T, variant, stage string) {
+	t.Helper()
+	t.Logf("ROBOTGO_HOSTED_BOUNDS_STAGE=%s-%s", variant, stage)
 }
 
 func assertHostedWaylandSocket(t *testing.T) {

--- a/internal/portalrunner/hosted_linux.go
+++ b/internal/portalrunner/hosted_linux.go
@@ -29,6 +29,19 @@ const (
 	hostedTestLogLimit      = 2 * 1024 * 1024
 	maximumPortalGeometry   = 256
 	hostedXvfbEnvKey        = "ROBOTGO_HOSTED_XVFB"
+	hostedBoundsStageMarker = "ROBOTGO_HOSTED_BOUNDS_STAGE="
+
+	hostedBoundsStageBuild        = "build"
+	hostedBoundsStageEnvironment  = "environment"
+	hostedBoundsStageTopology     = "topology"
+	hostedBoundsStageDisplayCount = "display-count"
+	hostedBoundsStageMainDisplay  = "main-display"
+	hostedBoundsStageDisplayZero  = "display-zero"
+	hostedBoundsStageDisplayOne   = "display-one"
+	hostedBoundsStageInvalidIndex = "invalid-index"
+	hostedBoundsStageAggregate    = "aggregate"
+	hostedBoundsStagePrimarySize  = "primary-size"
+	hostedBoundsStageComplete     = "complete"
 
 	// HostedCellRemoteDesktop exercises portal-backed pointer and keyboard
 	// input in a disposable desktop guest.
@@ -49,6 +62,35 @@ const (
 var portalFailureStagePattern = regexp.MustCompile(
 	`ROBOTGO_PORTAL_STAGE=([a-z0-9-]{1,32})`,
 )
+
+var hostedBoundsFailureStagePattern = regexp.MustCompile(
+	hostedBoundsStageMarker + `([a-z0-9-]{1,48})`,
+)
+
+var hostedBoundsFailureStages = func() map[string]struct{} {
+	allowed := make(map[string]struct{})
+	for _, variant := range []string{
+		HostedBoundsVariantNativeCGO,
+		HostedBoundsVariantPureGo,
+	} {
+		for _, stage := range []string{
+			hostedBoundsStageBuild,
+			hostedBoundsStageEnvironment,
+			hostedBoundsStageTopology,
+			hostedBoundsStageDisplayCount,
+			hostedBoundsStageMainDisplay,
+			hostedBoundsStageDisplayZero,
+			hostedBoundsStageDisplayOne,
+			hostedBoundsStageInvalidIndex,
+			hostedBoundsStageAggregate,
+			hostedBoundsStagePrimarySize,
+			hostedBoundsStageComplete,
+		} {
+			allowed[variant+"-"+stage] = struct{}{}
+		}
+	}
+	return allowed
+}()
 
 var hostedDisplayFailureStagePattern = regexp.MustCompile(
 	hostedDisplayFailureMarker + `([a-z0-9-]{1,32})`,
@@ -553,9 +595,17 @@ func RunHosted(
 				)
 			}
 		} else {
-			testError = errors.New(
-				"hosted display-bounds integration test failed",
-			)
+			stage := readHostedBoundsFailureStage(testLogPath)
+			if stage == "" {
+				testError = errors.New(
+					"hosted display-bounds integration test failed",
+				)
+			} else {
+				testError = fmt.Errorf(
+					"hosted display-bounds integration test failed at stage %q",
+					stage,
+				)
+			}
 		}
 	}
 	if err := errors.Join(testError, cleanupError); err != nil {
@@ -701,6 +751,22 @@ func readPortalFailureStage(path string) string {
 		return ""
 	}
 	return string(matches[len(matches)-1][1])
+}
+
+func readHostedBoundsFailureStage(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) > hostedTestLogLimit {
+		return ""
+	}
+	matches := hostedBoundsFailureStagePattern.FindAllSubmatch(data, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	stage := string(matches[len(matches)-1][1])
+	if _, allowed := hostedBoundsFailureStages[stage]; !allowed {
+		return ""
+	}
+	return stage
 }
 
 func validateHostedIdentity(commit, cell, topology string) error {
@@ -1064,10 +1130,20 @@ func hostedPortalTestCommandForTopology(
 	case HostedCellDisplayBounds:
 		environment += " ROBOTGO_HOSTED_BOUNDS_E2E=1"
 		boundsTests := strings.Join([]string{
-			"go test -count=1 -timeout=3m " +
+			"printf '%s\\n' '" + hostedBoundsStageMarker +
+				HostedBoundsVariantNativeCGO + "-" +
+				hostedBoundsStageBuild + "' && " +
+				HostedBoundsVariantEnvKey + "=" +
+				HostedBoundsVariantNativeCGO +
+				" go test -count=1 -timeout=3m " +
 				"-tags=wayland,hostedboundsintegration . " +
 				"-run '^TestHostedWaylandBoundsCGORuntime$' -v",
-			"CGO_ENABLED=0 go test -count=1 -timeout=3m " +
+			"printf '%s\\n' '" + hostedBoundsStageMarker +
+				HostedBoundsVariantPureGo + "-" +
+				hostedBoundsStageBuild + "' && " +
+				HostedBoundsVariantEnvKey + "=" +
+				HostedBoundsVariantPureGo +
+				" CGO_ENABLED=0 go test -count=1 -timeout=3m " +
 				"-tags=hostedboundsintegration . " +
 				"-run '^TestHostedWaylandBoundsPureGoRuntime$' -v",
 		}, " && ")

--- a/internal/portalrunner/hosted_linux_test.go
+++ b/internal/portalrunner/hosted_linux_test.go
@@ -304,7 +304,13 @@ func TestHostedDisplayBoundsCommandIsWaylandOnlyAndConsentFree(t *testing.T) {
 		"ROBOTGO_HOSTED_BOUNDS_E2E=1",
 		HostedExpectedOutputsEnvKey +
 			"='0,0,1280,720;1280,0,1024,768'",
+		hostedBoundsStageMarker + HostedBoundsVariantNativeCGO +
+			"-" + hostedBoundsStageBuild,
+		HostedBoundsVariantEnvKey + "=" + HostedBoundsVariantNativeCGO,
 		"TestHostedWaylandBoundsCGORuntime",
+		hostedBoundsStageMarker + HostedBoundsVariantPureGo +
+			"-" + hostedBoundsStageBuild,
+		HostedBoundsVariantEnvKey + "=" + HostedBoundsVariantPureGo,
 		"CGO_ENABLED=0",
 		"TestHostedWaylandBoundsPureGoRuntime",
 	} {
@@ -830,6 +836,39 @@ func TestPortalFailureStageParserReturnsOnlyAllowlistedMarker(t *testing.T) {
 	}
 	if got := readPortalFailureStage(path); got != "capture-2" {
 		t.Fatalf("failure stage = %q", got)
+	}
+}
+
+func TestHostedBoundsFailureStageParserReturnsOnlyAllowlistedMarker(
+	t *testing.T,
+) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "hosted-test.log")
+	if err := os.WriteFile(
+		path,
+		[]byte(
+			"private diagnostic ignored\n"+
+				hostedBoundsStageMarker+"native-cgo-environment\n"+
+				"token=must-not-leak\n"+
+				hostedBoundsStageMarker+"native-cgo-display-one\n",
+		),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := readHostedBoundsFailureStage(path); got !=
+		"native-cgo-display-one" {
+		t.Fatalf("hosted bounds failure stage = %q", got)
+	}
+	if err := os.WriteFile(
+		path,
+		[]byte(hostedBoundsStageMarker+"private-token\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := readHostedBoundsFailureStage(path); got != "" {
+		t.Fatalf("unallowlisted hosted bounds stage escaped as %q", got)
 	}
 }
 

--- a/internal/portalrunner/manifest.go
+++ b/internal/portalrunner/manifest.go
@@ -29,6 +29,13 @@ const (
 	// HostedExpectedOutputsEnvKey carries the encoded logical topology for
 	// consent-free hosted display-bounds evidence.
 	HostedExpectedOutputsEnvKey = "ROBOTGO_HOSTED_EXPECTED_OUTPUTS"
+	// HostedBoundsVariantEnvKey identifies which public output implementation
+	// the hosted bounds contract is exercising.
+	HostedBoundsVariantEnvKey = "ROBOTGO_HOSTED_BOUNDS_VARIANT"
+	// HostedBoundsVariantNativeCGO identifies the native-CGO Wayland client.
+	HostedBoundsVariantNativeCGO = "native-cgo"
+	// HostedBoundsVariantPureGo identifies the Pure-Go Wayland client.
+	HostedBoundsVariantPureGo = "pure-go"
 	// PortalMultiOutputEnvKey enables the hosted multi-output portal contract.
 	PortalMultiOutputEnvKey = "ROBOTGO_PORTAL_MULTI_OUTPUT"
 	// PortalExpectedOutputsEnvKey carries the encoded hosted output topology.


### PR DESCRIPTION
## Goal

Make the failed LAB-61 GNOME/KDE hosted bounds evidence diagnosable without exposing desktop contents, raw guest logs, tokens, paths, or other private data.

Follow-up to #129 and the failed main run: https://github.com/marang/robotgo/actions/runs/30263400130

## Changes

- emit fixed, allowlisted build/runtime stage markers for native-CGO and Pure-Go bounds contracts
- report only the last validated marker when hosted evidence fails
- keep the complete guest test log private and delete it through the existing cleanup path
- reject malformed and non-allowlisted markers
- cover command construction and parser privacy behavior

## Validation

- `go test ./...`
- `CGO_ENABLED=0 go test ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go vet ./...`
- `go test ./internal/portalrunner ./internal/cmd/portalrunner ./scripts`
- tagged native-CGO and Pure-Go hosted-bounds compile checks
- `golangci-lint run ./...` (0 issues)
- `git diff --check`

## Risk and privacy

No public RobotGo API or backend selection changes. GitHub output is constrained to a closed set such as `native-cgo-build` or `pure-go-display-one`; raw guest output remains unavailable and is removed on cleanup.

Linear: LAB-61