### PR TITLE
docs: synchronize roadmap after P005 completion

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -986,6 +986,8 @@ also blocks packaging and publication. The consent-free GNOME and KDE
 multi-output bounds jobs and isolated Hyprland window-geometry cell are invoked
 for that exact candidate and are likewise required before the 28-check manifest
 can be packaged.
+The complete contract passes on exact merged `main` in
+[`Release Evidence` run 30272753885](https://github.com/marang/robotgo/actions/runs/30272753885).
 
 On a clean Linux native checkout, reproduce the generator/verifier path with:
 

--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -66,6 +66,14 @@ repository code; it only verifies the already packaged SHA-256 and uploads the
 two assets. Manual runs retain the bundle as a GitHub Actions artifact for 90
 days and do not modify a release.
 
+The current 28-check exact-candidate contract passes in
+[`Release Evidence` run 30272753885](https://github.com/marang/robotgo/actions/runs/30272753885)
+on merged `main` commit
+`a641236b1b8f8bd80d4fbffc526a10aa5862b001`. The packaged schema-v1
+`required-checks.json` contains both successful GitHub Actions GNOME/KDE
+multi-output bounds rows. This manual candidate evidence does not alter the
+immutable assets of an already published release.
+
 The latest published bundle is attached to
 [`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2):
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -38,14 +38,14 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 2. Capture | Complete for the scoped production and evidence contract | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames with static-desktop reuse, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, hosted GNOME/KDE single- and multi-output persistent-capture execution, non-skipping geometry/transform CI, sanitizer-backed native ownership gates, isolated hosted Sway native/multi-output evidence, and exact-release promotion | Keep runtime and release gates green; extend only for newly scoped formats/backends |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration plus Weston, hosted Sway, and hosted GNOME/KDE multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state, geometry, and active-identity error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, Sway active node/client geometry and PID, Hyprland active compositor-reported geometry/PID, provider-aware Hyprland 0.55+ Lua window dispatch, bounded process-group-owned compositor helpers with lifecycle evidence | Further trustworthy compositor-backed state/geometry operations and cross-platform/runtime matrix coverage |
-| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release snapshots, fail-closed real-compositor contracts, promoted six-cell hosted Sway gate, promoted GNOME/KDE multi-output portal release gates, and published exact-tag [`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2) evidence with a 25-check manifest | Continue the compatibility lifecycle and final `v1.0.0` readiness; keep open Phase 3/4 runtime gaps explicit |
+| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release snapshots, fail-closed real-compositor contracts, promoted Sway, GNOME/KDE portal, bounds, and Hyprland exact-release gates, passing current 28-check candidate evidence, and published exact-tag [`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2) historical 25-check evidence | Continue the compatibility lifecycle and final `v1.0.0` readiness; keep open Phase 3/4 runtime gaps explicit |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phases 1 and 2 now have implementation, real-compositor validation, and
 exact-release promotion for their scoped targets. The bounded cross-platform
 reliability-hardening
-project P002 is complete, while roadmap Phase 5 remains partial. The active
-[Protected Real-Compositor Evidence Plan](real-compositor-evidence.md) now
+projects P002 and P005 are complete, while roadmap Phase 5 remains partial. The
+completed [Protected Real-Compositor Evidence Plan](real-compositor-evidence.md)
 provides the shared evidence contract. Credential-free hosted GNOME/KDE jobs
 provide exact-tree transfer, real portal execution, independent QMP consent,
 digest-bound KDE ScreenCast dialog-geometry validation, and mandatory
@@ -424,7 +424,10 @@ The release workflow additionally invokes the isolated Hyprland
 active-window-geometry proof plus the GNOME/KDE multi-output bounds proof,
 bringing the current exact-candidate manifest to 28 checks while preserving
 the published beta.2 bundle as historical
-25-check evidence.
+25-check evidence. The complete current contract passes in
+[`Release Evidence` run 30272753885](https://github.com/marang/robotgo/actions/runs/30272753885)
+on exact merged `main` commit
+`a641236b1b8f8bd80d4fbffc526a10aa5862b001`.
 The first public
 pre-release, [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1),
 publishes that verified six-cell bundle and checksum for exact commit

--- a/docs/plan/real-compositor-evidence.md
+++ b/docs/plan/real-compositor-evidence.md
@@ -1,7 +1,7 @@
 # Protected Real-Compositor Evidence Plan
 
-Status: Complete; hosted wlroots and GNOME/KDE single-/multi-output portal
-execution delivered and exact-release gates promoted
+Status: Complete; hosted wlroots, GNOME/KDE portal and bounds, and Hyprland
+evidence delivered with a passing 28-check exact-release contract
 
 Linear project:
 [RobotGo | P005 | Protected Compositor Evidence](https://linear.app/riotbox/project/robotgo-or-p005-or-protected-compositor-evidence-d66467e3b5ee)
@@ -22,13 +22,12 @@ not actually demonstrate.
 
 ## Trust and runner model
 
-The P005 target design requires every matrix job to use a clean, ephemeral
+The P005 runner contract requires every matrix job to use a clean, ephemeral
 Linux environment that is destroyed afterward. Persistent personal desktop
 sessions are not eligible. GNOME and KDE run as nested guests on fresh
 GitHub-hosted runners without self-hosted registration credentials.
 
-Before the protected workflows are enabled, their implementation must enforce
-these boundaries:
+The protected workflows enforce these boundaries:
 
 - hosted GNOME/KDE runs only on trusted `main` pushes or explicit manual
   dispatch; fork and ordinary pull-request events never boot either guest
@@ -287,7 +286,7 @@ unfunded or unavailable infrastructure.
 
 ## Exit criteria
 
-P005 is complete only when:
+P005 completed after all of the following became blocking evidence:
 
 - GNOME, KDE, and wlroots runner definitions are reproducible and ephemeral
 - every configured job fails closed on missing infrastructure or consent
@@ -299,6 +298,12 @@ P005 is complete only when:
 - promoted checks block release evidence for the exact commit
 - `docs/compatibility/wayland-input.md`, `wayland-capture.md`, and
   `runtime-v1.md` link the retained evidence
+
+The completed contract passes in
+[`Release Evidence` run 30272753885](https://github.com/marang/robotgo/actions/runs/30272753885)
+on exact merged `main` commit
+`a641236b1b8f8bd80d4fbffc526a10aa5862b001`. Its schema-v1 manifest contains
+exactly 28 successful checks, including both hosted GNOME/KDE bounds lanes.
 
 ## Non-goals
 

--- a/docs/wayland-tasks.md
+++ b/docs/wayland-tasks.md
@@ -199,11 +199,13 @@ backends.
     state, and actionable remediation without sensitive session data. Release
     Evidence v1 binds that report and test-log digests to exact source across
     the six native/Pure-Go hosted platform cells; `v1.0.0-beta.2` additionally
-    records the protected 25-check manifest.
+    records its historical protected 25-check manifest. The current candidate
+    contract passes with 28 checks on exact merged `main`.
   - 7. Keep race/vet and the manifest-checked native ASan/LeakSanitizer ownership
     suites blocking. Hosted Sway and GNOME/KDE single-/multi-output jobs are
-    defined and evidenced. The six hosted Sway checks and four GNOME/KDE
-    multi-output portal checks remain required by exact-release evidence.
+    defined and evidenced. The six hosted Sway checks, four GNOME/KDE
+    multi-output portal checks, and two GNOME/KDE bounds checks remain required
+    by exact-release evidence.
 
 - Recently completed parity work:
   - Window state/query APIs expose `IsTopMostE`, `IsMinimizedE`,
@@ -228,7 +230,8 @@ backends.
     public native-CGO and Pure-Go bounds, count, primary, aggregate, invalid
     index, and legacy/error parity with `DISPLAY` unset. Retain passing
     [`exact-commit run 30268702514`](https://github.com/marang/robotgo/actions/runs/30268702514)
-    before promoting it into release evidence.
+    as the implementation proof; both lanes are now required by exact-release
+    evidence.
 - Portal Path:
   - Expand troubleshooting for xdg-desktop-portal backend selection and consent prompts.
   - Keep the hosted high-level RemoteDesktop input fallback validation green on
@@ -294,11 +297,11 @@ backends.
   - Keep the dedicated credential-free hosted GNOME and KDE portal workflows
     green. The six hosted wlroots/Sway checks are promoted into branch and
     release gates; the four GNOME/KDE multi-output portal checks are promoted
-    into exact-release gates. Keep the isolated `vkms` Hyprland window cell
-    green as a branch check and exact-release gate.
+    into exact-release gates. Keep the isolated `vkms` Hyprland window cell and
+    both GNOME/KDE bounds lanes green as exact-release gates.
   - Keep the consent-free hosted GNOME/KDE bounds workflow independent from
-    portal consent and pixel/input paths. Promote it only after both desktop
-    lanes pass for the same exact commit.
+    portal consent and pixel/input paths. Both desktop lanes pass on the same
+    exact commit and are included in the current 28-check candidate manifest.
   - Keep the race/vet and native ASan/LeakSanitizer CI jobs green and protected.
     The sanitizer gate covers the default CGO suite plus hermetic screencopy
     allocation/free, bounded timeout cleanup, and FD ownership paths.


### PR DESCRIPTION
## Outcome

Synchronizes RobotGo's durable roadmap and testing guidance with the completed P005 real-compositor evidence project.

Linear: [LAB-63](https://linear.app/riotbox/issue/LAB-63/synchronize-robotgo-roadmap-after-p005-completion)

## Changes

- mark P005 and its real-compositor plan complete
- record passing exact merged-main Release Evidence run 30272753885
- distinguish the current 28-check candidate contract from immutable beta.2 25-check history
- remove stale bounds `before promoting` instructions
- update the Wayland check inventory to six Sway, four portal, two bounds, and Hyprland
- preserve the still-open Phase 3 macOS granted-runtime and Phase 4 compositor-state gaps

## Validation

- `go test -count=1 ./...`
- `CGO_ENABLED=0 go test -count=1 ./...`
- `go vet ./...`
- `golangci-lint run`
- stale-phrase repository search
- `git diff --check`

Documentation only; no product or workflow behavior changes.