### PR TITLE
fix(release): enforce the v1.0.0 qualification window

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -1134,6 +1134,13 @@ test "$(git ls-remote --heads origin refs/heads/main | awk '{print $1}')" = "$co
 ./scripts/preflight-origin-release.sh v1.0.0 "$commit"
 ```
 
+For `v1.0.0`, the preflight fails closed before
+`2026-08-05T10:13:46Z`, the first instant after seven full days from the
+published RC. Its regression suite covers one second before the boundary, the
+exact boundary, later execution, malformed time output, and clock-command
+failure. RC-tag preflight remains independent of the stable qualification
+gate.
+
 The preflight checks `origin/main`, exact origin tag refs, GitHub tag refs, and
 GitHub releases. It rejects a non-`marang/robotgo` remote. A colliding local
 tag may have been fetched from `go-vgo/robotgo`; the preflight rejects it

--- a/TEST.md
+++ b/TEST.md
@@ -1136,10 +1136,12 @@ test "$(git ls-remote --heads origin refs/heads/main | awk '{print $1}')" = "$co
 
 For `v1.0.0`, the preflight fails closed before
 `2026-08-05T10:13:46Z`, the first instant after seven full days from the
-published RC. Its regression suite covers one second before the boundary, the
-exact boundary, later execution, malformed time output, and clock-command
-failure. RC-tag preflight remains independent of the stable qualification
-gate.
+published RC. It obtains the current time from the authoritative GitHub API
+`Date` header over the existing authenticated HTTPS path rather than trusting
+the operator machine's clock. Its regression suite covers one second before
+the boundary, the exact boundary, later execution, missing or duplicate remote
+time headers, malformed parsed time output, and remote/time-parser failure.
+RC-tag preflight remains independent of the stable qualification gate.
 
 The preflight checks `origin/main`, exact origin tag refs, GitHub tag refs, and
 GitHub releases. It rejects a non-`marang/robotgo` remote. A colliding local

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 - Made the seven-day stable qualification window a fail-closed release
   preflight gate: `v1.0.0` cannot pass before
-  `2026-08-05T10:13:46Z`, and deterministic boundary/error tests prevent
-  clock lookup failures from silently permitting publication.
+  `2026-08-05T10:13:46Z`; the gate validates GitHub's authoritative API time
+  instead of trusting the operator clock, and deterministic boundary/error
+  tests prevent remote clock lookup or parsing failures from silently
+  permitting publication.
 - Classified permission-granted macOS runtime evidence as an externally blocked,
   non-release-blocking promotion under LAB-69. Native and Pure-Go permission
   scopes remain implemented/evidence-pending until an isolated project-owned,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Made the seven-day stable qualification window a fail-closed release
+  preflight gate: `v1.0.0` cannot pass before
+  `2026-08-05T10:13:46Z`, and deterministic boundary/error tests prevent
+  clock lookup failures from silently permitting publication.
 - Classified permission-granted macOS runtime evidence as an externally blocked,
   non-release-blocking promotion under LAB-69. Native and Pure-Go permission
   scopes remain implemented/evidence-pending until an isolated project-owned,

--- a/docs/plan/stable-release-readiness.md
+++ b/docs/plan/stable-release-readiness.md
@@ -35,6 +35,10 @@ than `2026-08-05T10:13:46Z`.
   authoritative `origin/main`, and rejected a non-fork remote. The resulting
   annotated RC tag peels to
   `281d8cee29d696e334fe9d4a6f6a7069ab291083`; `v1.0.0` remains absent.
+- The same preflight now rejects `v1.0.0` before
+  `2026-08-05T10:13:46Z` and fails closed when UTC time cannot be obtained or
+  parsed. Deterministic tests cover the second before the boundary, the exact
+  boundary, and later execution without applying the stable gate to RC tags.
 - `go list -m -json github.com/marang/robotgo@latest` resolved
   `v1.0.0-rc.1` with the default proxy and `GOPROXY=direct` on 2026-07-29.
   `proxy.golang.org` identifies the exact tag commit and `sum.golang.org`
@@ -62,6 +66,7 @@ than `2026-08-05T10:13:46Z`.
 | 2026-07-29T10:32Z | Default proxy, `proxy.golang.org`, `GOPROXY=direct`, and `sum.golang.org` resolved the RC | Pass |
 | 2026-07-29T10:34Z | Linear RobotGo audit found no unresolved critical/high defect; LAB-69 remains a medium, explicitly unsupported-scope evidence task | Pass |
 | 2026-07-29T12:38Z | LAB-69 was classified externally blocked with four explicit reactivation paths; permission-granted macOS scopes remain evidence-pending and non-blocking for stable | Pass |
+| 2026-07-29T15:35Z | Stable preflight rejected an actual early `v1.0.0` attempt; deterministic before/at/after-boundary and clock-failure tests passed | Pass |
 
 GitHub Issues are disabled for this repository, so qualification findings are
 triaged in the Linear RobotGo project. LAB-68 stays open through the full
@@ -161,7 +166,7 @@ and requalified.
 | G2 API freeze | Checked-in public API baseline plus blocking compatibility CI | [LAB-65](https://linear.app/riotbox/issue/LAB-65/add-a-stable-public-go-api-compatibility-gate) | Complete — 14 variants and exact 29-check evidence | M1 Contract and API Freeze |
 | G3 Platform claims | Every supported row backed by blocking/approved evidence; pending rows explicit | [LAB-66](https://linear.app/riotbox/issue/LAB-66/resolve-stable-platform-support-claims-and-macos-evidence-scope) | Complete — checked runtime-v1 contract; macOS permission scope pending under LAB-69 | M1 Contract and API Freeze |
 | G4 Release candidate | Clean origin `v1.0.0-rc.1` tag, exact evidence, notes, migration, checksums | [LAB-67](https://linear.app/riotbox/issue/LAB-67/prepare-and-publish-robotgo-v100-rc1) | Complete — published tag, 29-check exact evidence, checksummed assets, and module resolution verified | M2 v1.0.0 Release Candidate |
-| G5 Stable qualification | At least seven calendar days, no unresolved critical/high regression, no API drift, final exact evidence | [LAB-68](https://linear.app/riotbox/issue/LAB-68/qualify-and-publish-robotgo-v100-stable) | In progress — window opened 2026-07-29T10:13:46Z; earliest stable 2026-08-05T10:13:46Z | M3 v1.0.0 Stable Qualification |
+| G5 Stable qualification | At least seven calendar days, no unresolved critical/high regression, no API drift, final exact evidence | [LAB-68](https://linear.app/riotbox/issue/LAB-68/qualify-and-publish-robotgo-v100-stable) | In progress — fail-closed preflight enforces the window opened 2026-07-29T10:13:46Z; earliest stable 2026-08-05T10:13:46Z | M3 v1.0.0 Stable Qualification |
 
 ## RC and stable rules
 

--- a/docs/plan/stable-release-readiness.md
+++ b/docs/plan/stable-release-readiness.md
@@ -37,7 +37,8 @@ than `2026-08-05T10:13:46Z`.
   `281d8cee29d696e334fe9d4a6f6a7069ab291083`; `v1.0.0` remains absent.
 - The same preflight now rejects `v1.0.0` before
   `2026-08-05T10:13:46Z` and fails closed when UTC time cannot be obtained or
-  parsed. Deterministic tests cover the second before the boundary, the exact
+  parsed from GitHub's authoritative API `Date` header. Deterministic tests
+  cover missing/duplicate headers, the second before the boundary, the exact
   boundary, and later execution without applying the stable gate to RC tags.
 - `go list -m -json github.com/marang/robotgo@latest` resolved
   `v1.0.0-rc.1` with the default proxy and `GOPROXY=direct` on 2026-07-29.

--- a/scripts/preflight-origin-release.sh
+++ b/scripts/preflight-origin-release.sh
@@ -6,6 +6,9 @@ readonly repository="marang/robotgo"
 readonly remote="origin"
 readonly git_bin="${ROBOTGO_RELEASE_GIT_BIN:-git}"
 readonly gh_bin="${ROBOTGO_RELEASE_GH_BIN:-gh}"
+readonly date_bin="${ROBOTGO_RELEASE_DATE_BIN:-date}"
+readonly stable_qualification_not_before="2026-08-05T10:13:46Z"
+readonly stable_qualification_not_before_epoch=1785924826
 
 usage() {
   printf 'usage: %s <tag> <40-character-origin-main-commit>\n' \
@@ -36,6 +39,24 @@ fi
 if [[ ! "$expected_commit" =~ ^[0-9a-f]{40}$ ]]; then
   printf 'expected commit must be a lowercase 40-character Git SHA\n' >&2
   exit 1
+fi
+
+if [[ "$tag" == "$stable_tag" ]]; then
+  if ! current_epoch="$("$date_bin" -u +%s)"; then
+    printf 'failed to obtain current UTC epoch for stable qualification\n' >&2
+    exit 1
+  fi
+  if [[ ! "$current_epoch" =~ ^[0-9]{1,10}$ ]]; then
+    printf 'invalid current UTC epoch for stable qualification: %s\n' \
+      "$current_epoch" >&2
+    exit 1
+  fi
+  if ((10#$current_epoch < stable_qualification_not_before_epoch)); then
+    printf 'stable qualification window is still open\n' >&2
+    printf 'not-before=%s\ncurrent-epoch=%s\n' \
+      "$stable_qualification_not_before" "$current_epoch" >&2
+    exit 1
+  fi
 fi
 
 remote_url="$("$git_bin" remote get-url "$remote")"
@@ -112,4 +133,7 @@ fi
 printf 'release preflight passed\n'
 printf 'repository=%s\nremote=%s\ntag=%s\ncommit=%s\n' \
   "$repository" "$remote" "$tag" "$expected_commit"
+if [[ "$tag" == "$stable_tag" ]]; then
+  printf 'stable-not-before=%s\n' "$stable_qualification_not_before"
+fi
 printf 'publish only the explicit tag ref; never use git push --tags\n'

--- a/scripts/preflight-origin-release.sh
+++ b/scripts/preflight-origin-release.sh
@@ -15,6 +15,15 @@ usage() {
     "$(basename -- "$0")" >&2
 }
 
+parse_http_date_epoch() {
+  local http_date="$1"
+  if LC_ALL=C "$date_bin" -u -d "$http_date" +%s 2>/dev/null; then
+    return 0
+  fi
+  LC_ALL=C "$date_bin" -j -u -f "%a, %d %b %Y %H:%M:%S GMT" \
+    "$http_date" +%s
+}
+
 if (($# != 2)); then
   usage
   exit 2
@@ -41,24 +50,6 @@ if [[ ! "$expected_commit" =~ ^[0-9a-f]{40}$ ]]; then
   exit 1
 fi
 
-if [[ "$tag" == "$stable_tag" ]]; then
-  if ! current_epoch="$("$date_bin" -u +%s)"; then
-    printf 'failed to obtain current UTC epoch for stable qualification\n' >&2
-    exit 1
-  fi
-  if [[ ! "$current_epoch" =~ ^[0-9]{1,10}$ ]]; then
-    printf 'invalid current UTC epoch for stable qualification: %s\n' \
-      "$current_epoch" >&2
-    exit 1
-  fi
-  if ((10#$current_epoch < stable_qualification_not_before_epoch)); then
-    printf 'stable qualification window is still open\n' >&2
-    printf 'not-before=%s\ncurrent-epoch=%s\n' \
-      "$stable_qualification_not_before" "$current_epoch" >&2
-    exit 1
-  fi
-fi
-
 remote_url="$("$git_bin" remote get-url "$remote")"
 case "$remote_url" in
   "git@github.com:${repository}.git" | \
@@ -72,6 +63,43 @@ case "$remote_url" in
     exit 1
     ;;
 esac
+
+if [[ "$tag" == "$stable_tag" ]]; then
+  if ! github_headers="$(
+    "$gh_bin" api "repos/$repository" --include --jq empty
+  )"; then
+    printf 'failed to obtain authoritative GitHub time for stable qualification\n' >&2
+    exit 1
+  fi
+  github_date="$(
+    awk '
+      tolower($1) == "date:" {
+        sub(/^[^:]*:[[:space:]]*/, "")
+        sub(/\r$/, "")
+        print
+      }
+    ' <<<"$github_headers"
+  )"
+  if [[ -z "$github_date" ]] || [[ "$(wc -l <<<"$github_date")" -ne 1 ]]; then
+    printf 'authoritative GitHub response did not contain exactly one Date header\n' >&2
+    exit 1
+  fi
+  if ! current_epoch="$(parse_http_date_epoch "$github_date")"; then
+    printf 'failed to parse authoritative GitHub time for stable qualification\n' >&2
+    exit 1
+  fi
+  if [[ ! "$current_epoch" =~ ^[0-9]{1,10}$ ]]; then
+    printf 'invalid authoritative GitHub epoch for stable qualification: %s\n' \
+      "$current_epoch" >&2
+    exit 1
+  fi
+  if ((10#$current_epoch < stable_qualification_not_before_epoch)); then
+    printf 'stable qualification window is still open\n' >&2
+    printf 'not-before=%s\ngithub-date=%s\n' \
+      "$stable_qualification_not_before" "$github_date" >&2
+    exit 1
+  fi
+fi
 
 main_rows="$("$git_bin" ls-remote --heads "$remote" refs/heads/main)"
 main_commit="$(awk '$2 == "refs/heads/main" { print $1 }' <<<"$main_rows")"

--- a/scripts/preflight_origin_release_test.go
+++ b/scripts/preflight_origin_release_test.go
@@ -33,45 +33,79 @@ func TestOriginReleasePreflight(t *testing.T) {
 			name: "clean stable release after qualification boundary",
 			tag:  "v1.0.0",
 			environment: map[string]string{
-				"FAKE_NOW_EPOCH": stableQualificationAfterGate,
+				"FAKE_GITHUB_DATE":  "Wed, 05 Aug 2026 10:13:47 GMT",
+				"FAKE_GITHUB_EPOCH": stableQualificationAfterGate,
+			},
+		},
+		{
+			name: "clean stable release with BSD date parser",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_GNU_DATE_STATUS": "1",
 			},
 		},
 		{
 			name: "stable release before qualification boundary",
 			tag:  "v1.0.0",
 			environment: map[string]string{
-				"FAKE_NOW_EPOCH": stableQualificationTooEarly,
+				"FAKE_GITHUB_DATE":  "Wed, 05 Aug 2026 10:13:45 GMT",
+				"FAKE_GITHUB_EPOCH": stableQualificationTooEarly,
 			},
 			wantError: "stable qualification window is still open",
 		},
 		{
-			name: "stable release rejects invalid current time",
+			name: "stable release rejects missing GitHub date header",
 			tag:  "v1.0.0",
 			environment: map[string]string{
-				"FAKE_NOW_EPOCH": "not-an-epoch",
+				"FAKE_GITHUB_DATE_MISSING": "1",
 			},
-			wantError: "invalid current UTC epoch for stable qualification",
+			wantError: "did not contain exactly one Date header",
 		},
 		{
-			name: "stable release rejects overflowing current time",
+			name: "stable release rejects duplicate GitHub date headers",
 			tag:  "v1.0.0",
 			environment: map[string]string{
-				"FAKE_NOW_EPOCH": "99999999999",
+				"FAKE_GITHUB_DATE_DUPLICATE": "1",
 			},
-			wantError: "invalid current UTC epoch for stable qualification",
+			wantError: "did not contain exactly one Date header",
 		},
 		{
-			name: "stable release fails closed when current time lookup fails",
+			name: "stable release rejects invalid authoritative time",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_GITHUB_EPOCH": "not-an-epoch",
+			},
+			wantError: "invalid authoritative GitHub epoch",
+		},
+		{
+			name: "stable release rejects overflowing authoritative time",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_GITHUB_EPOCH": "99999999999",
+			},
+			wantError: "invalid authoritative GitHub epoch",
+		},
+		{
+			name: "stable release fails closed when GitHub time lookup fails",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_GITHUB_CLOCK_STATUS": "17",
+			},
+			wantError: "failed to obtain authoritative GitHub time",
+		},
+		{
+			name: "stable release fails closed when GitHub time parsing fails",
 			tag:  "v1.0.0",
 			environment: map[string]string{
 				"FAKE_DATE_STATUS": "17",
 			},
-			wantError: "failed to obtain current UTC epoch",
+			wantError: "failed to parse authoritative GitHub time",
 		},
 		{
 			name: "release candidate does not require stable qualification time",
 			environment: map[string]string{
-				"FAKE_DATE_STATUS": "17",
+				"FAKE_GITHUB_CLOCK_STATUS": "17",
+				"FAKE_DATE_STATUS":         "17",
 			},
 		},
 		{
@@ -235,6 +269,23 @@ esac
 	writeExecutable(t, ghStub, `#!/usr/bin/env bash
 set -euo pipefail
 case "$2" in
