### PR TITLE
release: start v1.0.0 stable qualification

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -1121,6 +1121,7 @@ add the non-empty `docs/releases/v1.0.0.md` release notes. After that PR is
 merged, run from the clean `main` worktree:
 
 ```bash
+set -euo pipefail
 git pull --ff-only origin main
 test "$(git branch --show-current)" = main
 test -z "$(git status --porcelain --untracked-files=all)"
@@ -1131,13 +1132,16 @@ test "$(git ls-remote --heads origin refs/heads/main | awk '{print $1}')" = "$co
 ```
 
 The preflight checks `origin/main`, exact origin tag refs, GitHub tag refs, and
-GitHub releases. It rejects a non-`marang/robotgo` remote and deliberately
-ignores local tags, which may have been fetched from `go-vgo/robotgo`. Only
-after the stable-preparation PR, review, CI, and an exact manual
-release-evidence run on that merged commit pass may a release operator create
-the annotated tag, verify its peeled commit, and push that one ref:
+GitHub releases. It rejects a non-`marang/robotgo` remote. A colliding local
+tag may have been fetched from `go-vgo/robotgo`; the preflight rejects it
+without treating it as origin evidence. Inspect and explicitly delete that
+non-authoritative local ref before rerunning the preflight, and never
+force-replace it. Only after the stable-preparation PR, review, CI, and an exact
+manual release-evidence run on that merged commit pass may a release operator
+create the annotated tag, verify its peeled commit, and push that one ref:
 
 ```bash
+set -euo pipefail
 git tag -a v1.0.0 "$commit" -m "RobotGo v1.0.0"
 test "$(git rev-parse 'v1.0.0^{}')" = "$commit"
 git push origin refs/tags/v1.0.0:refs/tags/v1.0.0
@@ -1148,6 +1152,7 @@ Never use `git push --tags`. Create the GitHub stable release with
 attaches the checksum-bound archive:
 
 ```bash
+set -euo pipefail
 gh release create v1.0.0 \
   --repo marang/robotgo \
   --verify-tag \

--- a/TEST.md
+++ b/TEST.md
@@ -1114,12 +1114,13 @@ go run ./internal/cmd/releaseevidence verify \
   -expected-test-command "$test_command"
 ```
 
-Before creating a stable-line tag, synchronize `main`, use its full
-authoritative origin commit, and run:
+Before creating the stable tag, complete the documented seven-day RC
+qualification window with no unresolved critical/high regression, synchronize
+`main`, use its full authoritative origin commit, and run:
 
 ```bash
 commit="$(git ls-remote --heads origin refs/heads/main | awk '{print $1}')"
-./scripts/preflight-origin-release.sh v1.0.0-rc.1 "$commit"
+./scripts/preflight-origin-release.sh v1.0.0 "$commit"
 ```
 
 The preflight checks `origin/main`, exact origin tag refs, GitHub tag refs, and
@@ -1130,22 +1131,21 @@ on that merged commit pass may a release operator create the annotated tag,
 verify its peeled commit, and push that one ref:
 
 ```bash
-git tag -a v1.0.0-rc.1 "$commit" -m "RobotGo v1.0.0-rc.1"
-test "$(git rev-parse 'v1.0.0-rc.1^{}')" = "$commit"
-git push origin refs/tags/v1.0.0-rc.1:refs/tags/v1.0.0-rc.1
+git tag -a v1.0.0 "$commit" -m "RobotGo v1.0.0"
+test "$(git rev-parse 'v1.0.0^{}')" = "$commit"
+git push origin refs/tags/v1.0.0:refs/tags/v1.0.0
 ```
 
-Never use `git push --tags`. Create the GitHub prerelease with `--verify-tag`;
-its `release.published` event reruns exact-tag evidence and attaches the
-checksum-bound archive:
+Never use `git push --tags`. Create the GitHub stable release with
+`--verify-tag`; its `release.published` event reruns exact-tag evidence and
+attaches the checksum-bound archive:
 
 ```bash
-gh release create v1.0.0-rc.1 \
+gh release create v1.0.0 \
   --repo marang/robotgo \
   --verify-tag \
-  --prerelease \
-  --title "RobotGo v1.0.0-rc.1" \
-  --notes-file docs/releases/v1.0.0-rc.1.md
+  --title "RobotGo v1.0.0" \
+  --notes-file docs/releases/v1.0.0.md
 ```
 
 The versioned schema, matrix, release-asset behavior, and consumer verification

--- a/TEST.md
+++ b/TEST.md
@@ -1115,20 +1115,27 @@ go run ./internal/cmd/releaseevidence verify \
 ```
 
 Before creating the stable tag, complete the documented seven-day RC
-qualification window with no unresolved critical/high regression, synchronize
-`main`, use its full authoritative origin commit, and run:
+qualification window with no unresolved critical/high regression. A reviewed
+stable-preparation PR must update the package version, tests, changelog, and
+add the non-empty `docs/releases/v1.0.0.md` release notes. After that PR is
+merged, run from the clean `main` worktree:
 
 ```bash
-commit="$(git ls-remote --heads origin refs/heads/main | awk '{print $1}')"
+git pull --ff-only origin main
+test "$(git branch --show-current)" = main
+test -z "$(git status --porcelain --untracked-files=all)"
+test -s docs/releases/v1.0.0.md
+commit="$(git rev-parse HEAD)"
+test "$(git ls-remote --heads origin refs/heads/main | awk '{print $1}')" = "$commit"
 ./scripts/preflight-origin-release.sh v1.0.0 "$commit"
 ```
 
 The preflight checks `origin/main`, exact origin tag refs, GitHub tag refs, and
 GitHub releases. It rejects a non-`marang/robotgo` remote and deliberately
 ignores local tags, which may have been fetched from `go-vgo/robotgo`. Only