+  repos/marang/robotgo)
+    if [[ "$3" != "--include" || "$4" != "--jq" || "$5" != "empty" ]]; then
+      exit 2
+    fi
+    if [[ -n "${FAKE_GITHUB_CLOCK_STATUS:-}" ]]; then
+      exit "$FAKE_GITHUB_CLOCK_STATUS"
+    fi
+    printf 'HTTP/2.0 200 OK\n'
+    if [[ -z "${FAKE_GITHUB_DATE_MISSING:-}" ]]; then
+      printf 'Date: %s\n' \
+        "${FAKE_GITHUB_DATE:-Wed, 05 Aug 2026 10:13:46 GMT}"
+      if [[ -n "${FAKE_GITHUB_DATE_DUPLICATE:-}" ]]; then
+        printf 'date: Wed, 05 Aug 2026 10:13:47 GMT\n'
+      fi
+    fi
+    printf '\n'
+    ;;
   */git/matching-refs/tags/v1.0.0)
     printf '%s' "${FAKE_GITHUB_TAGS:-}"
     ;;
@@ -248,13 +299,24 @@ esac
 `)
 	writeExecutable(t, dateStub, `#!/usr/bin/env bash
 set -euo pipefail
-if (($# != 2)) || [[ "$1" != "-u" || "$2" != "+%s" ]]; then
+expected_date="${FAKE_GITHUB_DATE:-Wed, 05 Aug 2026 10:13:46 GMT}"
+if (($# == 4)) &&
+  [[ "$1" == "-u" && "$2" == "-d" && "$3" == "$expected_date" && "$4" == "+%s" ]]; then
+  if [[ -n "${FAKE_GNU_DATE_STATUS:-}" ]]; then
+    exit "$FAKE_GNU_DATE_STATUS"
+  fi
+elif (($# == 6)) &&
+  [[ "$1" == "-j" && "$2" == "-u" && "$3" == "-f" ]] &&
+  [[ "$4" == "%a, %d %b %Y %H:%M:%S GMT" ]] &&
+  [[ "$5" == "$expected_date" && "$6" == "+%s" ]]; then
+  :
+else
   exit 2
 fi
 if [[ -n "${FAKE_DATE_STATUS:-}" ]]; then
   exit "$FAKE_DATE_STATUS"
 fi
-printf '%s\n' "${FAKE_NOW_EPOCH:-1785924826}"
+printf '%s\n' "${FAKE_GITHUB_EPOCH:-1785924826}"
 `)
 
 	environment := append(os.Environ(),

--- a/scripts/preflight_origin_release_test.go
+++ b/scripts/preflight_origin_release_test.go
@@ -8,7 +8,12 @@ import (
 	"testing"
 )
 
-const releaseCommit = "0123456789abcdef0123456789abcdef01234567"
+const (
+	releaseCommit                = "0123456789abcdef0123456789abcdef01234567"
+	stableQualificationBoundary  = "1785924826"
+	stableQualificationTooEarly  = "1785924825"
+	stableQualificationAfterGate = "1785924827"
+)
 
 func TestOriginReleasePreflight(t *testing.T) {
 	t.Parallel()
@@ -20,7 +25,55 @@ func TestOriginReleasePreflight(t *testing.T) {
 		wantError   string
 	}{
 		{name: "clean authoritative origin"},
-		{name: "clean stable release", tag: "v1.0.0"},
+		{
+			name: "clean stable release at qualification boundary",
+			tag:  "v1.0.0",
+		},
+		{
+			name: "clean stable release after qualification boundary",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_NOW_EPOCH": stableQualificationAfterGate,
+			},
+		},
+		{
+			name: "stable release before qualification boundary",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_NOW_EPOCH": stableQualificationTooEarly,
+			},
+			wantError: "stable qualification window is still open",
+		},
+		{
+			name: "stable release rejects invalid current time",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_NOW_EPOCH": "not-an-epoch",
+			},
+			wantError: "invalid current UTC epoch for stable qualification",
+		},
+		{
+			name: "stable release rejects overflowing current time",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_NOW_EPOCH": "99999999999",
+			},
+			wantError: "invalid current UTC epoch for stable qualification",
+		},
+		{
+			name: "stable release fails closed when current time lookup fails",
+			tag:  "v1.0.0",
+			environment: map[string]string{
+				"FAKE_DATE_STATUS": "17",
+			},
+			wantError: "failed to obtain current UTC epoch",
+		},
+		{
+			name: "release candidate does not require stable qualification time",
+			environment: map[string]string{
+				"FAKE_DATE_STATUS": "17",
+			},
+		},
 		{
 			name: "wrong origin repository",
 			environment: map[string]string{
@@ -90,6 +143,16 @@ func TestOriginReleasePreflight(t *testing.T) {
 					!strings.Contains(output, "commit="+releaseCommit) {
 					t.Fatalf("preflight output missing success identity:\n%s", output)
 				}
+				if test.tag == "v1.0.0" &&
+					!strings.Contains(
+						output,
+						"stable-not-before=2026-08-05T10:13:46Z",
+					) {
+					t.Fatalf(
+						"stable preflight output missing qualification boundary:\n%s",
+						output,
+					)
+				}
 				return
 			}
 			if err == nil {
@@ -132,6 +195,7 @@ func runOriginReleasePreflight(
 	temporaryDirectory := t.TempDir()
 	gitStub := filepath.Join(temporaryDirectory, "git")
 	ghStub := filepath.Join(temporaryDirectory, "gh")
+	dateStub := filepath.Join(temporaryDirectory, "date")
 	writeExecutable(t, gitStub, `#!/usr/bin/env bash
 set -euo pipefail
 case "$1" in
@@ -182,10 +246,21 @@ case "$2" in
     ;;
 esac
 `)
+	writeExecutable(t, dateStub, `#!/usr/bin/env bash
+set -euo pipefail
+if (($# != 2)) || [[ "$1" != "-u" || "$2" != "+%s" ]]; then
+  exit 2
+fi
+if [[ -n "${FAKE_DATE_STATUS:-}" ]]; then
+  exit "$FAKE_DATE_STATUS"
+fi
+printf '%s\n' "${FAKE_NOW_EPOCH:-1785924826}"
+`)
 
 	environment := append(os.Environ(),
 		"ROBOTGO_RELEASE_GIT_BIN="+gitStub,
 		"ROBOTGO_RELEASE_GH_BIN="+ghStub,
+		"ROBOTGO_RELEASE_DATE_BIN="+dateStub,
 		"FAKE_MAIN_COMMIT="+releaseCommit,
 	)
 	for key, value := range overrides {


### PR DESCRIPTION
## Outcome

- makes the seven-day v1.0.0 qualification window a fail-closed release-preflight gate
- rejects stable publication before `2026-08-05T10:13:46Z`, the exact first allowed instant derived from the published RC timestamp
- rejects missing, malformed, or overflowing UTC epoch output instead of permitting publication
- keeps RC-tag preflight independent of the stable-only time gate
- records the gate and observed early rejection in the stable qualification log, operator guide, and changelog

## Why

The seven-day window was previously a documented operator rule only. A mistaken early stable command could pass the origin/tag/release checks even though publication was still prohibited. The release preflight now enforces the same boundary mechanically.

GitHub identifies the authoritative `v1.0.0-rc.1` publication time as `2026-07-29T10:13:46Z`; seven full days end at the encoded boundary.

## Risk and fallback

This affects only `scripts/preflight-origin-release.sh` when the requested tag is exactly `v1.0.0`. It does not create tags, releases, files, or external artifacts. A clock-command failure or unexpected value aborts. RC preflight behavior remains unchanged.

If qualification is reset by a critical/high regression, the boundary must be intentionally updated in a reviewed follow-up rather than bypassed at runtime.

## Validation

- `go test ./...`
- `go test ./scripts -run 'TestOriginReleasePreflight' -count=1`
- `./scripts/run-local-ci-preflight.sh`
- `bash -n scripts/preflight-origin-release.sh`
- actual pre-boundary invocation rejected with `stable qualification window is still open`
- `git diff --check`

The deterministic suite covers one second before the boundary, the exact boundary, after the boundary, malformed and overflowing timestamps, clock-command failure, and unaffected RC tags.

Linear: https://linear.app/riotbox/issue/LAB-68/qualify-and-publish-robotgo-v100-stable