-after the preparation PR, review, CI, and an exact manual release-evidence run
-on that merged commit pass may a release operator create the annotated tag,
-verify its peeled commit, and push that one ref:
+after the stable-preparation PR, review, CI, and an exact manual
+release-evidence run on that merged commit pass may a release operator create
+the annotated tag, verify its peeled commit, and push that one ref:
 
 ```bash
 git tag -a v1.0.0 "$commit" -m "RobotGo v1.0.0"

--- a/TEST.md
+++ b/TEST.md
@@ -1075,9 +1075,9 @@ for that exact candidate and are likewise required before the 29-check manifest
 can be packaged.
 The last pre-API-freeze 28-check contract passes on exact merged `main` in
 [`Release Evidence` run 30272753885](https://github.com/marang/robotgo/actions/runs/30272753885).
-The current post-freeze 29-check contract passes on exact merged `main` in
-[`Release Evidence` run 30434061380](https://github.com/marang/robotgo/actions/runs/30434061380)
-at commit `cd204c663e4ff5c8d33504d8cbf8b4dce1d8cc59`.
+The current post-freeze 29-check contract passes on the exact published tag in
+[`v1.0.0-rc.1` Release Evidence run 30442843617](https://github.com/marang/robotgo/actions/runs/30442843617)
+at commit `281d8cee29d696e334fe9d4a6f6a7069ab291083`.
 
 On a clean Linux native checkout, reproduce the generator/verifier path with:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-No changes yet.
+- Hardened stable-line publication against local tags inherited from another
+  remote: origin preflight now rejects an exact local tag collision, and the
+  operator procedure aborts on every error before it can push a tag.
 
 ## RobotGo v1.0.0-rc.1 — 2026-07-29
 

--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -67,15 +67,15 @@ repository code; it only verifies the already packaged SHA-256 and uploads the
 two assets. Manual runs retain the bundle as a GitHub Actions artifact for 90
 days and do not modify a release.
 
-The current post-API-freeze candidate contract passes in
-[`Release Evidence` run 30434061380](https://github.com/marang/robotgo/actions/runs/30434061380)
-on merged `main` commit
-`cd204c663e4ff5c8d33504d8cbf8b4dce1d8cc59`. Its bundle contains all six
+The published post-API-freeze RC contract passes in
+[`v1.0.0-rc.1` Release Evidence run 30442843617](https://github.com/marang/robotgo/actions/runs/30442843617)
+on tagged commit
+`281d8cee29d696e334fe9d4a6f6a7069ab291083`. Its bundle contains all six
 native/Pure-Go snapshots and exactly 29 successful checks, including
 `api-compat`, all GNOME/KDE multi-output release lanes, Sway, and Hyprland. The
 bundle SHA-256, exact commit/tree/ref, six evidence documents, and 29-check
-manifest were independently reverified after download; the temporary
-verification directory was then removed.
+manifest were independently reverified from the public release streams without
+persisting a local verification directory.
 
 The preceding pre-API-freeze 28-check exact-candidate contract passes in
 [`Release Evidence` run 30272753885](https://github.com/marang/robotgo/actions/runs/30272753885)
@@ -86,7 +86,21 @@ multi-output bounds rows. This manual candidate evidence does not alter the
 immutable assets of an already published release.
 
 The latest published bundle is attached to
-[`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2):
+[`v1.0.0-rc.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-rc.1):
+
+- [`robotgo-release-evidence-v1.0.0-rc.1-281d8cee29d6.tar.gz`](https://github.com/marang/robotgo/releases/download/v1.0.0-rc.1/robotgo-release-evidence-v1.0.0-rc.1-281d8cee29d6.tar.gz)
+- [`robotgo-release-evidence-v1.0.0-rc.1-281d8cee29d6.tar.gz.sha256`](https://github.com/marang/robotgo/releases/download/v1.0.0-rc.1/robotgo-release-evidence-v1.0.0-rc.1-281d8cee29d6.tar.gz.sha256)
+
+It records exact source commit
+`281d8cee29d696e334fe9d4a6f6a7069ab291083`, tree
+`a362b429ebabb064fd7b55dc9b230579bc1f3134`, tag ref
+`refs/tags/v1.0.0-rc.1`, and release run `30442843617`. The published archive
+has SHA-256
+`7761b673a8f6a8de8e36e74232149a24491fe8ef87dabd8023a665f313f31738`.
+
+The preceding published bundle remains attached to
+[`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2)
+as immutable historical evidence:
 
 - [`robotgo-release-evidence-v1.0.0-beta.2-f3530594f30b.tar.gz`](https://github.com/marang/robotgo/releases/download/v1.0.0-beta.2/robotgo-release-evidence-v1.0.0-beta.2-f3530594f30b.tar.gz)
 - [`robotgo-release-evidence-v1.0.0-beta.2-f3530594f30b.tar.gz.sha256`](https://github.com/marang/robotgo/releases/download/v1.0.0-beta.2/robotgo-release-evidence-v1.0.0-beta.2-f3530594f30b.tar.gz.sha256)

--- a/docs/compatibility/runtime-v1.json
+++ b/docs/compatibility/runtime-v1.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "published": "2026-07-29",
-  "releaseRun": "https://github.com/marang/robotgo/actions/runs/30434061380",
-  "releaseCommit": "cd204c663e4ff5c8d33504d8cbf8b4dce1d8cc59",
+  "releaseRun": "https://github.com/marang/robotgo/actions/runs/30442843617",
+  "releaseCommit": "281d8cee29d696e334fe9d4a6f6a7069ab291083",
   "releaseChecks": [
     "Display bounds evidence / GitHub-hosted gnome multi-output Wayland bounds",
     "Display bounds evidence / GitHub-hosted kde multi-output Wayland bounds",

--- a/docs/compatibility/runtime-v1.md
+++ b/docs/compatibility/runtime-v1.md
@@ -13,8 +13,8 @@ pending row is not a passing row.
 The machine-readable source is
 [`runtime-v1.json`](runtime-v1.json). The generated table below is checked by
 the default suite, and every evidence name must exist in the exact 29-check
-[`Release Evidence` run 30434061380](https://github.com/marang/robotgo/actions/runs/30434061380)
-for merged commit `cd204c663e4ff5c8d33504d8cbf8b4dce1d8cc59`.
+[`v1.0.0-rc.1` Release Evidence run 30442843617](https://github.com/marang/robotgo/actions/runs/30442843617)
+for tagged commit `281d8cee29d696e334fe9d4a6f6a7069ab291083`.
 
 ## Platform and build matrix
 

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -437,7 +437,7 @@ The first public
 pre-release, [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1),
 publishes that verified six-cell bundle and checksum for exact commit
 `1bab5e173f6b96f61d349473b348f839291b9a89`; manual runs remain read-only
-artifacts. The latest pre-release,
+artifacts. The preceding pre-release,
 [`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2),
 publishes exact-tag
 [release evidence](https://github.com/marang/robotgo/actions/runs/30244107872)

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -38,7 +38,7 @@ The July 2026 hardening work establishes the foundation for this roadmap:
 | 2. Capture | Complete for the scoped production and evidence contract | Reliable one-shot paths plus one consent-aware ScreenCast session, reusable PipeWire frames with static-desktop reuse, logical region crop, raw pixel conversion, metadata/restore tokens, cleanup, hosted GNOME/KDE single- and multi-output persistent-capture execution, non-skipping geometry/transform CI, sanitizer-backed native ownership gates, isolated hosted Sway native/multi-output evidence, and exact-release promotion | Keep runtime and release gates green; extend only for newly scoped formats/backends |
 | 3. Pure-Go | X11 complete; Windows input/window CI-evidenced; macOS capture/display/input and window implementation delivered; Wayland logical output enumeration plus Weston, hosted Sway, and hosted GNOME/KDE multi-output evidence delivered; broader phase partial | Build and feature-level introspection; non-CGO macOS CoreGraphics capture/display, Quartz input, and Accessibility window inspection/control with explicit gaps; Windows capture, `SendInput` keyboard/pointer, and Win32 window control with blocking runtime probes; X11 capture, XGB/XTEST input, and X11/EWMH window introspection/control; Wayland portal capture/input plus bounded native `wl_output`/`xdg-output` geometry; permission/error contracts; shared behavioral parity; reproducible balanced benchmark tooling; optimized guardian-path decision evidence; explicit decision to retain native CGO as the X11 default; race-testable internal X11 core; re-exec guardian with application-`SIGKILL` recovery; protected three-OS CI | Collect opt-in real macOS input and self-owned-window evidence and assess further backends selectively |
 | 4. API/compositor gaps | Parity surface delivered; runtime support partial | Window-state, geometry, and active-identity error APIs, bitmap string helpers, `FindColorCS`, hook/event capability reporting, Sway/Hyprland/wlroots resolver, Sway active node/client geometry and PID, Hyprland active compositor-reported geometry/PID, provider-aware Hyprland 0.55+ Lua window dispatch, bounded process-group-owned compositor helpers with lifecycle evidence | Further trustworthy compositor-backed state/geometry operations and cross-platform/runtime matrix coverage |
-| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release snapshots, fail-closed real-compositor contracts, promoted Sway, GNOME/KDE portal, bounds, and Hyprland exact-release gates, a blocking reviewable public Go API freeze, a passing 29-check exact-release workflow, authoritative origin release preflight, and published exact-tag [`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2) historical 25-check evidence | Publish and qualify `v1.0.0-rc.1`, then complete the remaining [stable-release gates](stable-release-readiness.md) for `v1.0.0`; keep open Phase 3/4 runtime gaps explicit |
+| 5. Reliability product | Partial | Capability APIs, versioned sanitized runtime diagnostics/example, compatibility matrix v1, expanded CI variants, blocking ASan/LeakSanitizer ownership gates, six-cell checksummed release snapshots, fail-closed real-compositor contracts, promoted Sway, GNOME/KDE portal, bounds, and Hyprland exact-release gates, a blocking reviewable public Go API freeze, authoritative origin release preflight, historical exact-tag [`v1.0.0-beta.2`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.2) evidence, and published [`v1.0.0-rc.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-rc.1) with a passing 29-check exact-tag bundle | Complete the seven-day RC qualification and remaining [stable-release gates](stable-release-readiness.md) for `v1.0.0`; keep open Phase 3/4 runtime gaps explicit |
 
 No delivery phase is complete until all of its exit criteria are blocking and
 green. Phases 1 and 2 now have implementation, real-compositor validation, and
@@ -58,8 +58,8 @@ the separate hosted Sway multi-output cell is passing with retained
 [exact-commit evidence](https://github.com/marang/robotgo/actions/runs/29861058126).
 The GNOME/KDE evidence and release-promotion gap across phases 1, 2, and 3 is
 closed; Phase 5 continues through the
-[P009 stable-release plan](stable-release-readiness.md) toward
-`v1.0.0-rc.1` and `v1.0.0`.
+[P009 stable-release plan](stable-release-readiness.md) and the published
+`v1.0.0-rc.1` qualification window toward `v1.0.0`.
 The completed [Agent Adapter and Evaluation Plan](agent-adapter-evaluation.md)
 provides a local, policy-gated MCP boundary on the agent-session proof. The
 adjacent [Safe Agent Visual Conditions Plan](agent-visual-conditions.md) now
@@ -429,10 +429,10 @@ The release workflow additionally invokes the isolated Hyprland
 active-window-geometry proof plus the GNOME/KDE multi-output bounds proof and
 the stable public API gate, bringing the current exact-candidate manifest to
 29 checks while preserving the published beta.2 bundle as historical
-25-check evidence. The complete current contract passes in
-[`Release Evidence` run 30434061380](https://github.com/marang/robotgo/actions/runs/30434061380)
-on exact merged `main` commit
-`cd204c663e4ff5c8d33504d8cbf8b4dce1d8cc59`.
+25-check evidence. The complete current contract passes in published exact-tag
+[`v1.0.0-rc.1` Release Evidence run 30442843617](https://github.com/marang/robotgo/actions/runs/30442843617)
+on commit
+`281d8cee29d696e334fe9d4a6f6a7069ab291083`.
 The first public
 pre-release, [`v1.0.0-beta.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-beta.1),
 publishes that verified six-cell bundle and checksum for exact commit
@@ -449,6 +449,16 @@ before invoking the operating system, preventing Unix process-group signaling
 through `Kill(0)` or a narrowed negative PID. Dedicated GNOME/KDE portal jobs
 are hosted; their multi-output cells are promoted into exact-release evidence
 alongside the hosted wlroots jobs.
+
+The current release candidate,
+[`v1.0.0-rc.1`](https://github.com/marang/robotgo/releases/tag/v1.0.0-rc.1),
+publishes exact-tag
+[release evidence](https://github.com/marang/robotgo/actions/runs/30442843617)
+for commit `281d8cee29d696e334fe9d4a6f6a7069ab291083`: all six platform snapshots,
+all 29 protected checks, GNOME/KDE portal input, persistent capture and bounds,
+plus isolated Sway and Hyprland evidence passed before the checksum-bound assets
+were attached. Stable qualification runs for at least seven full calendar days
+from `2026-07-29T10:13:46Z`.
 
 Releases require:
 

--- a/docs/plan/real-compositor-evidence.md
+++ b/docs/plan/real-compositor-evidence.md
@@ -300,10 +300,10 @@ P005 completed after all of the following became blocking evidence:
 - `docs/compatibility/wayland-input.md`, `wayland-capture.md`, and
   `runtime-v1.md` link the retained evidence
 
-The current completed contract passes in
-[`Release Evidence` run 30434061380](https://github.com/marang/robotgo/actions/runs/30434061380)
-on exact merged `main` commit
-`cd204c663e4ff5c8d33504d8cbf8b4dce1d8cc59`. Its schema-v1 manifest contains
+The current completed contract passes in the published
+[`v1.0.0-rc.1` Release Evidence run 30442843617](https://github.com/marang/robotgo/actions/runs/30442843617)
+on exact tagged commit
+`281d8cee29d696e334fe9d4a6f6a7069ab291083`. Its schema-v1 manifest contains
 exactly 29 successful checks, including both hosted GNOME/KDE bounds lanes and
 the stable public API gate.
 

--- a/docs/plan/stable-release-readiness.md
+++ b/docs/plan/stable-release-readiness.md
@@ -15,37 +15,58 @@ The independent `github.com/marang/robotgo` module will use:
 1. `v1.0.0-rc.1` for the first stable-line release candidate.
 2. `v1.0.0` for the first stable release after qualification.
 
-Before RC publication, the authoritative `marang/robotgo` origin contains only
-`v1.0.0-beta.1` and `v1.0.0-beta.2`. Development clones can also contain
+The authoritative `marang/robotgo` origin now contains the published,
+annotated `v1.0.0-rc.1` tag in addition to `v1.0.0-beta.1` and
+`v1.0.0-beta.2`; `v1.0.0` remains unused. Development clones can also contain
 `v1.0.0`, `v1.0.1`, and `v1.0.2` tags fetched from the separate
 `go-vgo/robotgo` upstream remote. Local tag names are therefore not evidence
 of origin state. Release preflight must use `git ls-remote --tags origin` and
 the GitHub repository API, and must never push an upstream-derived local tag.
 
-The release-candidate preparation branch changes package `Version`, tests,
-notes, tag, and evidence together to `v1.0.0-rc.1`.
+The release candidate changed package `Version`, tests, notes, tag, and
+evidence together to `v1.0.0-rc.1`. Stable qualification started at its
+publication time, `2026-07-29T10:13:46Z`; stable publication is no earlier
+than `2026-08-05T10:13:46Z`.
 
 ## Current evidence
 
-- `git ls-remote --tags origin`, the GitHub tag-ref API, and the GitHub release
-  API showed neither `v1.0.0-rc.1` nor `v1.0.0` on 2026-07-29. The similarly
-  named stable refs in the development clone came from `upstream`, not
-  `origin`. `scripts/preflight-origin-release.sh` now reproduces this check,
-  binds the selected commit to authoritative `origin/main`, and rejects a
-  non-fork remote.
+- `scripts/preflight-origin-release.sh` proved that neither `v1.0.0-rc.1` nor
+  `v1.0.0` existed in the fork before publication, bound the selected commit to
+  authoritative `origin/main`, and rejected a non-fork remote. The resulting
+  annotated RC tag peels to
+  `281d8cee29d696e334fe9d4a6f6a7069ab291083`; `v1.0.0` remains absent.
 - `go list -m -json github.com/marang/robotgo@latest` resolved
-  `v1.0.0-beta.2` with both the default proxy and `GOPROXY=direct` on
-  2026-07-27. Explicit versions remain required for reproducible installs and
-  custom/caching proxies can lag.
-- Exact merged-main
-  [`Release Evidence` run 30434061380](https://github.com/marang/robotgo/actions/runs/30434061380)
+  `v1.0.0-rc.1` with the default proxy and `GOPROXY=direct` on 2026-07-29.
+  `proxy.golang.org` identifies the exact tag commit and `sum.golang.org`
+  publishes both module and `go.mod` hashes. Explicit versions remain required
+  for reproducible installs and custom/caching proxies can lag.
+- Exact published-tag
+  [`Release Evidence` run 30442843617](https://github.com/marang/robotgo/actions/runs/30442843617)
   passed six native/Pure-Go platform snapshots and the 29-check manifest on
-  commit `cd204c663e4ff5c8d33504d8cbf8b4dce1d8cc59`, including all promoted
-  GNOME/KDE portal/bounds lanes and Hyprland.
+  commit `281d8cee29d696e334fe9d4a6f6a7069ab291083`, including all promoted
+  GNOME/KDE portal/bounds lanes and Hyprland. Its two public assets have the
+  independently verified archive SHA-256
+  `7761b673a8f6a8de8e36e74232149a24491fe8ef87dabd8023a665f313f31738`.
 - P005 is complete with all five milestones at 100%.
 - `go doc` currently exposes 259 root declarations, 44 `agent` declarations,
   and 12 `input/portal` declarations. That breadth makes an automated API
   freeze a stable-release requirement.
+
+## Stable qualification log
+
+| Observed at (UTC) | Observation | Result |
+|---|---|---|
+| 2026-07-29T10:13:46Z | GitHub published the immutable annotated `v1.0.0-rc.1` prerelease | Qualification window opened |
+| 2026-07-29T10:30:36Z | Exact tag run `30442843617` completed; 17 workflow jobs, six snapshots, and all 29 required checks succeeded | Pass |
+| 2026-07-29T10:31Z | Public archive/checksum, six manifests, tag ref, tree, commit, and release run were independently streamed and verified | Pass |
+| 2026-07-29T10:32Z | Default proxy, `proxy.golang.org`, `GOPROXY=direct`, and `sum.golang.org` resolved the RC | Pass |
+| 2026-07-29T10:34Z | Linear RobotGo audit found no unresolved critical/high defect; LAB-69 remains a medium, explicitly unsupported-scope evidence task | Pass |
+
+GitHub Issues are disabled for this repository, so qualification findings are
+triaged in the Linear RobotGo project. LAB-68 stays open through the full
+window. A later observation cannot shorten the minimum duration, and any
+critical/high regression resets the release decision to no-go until resolved
+and requalified.
 
 ## Codebase review findings
 
@@ -131,8 +152,8 @@ notes, tag, and evidence together to `v1.0.0-rc.1`.
 | G1 Version line | Authoritative origin preflight, v1.0 decision, and truthful `@latest` guidance | LAB-64 | Complete — LAB-64 | M1 Contract and API Freeze |
 | G2 API freeze | Checked-in public API baseline plus blocking compatibility CI | [LAB-65](https://linear.app/riotbox/issue/LAB-65/add-a-stable-public-go-api-compatibility-gate) | Complete — 14 variants and exact 29-check evidence | M1 Contract and API Freeze |
 | G3 Platform claims | Every supported row backed by blocking/approved evidence; pending rows explicit | [LAB-66](https://linear.app/riotbox/issue/LAB-66/resolve-stable-platform-support-claims-and-macos-evidence-scope) | Complete — checked runtime-v1 contract; macOS permission scope pending under LAB-69 | M1 Contract and API Freeze |
-| G4 Release candidate | Clean origin `v1.0.0-rc.1` tag, exact evidence, notes, migration, checksums | [LAB-67](https://linear.app/riotbox/issue/LAB-67/prepare-and-publish-robotgo-v100-rc1) | In progress — origin preflight passed; preparing tag commit | M2 v1.0.0 Release Candidate |
-| G5 Stable qualification | At least seven calendar days, no unresolved critical/high regression, no API drift, final exact evidence | [LAB-68](https://linear.app/riotbox/issue/LAB-68/qualify-and-publish-robotgo-v100-stable) | Blocked by G4 | M3 v1.0.0 Stable Qualification |
+| G4 Release candidate | Clean origin `v1.0.0-rc.1` tag, exact evidence, notes, migration, checksums | [LAB-67](https://linear.app/riotbox/issue/LAB-67/prepare-and-publish-robotgo-v100-rc1) | Complete — published tag, 29-check exact evidence, checksummed assets, and module resolution verified | M2 v1.0.0 Release Candidate |
+| G5 Stable qualification | At least seven calendar days, no unresolved critical/high regression, no API drift, final exact evidence | [LAB-68](https://linear.app/riotbox/issue/LAB-68/qualify-and-publish-robotgo-v100-stable) | In progress — window opened 2026-07-29T10:13:46Z; earliest stable 2026-08-05T10:13:46Z | M3 v1.0.0 Stable Qualification |
 
 ## RC and stable rules
 

--- a/scripts/preflight-origin-release.sh
+++ b/scripts/preflight-origin-release.sh
@@ -71,6 +71,13 @@ if "$git_bin" show-ref --verify --quiet "refs/tags/$tag"; then
   printf 'refusing existing local tag collision: refs/tags/%s\n' "$tag" >&2
   printf 'inspect and delete the non-authoritative local tag before retrying; never force-replace it\n' >&2
   exit 1
+else
+  local_tag_status=$?
+  if ((local_tag_status != 1)); then
+    printf 'failed to inspect local tag refs/tags/%s (status %d)\n' \
+      "$tag" "$local_tag_status" >&2
+    exit 1
+  fi
 fi
 
 remote_tag_rows="$(

--- a/scripts/preflight-origin-release.sh
+++ b/scripts/preflight-origin-release.sh
@@ -67,6 +67,12 @@ if [[ "$main_commit" != "$expected_commit" ]]; then
   exit 1
 fi
 
+if "$git_bin" show-ref --verify --quiet "refs/tags/$tag"; then
+  printf 'refusing existing local tag collision: refs/tags/%s\n' "$tag" >&2
+  printf 'inspect and delete the non-authoritative local tag before retrying; never force-replace it\n' >&2
+  exit 1
+fi
+
 remote_tag_rows="$(
   "$git_bin" ls-remote --tags "$remote" \
     "refs/tags/$tag" "refs/tags/$tag^{}" \

--- a/scripts/preflight_origin_release_test.go
+++ b/scripts/preflight_origin_release_test.go
@@ -44,6 +44,13 @@ func TestOriginReleasePreflight(t *testing.T) {
 			wantError: "refusing existing local tag collision",
 		},
 		{
+			name: "local tag lookup error",
+			environment: map[string]string{
+				"FAKE_LOCAL_TAG_LOOKUP_STATUS": "128",
+			},
+			wantError: "failed to inspect local tag",
+		},
+		{
 			name: "origin tag already exists",
 			environment: map[string]string{
 				"FAKE_ORIGIN_TAGS": releaseCommit + "\trefs/tags/v1.0.0-rc.1\n",
@@ -147,6 +154,9 @@ case "$1" in
   show-ref)
     if [[ "$2" != "--verify" || "$3" != "--quiet" ]]; then
       exit 2
+    fi
+    if [[ -n "${FAKE_LOCAL_TAG_LOOKUP_STATUS:-}" ]]; then
+      exit "$FAKE_LOCAL_TAG_LOOKUP_STATUS"
     fi
     if [[ "${FAKE_LOCAL_TAG:-}" == "${4#refs/tags/}" ]]; then
       exit 0

--- a/scripts/preflight_origin_release_test.go
+++ b/scripts/preflight_origin_release_test.go
@@ -15,10 +15,12 @@ func TestOriginReleasePreflight(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		tag         string
 		environment map[string]string
 		wantError   string
 	}{
 		{name: "clean authoritative origin"},
+		{name: "clean stable release", tag: "v1.0.0"},
 		{
 			name: "wrong origin repository",
 			environment: map[string]string{
@@ -32,6 +34,14 @@ func TestOriginReleasePreflight(t *testing.T) {
 				"FAKE_MAIN_COMMIT": "abcdef0123456789abcdef0123456789abcdef01",
 			},
 			wantError: "release commit is not authoritative origin/main",
+		},
+		{
+			name: "local stable tag collision",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_LOCAL_TAG": "v1.0.0",
+			},
+			wantError: "refusing existing local tag collision",
 		},
 		{
 			name: "origin tag already exists",
@@ -60,7 +70,11 @@ func TestOriginReleasePreflight(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			output, err := runOriginReleasePreflight(t, test.environment)
+			output, err := runOriginReleasePreflight(
+				t,
+				test.tag,
+				test.environment,
+			)
 			if test.wantError == "" {
 				if err != nil {
 					t.Fatalf("preflight failed: %v\n%s", err, output)
@@ -100,9 +114,13 @@ func TestOriginReleasePreflightRejectsMalformedInputs(t *testing.T) {
 
 func runOriginReleasePreflight(
 	t *testing.T,
+	tag string,
 	overrides map[string]string,
 ) (string, error) {
 	t.Helper()
+	if tag == "" {
+		tag = "v1.0.0-rc.1"
+	}
 
 	temporaryDirectory := t.TempDir()
 	gitStub := filepath.Join(temporaryDirectory, "git")
@@ -125,6 +143,15 @@ case "$1" in
         exit 2
         ;;
     esac
+    ;;
+  show-ref)
+    if [[ "$2" != "--verify" || "$3" != "--quiet" ]]; then
+      exit 2
+    fi
+    if [[ "${FAKE_LOCAL_TAG:-}" == "${4#refs/tags/}" ]]; then
+      exit 0
+    fi
+    exit 1
     ;;
   *)
     exit 2
@@ -157,7 +184,7 @@ esac
 	command := exec.Command(
 		"bash",
 		filepath.Join(".", "preflight-origin-release.sh"),
-		"v1.0.0-rc.1",
+		tag,
 		releaseCommit,
 	)
 	command.Env = environment


### PR DESCRIPTION
## Summary

- record the published `v1.0.0-rc.1` tag, exact release evidence, public bundle digest, and module-proxy resolution
- open the seven-day stable qualification window with an explicit earliest publication timestamp
- update the runtime matrix, evidence contract, roadmap, and testing guide from the pre-RC baseline to the immutable RC evidence
- point the next operator procedure at stable `v1.0.0`, require reviewed stable notes, and abort on every shell failure
- reject exact local tag collisions in origin preflight so an upstream-derived `v1.0.0` cannot be pushed accidentally
- keep permission-granted macOS behavior explicitly evidence-pending under LAB-69

## Verification

- `bash scripts/run-local-ci-preflight.sh`
- `go test -count=1 ./scripts`
- live negative preflight verified the existing local upstream-derived `v1.0.0` is rejected
- 12 local CI preflight gates passed, including native/Pure-Go tests, vet, runtime contract, API compatibility, and lint
- exact manual evidence: https://github.com/marang/robotgo/actions/runs/30441404235
- exact tag/release evidence: https://github.com/marang/robotgo/actions/runs/30442843617
- public release archive SHA-256 independently verified: `7761b673a8f6a8de8e36e74232149a24491fe8ef87dabd8023a665f313f31738`
- `@latest` resolves to `v1.0.0-rc.1` through the default proxy, `proxy.golang.org`, and `GOPROXY=direct`

Linear: LAB-68