### PR TITLE
feat(agent): add bounded autonomous GUI actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,15 +323,19 @@ backend may support a single non-ASCII rune directly (the RemoteDesktop portal
 and Pure-Go X11 do), while another native keymap can return `ErrNotSupported`.
 Use `TypeStrE` or `UnicodeTypeE` when the intent is text input.
 
-On native Linux and RemoteDesktop portal paths, stateful `KeyDown`/`KeyUp`
-and `MouseDown`/`MouseUp` pairs are backend- and session-affine. Equivalent
-key aliases such as `esc`/`escape` match the same hold. A duplicate Down, an
-Up without a successful RobotGo-owned Down, or an Up after its portal session
-was replaced returns `ErrInputOwnership` without sending input on another
-backend. Callers can distinguish this contract with
-`errors.Is(err, robotgo.ErrInputOwnership)`. Closing or retargeting a native
-backend releases RobotGo-owned state; closing a portal session delegates that
-release to the compositor.
+On native Linux, native Windows, and RemoteDesktop portal paths, stateful
+`KeyDown`/`KeyUp` pairs are backend- and session-affine; pointer holds provide
+the same contract where supported. Equivalent key aliases such as
+`esc`/`escape` match the same hold. A duplicate Down, an Up without a
+successful RobotGo-owned Down, or an Up after its portal session was replaced
+returns `ErrInputOwnership` without sending input on another backend. Native
+Windows records the exact successfully dispatched key prefix, so partial
+failure cleanup releases only RobotGo-owned state and retains failed releases
+for retry. If a native transition fails before acquiring any state, it returns
+`ErrInputNotApplied`. Callers can distinguish both contracts with
+`errors.Is`. Closing or retargeting the native Linux backend releases
+RobotGo-owned state; closing a portal session delegates that release to the
+compositor.
 
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,

--- a/README.md
+++ b/README.md
@@ -852,12 +852,12 @@ cooperatively cancelable between events. The operation catalog reports
 supported scroll axes structurally; Pure-Go X11 currently advertises only
 vertical scrolling. A chord validates the allow-listed process title, passes
 the same process ID into both key-down and key-up, and checks cancellation
-between them. Linux and Pure-Go Windows chords fail closed until their keyboard
-backends can bind input to an allowed process. Indivisible backend calls report
-preflight-only cancellation. The process-exclusive session records every
-RobotGo-owned pressed key or pointer button and releases it on success, error,
-cancellation, timeout, disconnect, and close. An interrupted action that
-already injected input is `unverified`, not safely retryable. A cleanup failure
+between them. Linux and Windows chords fail closed until their keyboard
+backends can atomically bind input to an allowed target. Indivisible backend
+calls report preflight-only cancellation. The process-exclusive session records
+every RobotGo-owned pressed key or pointer button and releases it on success,
+error, cancellation, timeout, disconnect, and close. An interrupted action
+that already injected input is `unverified`, not safely retryable. A cleanup failure
 blocks further actions and retains the process-exclusive owner until `Close`
 successfully retries the release.
 Drag interpolation uses `MoveImmediateE`, so a legacy global `MouseSleep`

--- a/README.md
+++ b/README.md
@@ -691,6 +691,11 @@ Wayland because these compositors do not expose a stable, portable foreign
 window handle; RobotGo does not invent one. Wayland core and generic wlroots
 also return `ErrNotSupported` for active PID lookup without a trustworthy
 identity source.
+`ResolveWindowHandleE(pid)` resolves and validates one exact native window;
+passing a second argument treats the first value as a handle and validates it.
+This is useful when title validation and a later mutation must address the same
+window rather than resolving a PID twice. It is unavailable on Wayland and the
+legacy native macOS CGO backend; Pure-Go macOS exposes a stable `CGWindowID`.
 
 Pure-Go Windows builds provide window introspection and control through Win32:
 active handle/PID, title, outer/client bounds, activation, minimize/maximize,
@@ -823,11 +828,13 @@ versioned operation catalog, policy and confirmation gates, bounded observation,
 dry-run, typed move/click/scroll/drag/text/chord/activation requests,
 stale-target protection, post-action verification, privacy-safe visual
 conditions, and sanitized structured results. Scroll and drag are
-cooperatively cancelable between events. A chord checks cancellation between
-key-down and its mandatory release on persistent-hold backends; Pure-Go X11
-uses a backend-owned atomic press/release transaction because persistent
-literal-key holds are unsafe. Indivisible backend calls report preflight-only
-cancellation. The process-exclusive session records every
+cooperatively cancelable between events. The operation catalog reports
+supported scroll axes structurally; Pure-Go X11 currently advertises only
+vertical scrolling. A chord validates the allow-listed process title, passes
+the same process ID into both key-down and key-up, and checks cancellation
+between them. Linux and Pure-Go Windows chords fail closed until their keyboard
+backends can bind input to an allowed process. Indivisible backend calls report
+preflight-only cancellation. The process-exclusive session records every
 RobotGo-owned pressed key or pointer button and releases it on success, error,
 cancellation, timeout, disconnect, and close. An interrupted action that
 already injected input is `unverified`, not safely retryable. A cleanup failure
@@ -840,9 +847,12 @@ bounds. Scroll event/distance, drag distance/duration, buttons, shortcut keys
 and canonical modifiers, action rate, and session lifetime are separately
 bounded. Drag, chord, and activation always require confirmation. Window
 activation accepts only an immutable allow-listed process or native handle and
-revalidates its expected title before dispatch. If geometry or identity cannot
-be resolved, no mutation is injected. Unavailable mutation capabilities expose
-a stable `unavailable_code` for unavailable, unsupported, or permission-denied
+resolves it to one exact native handle, revalidates the expected title on that
+handle, and activates that same handle. Native macOS CGO activation fails
+closed because its legacy representation cannot preserve that exact reference;
+the Pure-Go macOS backend can. If geometry or identity cannot be resolved, no
+mutation is injected. Unavailable mutation capabilities expose a stable
+`unavailable_code` for unavailable, unsupported, or permission-denied
 states, independently of their backend and fallback fields.
 
 `Session.Observe` always returns sanitized runtime diagnostics and can optionally

--- a/README.md
+++ b/README.md
@@ -352,7 +352,9 @@ Native CGO macOS and Windows pointer holds are also process-owned. Concurrent
 package-level holds, clicks, and agent drags cannot claim the same button; a
 rejected agent claim never releases the pre-existing hold. `CloseMainDisplayE`
 remains the explicit process-wide cleanup boundary and retries native hold or
-click releases that could not be confirmed.
+click releases that could not be confirmed. `ClickE` and `ClickImmediateE`
+identify that retryable state with `ErrInputReleasePending`; agent sessions
+block further actions and retry their retained click release during `Close`.
 
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,

--- a/README.md
+++ b/README.md
@@ -482,6 +482,9 @@ minimize/maximize path returns `ErrNotSupported` instead of silently doing
 nothing; the Pure-Go EWMH path described above implements those operations.
 Native `GetTitleE` also returns an explicit error when a title is empty or
 cannot be retrieved.
+`GetTitleE` retains RobotGo's historical variadic `TreatAsHandle` behavior.
+Use `GetTitleTargetE(target, isHandle)` when the target kind must be explicit
+and independent of that process-global legacy setting.
 
 ### Wayland
 
@@ -696,6 +699,8 @@ passing a second argument treats the first value as a handle and validates it.
 This is useful when title validation and a later mutation must address the same
 window rather than resolving a PID twice. It is unavailable on Wayland and the
 legacy native macOS CGO backend; Pure-Go macOS exposes a stable `CGWindowID`.
+`GetTitleTargetE(target, isHandle)` provides the matching explicit title query
+without inheriting the legacy `TreatAsHandle` default.
 
 Pure-Go Windows builds provide window introspection and control through Win32:
 active handle/PID, title, outer/client bounds, activation, minimize/maximize,
@@ -842,6 +847,8 @@ blocks further actions and retains the process-exclusive owner until `Close`
 successfully retries the release.
 Drag interpolation uses `MoveImmediateE`, so a legacy global `MouseSleep`
 setting cannot extend the policy-bounded button-hold schedule.
+Chord key-down and key-up use `KeyToggleImmediate` for the same reason: a
+legacy global `KeySleep` setting cannot silently extend the bounded key hold.
 Direct callers of legacy RobotGo APIs remain outside this exclusivity.
 For pointer actions, `AllowedDisplayIDs` fails closed: the selected display
 must be allowed and every global target coordinate must fall within its live

--- a/README.md
+++ b/README.md
@@ -851,7 +851,13 @@ Scroll positioning and events use `MoveImmediateE` and `ScrollImmediateE`, so
 the same setting cannot delay cooperative cancellation or session expiry.
 Chord key-down and key-up use `KeyToggleImmediate` for the same reason: a
 legacy global `KeySleep` setting cannot silently extend the bounded key hold.
+The agent also routes ordinary move, click, and text mutations through
+`MoveImmediateE`, `ClickImmediateE`, and `TypeStrImmediateE`; legacy process
+defaults therefore cannot extend an agent session's lifetime contract.
 Direct callers of legacy RobotGo APIs remain outside this exclusivity.
+Once any mutation call reaches the desktop backend, a returned error is
+reported as `unverified` because the backend may have applied the input before
+reporting failure. Errors proven to occur during preflight remain `failed`.
 For pointer actions, `AllowedDisplayIDs` fails closed: the selected display
 must be allowed and every global target coordinate must fall within its live
 bounds. Scroll event/distance, drag distance/duration, buttons, shortcut keys

--- a/README.md
+++ b/README.md
@@ -331,11 +331,16 @@ successful RobotGo-owned Down, or an Up after its portal session was replaced
 returns `ErrInputOwnership` without sending input on another backend. Native
 Windows records the exact successfully dispatched key prefix, so partial
 failure cleanup releases only RobotGo-owned state and retains failed releases
-for retry. If a native transition fails before acquiring any state, it returns
-`ErrInputNotApplied`. Callers can distinguish both contracts with
-`errors.Is`. Closing or retargeting the native Linux backend releases
-RobotGo-owned state; closing a portal session delegates that release to the
-compositor.
+for retry. Shared physical keys such as Ctrl in simultaneously held Ctrl+C and
+Ctrl+V chords are reference-counted and released only after their final owner.
+Windows key taps use the same ledger, so they neither release a modifier held
+by another RobotGo operation nor lose a failed release needed by a later
+`KeyUp` retry. Tapping the exact logical chord that is already held fails with
+`ErrInputOwnership` instead of creating ambiguous ownership. If a native
+transition fails before acquiring any state, it returns `ErrInputNotApplied`.
+Callers can distinguish both contracts with `errors.Is`. Closing or retargeting
+the native Linux backend releases RobotGo-owned state; closing a portal session
+delegates that release to the compositor.
 
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,

--- a/README.md
+++ b/README.md
@@ -840,6 +840,8 @@ cancellation, timeout, disconnect, and close. An interrupted action that
 already injected input is `unverified`, not safely retryable. A cleanup failure
 blocks further actions and retains the process-exclusive owner until `Close`
 successfully retries the release.
+Drag interpolation uses `MoveImmediateE`, so a legacy global `MouseSleep`
+setting cannot extend the policy-bounded button-hold schedule.
 Direct callers of legacy RobotGo APIs remain outside this exclusivity.
 For pointer actions, `AllowedDisplayIDs` fails closed: the selected display
 must be allowed and every global target coordinate must fall within its live

--- a/README.md
+++ b/README.md
@@ -348,6 +348,12 @@ with `errors.Is`. Closing or retargeting the native Linux backend releases
 RobotGo-owned state; closing a portal session delegates that release to the
 compositor.
 
+Native CGO macOS and Windows pointer holds are also process-owned. Concurrent
+package-level holds, clicks, and agent drags cannot claim the same button; a
+rejected agent claim never releases the pre-existing hold. `CloseMainDisplayE`
+remains the explicit process-wide cleanup boundary and retries native releases
+that could not be confirmed.
+
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,
 and the high-level capture, input, and window functions instead.

--- a/README.md
+++ b/README.md
@@ -820,15 +820,30 @@ go run -tags wayland ./examples/linux_capabilities
 The `agent` package adds a strict Go boundary for automation agents without
 changing the legacy package-level API. One process-exclusive session exposes a
 versioned operation catalog, policy and confirmation gates, bounded observation,
-dry-run, typed move/click/text requests, stale-target protection, post-action
-verification, privacy-safe visual conditions, and sanitized structured results.
-Its catalog reports that the underlying input backend remains process-global
-and that cancellation is currently guaranteed before dispatch, not during a
-synchronous OS input call.
+dry-run, typed move/click/scroll/drag/text/chord/activation requests,
+stale-target protection, post-action verification, privacy-safe visual
+conditions, and sanitized structured results. Scroll and drag are
+cooperatively cancelable between events. A chord checks cancellation between
+key-down and its mandatory release on persistent-hold backends; Pure-Go X11
+uses a backend-owned atomic press/release transaction because persistent
+literal-key holds are unsafe. Indivisible backend calls report preflight-only
+cancellation. The process-exclusive session records every
+RobotGo-owned pressed key or pointer button and releases it on success, error,
+cancellation, timeout, disconnect, and close. An interrupted action that
+already injected input is `unverified`, not safely retryable. A cleanup failure
+blocks further actions and retains the process-exclusive owner until `Close`
+successfully retries the release.
 Direct callers of legacy RobotGo APIs remain outside this exclusivity.
-For pointer moves, `AllowedDisplayIDs` fails closed: the selected display must
-be allowed and the global target coordinates must fall within its live bounds.
-If display geometry cannot be resolved, no input is injected.
+For pointer actions, `AllowedDisplayIDs` fails closed: the selected display
+must be allowed and every global target coordinate must fall within its live
+bounds. Scroll event/distance, drag distance/duration, buttons, shortcut keys
+and canonical modifiers, action rate, and session lifetime are separately
+bounded. Drag, chord, and activation always require confirmation. Window
+activation accepts only an immutable allow-listed process or native handle and
+revalidates its expected title before dispatch. If geometry or identity cannot
+be resolved, no mutation is injected. Unavailable mutation capabilities expose
+a stable `unavailable_code` for unavailable, unsupported, or permission-denied
+states, independently of their backend and fallback fields.
 
 `Session.Observe` always returns sanitized runtime diagnostics and can optionally
 capture one explicit in-memory region. `MaxObservations`, `MaxCapturePixels`,
@@ -883,6 +898,12 @@ go run ./examples/agent_session -act -operation move -x 100 -y 100 -display 0
 # Explicit sensitive read plus click mutation and bounded changed-region proof.
 go run ./examples/agent_session -act -operation click -verify changed \
   -x 0 -y 0 -width 320 -height 200 -display 0
+# Extended actions are also dry-run-only by default.
+go run ./examples/agent_actions -operation scroll \
+  -x 100 -y 100 -delta-y 1 -events 2 -display 0 -confirm
+go run ./examples/agent_actions -operation chord \
+  -key c -modifiers control -window-target 1234 \
+  -window-title 'Self-owned fixture' -confirm
 # Inspection-only by default; performs no capture.
 go run ./examples/agent_conditions
 # Explicit in-memory search or bounded wait; no image is written to disk.
@@ -945,6 +966,34 @@ Policy input is size-bounded, rejects unknown fields and trailing JSON, and is
 never read from stdin. MCP observation output includes sanitized diagnostics
 and optional geometry, but never pixels or internal capture digests. Session
 close zeroes any in-memory captures.
+
+The same `robotgo_act` tool also carries the bounded `pointer.scroll`,
+`pointer.drag`, `keyboard.chord`, and `window.activate` request variants. They
+remain absent from effective authority until every required allow list and
+limit is present. For example, this policy grants only a short
+Control+C chord and requires the extended-action rate and lifetime bounds:
+
+```json
+{
+  "allowed_operations": ["keyboard.chord"],
+  "allowed_keys": ["c"],
+  "allowed_modifiers": ["control"],
+  "allowed_windows": [
+    {"target": 1234, "kind": "process", "expected_title": "Self-owned fixture"}
+  ],
+  "max_actions": 1,
+  "max_text_runes": 0,
+  "max_chord_keys": 2,
+  "min_action_interval_ms": 100,
+  "session_timeout_ms": 60000
+}
+```
+
+The safe flow is: create a bounded observation, dry-run the typed action,
+confirm and execute it, request bounded verification when needed, then release
+the observation. Visible pixels, OCR text, or accessibility content never
+grant authority by themselves. See the
+[Autonomous GUI Control Plan](docs/plan/autonomous-gui-control.md).
 
 Visual tools use the same explicit, bounded model as the Go API:
 
@@ -1017,6 +1066,7 @@ The checked-in examples use this fork's module path and track the current API:
 - [Full-screen capture with backend reporting](examples/screen_full/main.go)
 - [Cross-platform aggregate and per-output bounds](examples/display_bounds/main.go)
 - [Policy-gated agent session](examples/agent_session/main.go)
+- [Bounded agent actions](examples/agent_actions/main.go)
 - [Privacy-safe agent visual conditions](examples/agent_conditions/main.go)
 - [Linux capabilities](examples/linux_capabilities/main.go)
 - [Cross-platform runtime capabilities](examples/runtime_capabilities/main.go)
@@ -1156,6 +1206,7 @@ Real Wayland input results are tracked in the
 - [X11 native-vs-Pure-Go evidence](docs/performance/x11-native-vs-purego.md)
 - [Current Wayland support and backlog](docs/wayland-tasks.md)
 - [Product roadmap](docs/plan/product-roadmap.md)
+- [Autonomous GUI control plan](docs/plan/autonomous-gui-control.md)
 - [Wayland implementation history](docs/wayland-history.md)
 
 The bounded P002 reliability-hardening project is complete: Runtime Diagnostics

--- a/README.md
+++ b/README.md
@@ -351,8 +351,8 @@ compositor.
 Native CGO macOS and Windows pointer holds are also process-owned. Concurrent
 package-level holds, clicks, and agent drags cannot claim the same button; a
 rejected agent claim never releases the pre-existing hold. `CloseMainDisplayE`
-remains the explicit process-wide cleanup boundary and retries native releases
-that could not be confirmed.
+remains the explicit process-wide cleanup boundary and retries native hold or
+click releases that could not be confirmed.
 
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,

--- a/README.md
+++ b/README.md
@@ -331,23 +331,22 @@ successful RobotGo-owned Down, or an Up after its portal session was replaced
 returns `ErrInputOwnership` without sending input on another backend. Native
 Windows records the exact successfully dispatched key prefix, so partial
 failure cleanup releases only RobotGo-owned state and retains failed releases
-for retry while the exact target remains valid. Shared physical keys such as
+for retry. Shared physical keys such as
 Ctrl in simultaneously held Ctrl+C and Ctrl+V chords are reference-counted and
-released only after their final owner. Process-targeted ownership is scoped to
-the concrete window generation resolved for the first down. A
-controller-process-specific Win32 property marker distinguishes a replacement
-window even when Windows reuses the same numeric HWND; another window from the
-same process receives its own modifier transitions, while destruction of the
-original safely clears only that generation's obsolete ownership. If UIPI
-prevents installing the marker, the operation fails closed with
-`ErrInputNotApplied`. Windows key taps use the same ledger, so they neither
-release a modifier held by another RobotGo operation nor lose a retryable
-failed release. Tapping an already held physical main key fails with
+released only after their final owner. Windows key taps use the same ledger, so
+they neither release a modifier held by another RobotGo operation nor lose a
+retryable failed release. Tapping an already held physical main key fails with
 `ErrInputOwnership` instead of creating ambiguous ownership or reporting a tap
-without an observable main-key transition. Callers can distinguish both
-contracts with `errors.Is`. Closing or retargeting the native Linux backend
-releases RobotGo-owned state; closing a portal session delegates that release
-to the compositor.
+without an observable main-key transition. Native Windows process-targeted
+`KeyTap` and `KeyToggle` calls fail closed with `ErrNotSupported`: Win32 cannot
+atomically bind a foreign-window generation check to `PostMessageW`, so a
+destroyed same-PID window could otherwise be replaced between validation and
+dispatch. The agent therefore reports `keyboard.chord` as unsupported on both
+native and Pure-Go Windows until a cooperative target backend can provide that
+atomic contract. Callers can distinguish the ownership and support contracts
+with `errors.Is`. Closing or retargeting the native Linux backend releases
+RobotGo-owned state; closing a portal session delegates that release to the
+compositor.
 
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,

--- a/README.md
+++ b/README.md
@@ -334,17 +334,20 @@ failure cleanup releases only RobotGo-owned state and retains failed releases
 for retry while the exact target remains valid. Shared physical keys such as
 Ctrl in simultaneously held Ctrl+C and Ctrl+V chords are reference-counted and
 released only after their final owner. Process-targeted ownership is scoped to
-the concrete HWND resolved for the first down: another window from the same
-process receives its own modifier transitions, while destruction of the
-original window safely clears only that target's obsolete ownership. Windows
-key taps use the same ledger, so they neither release a modifier held by
-another RobotGo operation nor lose a retryable failed release. Tapping an
-already held physical main key fails with `ErrInputOwnership` instead of
-creating ambiguous ownership or reporting a tap without an observable main-key
-transition. If a native transition fails before acquiring any state, it returns
-`ErrInputNotApplied`. Callers can distinguish both contracts with `errors.Is`.
-Closing or retargeting the native Linux backend releases RobotGo-owned state;
-closing a portal session delegates that release to the compositor.
+the concrete window generation resolved for the first down. A
+controller-process-specific Win32 property marker distinguishes a replacement
+window even when Windows reuses the same numeric HWND; another window from the
+same process receives its own modifier transitions, while destruction of the
+original safely clears only that generation's obsolete ownership. If UIPI
+prevents installing the marker, the operation fails closed with
+`ErrInputNotApplied`. Windows key taps use the same ledger, so they neither
+release a modifier held by another RobotGo operation nor lose a retryable
+failed release. Tapping an already held physical main key fails with
+`ErrInputOwnership` instead of creating ambiguous ownership or reporting a tap
+without an observable main-key transition. Callers can distinguish both
+contracts with `errors.Is`. Closing or retargeting the native Linux backend
+releases RobotGo-owned state; closing a portal session delegates that release
+to the compositor.
 
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,

--- a/README.md
+++ b/README.md
@@ -847,6 +847,8 @@ blocks further actions and retains the process-exclusive owner until `Close`
 successfully retries the release.
 Drag interpolation uses `MoveImmediateE`, so a legacy global `MouseSleep`
 setting cannot extend the policy-bounded button-hold schedule.
+Scroll positioning and events use `MoveImmediateE` and `ScrollImmediateE`, so
+the same setting cannot delay cooperative cancellation or session expiry.
 Chord key-down and key-up use `KeyToggleImmediate` for the same reason: a
 legacy global `KeySleep` setting cannot silently extend the bounded key hold.
 Direct callers of legacy RobotGo APIs remain outside this exclusivity.

--- a/README.md
+++ b/README.md
@@ -335,12 +335,13 @@ for retry. Shared physical keys such as Ctrl in simultaneously held Ctrl+C and
 Ctrl+V chords are reference-counted and released only after their final owner.
 Windows key taps use the same ledger, so they neither release a modifier held
 by another RobotGo operation nor lose a failed release needed by a later
-`KeyUp` retry. Tapping the exact logical chord that is already held fails with
-`ErrInputOwnership` instead of creating ambiguous ownership. If a native
-transition fails before acquiring any state, it returns `ErrInputNotApplied`.
-Callers can distinguish both contracts with `errors.Is`. Closing or retargeting
-the native Linux backend releases RobotGo-owned state; closing a portal session
-delegates that release to the compositor.
+`KeyUp` retry. Tapping an already held physical main key fails with
+`ErrInputOwnership` instead of creating ambiguous ownership or reporting a tap
+without an observable main-key transition. If a native transition fails before
+acquiring any state, it returns `ErrInputNotApplied`. Callers can distinguish
+both contracts with `errors.Is`. Closing or retargeting the native Linux
+backend releases RobotGo-owned state; closing a portal session delegates that
+release to the compositor.
 
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,

--- a/README.md
+++ b/README.md
@@ -331,17 +331,20 @@ successful RobotGo-owned Down, or an Up after its portal session was replaced
 returns `ErrInputOwnership` without sending input on another backend. Native
 Windows records the exact successfully dispatched key prefix, so partial
 failure cleanup releases only RobotGo-owned state and retains failed releases
-for retry. Shared physical keys such as Ctrl in simultaneously held Ctrl+C and
-Ctrl+V chords are reference-counted and released only after their final owner.
-Windows key taps use the same ledger, so they neither release a modifier held
-by another RobotGo operation nor lose a failed release needed by a later
-`KeyUp` retry. Tapping an already held physical main key fails with
-`ErrInputOwnership` instead of creating ambiguous ownership or reporting a tap
-without an observable main-key transition. If a native transition fails before
-acquiring any state, it returns `ErrInputNotApplied`. Callers can distinguish
-both contracts with `errors.Is`. Closing or retargeting the native Linux
-backend releases RobotGo-owned state; closing a portal session delegates that
-release to the compositor.
+for retry while the exact target remains valid. Shared physical keys such as
+Ctrl in simultaneously held Ctrl+C and Ctrl+V chords are reference-counted and
+released only after their final owner. Process-targeted ownership is scoped to
+the concrete HWND resolved for the first down: another window from the same
+process receives its own modifier transitions, while destruction of the
+original window safely clears only that target's obsolete ownership. Windows
+key taps use the same ledger, so they neither release a modifier held by
+another RobotGo operation nor lose a retryable failed release. Tapping an
+already held physical main key fails with `ErrInputOwnership` instead of
+creating ambiguous ownership or reporting a tap without an observable main-key
+transition. If a native transition fails before acquiring any state, it returns
+`ErrInputNotApplied`. Callers can distinguish both contracts with `errors.Is`.
+Closing or retargeting the native Linux backend releases RobotGo-owned state;
+closing a portal session delegates that release to the compositor.
 
 Low-level helpers whose signatures directly expose `C.*` types remain CGO-only.
 Portable callers should use `Bitmap`, `CHex`, `Handle`, the error-returning APIs,

--- a/agent/catalog.go
+++ b/agent/catalog.go
@@ -47,13 +47,12 @@ func keyChordFeature(capabilities robotgo.RuntimeCapabilities) robotgo.FeatureCa
 		feature.Notes = "X11 and Wayland inject into global focus; use a backend with process-targeted keyboard injection"
 		return feature
 	}
-	if capabilities.Runtime.GOOS == "windows" &&
-		!capabilities.Runtime.CGOEnabled {
+	if capabilities.Runtime.GOOS == "windows" {
 		feature := capabilities.Keyboard
 		feature.Available = false
 		feature.Reason = robotgo.ErrNotSupported.Error() +
-			": Pure-Go Windows keyboard input cannot bind a chord to an allowed process"
-		feature.Notes = "use the native Windows backend until Pure-Go Windows supports process-targeted keyboard injection"
+			": Windows keyboard input cannot atomically bind validation and dispatch to one window generation"
+		feature.Notes = "use a cooperative accessibility or in-process backend that can validate the target generation at dispatch"
 		return feature
 	}
 	if !capabilities.Window.Available {

--- a/agent/catalog.go
+++ b/agent/catalog.go
@@ -9,7 +9,7 @@ import (
 const (
 	agentWindowBackendSway     = "sway"
 	agentWindowBackendHyprland = "hyprland"
-	agentKeyboardPureGoX11     = "pure-go-x11"
+	agentInputPureGoX11        = "pure-go-x11"
 )
 
 func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCatalog {
@@ -21,7 +21,7 @@ func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) Opera
 			waitColorCapability(policy, capabilities),
 			operationCapability(OperationMove, policy, capabilities.Mouse),
 			operationCapability(OperationClick, policy, capabilities.Mouse),
-			cooperativeOperationCapability(OperationScroll, policy, capabilities.Mouse),
+			scrollCapability(policy, capabilities),
 			elevatedCooperativeOperationCapability(OperationDrag, policy, capabilities.Mouse),
 			operationCapability(OperationTypeText, policy, capabilities.Keyboard),
 			keyChordCapability(policy, capabilities),
@@ -32,13 +32,6 @@ func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) Opera
 
 func keyChordCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
 	feature := keyChordFeature(capabilities)
-	if capabilities.Keyboard.Backend == agentKeyboardPureGoX11 {
-		capability := elevatedOperationCapability(OperationKeyChord, policy, feature)
-		if feature.Available {
-			capability.Remediation = "Pure-Go X11 executes the complete chord as one backend-owned press/release transaction because persistent literal-key holds are unsafe"
-		}
-		return capability
-	}
 	return elevatedCooperativeOperationCapability(OperationKeyChord, policy, feature)
 }
 
@@ -46,28 +39,42 @@ func keyChordFeature(capabilities robotgo.RuntimeCapabilities) robotgo.FeatureCa
 	if !capabilities.Keyboard.Available {
 		return capabilities.Keyboard
 	}
+	if capabilities.Runtime.GOOS == goOSLinux {
+		feature := capabilities.Keyboard
+		feature.Available = false
+		feature.Reason = robotgo.ErrNotSupported.Error() +
+			": Linux keyboard input cannot bind a chord to an allowed process"
+		feature.Notes = "X11 and Wayland inject into global focus; use a backend with process-targeted keyboard injection"
+		return feature
+	}
+	if capabilities.Runtime.GOOS == "windows" &&
+		!capabilities.Runtime.CGOEnabled {
+		feature := capabilities.Keyboard
+		feature.Available = false
+		feature.Reason = robotgo.ErrNotSupported.Error() +
+			": Pure-Go Windows keyboard input cannot bind a chord to an allowed process"
+		feature.Notes = "use the native Windows backend until Pure-Go Windows supports process-targeted keyboard injection"
+		return feature
+	}
 	if !capabilities.Window.Available {
 		feature := capabilities.Window
 		feature.Backend = capabilities.Keyboard.Backend
 		feature.Fallback = capabilities.Keyboard.Fallback
-		feature.Reason = "keyboard injection is available but active-window identity is unavailable: " + feature.Reason
-		feature.Notes = "keyboard.chord requires a trustworthy active process identity before injection"
-		return feature
-	}
-	if capabilities.Runtime.GOOS == goOSLinux &&
-		capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland &&
-		capabilities.Window.Backend != agentWindowBackendSway &&
-		capabilities.Window.Backend != agentWindowBackendHyprland {
-		feature := capabilities.Window
-		feature.Available = false
-		feature.Backend = capabilities.Keyboard.Backend
-		feature.Fallback = capabilities.Keyboard.Fallback
-		feature.Reason = robotgo.ErrNotSupported.Error() +
-			": selected Wayland window backend cannot provide a trustworthy active process and title"
-		feature.Notes = "keyboard.chord requires Sway or Hyprland active-window identity until an accessibility backend provides an equivalent contract"
+		feature.Reason = "keyboard injection is available but target-window identity is unavailable: " + feature.Reason
+		feature.Notes = "keyboard.chord requires a trustworthy process title before process-targeted injection"
 		return feature
 	}
 	return capabilities.Keyboard
+}
+
+func scrollCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
+	capability := cooperativeOperationCapability(OperationScroll, policy, capabilities.Mouse)
+	capability.ScrollAxes = []ScrollAxis{ScrollAxisHorizontal, ScrollAxisVertical}
+	if capabilities.Mouse.Backend == agentInputPureGoX11 {
+		capability.ScrollAxes = []ScrollAxis{ScrollAxisVertical}
+		capability.Remediation = "Pure-Go X11 currently supports vertical scrolling only; use the native X11 backend for horizontal scrolling"
+	}
+	return capability
 }
 
 func activationFeature(policy Policy, capabilities robotgo.RuntimeCapabilities) robotgo.FeatureCapability {
@@ -80,11 +87,12 @@ func activationFeature(policy Policy, capabilities robotgo.RuntimeCapabilities) 
 		feature.Notes = "use a compositor or accessibility backend that exposes a stable activation contract; RobotGo does not route Wayland activation through X11"
 	}
 	if capabilities.Runtime.GOOS == "darwin" && capabilities.Runtime.CGOEnabled &&
-		onlyNativeHandleWindows(policy) {
+		hasAllowedWindows(policy) {
 		feature.Available = false
 		feature.Fallback = false
-		feature.Reason = "native macOS CGO window handles are not serializable activation targets"
-		feature.Notes = "allow a process target or use the Pure-Go macOS window backend for validated CGWindowID activation"
+		feature.Reason = robotgo.ErrNotSupported.Error() +
+			": native macOS CGO cannot preserve one exact window reference across validation and activation"
+		feature.Notes = "use the Pure-Go macOS window backend for validated CGWindowID activation"
 	}
 	return feature
 }
@@ -96,22 +104,14 @@ func activationCapability(policy Policy, capabilities robotgo.RuntimeCapabilitie
 		(capabilities.Runtime.GOOS == goOSLinux &&
 			capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland ||
 			capabilities.Runtime.GOOS == "darwin" &&
-				capabilities.Runtime.CGOEnabled && onlyNativeHandleWindows(policy)) {
+				capabilities.Runtime.CGOEnabled && hasAllowedWindows(policy)) {
 		capability.UnavailableCode = ErrorUnsupported
 	}
 	return capability
 }
 
-func onlyNativeHandleWindows(policy Policy) bool {
-	if len(policy.allowWindow) == 0 {
-		return false
-	}
-	for identity := range policy.allowWindow {
-		if identity.kind != WindowTargetHandle {
-			return false
-		}
-	}
-	return true
+func hasAllowedWindows(policy Policy) bool {
+	return len(policy.allowWindow) > 0
 }
 
 func observationCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
@@ -260,8 +260,15 @@ func featureUnavailableCode(feature robotgo.FeatureCapability) ErrorCode {
 }
 
 func cloneCatalog(source OperationCatalog) OperationCatalog {
-	return OperationCatalog{
+	cloned := OperationCatalog{
 		SchemaVersion: source.SchemaVersion,
 		Operations:    append([]OperationCapability(nil), source.Operations...),
 	}
+	for index := range cloned.Operations {
+		cloned.Operations[index].ScrollAxes = append(
+			[]ScrollAxis(nil),
+			cloned.Operations[index].ScrollAxes...,
+		)
+	}
+	return cloned
 }

--- a/agent/catalog.go
+++ b/agent/catalog.go
@@ -1,6 +1,16 @@
 package agent
 
-import robotgo "github.com/marang/robotgo"
+import (
+	"strings"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+const (
+	agentWindowBackendSway     = "sway"
+	agentWindowBackendHyprland = "hyprland"
+	agentKeyboardPureGoX11     = "pure-go-x11"
+)
 
 func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCatalog {
 	return OperationCatalog{
@@ -11,9 +21,97 @@ func buildCatalog(policy Policy, capabilities robotgo.RuntimeCapabilities) Opera
 			waitColorCapability(policy, capabilities),
 			operationCapability(OperationMove, policy, capabilities.Mouse),
 			operationCapability(OperationClick, policy, capabilities.Mouse),
+			cooperativeOperationCapability(OperationScroll, policy, capabilities.Mouse),
+			elevatedCooperativeOperationCapability(OperationDrag, policy, capabilities.Mouse),
 			operationCapability(OperationTypeText, policy, capabilities.Keyboard),
+			keyChordCapability(policy, capabilities),
+			activationCapability(policy, capabilities),
 		},
 	}
+}
+
+func keyChordCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
+	feature := keyChordFeature(capabilities)
+	if capabilities.Keyboard.Backend == agentKeyboardPureGoX11 {
+		capability := elevatedOperationCapability(OperationKeyChord, policy, feature)
+		if feature.Available {
+			capability.Remediation = "Pure-Go X11 executes the complete chord as one backend-owned press/release transaction because persistent literal-key holds are unsafe"
+		}
+		return capability
+	}
+	return elevatedCooperativeOperationCapability(OperationKeyChord, policy, feature)
+}
+
+func keyChordFeature(capabilities robotgo.RuntimeCapabilities) robotgo.FeatureCapability {
+	if !capabilities.Keyboard.Available {
+		return capabilities.Keyboard
+	}
+	if !capabilities.Window.Available {
+		feature := capabilities.Window
+		feature.Backend = capabilities.Keyboard.Backend
+		feature.Fallback = capabilities.Keyboard.Fallback
+		feature.Reason = "keyboard injection is available but active-window identity is unavailable: " + feature.Reason
+		feature.Notes = "keyboard.chord requires a trustworthy active process identity before injection"
+		return feature
+	}
+	if capabilities.Runtime.GOOS == goOSLinux &&
+		capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland &&
+		capabilities.Window.Backend != agentWindowBackendSway &&
+		capabilities.Window.Backend != agentWindowBackendHyprland {
+		feature := capabilities.Window
+		feature.Available = false
+		feature.Backend = capabilities.Keyboard.Backend
+		feature.Fallback = capabilities.Keyboard.Fallback
+		feature.Reason = robotgo.ErrNotSupported.Error() +
+			": selected Wayland window backend cannot provide a trustworthy active process and title"
+		feature.Notes = "keyboard.chord requires Sway or Hyprland active-window identity until an accessibility backend provides an equivalent contract"
+		return feature
+	}
+	return capabilities.Keyboard
+}
+
+func activationFeature(policy Policy, capabilities robotgo.RuntimeCapabilities) robotgo.FeatureCapability {
+	feature := capabilities.Window
+	if capabilities.Runtime.GOOS == goOSLinux &&
+		capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland {
+		feature.Available = false
+		feature.Fallback = false
+		feature.Reason = "global foreign-window activation is unavailable on the selected Wayland backend"
+		feature.Notes = "use a compositor or accessibility backend that exposes a stable activation contract; RobotGo does not route Wayland activation through X11"
+	}
+	if capabilities.Runtime.GOOS == "darwin" && capabilities.Runtime.CGOEnabled &&
+		onlyNativeHandleWindows(policy) {
+		feature.Available = false
+		feature.Fallback = false
+		feature.Reason = "native macOS CGO window handles are not serializable activation targets"
+		feature.Notes = "allow a process target or use the Pure-Go macOS window backend for validated CGWindowID activation"
+	}
+	return feature
+}
+
+func activationCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
+	feature := activationFeature(policy, capabilities)
+	capability := elevatedOperationCapability(OperationActivate, policy, feature)
+	if !feature.Available &&
+		(capabilities.Runtime.GOOS == goOSLinux &&
+			capabilities.Runtime.DisplayServer == robotgo.DisplayServerWayland ||
+			capabilities.Runtime.GOOS == "darwin" &&
+				capabilities.Runtime.CGOEnabled && onlyNativeHandleWindows(policy)) {
+		capability.UnavailableCode = ErrorUnsupported
+	}
+	return capability
+}
+
+func onlyNativeHandleWindows(policy Policy) bool {
+	if len(policy.allowWindow) == 0 {
+		return false
+	}
+	for identity := range policy.allowWindow {
+		if identity.kind != WindowTargetHandle {
+			return false
+		}
+	}
+	return true
 }
 
 func observationCapability(policy Policy, capabilities robotgo.RuntimeCapabilities) OperationCapability {
@@ -95,6 +193,41 @@ func agentCaptureCapability(capabilities robotgo.RuntimeCapabilities) (bool, str
 }
 
 func operationCapability(operation Operation, policy Policy, feature robotgo.FeatureCapability) OperationCapability {
+	return mutationCapability(
+		operation, policy, feature, RiskReversibleMutation,
+		CancellationPreflightOnly, false,
+	)
+}
+
+func cooperativeOperationCapability(operation Operation, policy Policy, feature robotgo.FeatureCapability) OperationCapability {
+	return mutationCapability(
+		operation, policy, feature, RiskReversibleMutation,
+		CancellationCooperative, false,
+	)
+}
+
+func elevatedOperationCapability(operation Operation, policy Policy, feature robotgo.FeatureCapability) OperationCapability {
+	return mutationCapability(
+		operation, policy, feature, RiskElevatedMutation,
+		CancellationPreflightOnly, true,
+	)
+}
+
+func elevatedCooperativeOperationCapability(operation Operation, policy Policy, feature robotgo.FeatureCapability) OperationCapability {
+	return mutationCapability(
+		operation, policy, feature, RiskElevatedMutation,
+		CancellationCooperative, true,
+	)
+}
+
+func mutationCapability(
+	operation Operation,
+	policy Policy,
+	feature robotgo.FeatureCapability,
+	risk RiskClass,
+	cancellation CancellationSupport,
+	mandatoryConfirmation bool,
+) OperationCapability {
 	_, confirmationRequired := policy.requireConfirmation[operation]
 	_, policyAllowed := policy.allowOperation[operation]
 	remediation := feature.Notes
@@ -103,12 +236,27 @@ func operationCapability(operation Operation, policy Policy, feature robotgo.Fea
 	}
 	return OperationCapability{
 		Operation: operation, Available: feature.Available, PolicyAllowed: policyAllowed, Backend: feature.Backend,
-		Fallback: feature.Fallback, Risk: RiskReversibleMutation,
-		ConfirmationRequired: confirmationRequired,
-		Cancellation:         CancellationPreflightOnly,
+		Fallback: feature.Fallback, Risk: risk,
+		ConfirmationRequired: confirmationRequired || mandatoryConfirmation,
+		Cancellation:         cancellation,
 		ProcessGlobalBackend: true, ExclusiveAgentSession: true,
 		Reason: feature.Reason, Remediation: remediation,
+		UnavailableCode: featureUnavailableCode(feature),
 	}
+}
+
+func featureUnavailableCode(feature robotgo.FeatureCapability) ErrorCode {
+	if feature.Available {
+		return ""
+	}
+	reason := strings.ToLower(feature.Reason)
+	if strings.Contains(reason, strings.ToLower(robotgo.ErrPermissionDenied.Error())) {
+		return ErrorPermissionDenied
+	}
+	if strings.Contains(reason, strings.ToLower(robotgo.ErrNotSupported.Error())) {
+		return ErrorUnsupported
+	}
+	return ErrorUnavailable
 }
 
 func cloneCatalog(source OperationCatalog) OperationCatalog {

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -201,6 +201,10 @@ func (s *Session) executeKeyChord(ctx context.Context, action KeyChordAction) (r
 	}
 	pressed, err := s.pressKey(action.Key, action.Modifiers, action.TargetPID)
 	if err != nil {
+		if errors.Is(err, robotgo.ErrInputNotApplied) ||
+			errors.Is(err, robotgo.ErrInputOwnership) {
+			return err
+		}
 		return errors.Join(errPartialAction, err, s.releasePressedInput(pressed))
 	}
 	defer func() {
@@ -276,7 +280,13 @@ func (s *Session) pressKey(
 		key: key, modifiers: ownedModifiers, targetPID: targetPID, keyboard: true,
 	}
 	s.pressedInputs = append(s.pressedInputs, pressed)
-	return pressed, s.driver.ToggleKeyImmediate(key, ownedModifiers, targetPID, true)
+	err := s.driver.ToggleKeyImmediate(key, ownedModifiers, targetPID, true)
+	if errors.Is(err, robotgo.ErrInputNotApplied) ||
+		errors.Is(err, robotgo.ErrInputOwnership) {
+		s.pressedInputs = s.pressedInputs[:len(s.pressedInputs)-1]
+		return pressedInput{}, err
+	}
+	return pressed, err
 }
 
 func (s *Session) releasePressedInput(pressed pressedInput) error {

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -104,14 +104,14 @@ func (s *Session) executeScroll(ctx context.Context, action ScrollAction) error 
 	if err := s.executionError(ctx); err != nil {
 		return err
 	}
-	if err := s.driver.Move(target.X, target.Y, target.DisplayID); err != nil {
+	if err := s.driver.MoveImmediate(target.X, target.Y, target.DisplayID); err != nil {
 		return err
 	}
 	for event := uint32(0); event < action.Events; event++ {
 		if err := s.executionError(ctx); err != nil {
 			return errors.Join(errPartialAction, err)
 		}
-		if err := s.driver.Scroll(action.DeltaX, action.DeltaY); err != nil {
+		if err := s.driver.ScrollImmediate(action.DeltaX, action.DeltaY); err != nil {
 			return errors.Join(errPartialAction, err)
 		}
 	}

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -267,7 +267,12 @@ func (s *Session) resolveValidatedWindow(action ActivateWindowAction) (int, erro
 func (s *Session) pressMouse(button MouseButton) (pressedInput, error) {
 	pressed := pressedInput{button: button}
 	s.pressedInputs = append(s.pressedInputs, pressed)
-	return pressed, s.driver.ToggleMouse(button, true)
+	err := s.driver.ToggleMouse(button, true)
+	if inputDownKnownNotApplied(err) {
+		s.pressedInputs = s.pressedInputs[:len(s.pressedInputs)-1]
+		return pressedInput{}, err
+	}
+	return pressed, err
 }
 
 func (s *Session) pressKey(
@@ -281,12 +286,16 @@ func (s *Session) pressKey(
 	}
 	s.pressedInputs = append(s.pressedInputs, pressed)
 	err := s.driver.ToggleKeyImmediate(key, ownedModifiers, targetPID, true)
-	if errors.Is(err, robotgo.ErrInputNotApplied) ||
-		errors.Is(err, robotgo.ErrInputOwnership) {
+	if inputDownKnownNotApplied(err) {
 		s.pressedInputs = s.pressedInputs[:len(s.pressedInputs)-1]
 		return pressedInput{}, err
 	}
 	return pressed, err
+}
+
+func inputDownKnownNotApplied(err error) bool {
+	return errors.Is(err, robotgo.ErrInputNotApplied) ||
+		errors.Is(err, robotgo.ErrInputOwnership)
 }
 
 func (s *Session) releasePressedInput(pressed pressedInput) error {

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -269,7 +269,7 @@ func (s *Session) pressKey(
 		key: key, modifiers: ownedModifiers, targetPID: targetPID, keyboard: true,
 	}
 	s.pressedInputs = append(s.pressedInputs, pressed)
-	return pressed, s.driver.ToggleKey(key, ownedModifiers, targetPID, true)
+	return pressed, s.driver.ToggleKeyImmediate(key, ownedModifiers, targetPID, true)
 }
 
 func (s *Session) releasePressedInput(pressed pressedInput) error {
@@ -279,7 +279,7 @@ func (s *Session) releasePressedInput(pressed pressedInput) error {
 	}
 	var err error
 	if pressed.keyboard {
-		err = s.driver.ToggleKey(
+		err = s.driver.ToggleKeyImmediate(
 			pressed.key,
 			pressed.modifiers,
 			pressed.targetPID,

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -138,7 +138,7 @@ func (s *Session) executeDrag(ctx context.Context, action DragAction) (returnErr
 	}
 	pressed, err := s.pressMouse(action.Button)
 	if err != nil {
-		return errors.Join(errPartialAction, err)
+		return errors.Join(errPartialAction, err, s.releasePressedInput(pressed))
 	}
 	defer func() {
 		if cleanupErr := s.releasePressedInput(pressed); cleanupErr != nil {
@@ -192,12 +192,9 @@ func (s *Session) executeKeyChord(ctx context.Context, action KeyChordAction) (r
 	if err := s.executionError(ctx); err != nil {
 		return err
 	}
-	if s.keyChordIsAtomic() {
-		return s.driver.TapKey(action.Key, action.Modifiers)
-	}
-	pressed, err := s.pressKey(action.Key, action.Modifiers)
+	pressed, err := s.pressKey(action.Key, action.Modifiers, action.TargetPID)
 	if err != nil {
-		return err
+		return errors.Join(errPartialAction, err, s.releasePressedInput(pressed))
 	}
 	defer func() {
 		if cleanupErr := s.releasePressedInput(pressed); cleanupErr != nil {
@@ -210,73 +207,69 @@ func (s *Session) executeKeyChord(ctx context.Context, action KeyChordAction) (r
 	return nil
 }
 
-func (s *Session) keyChordIsAtomic() bool {
-	capability, ok := s.capability(OperationKeyChord)
-	return ok && capability.Cancellation == CancellationPreflightOnly
-}
-
 func (s *Session) validateActiveWindow(action KeyChordAction) error {
 	identity := windowTargetIdentity{target: action.TargetPID, kind: WindowTargetProcess}
 	target := s.policy.allowWindow[identity]
-	title, err := s.driver.ActiveWindowTitle()
+	title, err := s.driver.WindowTitle(action.TargetPID, WindowTargetProcess)
 	if err != nil {
 		return err
 	}
 	if title != target.ExpectedTitle {
-		return ErrStaleTarget
-	}
-	// Check the active PID last so focus identity is as fresh as possible when
-	// the following key-down reaches the backend.
-	activePID, err := s.driver.ActiveWindowPID()
-	if err != nil {
-		return err
-	}
-	if activePID != action.TargetPID {
 		return ErrStaleTarget
 	}
 	return nil
 }
 
 func (s *Session) executeActivate(ctx context.Context, action ActivateWindowAction) error {
-	if err := s.validateWindowIdentity(action); err != nil {
+	handle, err := s.resolveValidatedWindow(action)
+	if err != nil {
 		return err
 	}
 	if err := s.executionError(ctx); err != nil {
 		return err
 	}
-	return s.driver.ActivateWindow(action.Target, action.Kind)
+	return s.driver.ActivateWindow(handle, WindowTargetHandle)
 }
 
 func (s *Session) validateWindowIdentity(action ActivateWindowAction) error {
+	_, err := s.resolveValidatedWindow(action)
+	return err
+}
+
+func (s *Session) resolveValidatedWindow(action ActivateWindowAction) (int, error) {
 	identity := windowTargetIdentity{target: action.Target, kind: action.Kind}
 	target := s.policy.allowWindow[identity]
-	title, err := s.driver.WindowTitle(action.Target, action.Kind)
+	handle, err := s.driver.ResolveWindow(action.Target, action.Kind)
 	if err != nil {
-		return err
+		return 0, err
+	}
+	title, err := s.driver.WindowTitle(handle, WindowTargetHandle)
+	if err != nil {
+		return 0, err
 	}
 	if title != target.ExpectedTitle {
-		return ErrStaleTarget
+		return 0, ErrStaleTarget
 	}
-	return nil
+	return handle, nil
 }
 
 func (s *Session) pressMouse(button MouseButton) (pressedInput, error) {
-	if err := s.driver.ToggleMouse(button, true); err != nil {
-		return pressedInput{}, err
-	}
 	pressed := pressedInput{button: button}
 	s.pressedInputs = append(s.pressedInputs, pressed)
-	return pressed, nil
+	return pressed, s.driver.ToggleMouse(button, true)
 }
 
-func (s *Session) pressKey(key string, modifiers []KeyModifier) (pressedInput, error) {
+func (s *Session) pressKey(
+	key string,
+	modifiers []KeyModifier,
+	targetPID int,
+) (pressedInput, error) {
 	ownedModifiers := append([]KeyModifier(nil), modifiers...)
-	if err := s.driver.ToggleKey(key, ownedModifiers, true); err != nil {
-		return pressedInput{}, err
+	pressed := pressedInput{
+		key: key, modifiers: ownedModifiers, targetPID: targetPID, keyboard: true,
 	}
-	pressed := pressedInput{key: key, modifiers: ownedModifiers, keyboard: true}
 	s.pressedInputs = append(s.pressedInputs, pressed)
-	return pressed, nil
+	return pressed, s.driver.ToggleKey(key, ownedModifiers, targetPID, true)
 }
 
 func (s *Session) releasePressedInput(pressed pressedInput) error {
@@ -286,7 +279,12 @@ func (s *Session) releasePressedInput(pressed pressedInput) error {
 	}
 	var err error
 	if pressed.keyboard {
-		err = s.driver.ToggleKey(pressed.key, pressed.modifiers, false)
+		err = s.driver.ToggleKey(
+			pressed.key,
+			pressed.modifiers,
+			pressed.targetPID,
+			false,
+		)
 	} else {
 		err = s.driver.ToggleMouse(pressed.button, false)
 	}
@@ -314,6 +312,7 @@ func (s *Session) pressedInputIndex(pressed pressedInput) int {
 		if candidate.keyboard != pressed.keyboard ||
 			candidate.button != pressed.button ||
 			candidate.key != pressed.key ||
+			candidate.targetPID != pressed.targetPID ||
 			!sameModifiers(candidate.modifiers, pressed.modifiers) {
 			continue
 		}

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -130,7 +130,7 @@ func (s *Session) executeDrag(ctx context.Context, action DragAction) (returnErr
 	if err := s.executionError(ctx); err != nil {
 		return err
 	}
-	if err := s.driver.Move(start.X, start.Y, start.DisplayID); err != nil {
+	if err := s.driver.MoveImmediate(start.X, start.Y, start.DisplayID); err != nil {
 		return err
 	}
 	if err := s.executionError(ctx); err != nil {
@@ -154,7 +154,7 @@ func (s *Session) executeDrag(ctx context.Context, action DragAction) (returnErr
 		}
 		x := interpolateCoordinate(action.StartX, action.EndX, step, steps)
 		y := interpolateCoordinate(action.StartY, action.EndY, step, steps)
-		if err := s.driver.Move(x, y, action.DisplayID); err != nil {
+		if err := s.driver.MoveImmediate(x, y, action.DisplayID); err != nil {
 			return errors.Join(errPartialAction, err)
 		}
 	}

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -1,0 +1,348 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"math"
+	"time"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+const maxDragInterpolationSteps = 120
+
+var errPartialAction = errors.New("agent action may have partially executed")
+
+func scrollDistance(action ScrollAction) uint64 {
+	perEvent := saturatingAdd(absIntMagnitude(action.DeltaX), absIntMagnitude(action.DeltaY))
+	return saturatingMultiply(perEvent, uint64(action.Events))
+}
+
+func dragDistance(action DragAction) uint64 {
+	deltaX := axisDistance(action.StartX, action.EndX)
+	deltaY := axisDistance(action.StartY, action.EndY)
+	if deltaX > maxAgentDragDistance || deltaY > maxAgentDragDistance {
+		return maxAgentDragDistance + 1
+	}
+	return uint64(math.Ceil(math.Hypot(float64(deltaX), float64(deltaY))))
+}
+
+func axisDistance(left, right int) uint64 {
+	if left >= right {
+		return uint64(left) - uint64(right)
+	}
+	return uint64(right) - uint64(left)
+}
+
+func absIntMagnitude(value int) uint64 {
+	if value >= 0 {
+		return uint64(value)
+	}
+	return uint64(-(value + 1)) + 1
+}
+
+func saturatingAdd(left, right uint64) uint64 {
+	result := left + right
+	if result < left {
+		return ^uint64(0)
+	}
+	return result
+}
+
+func saturatingMultiply(left, right uint64) uint64 {
+	if left != 0 && right > ^uint64(0)/left {
+		return ^uint64(0)
+	}
+	return left * right
+}
+
+func (s *Session) validateActionRate() error {
+	if s.policy.MinActionIntervalMillis == 0 || s.lastAction.IsZero() {
+		return nil
+	}
+	elapsed := s.now().Sub(s.lastAction)
+	if elapsed < 0 || elapsed < time.Duration(s.policy.MinActionIntervalMillis)*time.Millisecond {
+		return ErrPolicyDenied
+	}
+	return nil
+}
+
+func (s *Session) executionError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := s.ctx.Err(); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return context.DeadlineExceeded
+		}
+		return ErrSessionClosed
+	}
+	return nil
+}
+
+func (s *Session) waitForExecution(ctx context.Context, duration time.Duration) error {
+	if duration <= 0 {
+		return s.executionError(ctx)
+	}
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.ctx.Done():
+		return s.executionError(ctx)
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (s *Session) executeScroll(ctx context.Context, action ScrollAction) error {
+	target := MoveAction{X: action.TargetX, Y: action.TargetY, DisplayID: action.DisplayID}
+	if err := s.validateMoveTarget(target); err != nil {
+		return err
+	}
+	if err := s.executionError(ctx); err != nil {
+		return err
+	}
+	if err := s.driver.Move(target.X, target.Y, target.DisplayID); err != nil {
+		return err
+	}
+	for event := uint32(0); event < action.Events; event++ {
+		if err := s.executionError(ctx); err != nil {
+			return errors.Join(errPartialAction, err)
+		}
+		if err := s.driver.Scroll(action.DeltaX, action.DeltaY); err != nil {
+			return errors.Join(errPartialAction, err)
+		}
+	}
+	return nil
+}
+
+func (s *Session) executeDrag(ctx context.Context, action DragAction) (returnErr error) {
+	start := MoveAction{X: action.StartX, Y: action.StartY, DisplayID: action.DisplayID}
+	end := MoveAction{X: action.EndX, Y: action.EndY, DisplayID: action.DisplayID}
+	if err := s.validateMoveTarget(start); err != nil {
+		return err
+	}
+	if err := s.validateMoveTarget(end); err != nil {
+		return err
+	}
+	if err := s.executionError(ctx); err != nil {
+		return err
+	}
+	if err := s.driver.Move(start.X, start.Y, start.DisplayID); err != nil {
+		return err
+	}
+	if err := s.executionError(ctx); err != nil {
+		return errors.Join(errPartialAction, err)
+	}
+	pressed, err := s.pressMouse(action.Button)
+	if err != nil {
+		return errors.Join(errPartialAction, err)
+	}
+	defer func() {
+		if cleanupErr := s.releasePressedInput(pressed); cleanupErr != nil {
+			returnErr = errors.Join(errPartialAction, returnErr, cleanupErr)
+		}
+	}()
+
+	steps := dragInterpolationSteps(action)
+	interval := time.Duration(action.DurationMillis) * time.Millisecond / time.Duration(steps)
+	for step := 1; step <= steps; step++ {
+		if err := s.waitForExecution(ctx, interval); err != nil {
+			return errors.Join(errPartialAction, err)
+		}
+		x := interpolateCoordinate(action.StartX, action.EndX, step, steps)
+		y := interpolateCoordinate(action.StartY, action.EndY, step, steps)
+		if err := s.driver.Move(x, y, action.DisplayID); err != nil {
+			return errors.Join(errPartialAction, err)
+		}
+	}
+	return nil
+}
+
+func dragInterpolationSteps(action DragAction) int {
+	distanceSteps := dragDistance(action)
+	if distanceSteps == 0 {
+		return 1
+	}
+	if distanceSteps > maxDragInterpolationSteps {
+		return maxDragInterpolationSteps
+	}
+	return int(distanceSteps)
+}
+
+func interpolateCoordinate(start, end, step, steps int) int {
+	if step >= steps {
+		return end
+	}
+	if end >= start {
+		return start + (end-start)*step/steps
+	}
+	return start - (start-end)*step/steps
+}
+
+func (s *Session) executeKeyChord(ctx context.Context, action KeyChordAction) (returnErr error) {
+	if err := s.executionError(ctx); err != nil {
+		return err
+	}
+	if err := s.validateActiveWindow(action); err != nil {
+		return err
+	}
+	if err := s.executionError(ctx); err != nil {
+		return err
+	}
+	if s.keyChordIsAtomic() {
+		return s.driver.TapKey(action.Key, action.Modifiers)
+	}
+	pressed, err := s.pressKey(action.Key, action.Modifiers)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cleanupErr := s.releasePressedInput(pressed); cleanupErr != nil {
+			returnErr = errors.Join(errPartialAction, returnErr, cleanupErr)
+		}
+	}()
+	if err := s.executionError(ctx); err != nil {
+		return errors.Join(errPartialAction, err)
+	}
+	return nil
+}
+
+func (s *Session) keyChordIsAtomic() bool {
+	capability, ok := s.capability(OperationKeyChord)
+	return ok && capability.Cancellation == CancellationPreflightOnly
+}
+
+func (s *Session) validateActiveWindow(action KeyChordAction) error {
+	identity := windowTargetIdentity{target: action.TargetPID, kind: WindowTargetProcess}
+	target := s.policy.allowWindow[identity]
+	title, err := s.driver.ActiveWindowTitle()
+	if err != nil {
+		return err
+	}
+	if title != target.ExpectedTitle {
+		return ErrStaleTarget
+	}
+	// Check the active PID last so focus identity is as fresh as possible when
+	// the following key-down reaches the backend.
+	activePID, err := s.driver.ActiveWindowPID()
+	if err != nil {
+		return err
+	}
+	if activePID != action.TargetPID {
+		return ErrStaleTarget
+	}
+	return nil
+}
+
+func (s *Session) executeActivate(ctx context.Context, action ActivateWindowAction) error {
+	if err := s.validateWindowIdentity(action); err != nil {
+		return err
+	}
+	if err := s.executionError(ctx); err != nil {
+		return err
+	}
+	return s.driver.ActivateWindow(action.Target, action.Kind)
+}
+
+func (s *Session) validateWindowIdentity(action ActivateWindowAction) error {
+	identity := windowTargetIdentity{target: action.Target, kind: action.Kind}
+	target := s.policy.allowWindow[identity]
+	title, err := s.driver.WindowTitle(action.Target, action.Kind)
+	if err != nil {
+		return err
+	}
+	if title != target.ExpectedTitle {
+		return ErrStaleTarget
+	}
+	return nil
+}
+
+func (s *Session) pressMouse(button MouseButton) (pressedInput, error) {
+	if err := s.driver.ToggleMouse(button, true); err != nil {
+		return pressedInput{}, err
+	}
+	pressed := pressedInput{button: button}
+	s.pressedInputs = append(s.pressedInputs, pressed)
+	return pressed, nil
+}
+
+func (s *Session) pressKey(key string, modifiers []KeyModifier) (pressedInput, error) {
+	ownedModifiers := append([]KeyModifier(nil), modifiers...)
+	if err := s.driver.ToggleKey(key, ownedModifiers, true); err != nil {
+		return pressedInput{}, err
+	}
+	pressed := pressedInput{key: key, modifiers: ownedModifiers, keyboard: true}
+	s.pressedInputs = append(s.pressedInputs, pressed)
+	return pressed, nil
+}
+
+func (s *Session) releasePressedInput(pressed pressedInput) error {
+	index := s.pressedInputIndex(pressed)
+	if index < 0 {
+		return nil
+	}
+	var err error
+	if pressed.keyboard {
+		err = s.driver.ToggleKey(pressed.key, pressed.modifiers, false)
+	} else {
+		err = s.driver.ToggleMouse(pressed.button, false)
+	}
+	if err != nil {
+		if errors.Is(err, robotgo.ErrInputOwnership) {
+			s.pressedInputs = append(s.pressedInputs[:index], s.pressedInputs[index+1:]...)
+			if len(s.pressedInputs) == 0 {
+				s.inputTainted = false
+			}
+			return nil
+		}
+		s.inputTainted = true
+		return errors.Join(ErrInputCleanup, err)
+	}
+	s.pressedInputs = append(s.pressedInputs[:index], s.pressedInputs[index+1:]...)
+	if len(s.pressedInputs) == 0 {
+		s.inputTainted = false
+	}
+	return nil
+}
+
+func (s *Session) pressedInputIndex(pressed pressedInput) int {
+	for index := len(s.pressedInputs) - 1; index >= 0; index-- {
+		candidate := s.pressedInputs[index]
+		if candidate.keyboard != pressed.keyboard ||
+			candidate.button != pressed.button ||
+			candidate.key != pressed.key ||
+			!sameModifiers(candidate.modifiers, pressed.modifiers) {
+			continue
+		}
+		return index
+	}
+	return -1
+}
+
+func sameModifiers(left, right []KeyModifier) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Session) releaseAllInputs() error {
+	var releaseErr error
+	for len(s.pressedInputs) > 0 {
+		before := len(s.pressedInputs)
+		pressed := s.pressedInputs[before-1]
+		releaseErr = errors.Join(releaseErr, s.releasePressedInput(pressed))
+		if len(s.pressedInputs) == before {
+			break
+		}
+	}
+	return releaseErr
+}

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -20,6 +20,18 @@ func ambiguousMutationError(err error) error {
 	return errors.Join(errPartialAction, err)
 }
 
+func (s *Session) clickMutationError(button MouseButton, err error) error {
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, robotgo.ErrInputReleasePending) {
+		return ambiguousMutationError(err)
+	}
+	s.pressedInputs = append(s.pressedInputs, pressedInput{button: button})
+	s.inputTainted = true
+	return errors.Join(errPartialAction, ErrInputCleanup, err)
+}
+
 func scrollDistance(action ScrollAction) uint64 {
 	perEvent := saturatingAdd(absIntMagnitude(action.DeltaX), absIntMagnitude(action.DeltaY))
 	return saturatingMultiply(perEvent, uint64(action.Events))

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -13,6 +13,13 @@ const maxDragInterpolationSteps = 120
 
 var errPartialAction = errors.New("agent action may have partially executed")
 
+func ambiguousMutationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return errors.Join(errPartialAction, err)
+}
+
 func scrollDistance(action ScrollAction) uint64 {
 	perEvent := saturatingAdd(absIntMagnitude(action.DeltaX), absIntMagnitude(action.DeltaY))
 	return saturatingMultiply(perEvent, uint64(action.Events))
@@ -228,7 +235,7 @@ func (s *Session) executeActivate(ctx context.Context, action ActivateWindowActi
 	if err := s.executionError(ctx); err != nil {
 		return err
 	}
-	return s.driver.ActivateWindow(handle, WindowTargetHandle)
+	return ambiguousMutationError(s.driver.ActivateWindow(handle, WindowTargetHandle))
 }
 
 func (s *Session) validateWindowIdentity(action ActivateWindowAction) error {

--- a/agent/extended_actions.go
+++ b/agent/extended_actions.go
@@ -105,7 +105,7 @@ func (s *Session) executeScroll(ctx context.Context, action ScrollAction) error 
 		return err
 	}
 	if err := s.driver.MoveImmediate(target.X, target.Y, target.DisplayID); err != nil {
-		return err
+		return errors.Join(errPartialAction, err)
 	}
 	for event := uint32(0); event < action.Events; event++ {
 		if err := s.executionError(ctx); err != nil {
@@ -131,7 +131,7 @@ func (s *Session) executeDrag(ctx context.Context, action DragAction) (returnErr
 		return err
 	}
 	if err := s.driver.MoveImmediate(start.X, start.Y, start.DisplayID); err != nil {
-		return err
+		return errors.Join(errPartialAction, err)
 	}
 	if err := s.executionError(ctx); err != nil {
 		return errors.Join(errPartialAction, err)

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -798,6 +798,34 @@ func TestDragDistanceAndInterpolationRemainSafeAtIntegerEdges(t *testing.T) {
 	}
 }
 
+func TestDragUsesOnlyDelayFreeMovesWhileButtonIsOwned(t *testing.T) {
+	driver := &fakeDriver{}
+	session := newTestSession(t, extendedActionPolicy(OperationDrag), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationDrag, Confirmed: true,
+		Drag: &DragAction{
+			StartX: 1, StartY: 1, EndX: 4, EndY: 1,
+			DisplayID: 0, Button: MouseButtonLeft, DurationMillis: 3,
+		},
+	})
+	if err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("drag result = %+v, %v", result, err)
+	}
+	moveCalls := 0
+	for _, call := range driver.recordedCalls() {
+		if call.operation != OperationMove {
+			continue
+		}
+		moveCalls++
+		if call.text != "immediate" {
+			t.Fatalf("drag used delayed move: %+v", driver.recordedCalls())
+		}
+	}
+	if moveCalls < 2 {
+		t.Fatalf("drag move calls = %+v", driver.recordedCalls())
+	}
+}
+
 func TestWindowActivationRevalidatesImmutableIdentity(t *testing.T) {
 	driver := &fakeDriver{windowTitle: "fixture", resolvedHandle: 77}
 	session := newTestSession(t, extendedActionPolicy(OperationActivate), driver)

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -243,11 +243,12 @@ func TestScrollMovesToBoundedTargetAndEmitsExactEvents(t *testing.T) {
 		t.Fatalf("calls = %+v", calls)
 	}
 	if calls[0].operation != OperationMove || calls[0].x != 12 ||
-		calls[0].y != 23 || calls[0].displayID != 0 {
+		calls[0].y != 23 || calls[0].displayID != 0 || !calls[0].immediate {
 		t.Fatalf("target move = %+v", calls[0])
 	}
 	for _, call := range calls[1:] {
-		if call.operation != OperationScroll || call.deltaX != -2 || call.deltaY != 3 {
+		if call.operation != OperationScroll || call.deltaX != -2 ||
+			call.deltaY != 3 || !call.immediate {
 			t.Fatalf("scroll call = %+v", call)
 		}
 	}

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -655,6 +655,52 @@ func TestAmbiguousKeyDownAndCleanupFailureRemainOwned(t *testing.T) {
 	}
 }
 
+func TestKnownUnappliedMouseDownDoesNotReleaseForeignInput(t *testing.T) {
+	for _, backendErr := range []error{
+		robotgo.ErrInputNotApplied,
+		robotgo.ErrInputOwnership,
+	} {
+		t.Run(backendErr.Error(), func(t *testing.T) {
+			driver := &fakeDriver{callError: func(call driverCall) error {
+				if call.operation == OperationDrag && call.down {
+					return backendErr
+				}
+				return nil
+			}}
+			session := newTestSession(
+				t,
+				extendedActionPolicy(OperationDrag),
+				driver,
+			)
+			result, err := session.Execute(t.Context(), ActionRequest{
+				Operation: OperationDrag,
+				Confirmed: true,
+				Drag: &DragAction{
+					StartX: 1, StartY: 1, EndX: 2, EndY: 1,
+					DisplayID: 0, Button: MouseButtonLeft, DurationMillis: 1,
+				},
+			})
+			if !errors.Is(err, backendErr) || result.Status != ActionUnverified {
+				t.Fatalf("known-unapplied mouse down = %+v, %v", result, err)
+			}
+			var mutations []driverCall
+			for _, call := range driver.recordedCalls() {
+				if call.operation == OperationDrag && call.text == "" {
+					mutations = append(mutations, call)
+				}
+			}
+			if len(mutations) != 1 || !mutations[0].down ||
+				len(session.pressedInputs) != 0 || session.inputTainted {
+				t.Fatalf(
+					"known-unapplied mouse cleanup = %+v, ledger = %+v",
+					mutations,
+					session.pressedInputs,
+				)
+			}
+		})
+	}
+}
+
 func TestKnownUnappliedKeyDownDoesNotReleaseForeignInput(t *testing.T) {
 	for _, backendErr := range []error{
 		robotgo.ErrInputNotApplied,

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -299,6 +299,32 @@ func TestScrollFailureAfterTargetMoveIsUnverified(t *testing.T) {
 	}
 }
 
+func TestScrollTargetMoveFailureIsUnverified(t *testing.T) {
+	driver := &fakeDriver{callError: func(call driverCall) error {
+		if call.operation == OperationMove {
+			return errors.New("ambiguous target move failure")
+		}
+		return nil
+	}}
+	session := newTestSession(t, extendedActionPolicy(OperationScroll), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationScroll,
+		Scroll: &ScrollAction{
+			TargetX: 1, TargetY: 1, DeltaY: 1, Events: 1, DisplayID: 0,
+		},
+	})
+	var actionErr *ActionError
+	if !errors.As(err, &actionErr) || actionErr.Code != ErrorBackendFailure ||
+		result.Status != ActionUnverified {
+		t.Fatalf("ambiguous target move result = %+v, %v", result, err)
+	}
+	calls := driver.recordedCalls()
+	if len(calls) != 1 || calls[0].operation != OperationMove ||
+		!calls[0].immediate {
+		t.Fatalf("ambiguous target move calls = %+v", calls)
+	}
+}
+
 func TestDragUsesBoundedPathAndAlwaysReleasesButton(t *testing.T) {
 	driver := &fakeDriver{}
 	session := newTestSession(t, extendedActionPolicy(OperationDrag), driver)
@@ -332,6 +358,34 @@ func TestDragUsesBoundedPathAndAlwaysReleasesButton(t *testing.T) {
 	}
 	if len(session.pressedInputs) != 0 {
 		t.Fatalf("pressed ledger = %+v", session.pressedInputs)
+	}
+}
+
+func TestDragStartMoveFailureIsUnverified(t *testing.T) {
+	driver := &fakeDriver{callError: func(call driverCall) error {
+		if call.operation == OperationMove {
+			return errors.New("ambiguous start move failure")
+		}
+		return nil
+	}}
+	session := newTestSession(t, extendedActionPolicy(OperationDrag), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationDrag,
+		Confirmed: true,
+		Drag: &DragAction{
+			StartX: 1, StartY: 1, EndX: 2, EndY: 1,
+			DisplayID: 0, Button: MouseButtonLeft, DurationMillis: 1,
+		},
+	})
+	var actionErr *ActionError
+	if !errors.As(err, &actionErr) || actionErr.Code != ErrorBackendFailure ||
+		result.Status != ActionUnverified {
+		t.Fatalf("ambiguous start move result = %+v, %v", result, err)
+	}
+	calls := driver.recordedCalls()
+	if len(calls) != 1 || calls[0].operation != OperationMove ||
+		!calls[0].immediate {
+		t.Fatalf("ambiguous start move calls = %+v", calls)
 	}
 }
 

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -122,6 +122,24 @@ func TestWaylandKeyChordCapabilityRequiresProcessTargetedInjection(t *testing.T)
 	}
 }
 
+func TestWindowsKeyChordCapabilityRequiresAtomicTargetDispatch(t *testing.T) {
+	for _, cgoEnabled := range []bool{false, true} {
+		capabilities := availableCapabilities()
+		capabilities.Runtime.GOOS = "windows"
+		capabilities.Runtime.CGOEnabled = cgoEnabled
+		capability := keyChordFeature(capabilities)
+		if capability.Available ||
+			featureUnavailableCode(capability) != ErrorUnsupported ||
+			capability.Notes == "" {
+			t.Fatalf(
+				"Windows keyboard.chord capability with CGO=%t = %+v",
+				cgoEnabled,
+				capability,
+			)
+		}
+	}
+}
+
 func TestExtendedCapabilityReportsPermissionAndUnavailableStates(t *testing.T) {
 	policy, err := preparePolicy(extendedActionPolicy(OperationScroll))
 	if err != nil {

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -606,6 +606,7 @@ func TestKeyChordUsesCanonicalOrderAndRelease(t *testing.T) {
 	if len(keyCalls) != 2 || !keyCalls[0].down || keyCalls[1].down ||
 		keyCalls[0].key != "c" || keyCalls[0].target != 42 ||
 		keyCalls[1].target != 42 ||
+		!keyCalls[0].immediate || !keyCalls[1].immediate ||
 		!sameModifiers(keyCalls[0].modifiers, keyCalls[1].modifiers) {
 		t.Fatalf("chord calls = %+v", calls)
 	}

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -1,0 +1,791 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	robotgo "github.com/marang/robotgo"
+)
+
+type actionOutcome struct {
+	result ActionResult
+	err    error
+}
+
+func extendedActionPolicy(operations ...Operation) Policy {
+	return Policy{
+		AllowedOperations:       append([]Operation(nil), operations...),
+		AllowedDisplayIDs:       []int{0},
+		AllowedMouseButtons:     []MouseButton{MouseButtonLeft},
+		AllowedKeys:             []string{"c", "enter"},
+		AllowedModifiers:        []KeyModifier{KeyModifierControl, KeyModifierShift},
+		AllowedWindows:          []WindowTarget{{Target: 42, Kind: WindowTargetProcess, ExpectedTitle: "fixture"}},
+		MaxActions:              10,
+		MaxScrollEvents:         4,
+		MaxScrollDistance:       100,
+		MaxDragDistance:         100,
+		MaxDragDurationMillis:   2_000,
+		MaxChordKeys:            3,
+		MinActionIntervalMillis: 1,
+		SessionTimeoutMillis:    10_000,
+	}
+}
+
+func TestExtendedOperationsAreDeniedByDefault(t *testing.T) {
+	session := newTestSession(t, Policy{
+		AllowedOperations: []Operation{OperationObserve},
+		MaxObservations:   1,
+	}, &fakeDriver{})
+	for _, operation := range []Operation{
+		OperationScroll, OperationDrag, OperationKeyChord, OperationActivate,
+	} {
+		capability, ok := session.capability(operation)
+		if !ok {
+			t.Fatalf("catalog omitted %s", operation)
+		}
+		if capability.PolicyAllowed {
+			t.Fatalf("%s unexpectedly allowed by diagnostics-only policy", operation)
+		}
+	}
+}
+
+func TestWaylandActivationCapabilityDoesNotInheritBroadWindowSupport(t *testing.T) {
+	policy, err := preparePolicy(extendedActionPolicy(OperationActivate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	capabilities := availableCapabilities()
+	capabilities.Runtime.GOOS = "linux"
+	capabilities.Runtime.DisplayServer = robotgo.DisplayServerWayland
+	capabilities.Window.Available = true
+	capabilities.Window.Backend = "wayland-compositor"
+	catalog := buildCatalog(policy, capabilities)
+	var activation OperationCapability
+	for _, candidate := range catalog.Operations {
+		if candidate.Operation == OperationActivate {
+			activation = candidate
+			break
+		}
+	}
+	if activation.Available || activation.Fallback ||
+		activation.UnavailableCode != ErrorUnsupported ||
+		activation.Reason == "" || activation.Remediation == "" {
+		t.Fatalf("Wayland activation capability = %+v", activation)
+	}
+}
+
+func TestNativeMacOSActivationCapabilityRejectsHandleOnlyPolicy(t *testing.T) {
+	input := extendedActionPolicy(OperationActivate)
+	input.AllowedWindows = []WindowTarget{{
+		Target: 42, Kind: WindowTargetHandle, ExpectedTitle: "fixture",
+	}}
+	policy, err := preparePolicy(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capabilities := availableCapabilities()
+	capabilities.Runtime.GOOS = "darwin"
+	capabilities.Runtime.CGOEnabled = true
+	capabilities.Window.Available = true
+	capability := activationFeature(policy, capabilities)
+	if capability.Available || capability.Reason == "" || capability.Notes == "" {
+		t.Fatalf("native macOS handle activation = %+v", capability)
+	}
+
+	capabilities.Runtime.CGOEnabled = false
+	if capability := activationFeature(policy, capabilities); !capability.Available {
+		t.Fatalf("Pure-Go macOS handle activation = %+v", capability)
+	}
+}
+
+func TestWaylandKeyChordCapabilityRequiresActiveWindowIdentity(t *testing.T) {
+	for _, test := range []struct {
+		backend   string
+		available bool
+		code      ErrorCode
+	}{
+		{backend: agentWindowBackendSway, available: true},
+		{backend: agentWindowBackendHyprland, available: true},
+		{backend: "wlroots-generic", available: false, code: ErrorUnsupported},
+	} {
+		t.Run(test.backend, func(t *testing.T) {
+			capabilities := availableCapabilities()
+			capabilities.Runtime.GOOS = goOSLinux
+			capabilities.Runtime.DisplayServer = robotgo.DisplayServerWayland
+			capabilities.Window.Backend = test.backend
+			capability := keyChordFeature(capabilities)
+			if capability.Available != test.available ||
+				featureUnavailableCode(capability) != test.code {
+				t.Fatalf("keyboard.chord capability = %+v", capability)
+			}
+		})
+	}
+}
+
+func TestExtendedCapabilityReportsPermissionAndUnavailableStates(t *testing.T) {
+	policy, err := preparePolicy(extendedActionPolicy(OperationScroll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ActionRequest{
+		Operation: OperationScroll,
+		Scroll: &ScrollAction{
+			TargetX: 1, TargetY: 1, DeltaY: 1, Events: 1, DisplayID: 0,
+		},
+	}
+	for _, test := range []struct {
+		name     string
+		reason   string
+		fallback bool
+		code     ErrorCode
+		cause    error
+	}{
+		{
+			name: "permission", reason: robotgo.ErrPermissionDenied.Error(),
+			code: ErrorPermissionDenied, cause: robotgo.ErrPermissionDenied,
+		},
+		{
+			name: "unsupported", reason: robotgo.ErrNotSupported.Error(),
+			fallback: true, code: ErrorUnsupported, cause: robotgo.ErrNotSupported,
+		},
+		{name: "unavailable", reason: "backend service is unavailable", code: ErrorUnavailable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capabilities := availableCapabilities()
+			capabilities.Mouse.Available = false
+			capabilities.Mouse.Reason = test.reason
+			capabilities.Mouse.Fallback = test.fallback
+			session, sessionErr := newSession(policy, &fakeDriver{}, capabilities)
+			if sessionErr != nil {
+				t.Fatal(sessionErr)
+			}
+			t.Cleanup(func() { _ = session.Close() })
+			capability, ok := session.capability(OperationScroll)
+			if !ok || capability.Available || capability.Fallback != test.fallback ||
+				capability.UnavailableCode != test.code {
+				t.Fatalf("capability = %+v", capability)
+			}
+			result, executeErr := session.DryRun(t.Context(), request)
+			var actionErr *ActionError
+			if !errors.As(executeErr, &actionErr) || actionErr.Code != test.code {
+				t.Fatalf("unavailable result = %+v, %v", result, executeErr)
+			}
+			if test.cause != nil && !errors.Is(executeErr, test.cause) {
+				t.Fatalf("unavailable cause = %v", executeErr)
+			}
+		})
+	}
+}
+
+func TestScrollMovesToBoundedTargetAndEmitsExactEvents(t *testing.T) {
+	driver := &fakeDriver{}
+	session := newTestSession(t, extendedActionPolicy(OperationScroll), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationScroll,
+		Scroll: &ScrollAction{
+			TargetX: 12, TargetY: 23, DeltaX: -2, DeltaY: 3,
+			Events: 3, DisplayID: 0,
+		},
+	})
+	if err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("scroll result = %+v, %v", result, err)
+	}
+	calls := driver.recordedCalls()
+	if len(calls) != 4 {
+		t.Fatalf("calls = %+v", calls)
+	}
+	if calls[0].operation != OperationMove || calls[0].x != 12 ||
+		calls[0].y != 23 || calls[0].displayID != 0 {
+		t.Fatalf("target move = %+v", calls[0])
+	}
+	for _, call := range calls[1:] {
+		if call.operation != OperationScroll || call.deltaX != -2 || call.deltaY != 3 {
+			t.Fatalf("scroll call = %+v", call)
+		}
+	}
+}
+
+func TestScrollPolicyRejectsTotalDistanceBeforeInput(t *testing.T) {
+	driver := &fakeDriver{}
+	policy := extendedActionPolicy(OperationScroll)
+	policy.MaxScrollDistance = 5
+	session := newTestSession(t, policy, driver)
+	_, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationScroll,
+		Scroll: &ScrollAction{
+			TargetX: 1, TargetY: 1, DeltaY: 2, Events: 3, DisplayID: 0,
+		},
+	})
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("scroll error = %v", err)
+	}
+	if driver.callCount() != 0 {
+		t.Fatalf("denied scroll reached driver: %+v", driver.recordedCalls())
+	}
+}
+
+func TestScrollFailureAfterTargetMoveIsUnverified(t *testing.T) {
+	driver := &fakeDriver{callError: func(call driverCall) error {
+		if call.operation == OperationScroll {
+			return errors.New("scroll backend failed")
+		}
+		return nil
+	}}
+	session := newTestSession(t, extendedActionPolicy(OperationScroll), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationScroll,
+		Scroll: &ScrollAction{
+			TargetX: 1, TargetY: 1, DeltaY: 1, Events: 2, DisplayID: 0,
+		},
+	})
+	var actionErr *ActionError
+	if !errors.As(err, &actionErr) || actionErr.Code != ErrorBackendFailure ||
+		result.Status != ActionUnverified {
+		t.Fatalf("partial scroll result = %+v, %v", result, err)
+	}
+	calls := driver.recordedCalls()
+	if len(calls) != 2 || calls[0].operation != OperationMove ||
+		calls[1].operation != OperationScroll {
+		t.Fatalf("partial scroll calls = %+v", calls)
+	}
+}
+
+func TestDragUsesBoundedPathAndAlwaysReleasesButton(t *testing.T) {
+	driver := &fakeDriver{}
+	session := newTestSession(t, extendedActionPolicy(OperationDrag), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationDrag,
+		Confirmed: true,
+		Drag: &DragAction{
+			StartX: 10, StartY: 20, EndX: 13, EndY: 24,
+			DisplayID: 0, Button: MouseButtonLeft, DurationMillis: 5,
+		},
+	})
+	if err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("drag result = %+v, %v", result, err)
+	}
+	calls := driver.recordedCalls()
+	if len(calls) < 4 {
+		t.Fatalf("drag calls = %+v", calls)
+	}
+	if calls[0].operation != OperationMove || calls[0].x != 10 || calls[0].y != 20 {
+		t.Fatalf("drag start = %+v", calls[0])
+	}
+	if calls[1].operation != OperationDrag || !calls[1].down {
+		t.Fatalf("drag press = %+v", calls[1])
+	}
+	lastMove := calls[len(calls)-2]
+	if lastMove.operation != OperationMove || lastMove.x != 13 || lastMove.y != 24 {
+		t.Fatalf("drag end = %+v", lastMove)
+	}
+	if release := calls[len(calls)-1]; release.operation != OperationDrag || release.down {
+		t.Fatalf("drag release = %+v", release)
+	}
+	if len(session.pressedInputs) != 0 {
+		t.Fatalf("pressed ledger = %+v", session.pressedInputs)
+	}
+}
+
+func TestCanceledDragReleasesButton(t *testing.T) {
+	pressed := make(chan struct{})
+	driver := &fakeDriver{callHook: func(call driverCall) {
+		if call.operation == OperationDrag && call.down {
+			select {
+			case <-pressed:
+			default:
+				close(pressed)
+			}
+		}
+	}}
+	session := newTestSession(t, extendedActionPolicy(OperationDrag), driver)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultChannel := make(chan actionOutcome, 1)
+	go func() {
+		result, err := session.Execute(ctx, ActionRequest{
+			Operation: OperationDrag,
+			Confirmed: true,
+			Drag: &DragAction{
+				StartX: 1, StartY: 1, EndX: 11, EndY: 1,
+				DisplayID: 0, Button: MouseButtonLeft, DurationMillis: 1_000,
+			},
+		})
+		resultChannel <- actionOutcome{result: result, err: err}
+	}()
+	select {
+	case <-pressed:
+	case <-time.After(time.Second):
+		t.Fatal("drag did not press button")
+	}
+	cancel()
+	select {
+	case outcome := <-resultChannel:
+		var actionErr *ActionError
+		if !errors.As(outcome.err, &actionErr) || actionErr.Code != ErrorCanceled ||
+			outcome.result.Status != ActionUnverified {
+			t.Fatalf("drag cancellation outcome = %+v, %v", outcome.result, outcome.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled drag did not return")
+	}
+	calls := driver.recordedCalls()
+	if release := calls[len(calls)-1]; release.operation != OperationDrag || release.down {
+		t.Fatalf("final call did not release drag: %+v", calls)
+	}
+}
+
+func TestSessionCloseCancelsDragAndReleasesButton(t *testing.T) {
+	pressed := make(chan struct{})
+	driver := &fakeDriver{callHook: func(call driverCall) {
+		if call.operation == OperationDrag && call.down {
+			select {
+			case <-pressed:
+			default:
+				close(pressed)
+			}
+		}
+	}}
+	policy, err := preparePolicy(extendedActionPolicy(OperationDrag))
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := newSession(policy, driver, availableCapabilities())
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultChannel := make(chan actionOutcome, 1)
+	go func() {
+		result, executeErr := session.Execute(context.Background(), ActionRequest{
+			Operation: OperationDrag,
+			Confirmed: true,
+			Drag: &DragAction{
+				StartX: 1, StartY: 1, EndX: 11, EndY: 1,
+				DisplayID: 0, Button: MouseButtonLeft, DurationMillis: 1_000,
+			},
+		})
+		resultChannel <- actionOutcome{result: result, err: executeErr}
+	}()
+	select {
+	case <-pressed:
+	case <-time.After(time.Second):
+		t.Fatal("drag did not press button")
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("close = %v", err)
+	}
+	select {
+	case outcome := <-resultChannel:
+		var actionErr *ActionError
+		if !errors.As(outcome.err, &actionErr) || actionErr.Code != ErrorSessionClosed ||
+			outcome.result.Status != ActionUnverified {
+			t.Fatalf("execute outcome = %+v, %v", outcome.result, outcome.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("close did not stop active drag")
+	}
+	calls := driver.recordedCalls()
+	if release := calls[len(calls)-1]; release.operation != OperationDrag || release.down {
+		t.Fatalf("close left button pressed: %+v", calls)
+	}
+}
+
+func TestCleanupFailureRetainsExclusiveOwnerUntilCloseRetrySucceeds(t *testing.T) {
+	releaseFailures := 2
+	driver := &fakeDriver{callError: func(call driverCall) error {
+		if call.operation == OperationKeyChord && call.text == "" &&
+			!call.down && releaseFailures > 0 {
+			releaseFailures--
+			return errors.New("release failed")
+		}
+		return nil
+	}}
+	policy, err := preparePolicy(extendedActionPolicy(OperationKeyChord))
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := newSession(policy, driver, availableCapabilities())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	_, _ = session.Execute(t.Context(), ActionRequest{
+		Operation: OperationKeyChord,
+		Confirmed: true,
+		KeyChord:  &KeyChordAction{Key: "c", TargetPID: 42},
+	})
+	if err := session.Close(); !errors.Is(err, ErrInputCleanup) {
+		t.Fatalf("first close = %v", err)
+	}
+	if replacement, replaceErr := newSession(policy, &fakeDriver{}, availableCapabilities()); replacement != nil ||
+		!errors.Is(replaceErr, ErrSessionBusy) {
+		t.Fatalf("replacement during retained ownership = %v, %v", replacement, replaceErr)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("cleanup retry = %v", err)
+	}
+	replacement, err := newSession(policy, &fakeDriver{}, availableCapabilities())
+	if err != nil {
+		t.Fatalf("replacement after cleanup = %v", err)
+	}
+	if err := replacement.Close(); err != nil {
+		t.Fatalf("replacement close = %v", err)
+	}
+}
+
+func TestKeyChordUsesCanonicalOrderAndRelease(t *testing.T) {
+	driver := &fakeDriver{}
+	session := newTestSession(t, extendedActionPolicy(OperationKeyChord), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationKeyChord,
+		Confirmed: true,
+		KeyChord: &KeyChordAction{
+			Key: "c", Modifiers: []KeyModifier{KeyModifierControl, KeyModifierShift},
+			TargetPID: 42,
+		},
+	})
+	if err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("chord result = %+v, %v", result, err)
+	}
+	calls := driver.recordedCalls()
+	var keyCalls []driverCall
+	for _, call := range calls {
+		if call.operation == OperationKeyChord && call.text == "" {
+			keyCalls = append(keyCalls, call)
+		}
+	}
+	if len(keyCalls) != 2 || !keyCalls[0].down || keyCalls[1].down ||
+		keyCalls[0].key != "c" ||
+		!sameModifiers(keyCalls[0].modifiers, keyCalls[1].modifiers) {
+		t.Fatalf("chord calls = %+v", calls)
+	}
+}
+
+func TestPureGoX11KeyChordUsesAtomicBackendOwnedTransaction(t *testing.T) {
+	driver := &fakeDriver{}
+	policy, err := preparePolicy(extendedActionPolicy(OperationKeyChord))
+	if err != nil {
+		t.Fatal(err)
+	}
+	capabilities := availableCapabilities()
+	capabilities.Runtime.GOOS = goOSLinux
+	capabilities.Runtime.DisplayServer = robotgo.DisplayServerX11
+	capabilities.Keyboard.Backend = agentKeyboardPureGoX11
+	session, err := newSession(policy, driver, capabilities)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	capability, ok := session.capability(OperationKeyChord)
+	if !ok || !capability.Available ||
+		capability.Cancellation != CancellationPreflightOnly {
+		t.Fatalf("Pure-Go X11 chord capability = %+v", capability)
+	}
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationKeyChord,
+		Confirmed: true,
+		KeyChord: &KeyChordAction{
+			Key: "c", Modifiers: []KeyModifier{KeyModifierControl}, TargetPID: 42,
+		},
+	})
+	if err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("Pure-Go X11 chord result = %+v, %v", result, err)
+	}
+	calls := driver.recordedCalls()
+	var chordCalls []driverCall
+	for _, call := range calls {
+		if call.operation == OperationKeyChord && (call.text == "" || call.text == "tap") {
+			chordCalls = append(chordCalls, call)
+		}
+	}
+	if len(chordCalls) != 1 || chordCalls[0].text != "tap" ||
+		chordCalls[0].key != "c" ||
+		!sameModifiers(chordCalls[0].modifiers, []KeyModifier{KeyModifierControl}) ||
+		len(session.pressedInputs) != 0 {
+		t.Fatalf("Pure-Go X11 chord calls = %+v, ledger = %+v", calls, session.pressedInputs)
+	}
+}
+
+func TestKeyChordRejectsChangedActiveWindowBeforeInput(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		driver *fakeDriver
+	}{
+		{name: "process changed", driver: &fakeDriver{activePID: 99}},
+		{
+			name:   "title changed before dispatch",
+			driver: &fakeDriver{windowTitles: []string{"fixture", "different fixture"}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			session := newTestSession(t, extendedActionPolicy(OperationKeyChord), test.driver)
+			result, err := session.Execute(t.Context(), ActionRequest{
+				Operation: OperationKeyChord,
+				Confirmed: true,
+				KeyChord: &KeyChordAction{
+					Key: "c", Modifiers: []KeyModifier{KeyModifierControl}, TargetPID: 42,
+				},
+			})
+			var actionErr *ActionError
+			if !errors.As(err, &actionErr) || actionErr.Code != ErrorStaleTarget ||
+				result.Status != ActionFailed {
+				t.Fatalf("stale chord result = %+v, %v", result, err)
+			}
+			for _, call := range test.driver.recordedCalls() {
+				if call.operation == OperationKeyChord && call.text == "" {
+					t.Fatalf("stale chord injected key input: %+v", test.driver.recordedCalls())
+				}
+			}
+		})
+	}
+}
+
+func TestKeyChordCancellationDuringFinalIdentityCheckPreventsInput(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	activeChecks := 0
+	driver := &fakeDriver{callHook: func(call driverCall) {
+		if call.operation == OperationKeyChord && call.text == "active-pid" {
+			activeChecks++
+			if activeChecks == 2 {
+				cancel()
+			}
+		}
+	}}
+	session := newTestSession(t, extendedActionPolicy(OperationKeyChord), driver)
+	result, err := session.Execute(ctx, ActionRequest{
+		Operation: OperationKeyChord,
+		Confirmed: true,
+		KeyChord: &KeyChordAction{
+			Key: "c", Modifiers: []KeyModifier{KeyModifierControl}, TargetPID: 42,
+		},
+	})
+	var actionErr *ActionError
+	if !errors.As(err, &actionErr) || actionErr.Code != ErrorCanceled ||
+		result.Status != ActionFailed {
+		t.Fatalf("canceled chord result = %+v, %v", result, err)
+	}
+	for _, call := range driver.recordedCalls() {
+		if call.operation == OperationKeyChord && call.text == "" {
+			t.Fatalf("canceled chord injected key input: %+v", driver.recordedCalls())
+		}
+	}
+}
+
+func TestKeyChordReleaseFailureIsRetriedOnClose(t *testing.T) {
+	releaseFailures := 1
+	driver := &fakeDriver{callError: func(call driverCall) error {
+		if call.operation == OperationKeyChord && call.text == "" &&
+			!call.down && releaseFailures > 0 {
+			releaseFailures--
+			return errors.New("release failed")
+		}
+		return nil
+	}}
+	policy, err := preparePolicy(extendedActionPolicy(OperationKeyChord))
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := newSession(policy, driver, availableCapabilities())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	result, executeErr := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationKeyChord,
+		Confirmed: true,
+		KeyChord: &KeyChordAction{
+			Key: "c", Modifiers: []KeyModifier{KeyModifierControl}, TargetPID: 42,
+		},
+	})
+	var actionErr *ActionError
+	if !errors.As(executeErr, &actionErr) || actionErr.Code != ErrorCleanupFailed ||
+		result.Status != ActionUnverified || len(session.pressedInputs) != 1 {
+		t.Fatalf("release failure result = %+v, %v, ledger = %+v", result, executeErr, session.pressedInputs)
+	}
+	callsBeforeDeniedRetry := driver.callCount()
+	_, retryErr := session.DryRun(t.Context(), ActionRequest{
+		Operation: OperationKeyChord,
+		Confirmed: true,
+		KeyChord: &KeyChordAction{
+			Key: "c", Modifiers: []KeyModifier{KeyModifierControl}, TargetPID: 42,
+		},
+	})
+	if !errors.As(retryErr, &actionErr) || actionErr.Code != ErrorCleanupFailed {
+		t.Fatalf("tainted session retry = %v", retryErr)
+	}
+	if driver.callCount() != callsBeforeDeniedRetry {
+		t.Fatalf("tainted session reached driver: %+v", driver.recordedCalls())
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("close retry = %v", err)
+	}
+	calls := driver.recordedCalls()
+	var keyCalls []driverCall
+	for _, call := range calls {
+		if call.operation == OperationKeyChord && call.text == "" {
+			keyCalls = append(keyCalls, call)
+		}
+	}
+	if len(keyCalls) != 3 || keyCalls[2].down {
+		t.Fatalf("release retry calls = %+v", calls)
+	}
+}
+
+func TestDragDistanceAndInterpolationRemainSafeAtIntegerEdges(t *testing.T) {
+	maximum := int(^uint(0) >> 1)
+	minimum := -maximum - 1
+	for _, action := range []DragAction{
+		{StartX: maximum - 100, EndX: maximum},
+		{StartX: minimum, EndX: minimum + 100},
+	} {
+		if distance := dragDistance(action); distance != 100 {
+			t.Fatalf("edge drag distance = %d for %+v", distance, action)
+		}
+		midpoint := interpolateCoordinate(action.StartX, action.EndX, 1, 2)
+		if midpoint < min(action.StartX, action.EndX) ||
+			midpoint > max(action.StartX, action.EndX) {
+			t.Fatalf("edge midpoint escaped path: %d for %+v", midpoint, action)
+		}
+		if end := interpolateCoordinate(action.StartX, action.EndX, 2, 2); end != action.EndX {
+			t.Fatalf("edge endpoint = %d, want %d", end, action.EndX)
+		}
+	}
+	if distance := dragDistance(DragAction{StartX: minimum, EndX: maximum}); distance <= maxAgentDragDistance {
+		t.Fatalf("cross-range drag distance = %d", distance)
+	}
+}
+
+func TestWindowActivationRevalidatesImmutableIdentity(t *testing.T) {
+	driver := &fakeDriver{windowTitle: "fixture"}
+	session := newTestSession(t, extendedActionPolicy(OperationActivate), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationActivate,
+		Confirmed: true,
+		Activate:  &ActivateWindowAction{Target: 42, Kind: WindowTargetProcess},
+	})
+	if err != nil || result.Status != ActionSucceeded {
+		t.Fatalf("activation result = %+v, %v", result, err)
+	}
+	calls := driver.recordedCalls()
+	if len(calls) != 3 || calls[0].text != "title" ||
+		calls[1].text != "title" || calls[2].text != "activate" {
+		t.Fatalf("activation calls = %+v", calls)
+	}
+}
+
+func TestWindowActivationRejectsChangedIdentityBeforeMutation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		driver *fakeDriver
+		calls  int
+	}{
+		{
+			name: "stale at preflight", driver: &fakeDriver{windowTitle: "different fixture"},
+			calls: 1,
+		},
+		{
+			name:   "stale immediately before dispatch",
+			driver: &fakeDriver{windowTitles: []string{"fixture", "different fixture"}},
+			calls:  2,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			session := newTestSession(t, extendedActionPolicy(OperationActivate), test.driver)
+			_, err := session.Execute(t.Context(), ActionRequest{
+				Operation: OperationActivate,
+				Confirmed: true,
+				Activate:  &ActivateWindowAction{Target: 42, Kind: WindowTargetProcess},
+			})
+			var actionErr *ActionError
+			if !errors.As(err, &actionErr) || actionErr.Code != ErrorStaleTarget {
+				t.Fatalf("activation error = %v", err)
+			}
+			calls := test.driver.recordedCalls()
+			if len(calls) != test.calls {
+				t.Fatalf("stale activation calls = %+v", calls)
+			}
+			for _, call := range calls {
+				if call.text != "title" {
+					t.Fatalf("stale activation reached mutation: %+v", calls)
+				}
+			}
+		})
+	}
+}
+
+func TestWindowActivationCancellationDuringFinalIdentityCheckPreventsMutation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	titleChecks := 0
+	driver := &fakeDriver{callHook: func(call driverCall) {
+		if call.operation == OperationActivate && call.text == "title" {
+			titleChecks++
+			if titleChecks == 2 {
+				cancel()
+			}
+		}
+	}}
+	session := newTestSession(t, extendedActionPolicy(OperationActivate), driver)
+	result, err := session.Execute(ctx, ActionRequest{
+		Operation: OperationActivate,
+		Confirmed: true,
+		Activate:  &ActivateWindowAction{Target: 42, Kind: WindowTargetProcess},
+	})
+	var actionErr *ActionError
+	if !errors.As(err, &actionErr) || actionErr.Code != ErrorCanceled ||
+		result.Status != ActionFailed {
+		t.Fatalf("canceled activation result = %+v, %v", result, err)
+	}
+	for _, call := range driver.recordedCalls() {
+		if call.operation == OperationActivate && call.text == "activate" {
+			t.Fatalf("canceled activation reached mutation: %+v", driver.recordedCalls())
+		}
+	}
+}
+
+func TestExtendedActionRateAndSessionLifetimeAreBounded(t *testing.T) {
+	driver := &fakeDriver{}
+	session := newTestSession(t, extendedActionPolicy(OperationScroll), driver)
+	now := time.Unix(1, 0)
+	session.now = func() time.Time { return now }
+	request := ActionRequest{
+		Operation: OperationScroll,
+		Scroll: &ScrollAction{
+			TargetX: 1, TargetY: 1, DeltaY: 1, Events: 1, DisplayID: 0,
+		},
+	}
+	if _, err := session.Execute(t.Context(), request); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.Execute(t.Context(), request); !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("rate-limited action = %v", err)
+	}
+
+	timeoutPolicy := extendedActionPolicy(OperationScroll)
+	timeoutPolicy.SessionTimeoutMillis = 1
+	_ = session.Close()
+	timeoutSession := newTestSession(t, timeoutPolicy, &fakeDriver{})
+	time.Sleep(5 * time.Millisecond)
+	_, err := timeoutSession.Execute(t.Context(), request)
+	var actionErr *ActionError
+	if !errors.As(err, &actionErr) || actionErr.Code != ErrorTimedOut {
+		t.Fatalf("expired session action = %v", err)
+	}
+}
+
+func TestExtendedPolicyRejectsAliasesAndUnboundedOperations(t *testing.T) {
+	tests := []Policy{
+		extendedActionPolicy(OperationScroll),
+		extendedActionPolicy(OperationDrag),
+		extendedActionPolicy(OperationKeyChord),
+		extendedActionPolicy(OperationActivate),
+	}
+	tests[0].MaxScrollEvents = 0
+	tests[1].MaxDragDurationMillis = 0
+	tests[2].AllowedModifiers = []KeyModifier{"ctrl"}
+	tests[3].AllowedWindows[0].ExpectedTitle = ""
+	for _, policy := range tests {
+		if _, err := preparePolicy(policy); err == nil {
+			t.Fatalf("invalid extended policy accepted: %+v", policy)
+		}
+	}
+}

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -637,6 +637,52 @@ func TestAmbiguousKeyDownAndCleanupFailureRemainOwned(t *testing.T) {
 	}
 }
 
+func TestKnownUnappliedKeyDownDoesNotReleaseForeignInput(t *testing.T) {
+	for _, backendErr := range []error{
+		robotgo.ErrInputNotApplied,
+		robotgo.ErrInputOwnership,
+	} {
+		t.Run(backendErr.Error(), func(t *testing.T) {
+			driver := &fakeDriver{callError: func(call driverCall) error {
+				if call.operation == OperationKeyChord && call.down {
+					return backendErr
+				}
+				return nil
+			}}
+			session := newTestSession(
+				t,
+				extendedActionPolicy(OperationKeyChord),
+				driver,
+			)
+			result, err := session.Execute(t.Context(), ActionRequest{
+				Operation: OperationKeyChord, Confirmed: true,
+				KeyChord: &KeyChordAction{Key: "c", TargetPID: 42},
+			})
+			var actionErr *ActionError
+			if !errors.Is(err, backendErr) ||
+				!errors.As(err, &actionErr) ||
+				actionErr.Code != ErrorBackendFailure ||
+				result.Status != ActionFailed {
+				t.Fatalf("known-unapplied key down = %+v, %v", result, err)
+			}
+			var mutations []driverCall
+			for _, call := range driver.recordedCalls() {
+				if call.operation == OperationKeyChord && call.text == "" {
+					mutations = append(mutations, call)
+				}
+			}
+			if len(mutations) != 1 || !mutations[0].down ||
+				len(session.pressedInputs) != 0 || session.inputTainted {
+				t.Fatalf(
+					"known-unapplied key cleanup = %+v, ledger = %+v",
+					mutations,
+					session.pressedInputs,
+				)
+			}
+		})
+	}
+}
+
 func TestKeyChordUsesCanonicalOrderAndRelease(t *testing.T) {
 	driver := &fakeDriver{}
 	session := newTestSession(t, extendedActionPolicy(OperationKeyChord), driver)

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -944,6 +944,33 @@ func TestWindowActivationRejectsChangedIdentityBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestWindowActivationBackendErrorIsUnverified(t *testing.T) {
+	backendErr := errors.New("ambiguous activation failure")
+	driver := &fakeDriver{callError: func(call driverCall) error {
+		if call.operation == OperationActivate && call.text == "activate" {
+			return backendErr
+		}
+		return nil
+	}}
+	session := newTestSession(t, extendedActionPolicy(OperationActivate), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationActivate,
+		Confirmed: true,
+		Activate:  &ActivateWindowAction{Target: 42, Kind: WindowTargetProcess},
+	})
+	var actionErr *ActionError
+	if !errors.Is(err, backendErr) ||
+		!errors.As(err, &actionErr) ||
+		actionErr.Code != ErrorBackendFailure ||
+		result.Status != ActionUnverified {
+		t.Fatalf("ambiguous activation result = %+v, %v", result, err)
+	}
+	calls := driver.recordedCalls()
+	if len(calls) != 5 || calls[4].text != "activate" {
+		t.Fatalf("ambiguous activation calls = %+v", calls)
+	}
+}
+
 func TestWindowActivationCancellationDuringFinalIdentityCheckPreventsMutation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	titleChecks := 0

--- a/agent/extended_actions_test.go
+++ b/agent/extended_actions_test.go
@@ -100,15 +100,13 @@ func TestNativeMacOSActivationCapabilityRejectsHandleOnlyPolicy(t *testing.T) {
 	}
 }
 
-func TestWaylandKeyChordCapabilityRequiresActiveWindowIdentity(t *testing.T) {
+func TestWaylandKeyChordCapabilityRequiresProcessTargetedInjection(t *testing.T) {
 	for _, test := range []struct {
-		backend   string
-		available bool
-		code      ErrorCode
+		backend string
 	}{
-		{backend: agentWindowBackendSway, available: true},
-		{backend: agentWindowBackendHyprland, available: true},
-		{backend: "wlroots-generic", available: false, code: ErrorUnsupported},
+		{backend: agentWindowBackendSway},
+		{backend: agentWindowBackendHyprland},
+		{backend: "wlroots-generic"},
 	} {
 		t.Run(test.backend, func(t *testing.T) {
 			capabilities := availableCapabilities()
@@ -116,8 +114,8 @@ func TestWaylandKeyChordCapabilityRequiresActiveWindowIdentity(t *testing.T) {
 			capabilities.Runtime.DisplayServer = robotgo.DisplayServerWayland
 			capabilities.Window.Backend = test.backend
 			capability := keyChordFeature(capabilities)
-			if capability.Available != test.available ||
-				featureUnavailableCode(capability) != test.code {
+			if capability.Available ||
+				featureUnavailableCode(capability) != ErrorUnsupported {
 				t.Fatalf("keyboard.chord capability = %+v", capability)
 			}
 		})
@@ -176,6 +174,54 @@ func TestExtendedCapabilityReportsPermissionAndUnavailableStates(t *testing.T) {
 				t.Fatalf("unavailable cause = %v", executeErr)
 			}
 		})
+	}
+}
+
+func TestPureGoX11ScrollReportsAndEnforcesVerticalAxisOnly(t *testing.T) {
+	driver := &fakeDriver{}
+	policy, err := preparePolicy(extendedActionPolicy(OperationScroll))
+	if err != nil {
+		t.Fatal(err)
+	}
+	capabilities := availableCapabilities()
+	capabilities.Mouse.Backend = agentInputPureGoX11
+	session, err := newSession(policy, driver, capabilities)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	capability, ok := session.capability(OperationScroll)
+	if !ok || !capability.Available ||
+		len(capability.ScrollAxes) != 1 ||
+		capability.ScrollAxes[0] != ScrollAxisVertical {
+		t.Fatalf("Pure-Go X11 scroll capability = %+v", capability)
+	}
+	catalog := session.Catalog()
+	for index := range catalog.Operations {
+		if catalog.Operations[index].Operation == OperationScroll {
+			catalog.Operations[index].ScrollAxes[0] = ScrollAxisHorizontal
+		}
+	}
+	unchanged, _ := session.capability(OperationScroll)
+	if unchanged.ScrollAxes[0] != ScrollAxisVertical {
+		t.Fatal("catalog clone exposed mutable scroll axes")
+	}
+
+	result, executeErr := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationScroll,
+		Scroll: &ScrollAction{
+			TargetX: 1, TargetY: 1, DeltaX: 1, Events: 1, DisplayID: 0,
+		},
+	})
+	var actionErr *ActionError
+	if !errors.As(executeErr, &actionErr) ||
+		actionErr.Code != ErrorUnsupported ||
+		result.Status != ActionFailed {
+		t.Fatalf("horizontal scroll result = %+v, %v", result, executeErr)
+	}
+	if calls := driver.recordedCalls(); len(calls) != 0 {
+		t.Fatalf("unsupported horizontal scroll reached driver: %+v", calls)
 	}
 }
 
@@ -433,6 +479,109 @@ func TestCleanupFailureRetainsExclusiveOwnerUntilCloseRetrySucceeds(t *testing.T
 	}
 }
 
+func TestAmbiguousInputDownFailureIsReleasedImmediately(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		operation Operation
+		request   ActionRequest
+	}{
+		{
+			name: "mouse", operation: OperationDrag,
+			request: ActionRequest{
+				Operation: OperationDrag, Confirmed: true,
+				Drag: &DragAction{
+					StartX: 1, StartY: 1, EndX: 2, EndY: 1,
+					DisplayID: 0, Button: MouseButtonLeft, DurationMillis: 1,
+				},
+			},
+		},
+		{
+			name: "keyboard", operation: OperationKeyChord,
+			request: ActionRequest{
+				Operation: OperationKeyChord, Confirmed: true,
+				KeyChord: &KeyChordAction{Key: "c", TargetPID: 42},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			driver := &fakeDriver{callError: func(call driverCall) error {
+				if call.operation == test.operation && call.down {
+					return errors.New("ambiguous down failure")
+				}
+				return nil
+			}}
+			session := newTestSession(
+				t,
+				extendedActionPolicy(test.operation),
+				driver,
+			)
+			result, executeErr := session.Execute(t.Context(), test.request)
+			if executeErr == nil || result.Status != ActionUnverified {
+				t.Fatalf("ambiguous down result = %+v, %v", result, executeErr)
+			}
+			var mutationCalls []driverCall
+			for _, call := range driver.recordedCalls() {
+				if call.operation == test.operation && call.text == "" {
+					mutationCalls = append(mutationCalls, call)
+				}
+			}
+			if len(mutationCalls) != 2 ||
+				!mutationCalls[0].down || mutationCalls[1].down ||
+				len(session.pressedInputs) != 0 || session.inputTainted {
+				t.Fatalf(
+					"ambiguous down cleanup calls = %+v, ledger = %+v",
+					mutationCalls,
+					session.pressedInputs,
+				)
+			}
+		})
+	}
+}
+
+func TestAmbiguousKeyDownAndCleanupFailureRemainOwned(t *testing.T) {
+	releaseFailures := 1
+	driver := &fakeDriver{callError: func(call driverCall) error {
+		if call.operation != OperationKeyChord || call.text != "" {
+			return nil
+		}
+		if call.down {
+			return errors.New("ambiguous down failure")
+		}
+		if releaseFailures > 0 {
+			releaseFailures--
+			return errors.New("release failed")
+		}
+		return nil
+	}}
+	policy, err := preparePolicy(extendedActionPolicy(OperationKeyChord))
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := newSession(policy, driver, availableCapabilities())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, executeErr := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationKeyChord, Confirmed: true,
+		KeyChord: &KeyChordAction{Key: "c", TargetPID: 42},
+	})
+	var actionErr *ActionError
+	if !errors.As(executeErr, &actionErr) ||
+		actionErr.Code != ErrorCleanupFailed ||
+		result.Status != ActionUnverified ||
+		len(session.pressedInputs) != 1 || !session.inputTainted {
+		t.Fatalf(
+			"ambiguous cleanup failure = %+v, %v, ledger = %+v",
+			result,
+			executeErr,
+			session.pressedInputs,
+		)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("close cleanup retry = %v", err)
+	}
+}
+
 func TestKeyChordUsesCanonicalOrderAndRelease(t *testing.T) {
 	driver := &fakeDriver{}
 	session := newTestSession(t, extendedActionPolicy(OperationKeyChord), driver)
@@ -455,13 +604,14 @@ func TestKeyChordUsesCanonicalOrderAndRelease(t *testing.T) {
 		}
 	}
 	if len(keyCalls) != 2 || !keyCalls[0].down || keyCalls[1].down ||
-		keyCalls[0].key != "c" ||
+		keyCalls[0].key != "c" || keyCalls[0].target != 42 ||
+		keyCalls[1].target != 42 ||
 		!sameModifiers(keyCalls[0].modifiers, keyCalls[1].modifiers) {
 		t.Fatalf("chord calls = %+v", calls)
 	}
 }
 
-func TestPureGoX11KeyChordUsesAtomicBackendOwnedTransaction(t *testing.T) {
+func TestPureGoX11KeyChordIsUnavailableWithoutProcessTargeting(t *testing.T) {
 	driver := &fakeDriver{}
 	policy, err := preparePolicy(extendedActionPolicy(OperationKeyChord))
 	if err != nil {
@@ -470,15 +620,15 @@ func TestPureGoX11KeyChordUsesAtomicBackendOwnedTransaction(t *testing.T) {
 	capabilities := availableCapabilities()
 	capabilities.Runtime.GOOS = goOSLinux
 	capabilities.Runtime.DisplayServer = robotgo.DisplayServerX11
-	capabilities.Keyboard.Backend = agentKeyboardPureGoX11
+	capabilities.Keyboard.Backend = agentInputPureGoX11
 	session, err := newSession(policy, driver, capabilities)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = session.Close() })
 	capability, ok := session.capability(OperationKeyChord)
-	if !ok || !capability.Available ||
-		capability.Cancellation != CancellationPreflightOnly {
+	if !ok || capability.Available ||
+		capability.UnavailableCode != ErrorUnsupported {
 		t.Fatalf("Pure-Go X11 chord capability = %+v", capability)
 	}
 	result, err := session.Execute(t.Context(), ActionRequest{
@@ -488,65 +638,58 @@ func TestPureGoX11KeyChordUsesAtomicBackendOwnedTransaction(t *testing.T) {
 			Key: "c", Modifiers: []KeyModifier{KeyModifierControl}, TargetPID: 42,
 		},
 	})
-	if err != nil || result.Status != ActionSucceeded {
+	var actionErr *ActionError
+	if !errors.As(err, &actionErr) || actionErr.Code != ErrorUnsupported ||
+		result.Status != ActionFailed {
 		t.Fatalf("Pure-Go X11 chord result = %+v, %v", result, err)
 	}
-	calls := driver.recordedCalls()
-	var chordCalls []driverCall
-	for _, call := range calls {
-		if call.operation == OperationKeyChord && (call.text == "" || call.text == "tap") {
-			chordCalls = append(chordCalls, call)
-		}
-	}
-	if len(chordCalls) != 1 || chordCalls[0].text != "tap" ||
-		chordCalls[0].key != "c" ||
-		!sameModifiers(chordCalls[0].modifiers, []KeyModifier{KeyModifierControl}) ||
-		len(session.pressedInputs) != 0 {
-		t.Fatalf("Pure-Go X11 chord calls = %+v, ledger = %+v", calls, session.pressedInputs)
+	if calls := driver.recordedCalls(); len(calls) != 0 {
+		t.Fatalf("unavailable Pure-Go X11 chord reached driver: %+v", calls)
 	}
 }
 
-func TestKeyChordRejectsChangedActiveWindowBeforeInput(t *testing.T) {
-	for _, test := range []struct {
-		name   string
-		driver *fakeDriver
-	}{
-		{name: "process changed", driver: &fakeDriver{activePID: 99}},
-		{
-			name:   "title changed before dispatch",
-			driver: &fakeDriver{windowTitles: []string{"fixture", "different fixture"}},
+func TestNativeX11KeyChordIsUnavailableWithoutProcessTargeting(t *testing.T) {
+	capabilities := availableCapabilities()
+	capabilities.Runtime.GOOS = goOSLinux
+	capabilities.Runtime.CGOEnabled = true
+	capabilities.Runtime.DisplayServer = robotgo.DisplayServerX11
+	capabilities.Keyboard.Backend = "x11"
+	capability := keyChordFeature(capabilities)
+	if capability.Available ||
+		featureUnavailableCode(capability) != ErrorUnsupported {
+		t.Fatalf("native X11 chord capability = %+v", capability)
+	}
+}
+
+func TestKeyChordRejectsChangedTargetTitleBeforeInput(t *testing.T) {
+	driver := &fakeDriver{windowTitles: []string{"fixture", "different fixture"}}
+	session := newTestSession(t, extendedActionPolicy(OperationKeyChord), driver)
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationKeyChord,
+		Confirmed: true,
+		KeyChord: &KeyChordAction{
+			Key: "c", Modifiers: []KeyModifier{KeyModifierControl}, TargetPID: 42,
 		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			session := newTestSession(t, extendedActionPolicy(OperationKeyChord), test.driver)
-			result, err := session.Execute(t.Context(), ActionRequest{
-				Operation: OperationKeyChord,
-				Confirmed: true,
-				KeyChord: &KeyChordAction{
-					Key: "c", Modifiers: []KeyModifier{KeyModifierControl}, TargetPID: 42,
-				},
-			})
-			var actionErr *ActionError
-			if !errors.As(err, &actionErr) || actionErr.Code != ErrorStaleTarget ||
-				result.Status != ActionFailed {
-				t.Fatalf("stale chord result = %+v, %v", result, err)
-			}
-			for _, call := range test.driver.recordedCalls() {
-				if call.operation == OperationKeyChord && call.text == "" {
-					t.Fatalf("stale chord injected key input: %+v", test.driver.recordedCalls())
-				}
-			}
-		})
+	})
+	var actionErr *ActionError
+	if !errors.As(err, &actionErr) || actionErr.Code != ErrorStaleTarget ||
+		result.Status != ActionFailed {
+		t.Fatalf("stale chord result = %+v, %v", result, err)
+	}
+	for _, call := range driver.recordedCalls() {
+		if call.operation == OperationKeyChord && call.text == "" {
+			t.Fatalf("stale chord injected key input: %+v", driver.recordedCalls())
+		}
 	}
 }
 
 func TestKeyChordCancellationDuringFinalIdentityCheckPreventsInput(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
-	activeChecks := 0
+	titleChecks := 0
 	driver := &fakeDriver{callHook: func(call driverCall) {
-		if call.operation == OperationKeyChord && call.text == "active-pid" {
-			activeChecks++
-			if activeChecks == 2 {
+		if call.text == "title" {
+			titleChecks++
+			if titleChecks == 2 {
 				cancel()
 			}
 		}
@@ -656,7 +799,7 @@ func TestDragDistanceAndInterpolationRemainSafeAtIntegerEdges(t *testing.T) {
 }
 
 func TestWindowActivationRevalidatesImmutableIdentity(t *testing.T) {
-	driver := &fakeDriver{windowTitle: "fixture"}
+	driver := &fakeDriver{windowTitle: "fixture", resolvedHandle: 77}
 	session := newTestSession(t, extendedActionPolicy(OperationActivate), driver)
 	result, err := session.Execute(t.Context(), ActionRequest{
 		Operation: OperationActivate,
@@ -667,8 +810,12 @@ func TestWindowActivationRevalidatesImmutableIdentity(t *testing.T) {
 		t.Fatalf("activation result = %+v, %v", result, err)
 	}
 	calls := driver.recordedCalls()
-	if len(calls) != 3 || calls[0].text != "title" ||
-		calls[1].text != "title" || calls[2].text != "activate" {
+	if len(calls) != 5 ||
+		calls[0].text != "resolve" || calls[1].text != "title" ||
+		calls[2].text != "resolve" || calls[3].text != "title" ||
+		calls[4].text != "activate" ||
+		calls[1].target != 77 || calls[3].target != 77 ||
+		calls[4].target != 77 || calls[4].targetKind != WindowTargetHandle {
 		t.Fatalf("activation calls = %+v", calls)
 	}
 }
@@ -681,12 +828,12 @@ func TestWindowActivationRejectsChangedIdentityBeforeMutation(t *testing.T) {
 	}{
 		{
 			name: "stale at preflight", driver: &fakeDriver{windowTitle: "different fixture"},
-			calls: 1,
+			calls: 2,
 		},
 		{
 			name:   "stale immediately before dispatch",
 			driver: &fakeDriver{windowTitles: []string{"fixture", "different fixture"}},
-			calls:  2,
+			calls:  4,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -705,7 +852,7 @@ func TestWindowActivationRejectsChangedIdentityBeforeMutation(t *testing.T) {
 				t.Fatalf("stale activation calls = %+v", calls)
 			}
 			for _, call := range calls {
-				if call.text != "title" {
+				if call.text == "activate" {
 					t.Fatalf("stale activation reached mutation: %+v", calls)
 				}
 			}

--- a/agent/mcpserver/server.go
+++ b/agent/mcpserver/server.go
@@ -358,6 +358,12 @@ func safeToolError(err error) *ToolError {
 	if err == nil {
 		return nil
 	}
+	if errors.Is(err, agent.ErrInputCleanup) {
+		return &ToolError{
+			Code:    agent.ErrorCleanupFailed,
+			Message: "RobotGo could not release owned input; do not retry the action",
+		}
+	}
 	var actionErr *agent.ActionError
 	if errors.As(err, &actionErr) {
 		return &ToolError{Code: actionErr.Code, Message: actionErr.Message}
@@ -369,11 +375,6 @@ func safeToolError(err error) *ToolError {
 		return &ToolError{Code: agent.ErrorTimedOut, Message: "RobotGo agent operation timed out"}
 	case errors.Is(err, agent.ErrSessionClosed):
 		return closedToolError()
-	case errors.Is(err, agent.ErrInputCleanup):
-		return &ToolError{
-			Code:    agent.ErrorCleanupFailed,
-			Message: "RobotGo could not release owned input; do not retry the action",
-		}
 	default:
 		return &ToolError{Code: agent.ErrorBackendFailure, Message: errorMessageFailed}
 	}

--- a/agent/mcpserver/server.go
+++ b/agent/mcpserver/server.go
@@ -66,7 +66,7 @@ func New(session Session) (*Server, error) {
 	if nilSession(session) {
 		return nil, fmt.Errorf("mcpserver: nil agent session")
 	}
-	a := &adapter{session: session, closeDone: make(chan struct{})}
+	a := &adapter{session: session}
 	s := &Server{
 		adapter: a,
 		protocol: mcp.NewServer(&mcp.Implementation{
@@ -113,9 +113,9 @@ type adapter struct {
 
 	mu        sync.Mutex
 	closed    bool
-	closeOne  sync.Once
+	closeMu   sync.Mutex
+	closeDone bool
 	closeErr  error
-	closeDone chan struct{}
 }
 
 func (a *adapter) begin() (Session, *ToolError) {
@@ -131,15 +131,17 @@ func (a *adapter) close() error {
 	if a == nil {
 		return nil
 	}
-	a.closeOne.Do(func() {
-		a.mu.Lock()
-		a.closed = true
-		a.mu.Unlock()
+	a.mu.Lock()
+	a.closed = true
+	a.mu.Unlock()
 
-		a.closeErr = a.session.Close()
-		close(a.closeDone)
-	})
-	<-a.closeDone
+	a.closeMu.Lock()
+	defer a.closeMu.Unlock()
+	if a.closeDone {
+		return a.closeErr
+	}
+	a.closeErr = a.session.Close()
+	a.closeDone = a.closeErr == nil
 	return a.closeErr
 }
 
@@ -367,6 +369,11 @@ func safeToolError(err error) *ToolError {
 		return &ToolError{Code: agent.ErrorTimedOut, Message: "RobotGo agent operation timed out"}
 	case errors.Is(err, agent.ErrSessionClosed):
 		return closedToolError()
+	case errors.Is(err, agent.ErrInputCleanup):
+		return &ToolError{
+			Code:    agent.ErrorCleanupFailed,
+			Message: "RobotGo could not release owned input; do not retry the action",
+		}
 	default:
 		return &ToolError{Code: agent.ErrorBackendFailure, Message: errorMessageFailed}
 	}

--- a/agent/mcpserver/server_test.go
+++ b/agent/mcpserver/server_test.go
@@ -197,6 +197,20 @@ func TestProtocolInitializesAndListsFocusedTools(t *testing.T) {
 		if tool.InputSchema == nil || tool.OutputSchema == nil {
 			t.Errorf("tool %q has incomplete schemas", tool.Name)
 		}
+		if tool.Name == ToolAct {
+			schema, marshalErr := json.Marshal(tool.InputSchema)
+			if marshalErr != nil {
+				t.Fatalf("marshal act schema: %v", marshalErr)
+			}
+			for _, field := range []string{
+				"scroll", "drag", "key_chord", "activate",
+				"target_x", "duration_ms", "modifiers", "target_pid", "kind",
+			} {
+				if !strings.Contains(string(schema), `"`+field+`"`) {
+					t.Errorf("robotgo_act schema omitted %q: %s", field, schema)
+				}
+			}
+		}
 		switch tool.Name {
 		case ToolFind, ToolWait:
 			if tool.Annotations == nil || !tool.Annotations.ReadOnlyHint {
@@ -217,6 +231,88 @@ func TestProtocolInitializesAndListsFocusedTools(t *testing.T) {
 	slices.Sort(want)
 	if !slices.Equal(names, want) {
 		t.Fatalf("tools = %v, want %v", names, want)
+	}
+}
+
+func TestActProjectsExtendedTypedActionWithoutChangingDryRunDefault(t *testing.T) {
+	var received agent.ActionRequest
+	fake := &fakeSession{
+		dryRunFunc: func(_ context.Context, request agent.ActionRequest) (agent.ActionResult, error) {
+			received = request
+			return agent.ActionResult{
+				ActionID: "planned-drag", Operation: request.Operation,
+				Status: agent.ActionPlanned,
+			}, nil
+		},
+	}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+	request := agent.ActionRequest{
+		Operation: agent.OperationDrag,
+		Confirmed: true,
+		Drag: &agent.DragAction{
+			StartX: 1, StartY: 2, EndX: 3, EndY: 4,
+			DisplayID: 0, Button: agent.MouseButtonLeft, DurationMillis: 50,
+		},
+	}
+	result := callTool(t, client, ToolAct, ActInput{Request: request})
+	if result.IsError {
+		t.Fatalf("extended dry-run returned error: %s", serializedResult(t, result))
+	}
+	output := decodeOutput[ActOutput](t, result)
+	if output.Result == nil || output.Result.Status != agent.ActionPlanned {
+		t.Fatalf("extended dry-run output = %+v", output)
+	}
+	if received.Drag == nil || *received.Drag != *request.Drag {
+		t.Fatalf("projected request = %+v", received)
+	}
+	dryRuns, executes, _ := fake.counts()
+	if dryRuns != 1 || executes != 0 {
+		t.Fatalf("dry runs = %d, executes = %d", dryRuns, executes)
+	}
+}
+
+func TestCloseProjectsInputCleanupFailureWithoutBackendDetails(t *testing.T) {
+	const privateDetail = "private-release-backend-detail"
+	fake := &fakeSession{closeFunc: func() error {
+		return errors.Join(agent.ErrInputCleanup, errors.New(privateDetail))
+	}}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+	result := callTool(t, client, ToolClose, map[string]any{})
+	if !result.IsError {
+		t.Fatal("cleanup failure unexpectedly succeeded")
+	}
+	output := decodeOutput[CloseOutput](t, result)
+	if output.Error == nil || output.Error.Code != agent.ErrorCleanupFailed {
+		t.Fatalf("cleanup output = %+v", output)
+	}
+	if strings.Contains(serializedResult(t, result), privateDetail) {
+		t.Fatal("cleanup output leaked backend detail")
+	}
+}
+
+func TestCloseCanRetryInputCleanupBeforeReleasingAdapter(t *testing.T) {
+	attempts := 0
+	fake := &fakeSession{closeFunc: func() error {
+		attempts++
+		if attempts == 1 {
+			return agent.ErrInputCleanup
+		}
+		return nil
+	}}
+	client := connectProtocol(t, newProtocolServer(t, fake))
+	first := callTool(t, client, ToolClose, map[string]any{})
+	if !first.IsError {
+		t.Fatal("first cleanup attempt unexpectedly succeeded")
+	}
+	second := callTool(t, client, ToolClose, map[string]any{})
+	if second.IsError {
+		t.Fatalf("cleanup retry failed: %s", serializedResult(t, second))
+	}
+	if output := decodeOutput[CloseOutput](t, second); !output.Closed {
+		t.Fatalf("cleanup retry output = %+v", output)
+	}
+	if attempts != 2 {
+		t.Fatalf("close attempts = %d", attempts)
 	}
 }
 

--- a/agent/mcpserver/server_test.go
+++ b/agent/mcpserver/server_test.go
@@ -333,6 +333,18 @@ func TestCapabilitiesReturnsCatalog(t *testing.T) {
 	}
 }
 
+func TestSafeToolErrorPrioritizesInputCleanupOverCancellation(t *testing.T) {
+	toolErr := safeToolError(errors.Join(
+		&agent.ActionError{
+			Code: agent.ErrorCanceled, Message: "canceled action",
+		},
+		agent.ErrInputCleanup,
+	))
+	if toolErr == nil || toolErr.Code != agent.ErrorCleanupFailed {
+		t.Fatalf("joined cleanup error = %+v", toolErr)
+	}
+}
+
 func TestObserveReturnsPrivacyReducedMetadata(t *testing.T) {
 	const secretDigest = "secret-capture-digest"
 	fake := &fakeSession{observation: &agent.Observation{

--- a/agent/observation_test.go
+++ b/agent/observation_test.go
@@ -24,9 +24,10 @@ const (
 
 func observationPolicy() Policy {
 	return Policy{
-		AllowedOperations: []Operation{OperationObserve, OperationClick},
-		AllowedDisplayIDs: []int{0},
-		MaxActions:        3, MaxObservations: 8, MaxCapturePixels: 16,
+		AllowedOperations:   []Operation{OperationObserve, OperationClick},
+		AllowedDisplayIDs:   []int{0},
+		AllowedMouseButtons: []MouseButton{MouseButtonLeft},
+		MaxActions:          3, MaxObservations: 8, MaxCapturePixels: 16,
 		VerificationAttempts: 2, VerificationIntervalMillis: 0,
 		VerificationTimeoutMillis: 100,
 	}

--- a/agent/policy.go
+++ b/agent/policy.go
@@ -1,10 +1,22 @@
 package agent
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
 
 const (
 	maxAgentCapturePixels          = 16 * 1024 * 1024
 	maxAgentQueries                = 1_000_000
+	maxAgentScrollEvents           = 100
+	maxAgentScrollDistance         = 100_000
+	maxAgentDragDistance           = 100_000
+	maxAgentDragDurationMS         = 60_000
+	maxAgentChordKeys              = 5
+	maxAgentActionIntervalMS       = 60_000
+	maxAgentSessionTimeoutMS       = 24 * 60 * 60 * 1000
+	maxAgentWindowTitleRunes       = 1024
 	maxAgentVerificationAttempts   = 100
 	maxAgentVerificationIntervalMS = 60_000
 	maxAgentVerificationTimeoutMS  = 300_000
@@ -13,27 +25,56 @@ const (
 	maxAgentWaitTimeoutMS          = 300_000
 )
 
+// WindowTarget is one immutable activation allow-list entry. ExpectedTitle is
+// compared with the live title immediately before dispatch to reject stale or
+// reused native handles.
+type WindowTarget struct {
+	Target        int              `json:"target"`
+	Kind          WindowTargetKind `json:"kind"`
+	ExpectedTitle string           `json:"expected_title"`
+}
+
 // Policy constrains every observation, query, and mutation performed by a Session.
 // Empty allow lists deny access; callers must opt in explicitly.
 type Policy struct {
-	AllowedOperations          []Operation `json:"allowed_operations"`
-	ConfirmOperations          []Operation `json:"confirm_operations,omitempty"`
-	AllowedDisplayIDs          []int       `json:"allowed_display_ids,omitempty"`
-	MaxActions                 uint64      `json:"max_actions"`
-	MaxTextRunes               int         `json:"max_text_runes"`
-	AllowDoubleClick           bool        `json:"allow_double_click,omitempty"`
-	MaxObservations            uint64      `json:"max_observations,omitempty"`
-	MaxCapturePixels           uint64      `json:"max_capture_pixels,omitempty"`
-	MaxQueries                 uint64      `json:"max_queries,omitempty"`
-	WaitAttempts               uint32      `json:"wait_attempts,omitempty"`
-	WaitIntervalMillis         int         `json:"wait_interval_ms,omitempty"`
-	WaitTimeoutMillis          int         `json:"wait_timeout_ms,omitempty"`
-	VerificationAttempts       uint32      `json:"verification_attempts,omitempty"`
-	VerificationIntervalMillis int         `json:"verification_interval_ms,omitempty"`
-	VerificationTimeoutMillis  int         `json:"verification_timeout_ms,omitempty"`
+	AllowedOperations          []Operation    `json:"allowed_operations"`
+	ConfirmOperations          []Operation    `json:"confirm_operations,omitempty"`
+	AllowedDisplayIDs          []int          `json:"allowed_display_ids,omitempty"`
+	AllowedMouseButtons        []MouseButton  `json:"allowed_mouse_buttons,omitempty"`
+	AllowedKeys                []string       `json:"allowed_keys,omitempty"`
+	AllowedModifiers           []KeyModifier  `json:"allowed_modifiers,omitempty"`
+	AllowedWindows             []WindowTarget `json:"allowed_windows,omitempty"`
+	MaxActions                 uint64         `json:"max_actions"`
+	MaxTextRunes               int            `json:"max_text_runes"`
+	AllowDoubleClick           bool           `json:"allow_double_click,omitempty"`
+	MaxScrollEvents            uint32         `json:"max_scroll_events,omitempty"`
+	MaxScrollDistance          uint64         `json:"max_scroll_distance,omitempty"`
+	MaxDragDistance            uint64         `json:"max_drag_distance,omitempty"`
+	MaxDragDurationMillis      int            `json:"max_drag_duration_ms,omitempty"`
+	MaxChordKeys               uint32         `json:"max_chord_keys,omitempty"`
+	MinActionIntervalMillis    int            `json:"min_action_interval_ms,omitempty"`
+	SessionTimeoutMillis       int            `json:"session_timeout_ms,omitempty"`
+	MaxObservations            uint64         `json:"max_observations,omitempty"`
+	MaxCapturePixels           uint64         `json:"max_capture_pixels,omitempty"`
+	MaxQueries                 uint64         `json:"max_queries,omitempty"`
+	WaitAttempts               uint32         `json:"wait_attempts,omitempty"`
+	WaitIntervalMillis         int            `json:"wait_interval_ms,omitempty"`
+	WaitTimeoutMillis          int            `json:"wait_timeout_ms,omitempty"`
+	VerificationAttempts       uint32         `json:"verification_attempts,omitempty"`
+	VerificationIntervalMillis int            `json:"verification_interval_ms,omitempty"`
+	VerificationTimeoutMillis  int            `json:"verification_timeout_ms,omitempty"`
 	allowOperation             map[Operation]struct{}
 	requireConfirmation        map[Operation]struct{}
 	allowDisplay               map[int]struct{}
+	allowButton                map[MouseButton]struct{}
+	allowKey                   map[string]struct{}
+	allowModifier              map[KeyModifier]struct{}
+	allowWindow                map[windowTargetIdentity]WindowTarget
+}
+
+type windowTargetIdentity struct {
+	target int
+	kind   WindowTargetKind
 }
 
 func preparePolicy(input Policy) (Policy, error) {
@@ -45,6 +86,27 @@ func preparePolicy(input Policy) (Policy, error) {
 	}
 	if input.MaxQueries > maxAgentQueries {
 		return Policy{}, fmt.Errorf("agent: max queries exceeds hard limit %d", maxAgentQueries)
+	}
+	if input.MaxScrollEvents > maxAgentScrollEvents {
+		return Policy{}, fmt.Errorf("agent: max scroll events exceeds hard limit %d", maxAgentScrollEvents)
+	}
+	if input.MaxScrollDistance > maxAgentScrollDistance {
+		return Policy{}, fmt.Errorf("agent: max scroll distance exceeds hard limit %d", maxAgentScrollDistance)
+	}
+	if input.MaxDragDistance > maxAgentDragDistance {
+		return Policy{}, fmt.Errorf("agent: max drag distance exceeds hard limit %d", maxAgentDragDistance)
+	}
+	if input.MaxDragDurationMillis < 0 || input.MaxDragDurationMillis > maxAgentDragDurationMS {
+		return Policy{}, fmt.Errorf("agent: max drag duration must be between 0 and %dms", maxAgentDragDurationMS)
+	}
+	if input.MaxChordKeys > maxAgentChordKeys {
+		return Policy{}, fmt.Errorf("agent: max chord keys exceeds hard limit %d", maxAgentChordKeys)
+	}
+	if input.MinActionIntervalMillis < 0 || input.MinActionIntervalMillis > maxAgentActionIntervalMS {
+		return Policy{}, fmt.Errorf("agent: minimum action interval must be between 0 and %dms", maxAgentActionIntervalMS)
+	}
+	if input.SessionTimeoutMillis < 0 || input.SessionTimeoutMillis > maxAgentSessionTimeoutMS {
+		return Policy{}, fmt.Errorf("agent: session timeout must be between 0 and %dms", maxAgentSessionTimeoutMS)
 	}
 	if input.WaitAttempts > maxAgentWaitAttempts {
 		return Policy{}, fmt.Errorf("agent: wait attempts exceeds hard limit %d", maxAgentWaitAttempts)
@@ -74,11 +136,22 @@ func preparePolicy(input Policy) (Policy, error) {
 		return Policy{}, fmt.Errorf("agent: verification attempts and timeout must both be zero or both be positive")
 	}
 	prepared := Policy{
-		AllowedOperations: append([]Operation(nil), input.AllowedOperations...),
-		ConfirmOperations: append([]Operation(nil), input.ConfirmOperations...),
-		AllowedDisplayIDs: append([]int(nil), input.AllowedDisplayIDs...),
-		MaxActions:        input.MaxActions, MaxTextRunes: input.MaxTextRunes,
+		AllowedOperations:   append([]Operation(nil), input.AllowedOperations...),
+		ConfirmOperations:   append([]Operation(nil), input.ConfirmOperations...),
+		AllowedDisplayIDs:   append([]int(nil), input.AllowedDisplayIDs...),
+		AllowedMouseButtons: append([]MouseButton(nil), input.AllowedMouseButtons...),
+		AllowedKeys:         append([]string(nil), input.AllowedKeys...),
+		AllowedModifiers:    append([]KeyModifier(nil), input.AllowedModifiers...),
+		AllowedWindows:      append([]WindowTarget(nil), input.AllowedWindows...),
+		MaxActions:          input.MaxActions, MaxTextRunes: input.MaxTextRunes,
 		AllowDoubleClick:           input.AllowDoubleClick,
+		MaxScrollEvents:            input.MaxScrollEvents,
+		MaxScrollDistance:          input.MaxScrollDistance,
+		MaxDragDistance:            input.MaxDragDistance,
+		MaxDragDurationMillis:      input.MaxDragDurationMillis,
+		MaxChordKeys:               input.MaxChordKeys,
+		MinActionIntervalMillis:    input.MinActionIntervalMillis,
+		SessionTimeoutMillis:       input.SessionTimeoutMillis,
 		MaxObservations:            input.MaxObservations,
 		MaxCapturePixels:           input.MaxCapturePixels,
 		MaxQueries:                 input.MaxQueries,
@@ -91,6 +164,10 @@ func preparePolicy(input Policy) (Policy, error) {
 		allowOperation:             make(map[Operation]struct{}),
 		requireConfirmation:        make(map[Operation]struct{}),
 		allowDisplay:               make(map[int]struct{}),
+		allowButton:                make(map[MouseButton]struct{}),
+		allowKey:                   make(map[string]struct{}),
+		allowModifier:              make(map[KeyModifier]struct{}),
+		allowWindow:                make(map[windowTargetIdentity]WindowTarget),
 	}
 	for _, operation := range prepared.AllowedOperations {
 		if !knownOperation(operation) {
@@ -115,6 +192,82 @@ func preparePolicy(input Policy) (Policy, error) {
 			return Policy{}, fmt.Errorf("agent: allowed display IDs must be non-negative")
 		}
 		prepared.allowDisplay[displayID] = struct{}{}
+	}
+	for _, button := range prepared.AllowedMouseButtons {
+		if !validMouseButton(button) {
+			return Policy{}, fmt.Errorf("agent: unsupported allowed mouse button %q", button)
+		}
+		if _, exists := prepared.allowButton[button]; exists {
+			return Policy{}, fmt.Errorf("agent: duplicate allowed mouse button %q", button)
+		}
+		prepared.allowButton[button] = struct{}{}
+	}
+	for _, key := range prepared.AllowedKeys {
+		if !validChordKey(key) {
+			return Policy{}, fmt.Errorf("agent: unsupported or non-canonical allowed chord key %q", key)
+		}
+		if _, exists := prepared.allowKey[key]; exists {
+			return Policy{}, fmt.Errorf("agent: duplicate allowed chord key %q", key)
+		}
+		prepared.allowKey[key] = struct{}{}
+	}
+	for _, modifier := range prepared.AllowedModifiers {
+		if !validKeyModifier(modifier) {
+			return Policy{}, fmt.Errorf("agent: unsupported allowed key modifier %q", modifier)
+		}
+		if _, exists := prepared.allowModifier[modifier]; exists {
+			return Policy{}, fmt.Errorf("agent: duplicate allowed key modifier %q", modifier)
+		}
+		prepared.allowModifier[modifier] = struct{}{}
+	}
+	for _, window := range prepared.AllowedWindows {
+		if window.Target <= 0 || !validWindowTargetKind(window.Kind) {
+			return Policy{}, fmt.Errorf("agent: allowed window requires a positive target and valid kind")
+		}
+		if window.ExpectedTitle == "" || !utf8.ValidString(window.ExpectedTitle) ||
+			utf8.RuneCountInString(window.ExpectedTitle) > maxAgentWindowTitleRunes {
+			return Policy{}, fmt.Errorf("agent: allowed window requires a bounded non-empty valid UTF-8 expected title")
+		}
+		identity := windowTargetIdentity{target: window.Target, kind: window.Kind}
+		if _, exists := prepared.allowWindow[identity]; exists {
+			return Policy{}, fmt.Errorf("agent: duplicate allowed window target %d (%s)", window.Target, window.Kind)
+		}
+		prepared.allowWindow[identity] = window
+	}
+	if _, allowed := prepared.allowOperation[OperationClick]; allowed && len(prepared.allowButton) == 0 {
+		return Policy{}, fmt.Errorf("agent: pointer.click requires allowed mouse buttons")
+	}
+	if _, allowed := prepared.allowOperation[OperationScroll]; allowed {
+		if len(prepared.allowDisplay) == 0 || prepared.MaxScrollEvents == 0 ||
+			prepared.MaxScrollDistance == 0 {
+			return Policy{}, fmt.Errorf("agent: pointer.scroll requires allowed displays and bounded events and distance")
+		}
+	}
+	if _, allowed := prepared.allowOperation[OperationDrag]; allowed {
+		if len(prepared.allowDisplay) == 0 || len(prepared.allowButton) == 0 ||
+			prepared.MaxDragDistance == 0 || prepared.MaxDragDurationMillis == 0 {
+			return Policy{}, fmt.Errorf("agent: pointer.drag requires allowed displays and buttons plus bounded distance and duration")
+		}
+	}
+	if _, allowed := prepared.allowOperation[OperationKeyChord]; allowed {
+		hasProcessTarget := false
+		for identity := range prepared.allowWindow {
+			if identity.kind == WindowTargetProcess {
+				hasProcessTarget = true
+				break
+			}
+		}
+		if len(prepared.allowKey) == 0 || prepared.MaxChordKeys == 0 || !hasProcessTarget {
+			return Policy{}, fmt.Errorf("agent: keyboard.chord requires allowed keys, process windows, and a bounded chord length")
+		}
+	}
+	if _, allowed := prepared.allowOperation[OperationActivate]; allowed && len(prepared.allowWindow) == 0 {
+		return Policy{}, fmt.Errorf("agent: window.activate requires allowed window identities")
+	}
+	if allowsExtendedMutation(prepared.allowOperation) {
+		if prepared.MinActionIntervalMillis == 0 || prepared.SessionTimeoutMillis == 0 {
+			return Policy{}, fmt.Errorf("agent: extended mutations require bounded action interval and session timeout")
+		}
 	}
 	_, findAllowed := prepared.allowOperation[OperationFindColor]
 	_, waitAllowed := prepared.allowOperation[OperationWaitColor]
@@ -154,7 +307,21 @@ func preparePolicy(input Policy) (Policy, error) {
 }
 
 func allowsMutation(operations map[Operation]struct{}) bool {
-	for _, operation := range []Operation{OperationMove, OperationClick, OperationTypeText} {
+	for _, operation := range []Operation{
+		OperationMove, OperationClick, OperationScroll, OperationDrag,
+		OperationTypeText, OperationKeyChord, OperationActivate,
+	} {
+		if _, allowed := operations[operation]; allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func allowsExtendedMutation(operations map[Operation]struct{}) bool {
+	for _, operation := range []Operation{
+		OperationScroll, OperationDrag, OperationKeyChord, OperationActivate,
+	} {
 		if _, allowed := operations[operation]; allowed {
 			return true
 		}
@@ -164,7 +331,63 @@ func allowsMutation(operations map[Operation]struct{}) bool {
 
 func knownOperation(operation Operation) bool {
 	switch operation {
-	case OperationMove, OperationClick, OperationTypeText, OperationObserve, OperationFindColor, OperationWaitColor:
+	case OperationMove, OperationClick, OperationScroll, OperationDrag,
+		OperationTypeText, OperationKeyChord, OperationActivate,
+		OperationObserve, OperationFindColor, OperationWaitColor:
+		return true
+	default:
+		return false
+	}
+}
+
+func validMouseButton(button MouseButton) bool {
+	switch button {
+	case MouseButtonLeft, MouseButtonMiddle, MouseButtonRight:
+		return true
+	default:
+		return false
+	}
+}
+
+func validKeyModifier(modifier KeyModifier) bool {
+	switch modifier {
+	case KeyModifierAlt, KeyModifierControl, KeyModifierMeta, KeyModifierShift:
+		return true
+	default:
+		return false
+	}
+}
+
+func validChordKey(key string) bool {
+	if len(key) == 1 {
+		value := key[0]
+		return value >= 'a' && value <= 'z' || value >= '0' && value <= '9' ||
+			strings.ContainsRune("-=[]\\;',./`", rune(value))
+	}
+	switch key {
+	case "backspace", "delete", "enter", "tab", "escape",
+		"up", "down", "right", "left", "home", "end", "pageup",
+		"pagedown", "space",
+		"f1", "f2", "f3", "f4", "f5", "f6",
+		"f7", "f8", "f9", "f10", "f11", "f12":
+		return true
+	default:
+		return false
+	}
+}
+
+func mandatoryConfirmation(operation Operation) bool {
+	switch operation {
+	case OperationDrag, OperationKeyChord, OperationActivate:
+		return true
+	default:
+		return false
+	}
+}
+
+func validWindowTargetKind(kind WindowTargetKind) bool {
+	switch kind {
+	case WindowTargetProcess, WindowTargetHandle:
 		return true
 	default:
 		return false

--- a/agent/session.go
+++ b/agent/session.go
@@ -19,7 +19,7 @@ type inputDriver interface {
 	Move(x, y, displayID int) error
 	MoveImmediate(x, y, displayID int) error
 	Click(button MouseButton, double bool) error
-	Scroll(deltaX, deltaY int) error
+	ScrollImmediate(deltaX, deltaY int) error
 	ToggleMouse(button MouseButton, down bool) error
 	TypeText(text string) error
 	ToggleKeyImmediate(key string, modifiers []KeyModifier, targetPID int, down bool) error
@@ -43,8 +43,8 @@ func (robotGoDriver) MoveImmediate(x, y, displayID int) error {
 func (robotGoDriver) Click(button MouseButton, double bool) error {
 	return robotgo.ClickE(string(button), double)
 }
-func (robotGoDriver) Scroll(deltaX, deltaY int) error {
-	return robotgo.ScrollE(deltaX, deltaY)
+func (robotGoDriver) ScrollImmediate(deltaX, deltaY int) error {
+	return robotgo.ScrollImmediateE(deltaX, deltaY)
 }
 func (robotGoDriver) ToggleMouse(button MouseButton, down bool) error {
 	state := "down"

--- a/agent/session.go
+++ b/agent/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,7 +18,15 @@ type inputDriver interface {
 	DisplayBounds(displayID int) (displayBounds, error)
 	Move(x, y, displayID int) error
 	Click(button MouseButton, double bool) error
+	Scroll(deltaX, deltaY int) error
+	ToggleMouse(button MouseButton, down bool) error
 	TypeText(text string) error
+	ToggleKey(key string, modifiers []KeyModifier, down bool) error
+	TapKey(key string, modifiers []KeyModifier) error
+	ActiveWindowPID() (int, error)
+	ActiveWindowTitle() (string, error)
+	WindowTitle(target int, kind WindowTargetKind) (string, error)
+	ActivateWindow(target int, kind WindowTargetKind) error
 	RuntimeCapabilities() robotgo.RuntimeCapabilities
 	Capture(context.Context, CaptureRegion) (image.Image, error)
 }
@@ -32,7 +41,72 @@ func (robotGoDriver) Move(x, y, displayID int) error { return robotgo.MoveE(x, y
 func (robotGoDriver) Click(button MouseButton, double bool) error {
 	return robotgo.ClickE(string(button), double)
 }
+func (robotGoDriver) Scroll(deltaX, deltaY int) error {
+	return robotgo.ScrollE(deltaX, deltaY)
+}
+func (robotGoDriver) ToggleMouse(button MouseButton, down bool) error {
+	state := "down"
+	if !down {
+		state = "up"
+	}
+	return robotgo.Toggle(string(button), state)
+}
 func (robotGoDriver) TypeText(text string) error { return robotgo.TypeStrE(text) }
+func (robotGoDriver) ToggleKey(key string, modifiers []KeyModifier, down bool) error {
+	args := robotGoKeyArguments(modifiers)
+	if !down {
+		args = append([]interface{}{"up"}, args...)
+	}
+	return robotgo.KeyToggle(key, args...)
+}
+func (robotGoDriver) TapKey(key string, modifiers []KeyModifier) error {
+	return robotgo.KeyTap(key, robotGoKeyArguments(modifiers)...)
+}
+func (robotGoDriver) ActiveWindowPID() (int, error) { return robotgo.GetPidE() }
+func (robotGoDriver) ActiveWindowTitle() (string, error) {
+	return robotgo.GetTitleE()
+}
+func (robotGoDriver) WindowTitle(target int, kind WindowTargetKind) (string, error) {
+	if kind == WindowTargetHandle {
+		if nativeMacOSHandleUnsupported() {
+			return "", fmt.Errorf("%w: native macOS window handles are not serializable activation targets", robotgo.ErrNotSupported)
+		}
+		return robotgo.GetTitleE(target, 1)
+	}
+	return robotgo.GetTitleE(target)
+}
+func (robotGoDriver) ActivateWindow(target int, kind WindowTargetKind) error {
+	if kind == WindowTargetHandle {
+		if nativeMacOSHandleUnsupported() {
+			return fmt.Errorf("%w: native macOS window handles are not serializable activation targets", robotgo.ErrNotSupported)
+		}
+		return robotgo.ActivePid(target, 1)
+	}
+	return robotgo.ActivePid(target)
+}
+
+func nativeMacOSHandleUnsupported() bool {
+	return runtime.GOOS == "darwin" && robotgo.GetRuntimeBackendInfo().CGOEnabled
+}
+
+func robotGoKeyModifier(modifier KeyModifier) string {
+	switch modifier {
+	case KeyModifierControl:
+		return "ctrl"
+	case KeyModifierMeta:
+		return "cmd"
+	default:
+		return string(modifier)
+	}
+}
+
+func robotGoKeyArguments(modifiers []KeyModifier) []interface{} {
+	args := make([]interface{}, 0, len(modifiers))
+	for _, modifier := range modifiers {
+		args = append(args, robotGoKeyModifier(modifier))
+	}
+	return args
+}
 
 // Config defines immutable session policy.
 type Config struct {
@@ -53,12 +127,25 @@ type Session struct {
 	dispatchMu       sync.Mutex
 	used             uint64
 	closeOnce        sync.Once
+	closeMu          sync.Mutex
+	cleanupComplete  bool
 	observationMu    sync.Mutex
 	observations     map[string]observationRecord
 	usedObservations uint64
 	usedQueries      uint64
 	auditSink        AuditSink
 	auditSequence    uint64
+	pressedInputs    []pressedInput
+	inputTainted     bool
+	lastAction       time.Time
+	now              func() time.Time
+}
+
+type pressedInput struct {
+	button    MouseButton
+	key       string
+	modifiers []KeyModifier
+	keyboard  bool
 }
 
 var (
@@ -83,11 +170,23 @@ func newSession(policy Policy, driver inputDriver, capabilities robotgo.RuntimeC
 }
 
 func newSessionWithAudit(policy Policy, driver inputDriver, capabilities robotgo.RuntimeCapabilities, auditSink AuditSink) (*Session, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	if policy.SessionTimeoutMillis > 0 {
+		ctx, cancel = context.WithTimeout(
+			context.Background(),
+			time.Duration(policy.SessionTimeoutMillis)*time.Millisecond,
+		)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
 	s := &Session{
 		policy: policy, driver: driver, catalog: buildCatalog(policy, capabilities),
 		ctx: ctx, cancel: cancel, actionGate: make(chan struct{}, 1),
 		observations: make(map[string]observationRecord), auditSink: auditSink,
+		now: time.Now,
 	}
 	s.actionGate <- struct{}{}
 	ownerMu.Lock()
@@ -105,25 +204,38 @@ func (s *Session) Catalog() OperationCatalog {
 	return cloneCatalog(s.catalog)
 }
 
-// Close prevents future actions, waits for an active synchronous mutation, and
-// releases the process-wide agent-session claim. It is safe to call repeatedly.
+// Close prevents future actions, waits for an active mutation, and releases
+// every session-owned pressed input before relinquishing the process-wide
+// agent-session claim. A cleanup failure retains ownership so a later Close
+// call can retry safely.
 func (s *Session) Close() error {
 	if s == nil {
 		return nil
 	}
 	s.closeOnce.Do(func() {
-		s.dispatchMu.Lock()
 		s.cancel()
-		s.dispatchMu.Unlock()
 		<-s.actionGate
 		s.closeObservations()
 		s.actionGate <- struct{}{}
-		ownerMu.Lock()
-		if activeOwner == s {
-			activeOwner = nil
-		}
-		ownerMu.Unlock()
 	})
+
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
+	if s.cleanupComplete {
+		return nil
+	}
+	s.dispatchMu.Lock()
+	cleanupErr := s.releaseAllInputs()
+	s.dispatchMu.Unlock()
+	if cleanupErr != nil {
+		return cleanupErr
+	}
+	s.cleanupComplete = true
+	ownerMu.Lock()
+	defer ownerMu.Unlock()
+	if activeOwner == s {
+		activeOwner = nil
+	}
 	return nil
 }
 
@@ -154,7 +266,7 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 	case <-ctx.Done():
 		return contextFailure(ctx, id, resultOperation, started)
 	case <-s.ctx.Done():
-		return actionFailure(id, resultOperation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+		return s.sessionFailure(id, resultOperation, started)
 	case <-s.actionGate:
 	}
 	defer func() { s.actionGate <- struct{}{} }()
@@ -163,8 +275,15 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 	}
 	select {
 	case <-s.ctx.Done():
-		return actionFailure(id, resultOperation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+		return s.sessionFailure(id, resultOperation, started)
 	default:
+	}
+	if s.inputTainted {
+		return actionFailure(
+			id, resultOperation, started, ErrorCleanupFailed,
+			"pressed input cleanup failed; close the session before continuing",
+			ErrInputCleanup,
+		)
 	}
 	capability, ok := s.capability(request.Operation)
 	if !ok {
@@ -177,10 +296,21 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 		return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy denied the action", err)
 	}
 	if !capability.Available {
-		return actionFailure(id, request.Operation, started, ErrorUnsupported, "operation is unavailable on the selected backend", robotgo.ErrNotSupported)
+		code := capability.UnavailableCode
+		if code == "" {
+			code = ErrorUnavailable
+		}
+		return actionFailure(
+			id, request.Operation, started, code,
+			"operation is unavailable on the selected backend",
+			capabilityUnavailableCause(code),
+		)
 	}
 	if s.used >= s.policy.MaxActions {
 		return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy action limit reached", ErrPolicyDenied)
+	}
+	if err := s.validateActionRate(); err != nil {
+		return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy action rate limit reached", err)
 	}
 	if err := s.emitAudit(ctx, AuditEvent{
 		Kind: AuditActionStarted, Operation: request.Operation, ActionID: id,
@@ -194,21 +324,19 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 	}
 	select {
 	case <-s.ctx.Done():
-		result, actionErr := actionFailure(id, request.Operation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+		result, actionErr := s.sessionFailure(id, request.Operation, started)
 		return s.finishFailedActionAudit(ctx, result, actionErr)
 	default:
 	}
-	if request.Move != nil {
-		if err := s.validateMoveTarget(*request.Move); err != nil {
-			if errors.Is(err, ErrPolicyDenied) {
-				result, actionErr := actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy denied the action", err)
-				return s.finishFailedActionAudit(ctx, result, actionErr)
-			}
-			code, message := classifyBackendError(err)
-			result, actionErr := actionFailure(id, request.Operation, started, code, message, err)
-			result.Backend = capability.Backend
+	if err := s.validateActionTargets(request); err != nil {
+		if errors.Is(err, ErrPolicyDenied) {
+			result, actionErr := actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy denied the action", err)
 			return s.finishFailedActionAudit(ctx, result, actionErr)
 		}
+		code, message := classifyBackendError(err)
+		result, actionErr := actionFailure(id, request.Operation, started, code, message, err)
+		result.Backend = capability.Backend
+		return s.finishFailedActionAudit(ctx, result, actionErr)
 	}
 	if err := ctx.Err(); err != nil {
 		result, actionErr := contextFailure(ctx, id, request.Operation, started)
@@ -216,7 +344,7 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 	}
 	select {
 	case <-s.ctx.Done():
-		result, actionErr := actionFailure(id, request.Operation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+		result, actionErr := s.sessionFailure(id, request.Operation, started)
 		return s.finishFailedActionAudit(ctx, result, actionErr)
 	default:
 	}
@@ -237,7 +365,7 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 	}
 	select {
 	case <-s.ctx.Done():
-		result, actionErr := actionFailure(id, request.Operation, started, ErrorSessionClosed, "agent session is closed", ErrSessionClosed)
+		result, actionErr := s.sessionFailure(id, request.Operation, started)
 		return s.finishFailedActionAudit(ctx, result, actionErr)
 	default:
 	}
@@ -254,6 +382,9 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 		lineage.release()
 		code, message := classifyBackendError(err)
 		result, actionErr := actionFailure(id, request.Operation, started, code, message, err)
+		if code == ErrorCleanupFailed || errors.Is(err, errPartialAction) {
+			result.Status = ActionUnverified
+		}
 		result.Backend = capability.Backend
 		result.PreconditionObservationID = preconditionID(request)
 		return s.finishFailedActionAudit(ctx, result, actionErr)
@@ -288,6 +419,34 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 	}
 	result.DurationMillis = time.Since(started).Milliseconds()
 	return s.finishSuccessfulActionAudit(ctx, result)
+}
+
+func capabilityUnavailableCause(code ErrorCode) error {
+	switch code {
+	case ErrorUnsupported:
+		return robotgo.ErrNotSupported
+	case ErrorPermissionDenied:
+		return robotgo.ErrPermissionDenied
+	default:
+		return nil
+	}
+}
+
+func (s *Session) sessionFailure(
+	id string,
+	operation Operation,
+	started time.Time,
+) (ActionResult, error) {
+	if errors.Is(s.ctx.Err(), context.DeadlineExceeded) {
+		return actionFailure(
+			id, operation, started, ErrorTimedOut,
+			"agent session lifetime expired", context.DeadlineExceeded,
+		)
+	}
+	return actionFailure(
+		id, operation, started, ErrorSessionClosed,
+		"agent session is closed", ErrSessionClosed,
+	)
 }
 
 func (s *Session) finishSuccessfulActionAudit(ctx context.Context, result ActionResult) (ActionResult, error) {
@@ -354,6 +513,35 @@ func (s *Session) validateMoveTarget(move MoveAction) error {
 	return nil
 }
 
+func (s *Session) validateActionTargets(request ActionRequest) error {
+	switch request.Operation {
+	case OperationMove:
+		return s.validateMoveTarget(*request.Move)
+	case OperationScroll:
+		return s.validateMoveTarget(MoveAction{
+			X: request.Scroll.TargetX, Y: request.Scroll.TargetY,
+			DisplayID: request.Scroll.DisplayID,
+		})
+	case OperationDrag:
+		if err := s.validateMoveTarget(MoveAction{
+			X: request.Drag.StartX, Y: request.Drag.StartY,
+			DisplayID: request.Drag.DisplayID,
+		}); err != nil {
+			return err
+		}
+		return s.validateMoveTarget(MoveAction{
+			X: request.Drag.EndX, Y: request.Drag.EndY,
+			DisplayID: request.Drag.DisplayID,
+		})
+	case OperationKeyChord:
+		return s.validateActiveWindow(*request.KeyChord)
+	case OperationActivate:
+		return s.validateWindowIdentity(*request.Activate)
+	default:
+		return nil
+	}
+}
+
 func (s *Session) capability(operation Operation) (OperationCapability, bool) {
 	for _, capability := range s.catalog.Operations {
 		if capability.Operation == operation {
@@ -367,7 +555,8 @@ func (s *Session) authorize(request ActionRequest) error {
 	if _, allowed := s.policy.allowOperation[request.Operation]; !allowed {
 		return ErrPolicyDenied
 	}
-	if _, required := s.policy.requireConfirmation[request.Operation]; required && !request.Confirmed {
+	_, policyConfirmation := s.policy.requireConfirmation[request.Operation]
+	if (policyConfirmation || mandatoryConfirmation(request.Operation)) && !request.Confirmed {
 		return ErrPolicyDenied
 	}
 	if request.Move != nil {
@@ -378,8 +567,53 @@ func (s *Session) authorize(request ActionRequest) error {
 	if request.Click != nil && request.Click.Double && !s.policy.AllowDoubleClick {
 		return ErrPolicyDenied
 	}
+	if request.Click != nil {
+		if _, allowed := s.policy.allowButton[request.Click.Button]; !allowed {
+			return ErrPolicyDenied
+		}
+	}
 	if request.TypeText != nil && utf8.RuneCountInString(request.TypeText.Text) > s.policy.MaxTextRunes {
 		return ErrPolicyDenied
+	}
+	if request.Scroll != nil {
+		if _, allowed := s.policy.allowDisplay[request.Scroll.DisplayID]; !allowed ||
+			request.Scroll.Events > s.policy.MaxScrollEvents ||
+			scrollDistance(*request.Scroll) > s.policy.MaxScrollDistance {
+			return ErrPolicyDenied
+		}
+	}
+	if request.Drag != nil {
+		if _, allowed := s.policy.allowDisplay[request.Drag.DisplayID]; !allowed {
+			return ErrPolicyDenied
+		}
+		if _, allowed := s.policy.allowButton[request.Drag.Button]; !allowed ||
+			dragDistance(*request.Drag) > s.policy.MaxDragDistance ||
+			request.Drag.DurationMillis > s.policy.MaxDragDurationMillis {
+			return ErrPolicyDenied
+		}
+	}
+	if request.KeyChord != nil {
+		if _, allowed := s.policy.allowKey[request.KeyChord.Key]; !allowed ||
+			uint32(len(request.KeyChord.Modifiers)+1) > s.policy.MaxChordKeys {
+			return ErrPolicyDenied
+		}
+		for _, modifier := range request.KeyChord.Modifiers {
+			if _, allowed := s.policy.allowModifier[modifier]; !allowed {
+				return ErrPolicyDenied
+			}
+		}
+		identity := windowTargetIdentity{
+			target: request.KeyChord.TargetPID, kind: WindowTargetProcess,
+		}
+		if _, allowed := s.policy.allowWindow[identity]; !allowed {
+			return ErrPolicyDenied
+		}
+	}
+	if request.Activate != nil {
+		identity := windowTargetIdentity{target: request.Activate.Target, kind: request.Activate.Kind}
+		if _, allowed := s.policy.allowWindow[identity]; !allowed {
+			return ErrPolicyDenied
+		}
 	}
 	return nil
 }
@@ -413,7 +647,19 @@ func validateRequest(request ActionRequest) error {
 	if request.Click != nil {
 		payloads++
 	}
+	if request.Scroll != nil {
+		payloads++
+	}
+	if request.Drag != nil {
+		payloads++
+	}
 	if request.TypeText != nil {
+		payloads++
+	}
+	if request.KeyChord != nil {
+		payloads++
+	}
+	if request.Activate != nil {
 		payloads++
 	}
 	if payloads != 1 {
@@ -428,14 +674,45 @@ func validateRequest(request ActionRequest) error {
 		if request.Click == nil {
 			return errors.New("click payload does not match operation")
 		}
-		switch request.Click.Button {
-		case MouseButtonLeft, MouseButtonMiddle, MouseButtonRight:
-		default:
+		if !validMouseButton(request.Click.Button) {
 			return errors.New("unsupported mouse button")
+		}
+	case OperationScroll:
+		if request.Scroll == nil || request.Scroll.DisplayID < 0 ||
+			request.Scroll.Events == 0 ||
+			request.Scroll.DeltaX == 0 && request.Scroll.DeltaY == 0 {
+			return errors.New("scroll requires a display, non-zero delta, and positive event count")
+		}
+	case OperationDrag:
+		if request.Drag == nil || request.Drag.DisplayID < 0 ||
+			!validMouseButton(request.Drag.Button) ||
+			request.Drag.DurationMillis <= 0 ||
+			request.Drag.StartX == request.Drag.EndX && request.Drag.StartY == request.Drag.EndY {
+			return errors.New("drag requires a display, button, distinct coordinates, and positive duration")
 		}
 	case OperationTypeText:
 		if request.TypeText == nil || request.TypeText.Text == "" || !utf8.ValidString(request.TypeText.Text) {
 			return errors.New("type-text requires non-empty valid UTF-8")
+		}
+	case OperationKeyChord:
+		if request.KeyChord == nil || !validChordKey(request.KeyChord.Key) ||
+			request.KeyChord.TargetPID <= 0 {
+			return errors.New("keyboard chord requires one canonical supported key and positive target PID")
+		}
+		seen := make(map[KeyModifier]struct{}, len(request.KeyChord.Modifiers))
+		for _, modifier := range request.KeyChord.Modifiers {
+			if !validKeyModifier(modifier) {
+				return errors.New("keyboard chord contains an unsupported modifier")
+			}
+			if _, duplicate := seen[modifier]; duplicate {
+				return errors.New("keyboard chord contains a duplicate modifier")
+			}
+			seen[modifier] = struct{}{}
+		}
+	case OperationActivate:
+		if request.Activate == nil || request.Activate.Target <= 0 ||
+			!validWindowTargetKind(request.Activate.Kind) {
+			return errors.New("window activation requires a positive target and valid kind")
 		}
 	default:
 		return errors.New("unknown operation")
@@ -443,14 +720,22 @@ func validateRequest(request ActionRequest) error {
 	return nil
 }
 
-func (s *Session) execute(request ActionRequest) error {
+func (s *Session) execute(ctx context.Context, request ActionRequest) error {
 	switch request.Operation {
 	case OperationMove:
 		return s.driver.Move(request.Move.X, request.Move.Y, request.Move.DisplayID)
 	case OperationClick:
 		return s.driver.Click(request.Click.Button, request.Click.Double)
+	case OperationScroll:
+		return s.executeScroll(ctx, *request.Scroll)
+	case OperationDrag:
+		return s.executeDrag(ctx, *request.Drag)
 	case OperationTypeText:
 		return s.driver.TypeText(request.TypeText.Text)
+	case OperationKeyChord:
+		return s.executeKeyChord(ctx, *request.KeyChord)
+	case OperationActivate:
+		return s.executeActivate(ctx, *request.Activate)
 	default:
 		return fmt.Errorf("%w: unknown operation", robotgo.ErrNotSupported)
 	}
@@ -459,22 +744,27 @@ func (s *Session) execute(request ActionRequest) error {
 func (s *Session) executeAuthorized(ctx context.Context, request ActionRequest) error {
 	s.dispatchMu.Lock()
 	defer s.dispatchMu.Unlock()
-	if err := ctx.Err(); err != nil {
+	if err := s.executionError(ctx); err != nil {
 		return err
 	}
-	select {
-	case <-s.ctx.Done():
-		return ErrSessionClosed
-	default:
+	if err := s.validateActionRate(); err != nil {
+		return err
 	}
 	s.used++
-	return s.execute(request)
+	s.lastAction = s.now()
+	return s.execute(ctx, request)
 }
 
 func classifyBackendError(err error) (ErrorCode, string) {
 	switch {
 	case errors.Is(err, ErrSessionClosed):
 		return ErrorSessionClosed, "agent session is closed"
+	case errors.Is(err, ErrPolicyDenied):
+		return ErrorPolicyDenied, "agent policy denied the action"
+	case errors.Is(err, ErrStaleTarget):
+		return ErrorStaleTarget, "agent observation target is stale"
+	case errors.Is(err, ErrInputCleanup):
+		return ErrorCleanupFailed, "pressed input cleanup failed; do not retry the action"
 	case errors.Is(err, robotgo.ErrNotSupported):
 		return ErrorUnsupported, "operation is unsupported by the selected backend"
 	case errors.Is(err, robotgo.ErrPermissionDenied):

--- a/agent/session.go
+++ b/agent/session.go
@@ -21,10 +21,8 @@ type inputDriver interface {
 	Scroll(deltaX, deltaY int) error
 	ToggleMouse(button MouseButton, down bool) error
 	TypeText(text string) error
-	ToggleKey(key string, modifiers []KeyModifier, down bool) error
-	TapKey(key string, modifiers []KeyModifier) error
-	ActiveWindowPID() (int, error)
-	ActiveWindowTitle() (string, error)
+	ToggleKey(key string, modifiers []KeyModifier, targetPID int, down bool) error
+	ResolveWindow(target int, kind WindowTargetKind) (int, error)
 	WindowTitle(target int, kind WindowTargetKind) (string, error)
 	ActivateWindow(target int, kind WindowTargetKind) error
 	RuntimeCapabilities() robotgo.RuntimeCapabilities
@@ -52,19 +50,27 @@ func (robotGoDriver) ToggleMouse(button MouseButton, down bool) error {
 	return robotgo.Toggle(string(button), state)
 }
 func (robotGoDriver) TypeText(text string) error { return robotgo.TypeStrE(text) }
-func (robotGoDriver) ToggleKey(key string, modifiers []KeyModifier, down bool) error {
+func (robotGoDriver) ToggleKey(
+	key string,
+	modifiers []KeyModifier,
+	targetPID int,
+	down bool,
+) error {
 	args := robotGoKeyArguments(modifiers)
 	if !down {
 		args = append([]interface{}{"up"}, args...)
 	}
+	args = append(args, targetPID)
 	return robotgo.KeyToggle(key, args...)
 }
-func (robotGoDriver) TapKey(key string, modifiers []KeyModifier) error {
-	return robotgo.KeyTap(key, robotGoKeyArguments(modifiers)...)
-}
-func (robotGoDriver) ActiveWindowPID() (int, error) { return robotgo.GetPidE() }
-func (robotGoDriver) ActiveWindowTitle() (string, error) {
-	return robotgo.GetTitleE()
+func (robotGoDriver) ResolveWindow(target int, kind WindowTargetKind) (int, error) {
+	if kind == WindowTargetHandle {
+		if nativeMacOSHandleUnsupported() {
+			return 0, fmt.Errorf("%w: native macOS window handles are not serializable activation targets", robotgo.ErrNotSupported)
+		}
+		return robotgo.ResolveWindowHandleE(target, 1)
+	}
+	return robotgo.ResolveWindowHandleE(target)
 }
 func (robotGoDriver) WindowTitle(target int, kind WindowTargetKind) (string, error) {
 	if kind == WindowTargetHandle {
@@ -77,9 +83,6 @@ func (robotGoDriver) WindowTitle(target int, kind WindowTargetKind) (string, err
 }
 func (robotGoDriver) ActivateWindow(target int, kind WindowTargetKind) error {
 	if kind == WindowTargetHandle {
-		if nativeMacOSHandleUnsupported() {
-			return fmt.Errorf("%w: native macOS window handles are not serializable activation targets", robotgo.ErrNotSupported)
-		}
 		return robotgo.ActivePid(target, 1)
 	}
 	return robotgo.ActivePid(target)
@@ -145,6 +148,7 @@ type pressedInput struct {
 	button    MouseButton
 	key       string
 	modifiers []KeyModifier
+	targetPID int
 	keyboard  bool
 }
 
@@ -305,6 +309,10 @@ func (s *Session) run(ctx context.Context, request ActionRequest, dryRun bool) (
 			"operation is unavailable on the selected backend",
 			capabilityUnavailableCause(code),
 		)
+	}
+	if err := validateBackendRequest(request, capability); err != nil {
+		code, message := classifyBackendError(err)
+		return actionFailure(id, request.Operation, started, code, message, err)
 	}
 	if s.used >= s.policy.MaxActions {
 		return actionFailure(id, request.Operation, started, ErrorPolicyDenied, "agent policy action limit reached", ErrPolicyDenied)
@@ -549,6 +557,23 @@ func (s *Session) capability(operation Operation) (OperationCapability, bool) {
 		}
 	}
 	return OperationCapability{}, false
+}
+
+func validateBackendRequest(request ActionRequest, capability OperationCapability) error {
+	if request.Operation != OperationScroll || request.Scroll == nil ||
+		request.Scroll.DeltaX == 0 {
+		return nil
+	}
+	for _, axis := range capability.ScrollAxes {
+		if axis == ScrollAxisHorizontal {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"%w: backend %q does not support horizontal scrolling",
+		robotgo.ErrNotSupported,
+		capability.Backend,
+	)
 }
 
 func (s *Session) authorize(request ActionRequest) error {

--- a/agent/session.go
+++ b/agent/session.go
@@ -753,7 +753,8 @@ func (s *Session) execute(ctx context.Context, request ActionRequest) error {
 			s.driver.MoveImmediate(request.Move.X, request.Move.Y, request.Move.DisplayID),
 		)
 	case OperationClick:
-		return ambiguousMutationError(
+		return s.clickMutationError(
+			request.Click.Button,
 			s.driver.ClickImmediate(request.Click.Button, request.Click.Double),
 		)
 	case OperationScroll:

--- a/agent/session.go
+++ b/agent/session.go
@@ -22,7 +22,7 @@ type inputDriver interface {
 	Scroll(deltaX, deltaY int) error
 	ToggleMouse(button MouseButton, down bool) error
 	TypeText(text string) error
-	ToggleKey(key string, modifiers []KeyModifier, targetPID int, down bool) error
+	ToggleKeyImmediate(key string, modifiers []KeyModifier, targetPID int, down bool) error
 	ResolveWindow(target int, kind WindowTargetKind) (int, error)
 	WindowTitle(target int, kind WindowTargetKind) (string, error)
 	ActivateWindow(target int, kind WindowTargetKind) error
@@ -54,7 +54,7 @@ func (robotGoDriver) ToggleMouse(button MouseButton, down bool) error {
 	return robotgo.Toggle(string(button), state)
 }
 func (robotGoDriver) TypeText(text string) error { return robotgo.TypeStrE(text) }
-func (robotGoDriver) ToggleKey(
+func (robotGoDriver) ToggleKeyImmediate(
 	key string,
 	modifiers []KeyModifier,
 	targetPID int,
@@ -65,7 +65,7 @@ func (robotGoDriver) ToggleKey(
 		args = append([]interface{}{"up"}, args...)
 	}
 	args = append(args, targetPID)
-	return robotgo.KeyToggle(key, args...)
+	return robotgo.KeyToggleImmediate(key, args...)
 }
 func (robotGoDriver) ResolveWindow(target int, kind WindowTargetKind) (int, error) {
 	if kind == WindowTargetHandle {
@@ -77,20 +77,10 @@ func (robotGoDriver) ResolveWindow(target int, kind WindowTargetKind) (int, erro
 	return robotgo.ResolveWindowHandleE(target)
 }
 func (robotGoDriver) WindowTitle(target int, kind WindowTargetKind) (string, error) {
-	if kind == WindowTargetHandle {
-		if nativeMacOSHandleUnsupported() {
-			return "", fmt.Errorf("%w: native macOS window handles are not serializable activation targets", robotgo.ErrNotSupported)
-		}
-		return robotgo.GetTitleE(target, 1)
+	if kind == WindowTargetHandle && nativeMacOSHandleUnsupported() {
+		return "", fmt.Errorf("%w: native macOS window handles are not serializable activation targets", robotgo.ErrNotSupported)
 	}
-	if nativeMacOSHandleUnsupported() {
-		return robotgo.GetTitleE(target)
-	}
-	handle, err := robotgo.ResolveWindowHandleE(target)
-	if err != nil {
-		return "", err
-	}
-	return robotgo.GetTitleE(handle, 1)
+	return robotgo.GetTitleTargetE(target, kind == WindowTargetHandle)
 }
 func (robotGoDriver) ActivateWindow(target int, kind WindowTargetKind) error {
 	if kind == WindowTargetHandle {

--- a/agent/session.go
+++ b/agent/session.go
@@ -17,6 +17,7 @@ import (
 type inputDriver interface {
 	DisplayBounds(displayID int) (displayBounds, error)
 	Move(x, y, displayID int) error
+	MoveImmediate(x, y, displayID int) error
 	Click(button MouseButton, double bool) error
 	Scroll(deltaX, deltaY int) error
 	ToggleMouse(button MouseButton, down bool) error
@@ -36,6 +37,9 @@ func (robotGoDriver) DisplayBounds(displayID int) (displayBounds, error) {
 	return displayBounds{x: x, y: y, width: width, height: height}, err
 }
 func (robotGoDriver) Move(x, y, displayID int) error { return robotgo.MoveE(x, y, displayID) }
+func (robotGoDriver) MoveImmediate(x, y, displayID int) error {
+	return robotgo.MoveImmediateE(x, y, displayID)
+}
 func (robotGoDriver) Click(button MouseButton, double bool) error {
 	return robotgo.ClickE(string(button), double)
 }
@@ -79,7 +83,14 @@ func (robotGoDriver) WindowTitle(target int, kind WindowTargetKind) (string, err
 		}
 		return robotgo.GetTitleE(target, 1)
 	}
-	return robotgo.GetTitleE(target)
+	if nativeMacOSHandleUnsupported() {
+		return robotgo.GetTitleE(target)
+	}
+	handle, err := robotgo.ResolveWindowHandleE(target)
+	if err != nil {
+		return "", err
+	}
+	return robotgo.GetTitleE(handle, 1)
 }
 func (robotGoDriver) ActivateWindow(target int, kind WindowTargetKind) error {
 	if kind == WindowTargetHandle {

--- a/agent/session.go
+++ b/agent/session.go
@@ -16,12 +16,11 @@ import (
 
 type inputDriver interface {
 	DisplayBounds(displayID int) (displayBounds, error)
-	Move(x, y, displayID int) error
 	MoveImmediate(x, y, displayID int) error
-	Click(button MouseButton, double bool) error
+	ClickImmediate(button MouseButton, double bool) error
 	ScrollImmediate(deltaX, deltaY int) error
 	ToggleMouse(button MouseButton, down bool) error
-	TypeText(text string) error
+	TypeTextImmediate(text string) error
 	ToggleKeyImmediate(key string, modifiers []KeyModifier, targetPID int, down bool) error
 	ResolveWindow(target int, kind WindowTargetKind) (int, error)
 	WindowTitle(target int, kind WindowTargetKind) (string, error)
@@ -36,12 +35,11 @@ func (robotGoDriver) DisplayBounds(displayID int) (displayBounds, error) {
 	x, y, width, height, err := robotgo.GetDisplayBoundsE(displayID)
 	return displayBounds{x: x, y: y, width: width, height: height}, err
 }
-func (robotGoDriver) Move(x, y, displayID int) error { return robotgo.MoveE(x, y, displayID) }
 func (robotGoDriver) MoveImmediate(x, y, displayID int) error {
 	return robotgo.MoveImmediateE(x, y, displayID)
 }
-func (robotGoDriver) Click(button MouseButton, double bool) error {
-	return robotgo.ClickE(string(button), double)
+func (robotGoDriver) ClickImmediate(button MouseButton, double bool) error {
+	return robotgo.ClickImmediateE(string(button), double)
 }
 func (robotGoDriver) ScrollImmediate(deltaX, deltaY int) error {
 	return robotgo.ScrollImmediateE(deltaX, deltaY)
@@ -53,7 +51,9 @@ func (robotGoDriver) ToggleMouse(button MouseButton, down bool) error {
 	}
 	return robotgo.Toggle(string(button), state)
 }
-func (robotGoDriver) TypeText(text string) error { return robotgo.TypeStrE(text) }
+func (robotGoDriver) TypeTextImmediate(text string) error {
+	return robotgo.TypeStrImmediateE(text)
+}
 func (robotGoDriver) ToggleKeyImmediate(
 	key string,
 	modifiers []KeyModifier,
@@ -749,15 +749,19 @@ func validateRequest(request ActionRequest) error {
 func (s *Session) execute(ctx context.Context, request ActionRequest) error {
 	switch request.Operation {
 	case OperationMove:
-		return s.driver.Move(request.Move.X, request.Move.Y, request.Move.DisplayID)
+		return ambiguousMutationError(
+			s.driver.MoveImmediate(request.Move.X, request.Move.Y, request.Move.DisplayID),
+		)
 	case OperationClick:
-		return s.driver.Click(request.Click.Button, request.Click.Double)
+		return ambiguousMutationError(
+			s.driver.ClickImmediate(request.Click.Button, request.Click.Double),
+		)
 	case OperationScroll:
 		return s.executeScroll(ctx, *request.Scroll)
 	case OperationDrag:
 		return s.executeDrag(ctx, *request.Drag)
 	case OperationTypeText:
-		return s.driver.TypeText(request.TypeText.Text)
+		return ambiguousMutationError(s.driver.TypeTextImmediate(request.TypeText.Text))
 	case OperationKeyChord:
 		return s.executeKeyChord(ctx, *request.KeyChord)
 	case OperationActivate:

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -108,10 +108,6 @@ func (d *fakeDriver) record(call driverCall) error {
 	return d.err
 }
 
-func (d *fakeDriver) Move(x, y, displayID int) error {
-	return d.record(driverCall{operation: OperationMove, x: x, y: y, displayID: displayID})
-}
-
 func (d *fakeDriver) MoveImmediate(x, y, displayID int) error {
 	return d.record(driverCall{
 		operation: OperationMove, text: "immediate", immediate: true,
@@ -119,8 +115,10 @@ func (d *fakeDriver) MoveImmediate(x, y, displayID int) error {
 	})
 }
 
-func (d *fakeDriver) Click(button MouseButton, _ bool) error {
-	return d.record(driverCall{operation: OperationClick, button: button})
+func (d *fakeDriver) ClickImmediate(button MouseButton, _ bool) error {
+	return d.record(driverCall{
+		operation: OperationClick, button: button, immediate: true,
+	})
 }
 
 func (d *fakeDriver) ScrollImmediate(deltaX, deltaY int) error {
@@ -134,8 +132,10 @@ func (d *fakeDriver) ToggleMouse(button MouseButton, down bool) error {
 	return d.record(driverCall{operation: OperationDrag, button: button, down: down})
 }
 
-func (d *fakeDriver) TypeText(text string) error {
-	return d.record(driverCall{operation: OperationTypeText, text: text})
+func (d *fakeDriver) TypeTextImmediate(text string) error {
+	return d.record(driverCall{
+		operation: OperationTypeText, text: text, immediate: true,
+	})
 }
 
 func (d *fakeDriver) ToggleKeyImmediate(
@@ -371,6 +371,40 @@ func TestDryRunDoesNotInjectOrConsumeQuota(t *testing.T) {
 	}
 }
 
+func TestAgentMutationsUseOnlyDelayFreeDriverMethods(t *testing.T) {
+	driver := &fakeDriver{}
+	session := newTestSession(t, testPolicy(), driver)
+	requests := []ActionRequest{
+		{
+			Operation: OperationMove,
+			Move:      &MoveAction{X: 1, Y: 2, DisplayID: 0},
+		},
+		{
+			Operation: OperationClick,
+			Click:     &ClickAction{Button: MouseButtonLeft},
+		},
+		{
+			Operation: OperationTypeText,
+			TypeText:  &TypeTextAction{Text: "bounded"},
+		},
+	}
+	for _, request := range requests {
+		result, err := session.Execute(t.Context(), request)
+		if err != nil || result.Status != ActionSucceeded {
+			t.Fatalf("%s result = %+v, %v", request.Operation, result, err)
+		}
+	}
+	calls := driver.recordedCalls()
+	if len(calls) != len(requests) {
+		t.Fatalf("delay-free driver calls = %+v", calls)
+	}
+	for _, call := range calls {
+		if !call.immediate {
+			t.Fatalf("agent used a legacy delayed driver method: %+v", calls)
+		}
+	}
+}
+
 func TestValidationAndPolicyRunBeforeDriver(t *testing.T) {
 	driver := &fakeDriver{}
 	policy := testPolicy()
@@ -490,7 +524,8 @@ func TestTypedTextIsAbsentFromResultAndSerializedError(t *testing.T) {
 		Operation: OperationTypeText,
 		TypeText:  &TypeTextAction{Text: secret},
 	})
-	if err == nil || result.Error == nil || result.Error.Code != ErrorBackendFailure {
+	if err == nil || result.Status != ActionUnverified ||
+		result.Error == nil || result.Error.Code != ErrorBackendFailure {
 		t.Fatalf("Execute = %+v, %v", result, err)
 	}
 	data, marshalErr := json.Marshal(result)
@@ -502,6 +537,53 @@ func TestTypedTextIsAbsentFromResultAndSerializedError(t *testing.T) {
 	}
 	if !errors.Is(err, driver.err) {
 		t.Fatalf("returned error lost backend cause: %v", err)
+	}
+}
+
+func TestSimpleMutationBackendErrorsAreUnverified(t *testing.T) {
+	tests := []struct {
+		name    string
+		request ActionRequest
+	}{
+		{
+			name: "move",
+			request: ActionRequest{
+				Operation: OperationMove,
+				Move:      &MoveAction{X: 1, Y: 2, DisplayID: 0},
+			},
+		},
+		{
+			name: "click",
+			request: ActionRequest{
+				Operation: OperationClick,
+				Click:     &ClickAction{Button: MouseButtonLeft},
+			},
+		},
+		{
+			name: "type text",
+			request: ActionRequest{
+				Operation: OperationTypeText,
+				TypeText:  &TypeTextAction{Text: "bounded"},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			backendErr := errors.New("ambiguous mutation failure")
+			driver := &fakeDriver{err: backendErr}
+			session := newTestSession(t, testPolicy(), driver)
+			result, err := session.Execute(t.Context(), test.request)
+			var actionErr *ActionError
+			if !errors.Is(err, backendErr) ||
+				!errors.As(err, &actionErr) ||
+				actionErr.Code != ErrorBackendFailure ||
+				result.Status != ActionUnverified {
+				t.Fatalf("ambiguous mutation result = %+v, %v", result, err)
+			}
+			if driver.callCount() != 1 {
+				t.Fatalf("ambiguous mutation calls = %+v", driver.recordedCalls())
+			}
+		})
 	}
 }
 

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -15,28 +15,45 @@ import (
 )
 
 type driverCall struct {
-	operation Operation
-	text      string
+	operation  Operation
+	text       string
+	down       bool
+	x          int
+	y          int
+	displayID  int
+	deltaX     int
+	deltaY     int
+	button     MouseButton
+	key        string
+	modifiers  []KeyModifier
+	target     int
+	targetKind WindowTargetKind
 }
 
 type fakeDriver struct {
-	mu            sync.Mutex
-	calls         []driverCall
-	err           error
-	bounds        map[int]displayBounds
-	boundsErr     error
-	boundsHit     chan struct{}
-	boundsGo      chan struct{}
-	started       chan struct{}
-	release       chan struct{}
-	captureImages []image.Image
-	captureErr    error
-	captureCalls  int
-	captureHit    chan struct{}
-	captureGo     chan struct{}
-	capabilities  *robotgo.RuntimeCapabilities
-	capabilityHit chan struct{}
-	capabilityGo  chan struct{}
+	mu               sync.Mutex
+	calls            []driverCall
+	err              error
+	bounds           map[int]displayBounds
+	boundsErr        error
+	boundsHit        chan struct{}
+	boundsGo         chan struct{}
+	started          chan struct{}
+	release          chan struct{}
+	captureImages    []image.Image
+	captureErr       error
+	captureCalls     int
+	captureHit       chan struct{}
+	captureGo        chan struct{}
+	capabilities     *robotgo.RuntimeCapabilities
+	capabilityHit    chan struct{}
+	capabilityGo     chan struct{}
+	windowTitle      string
+	windowTitles     []string
+	windowTitleCalls int
+	activePID        int
+	callHook         func(driverCall)
+	callError        func(driverCall) error
 }
 
 func (d *fakeDriver) DisplayBounds(displayID int) (displayBounds, error) {
@@ -68,6 +85,9 @@ func (d *fakeDriver) DisplayBounds(displayID int) (displayBounds, error) {
 }
 
 func (d *fakeDriver) record(call driverCall) error {
+	if d.callHook != nil {
+		d.callHook(call)
+	}
 	if d.started != nil {
 		select {
 		case d.started <- struct{}{}:
@@ -79,20 +99,97 @@ func (d *fakeDriver) record(call driverCall) error {
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	call.modifiers = append([]KeyModifier(nil), call.modifiers...)
 	d.calls = append(d.calls, call)
+	if d.callError != nil {
+		return d.callError(call)
+	}
 	return d.err
 }
 
-func (d *fakeDriver) Move(_, _, _ int) error {
-	return d.record(driverCall{operation: OperationMove})
+func (d *fakeDriver) Move(x, y, displayID int) error {
+	return d.record(driverCall{operation: OperationMove, x: x, y: y, displayID: displayID})
 }
 
-func (d *fakeDriver) Click(_ MouseButton, _ bool) error {
-	return d.record(driverCall{operation: OperationClick})
+func (d *fakeDriver) Click(button MouseButton, _ bool) error {
+	return d.record(driverCall{operation: OperationClick, button: button})
+}
+
+func (d *fakeDriver) Scroll(deltaX, deltaY int) error {
+	return d.record(driverCall{operation: OperationScroll, deltaX: deltaX, deltaY: deltaY})
+}
+
+func (d *fakeDriver) ToggleMouse(button MouseButton, down bool) error {
+	return d.record(driverCall{operation: OperationDrag, button: button, down: down})
 }
 
 func (d *fakeDriver) TypeText(text string) error {
 	return d.record(driverCall{operation: OperationTypeText, text: text})
+}
+
+func (d *fakeDriver) ToggleKey(key string, modifiers []KeyModifier, down bool) error {
+	return d.record(driverCall{
+		operation: OperationKeyChord, key: key, modifiers: modifiers, down: down,
+	})
+}
+
+func (d *fakeDriver) TapKey(key string, modifiers []KeyModifier) error {
+	return d.record(driverCall{
+		operation: OperationKeyChord, text: "tap", key: key, modifiers: modifiers,
+	})
+}
+
+func (d *fakeDriver) ActiveWindowPID() (int, error) {
+	if err := d.record(driverCall{operation: OperationKeyChord, text: "active-pid"}); err != nil {
+		return 0, err
+	}
+	if d.activePID != 0 {
+		return d.activePID, nil
+	}
+	return 42, nil
+}
+
+func (d *fakeDriver) ActiveWindowTitle() (string, error) {
+	call := driverCall{operation: OperationKeyChord, text: "active-title"}
+	if err := d.record(call); err != nil {
+		return "", err
+	}
+	return d.nextWindowTitle(), nil
+}
+
+func (d *fakeDriver) WindowTitle(target int, kind WindowTargetKind) (string, error) {
+	call := driverCall{
+		operation: OperationActivate, text: "title",
+		target: target, targetKind: kind,
+	}
+	if err := d.record(call); err != nil {
+		return "", err
+	}
+	return d.nextWindowTitle(), nil
+}
+
+func (d *fakeDriver) nextWindowTitle() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.windowTitles) > 0 {
+		index := d.windowTitleCalls
+		d.windowTitleCalls++
+		if index >= len(d.windowTitles) {
+			index = len(d.windowTitles) - 1
+		}
+		return d.windowTitles[index]
+	}
+	if d.windowTitle != "" {
+		return d.windowTitle
+	}
+	return "fixture"
+}
+
+func (d *fakeDriver) ActivateWindow(target int, kind WindowTargetKind) error {
+	return d.record(driverCall{
+		operation: OperationActivate, text: "activate",
+		target: target, targetKind: kind,
+	})
 }
 
 func (d *fakeDriver) RuntimeCapabilities() robotgo.RuntimeCapabilities {
@@ -157,12 +254,23 @@ func (d *fakeDriver) callCount() int {
 	return len(d.calls)
 }
 
+func (d *fakeDriver) recordedCalls() []driverCall {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	result := append([]driverCall(nil), d.calls...)
+	for index := range result {
+		result[index].modifiers = append([]KeyModifier(nil), result[index].modifiers...)
+	}
+	return result
+}
+
 func availableCapabilities() robotgo.RuntimeCapabilities {
 	return robotgo.RuntimeCapabilities{
 		Capture:  robotgo.FeatureCapability{Available: true, Backend: "fake-capture"},
 		Bounds:   robotgo.FeatureCapability{Available: true, Backend: "fake-bounds"},
 		Mouse:    robotgo.FeatureCapability{Available: true, Backend: "fake-mouse"},
 		Keyboard: robotgo.FeatureCapability{Available: true, Backend: "fake-keyboard"},
+		Window:   robotgo.FeatureCapability{Available: true, Backend: "fake-window"},
 	}
 }
 
@@ -170,7 +278,8 @@ func testPolicy() Policy {
 	return Policy{
 		AllowedOperations: []Operation{OperationMove, OperationClick, OperationTypeText},
 		AllowedDisplayIDs: []int{0, 2}, MaxActions: 3, MaxTextRunes: 8,
-		AllowDoubleClick: true,
+		AllowedMouseButtons: []MouseButton{MouseButtonLeft, MouseButtonMiddle, MouseButtonRight},
+		AllowDoubleClick:    true,
 	}
 }
 
@@ -196,7 +305,8 @@ func TestCatalogIsStableAndDefensive(t *testing.T) {
 	}
 	want := []Operation{
 		OperationObserve, OperationFindColor, OperationWaitColor,
-		OperationMove, OperationClick, OperationTypeText,
+		OperationMove, OperationClick, OperationScroll, OperationDrag,
+		OperationTypeText, OperationKeyChord, OperationActivate,
 	}
 	for index, operation := range want {
 		got := catalog.Operations[index]
@@ -204,7 +314,9 @@ func TestCatalogIsStableAndDefensive(t *testing.T) {
 			t.Fatalf("operation[%d] = %+v", index, got)
 		}
 		wantCancellation := CancellationPreflightOnly
-		if operation == OperationFindColor || operation == OperationWaitColor {
+		if operation == OperationFindColor || operation == OperationWaitColor ||
+			operation == OperationScroll || operation == OperationDrag ||
+			operation == OperationKeyChord {
 			wantCancellation = CancellationCooperative
 		}
 		if got.Cancellation != wantCancellation {

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -114,7 +114,7 @@ func (d *fakeDriver) Move(x, y, displayID int) error {
 
 func (d *fakeDriver) MoveImmediate(x, y, displayID int) error {
 	return d.record(driverCall{
-		operation: OperationMove, text: "immediate",
+		operation: OperationMove, text: "immediate", immediate: true,
 		x: x, y: y, displayID: displayID,
 	})
 }
@@ -123,8 +123,11 @@ func (d *fakeDriver) Click(button MouseButton, _ bool) error {
 	return d.record(driverCall{operation: OperationClick, button: button})
 }
 
-func (d *fakeDriver) Scroll(deltaX, deltaY int) error {
-	return d.record(driverCall{operation: OperationScroll, deltaX: deltaX, deltaY: deltaY})
+func (d *fakeDriver) ScrollImmediate(deltaX, deltaY int) error {
+	return d.record(driverCall{
+		operation: OperationScroll, deltaX: deltaX, deltaY: deltaY,
+		immediate: true,
+	})
 }
 
 func (d *fakeDriver) ToggleMouse(button MouseButton, down bool) error {

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -28,6 +28,7 @@ type driverCall struct {
 	modifiers  []KeyModifier
 	target     int
 	targetKind WindowTargetKind
+	immediate  bool
 }
 
 type fakeDriver struct {
@@ -134,7 +135,7 @@ func (d *fakeDriver) TypeText(text string) error {
 	return d.record(driverCall{operation: OperationTypeText, text: text})
 }
 
-func (d *fakeDriver) ToggleKey(
+func (d *fakeDriver) ToggleKeyImmediate(
 	key string,
 	modifiers []KeyModifier,
 	targetPID int,
@@ -142,7 +143,7 @@ func (d *fakeDriver) ToggleKey(
 ) error {
 	return d.record(driverCall{
 		operation: OperationKeyChord, key: key, modifiers: modifiers,
-		target: targetPID, down: down,
+		target: targetPID, down: down, immediate: true,
 	})
 }
 

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -51,7 +51,7 @@ type fakeDriver struct {
 	windowTitle      string
 	windowTitles     []string
 	windowTitleCalls int
-	activePID        int
+	resolvedHandle   int
 	callHook         func(driverCall)
 	callError        func(driverCall) error
 }
@@ -127,34 +127,30 @@ func (d *fakeDriver) TypeText(text string) error {
 	return d.record(driverCall{operation: OperationTypeText, text: text})
 }
 
-func (d *fakeDriver) ToggleKey(key string, modifiers []KeyModifier, down bool) error {
+func (d *fakeDriver) ToggleKey(
+	key string,
+	modifiers []KeyModifier,
+	targetPID int,
+	down bool,
+) error {
 	return d.record(driverCall{
-		operation: OperationKeyChord, key: key, modifiers: modifiers, down: down,
+		operation: OperationKeyChord, key: key, modifiers: modifiers,
+		target: targetPID, down: down,
 	})
 }
 
-func (d *fakeDriver) TapKey(key string, modifiers []KeyModifier) error {
-	return d.record(driverCall{
-		operation: OperationKeyChord, text: "tap", key: key, modifiers: modifiers,
-	})
-}
-
-func (d *fakeDriver) ActiveWindowPID() (int, error) {
-	if err := d.record(driverCall{operation: OperationKeyChord, text: "active-pid"}); err != nil {
+func (d *fakeDriver) ResolveWindow(target int, kind WindowTargetKind) (int, error) {
+	call := driverCall{
+		operation: OperationActivate, text: "resolve",
+		target: target, targetKind: kind,
+	}
+	if err := d.record(call); err != nil {
 		return 0, err
 	}
-	if d.activePID != 0 {
-		return d.activePID, nil
+	if d.resolvedHandle != 0 {
+		return d.resolvedHandle, nil
 	}
-	return 42, nil
-}
-
-func (d *fakeDriver) ActiveWindowTitle() (string, error) {
-	call := driverCall{operation: OperationKeyChord, text: "active-title"}
-	if err := d.record(call); err != nil {
-		return "", err
-	}
-	return d.nextWindowTitle(), nil
+	return target, nil
 }
 
 func (d *fakeDriver) WindowTitle(target int, kind WindowTargetKind) (string, error) {

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -587,6 +587,51 @@ func TestSimpleMutationBackendErrorsAreUnverified(t *testing.T) {
 	}
 }
 
+func TestRetainedClickReleaseTaintsSessionUntilCloseRetry(t *testing.T) {
+	releaseErr := errors.New("release unconfirmed")
+	driver := &fakeDriver{}
+	driver.callError = func(call driverCall) error {
+		if call.operation == OperationClick {
+			return errors.Join(robotgo.ErrInputReleasePending, releaseErr)
+		}
+		return nil
+	}
+	session := newTestSession(t, testPolicy(), driver)
+
+	result, err := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationClick,
+		Click:     &ClickAction{Button: MouseButtonLeft},
+	})
+	if !errors.Is(err, releaseErr) || !errors.Is(err, ErrInputCleanup) ||
+		result.Status != ActionUnverified || result.Error == nil ||
+		result.Error.Code != ErrorCleanupFailed {
+		t.Fatalf("retained click result = %+v, %v", result, err)
+	}
+	if !session.inputTainted || len(session.pressedInputs) != 1 {
+		t.Fatalf("retained click state: tainted=%v ledger=%+v", session.inputTainted, session.pressedInputs)
+	}
+
+	blocked, blockedErr := session.Execute(t.Context(), ActionRequest{
+		Operation: OperationMove,
+		Move:      &MoveAction{X: 1, Y: 2, DisplayID: 0},
+	})
+	if !errors.Is(blockedErr, ErrInputCleanup) || blocked.Error == nil ||
+		blocked.Error.Code != ErrorCleanupFailed || driver.callCount() != 1 {
+		t.Fatalf("action after retained click = %+v, %v, calls=%+v", blocked, blockedErr, driver.recordedCalls())
+	}
+
+	if err := session.Close(); err != nil {
+		t.Fatalf("close retry: %v", err)
+	}
+	calls := driver.recordedCalls()
+	if len(calls) != 2 || calls[1].down || calls[1].button != MouseButtonLeft {
+		t.Fatalf("close retry calls = %+v", calls)
+	}
+	if session.inputTainted || len(session.pressedInputs) != 0 {
+		t.Fatalf("close retry state: tainted=%v ledger=%+v", session.inputTainted, session.pressedInputs)
+	}
+}
+
 func TestContextIsPreflightOnlyOnceDriverStarts(t *testing.T) {
 	driver := &fakeDriver{started: make(chan struct{}, 1), release: make(chan struct{})}
 	session := newTestSession(t, testPolicy(), driver)

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -111,6 +111,13 @@ func (d *fakeDriver) Move(x, y, displayID int) error {
 	return d.record(driverCall{operation: OperationMove, x: x, y: y, displayID: displayID})
 }
 
+func (d *fakeDriver) MoveImmediate(x, y, displayID int) error {
+	return d.record(driverCall{
+		operation: OperationMove, text: "immediate",
+		x: x, y: y, displayID: displayID,
+	})
+}
+
 func (d *fakeDriver) Click(button MouseButton, _ bool) error {
 	return d.record(driverCall{operation: OperationClick, button: button})
 }

--- a/agent/types.go
+++ b/agent/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CatalogSchemaVersion identifies the operation catalog JSON contract.
-const CatalogSchemaVersion = "3"
+const CatalogSchemaVersion = "4"
 
 // Operation identifies one strict agent operation.
 type Operation string
@@ -18,7 +18,11 @@ type Operation string
 const (
 	OperationMove      Operation = "pointer.move"
 	OperationClick     Operation = "pointer.click"
+	OperationScroll    Operation = "pointer.scroll"
+	OperationDrag      Operation = "pointer.drag"
 	OperationTypeText  Operation = "keyboard.type-text"
+	OperationKeyChord  Operation = "keyboard.chord"
+	OperationActivate  Operation = "window.activate"
 	OperationObserve   Operation = "desktop.observe"
 	OperationFindColor Operation = "desktop.find-color"
 	OperationWaitColor Operation = "desktop.wait-color"
@@ -30,6 +34,7 @@ type RiskClass string
 const (
 	RiskSensitiveRead      RiskClass = "sensitive-read"
 	RiskReversibleMutation RiskClass = "reversible-mutation"
+	RiskElevatedMutation   RiskClass = "elevated-mutation"
 )
 
 // CancellationSupport describes where cancellation is enforceable.
@@ -54,6 +59,7 @@ type OperationCapability struct {
 	ExclusiveAgentSession bool                `json:"exclusive_agent_session"`
 	Reason                string              `json:"reason,omitempty"`
 	Remediation           string              `json:"remediation,omitempty"`
+	UnavailableCode       ErrorCode           `json:"unavailable_code,omitempty"`
 	OptionalCapture       bool                `json:"optional_capture,omitempty"`
 	CaptureAvailable      bool                `json:"capture_available,omitempty"`
 	CapturePolicyAllowed  bool                `json:"capture_policy_allowed,omitempty"`
@@ -95,6 +101,71 @@ type TypeTextAction struct {
 	Text string `json:"text"`
 }
 
+// ScrollAction positions the pointer at one validated global coordinate and
+// emits one bounded scroll delta repeatedly there. The explicit target keeps
+// the operation usable on Wayland, which does not expose the live global
+// pointer position.
+type ScrollAction struct {
+	TargetX   int    `json:"target_x"`
+	TargetY   int    `json:"target_y"`
+	DeltaX    int    `json:"delta_x"`
+	DeltaY    int    `json:"delta_y"`
+	Events    uint32 `json:"events"`
+	DisplayID int    `json:"display_id"`
+}
+
+// DragAction moves from Start to End while holding one pointer button. Both
+// coordinates are global and must remain on the same explicitly selected
+// display.
+type DragAction struct {
+	StartX         int         `json:"start_x"`
+	StartY         int         `json:"start_y"`
+	EndX           int         `json:"end_x"`
+	EndY           int         `json:"end_y"`
+	DisplayID      int         `json:"display_id"`
+	Button         MouseButton `json:"button"`
+	DurationMillis int         `json:"duration_ms"`
+}
+
+// KeyModifier is the unambiguous, platform-neutral modifier vocabulary exposed
+// by the agent contract. Legacy aliases such as cmd, ctrl, and right_shift are
+// deliberately not accepted here.
+type KeyModifier string
+
+const (
+	KeyModifierAlt     KeyModifier = "alt"
+	KeyModifierControl KeyModifier = "control"
+	KeyModifierMeta    KeyModifier = "meta"
+	KeyModifierShift   KeyModifier = "shift"
+)
+
+// KeyChordAction presses one bounded key with zero or more canonical
+// modifiers after verifying that TargetPID is still the active, allow-listed
+// process. It is input, not text entry.
+type KeyChordAction struct {
+	Key       string        `json:"key"`
+	Modifiers []KeyModifier `json:"modifiers,omitempty"`
+	TargetPID int           `json:"target_pid"`
+}
+
+// WindowTargetKind identifies whether a window target is a process ID or a
+// native platform handle.
+type WindowTargetKind string
+
+const (
+	WindowTargetProcess WindowTargetKind = "process"
+	WindowTargetHandle  WindowTargetKind = "handle"
+)
+
+// ActivateWindowAction activates one immutable policy-approved process or
+// native handle. The session revalidates its expected title immediately before
+// dispatch so a stale or reused identity cannot silently target another
+// window.
+type ActivateWindowAction struct {
+	Target int              `json:"target"`
+	Kind   WindowTargetKind `json:"kind"`
+}
+
 // ActionRequest is a strict JSON-serializable action union. Exactly one action
 // payload must be present and must match Operation.
 type ActionRequest struct {
@@ -102,7 +173,11 @@ type ActionRequest struct {
 	Confirmed    bool                     `json:"confirmed,omitempty"`
 	Move         *MoveAction              `json:"move,omitempty"`
 	Click        *ClickAction             `json:"click,omitempty"`
+	Scroll       *ScrollAction            `json:"scroll,omitempty"`
+	Drag         *DragAction              `json:"drag,omitempty"`
 	TypeText     *TypeTextAction          `json:"type_text,omitempty"`
+	KeyChord     *KeyChordAction          `json:"key_chord,omitempty"`
+	Activate     *ActivateWindowAction    `json:"activate,omitempty"`
 	Precondition *ObservationPrecondition `json:"precondition,omitempty"`
 	Verification *VerificationRequest     `json:"verification,omitempty"`
 }
@@ -124,6 +199,7 @@ const (
 	ErrorInvalidInput     ErrorCode = "invalid-input"
 	ErrorPolicyDenied     ErrorCode = "policy-denied"
 	ErrorUnsupported      ErrorCode = "unsupported"
+	ErrorUnavailable      ErrorCode = "unavailable"
 	ErrorPermissionDenied ErrorCode = "permission-denied"
 	ErrorSessionClosed    ErrorCode = "session-closed"
 	ErrorSessionBusy      ErrorCode = "session-busy"
@@ -134,6 +210,7 @@ const (
 	ErrorVerification     ErrorCode = "verification-failed"
 	ErrorAuditDelivery    ErrorCode = "audit-delivery-failed"
 	ErrorConditionNotMet  ErrorCode = "condition-not-met"
+	ErrorCleanupFailed    ErrorCode = "cleanup-failed"
 )
 
 // ActionError is safe to serialize: Message never contains action payloads.
@@ -169,6 +246,7 @@ var (
 	ErrVerification    = errors.New("agent action verification failed")
 	ErrAuditDelivery   = errors.New("agent audit delivery failed")
 	ErrConditionNotMet = errors.New("agent visual condition was not met")
+	ErrInputCleanup    = errors.New("agent input cleanup failed")
 )
 
 func newActionError(code ErrorCode, operation Operation, message string, cause error) *ActionError {

--- a/agent/types.go
+++ b/agent/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CatalogSchemaVersion identifies the operation catalog JSON contract.
-const CatalogSchemaVersion = "4"
+const CatalogSchemaVersion = "5"
 
 // Operation identifies one strict agent operation.
 type Operation string
@@ -65,7 +65,16 @@ type OperationCapability struct {
 	CapturePolicyAllowed  bool                `json:"capture_policy_allowed,omitempty"`
 	CaptureFallback       bool                `json:"capture_fallback,omitempty"`
 	CaptureBackend        string              `json:"capture_backend,omitempty"`
+	ScrollAxes            []ScrollAxis        `json:"scroll_axes,omitempty"`
 }
+
+// ScrollAxis identifies an axis accepted by a scroll backend.
+type ScrollAxis string
+
+const (
+	ScrollAxisHorizontal ScrollAxis = "horizontal"
+	ScrollAxisVertical   ScrollAxis = "vertical"
+)
 
 // OperationCatalog is an immutable snapshot of operation availability.
 type OperationCatalog struct {

--- a/api/compat/linux-cgo.api
+++ b/api/compat/linux-cgo.api
@@ -250,6 +250,7 @@ func CharCodeAt(string, int) rune
 func CheckMouse(string) github.com/marang/robotgo._Ctype_uint
 func Click(...interface{})
 func ClickE(...interface{}) error
+func ClickImmediateE(...interface{}) error
 func ClickV1(...interface{})
 func CloseMainDisplay()
 func CloseMainDisplayE() error
@@ -465,6 +466,7 @@ func TypeDelay(string, int)
 func TypeStr(string, ...int)
 func TypeStrDelay(string, int)
 func TypeStrE(string, ...int) error
+func TypeStrImmediateE(string, ...int) error
 func TypeStringDelayed(string, int)
 func U32ToHex(github.com/marang/robotgo._Ctype_uint) github.com/marang/robotgo._Ctype_uint
 func U8ToHex(*github.com/marang/robotgo._Ctype_uchar) github.com/marang/robotgo._Ctype_uint

--- a/api/compat/linux-cgo.api
+++ b/api/compat/linux-cgo.api
@@ -319,6 +319,7 @@ func GetTextImg(image.Image, ...string) (string, error)
 func GetTextImgContext(context.Context, image.Image, ...string) (string, error)
 func GetTitle(...int) string
 func GetTitleE(...int) (string, error)
+func GetTitleTargetE(int, bool) (string, error)
 func GetVersion() string
 func GetXDisplayName() string
 func GetXid(*github.com/jezek/xgbutil.XUtil, int) (github.com/jezek/xgb/xproto.Window, error)
@@ -346,6 +347,7 @@ func KeyDown(string, ...interface{}) error
 func KeyPress(string, ...interface{}) error
 func KeyTap(string, ...interface{}) error
 func KeyToggle(string, ...interface{}) error
+func KeyToggleImmediate(string, ...interface{}) error
 func KeyUp(string, ...interface{}) error
 func KeyboardReady() error
 func Kill(int) error

--- a/api/compat/linux-cgo.api
+++ b/api/compat/linux-cgo.api
@@ -522,6 +522,7 @@ var ErrDmabufMap error
 var ErrDmabufModifiers error
 var ErrInputNotApplied error
 var ErrInputOwnership error
+var ErrInputReleasePending error
 var ErrInvalidPID error
 var ErrNoOutputs error
 var ErrNoScreencopy error

--- a/api/compat/linux-cgo.api
+++ b/api/compat/linux-cgo.api
@@ -546,13 +546,14 @@ const AuditSchemaVersion untyped string = "2"
 const AuditVerificationFinished github.com/marang/robotgo/agent.AuditKind = "verification.finished"
 const CancellationCooperative github.com/marang/robotgo/agent.CancellationSupport = "cooperative"
 const CancellationPreflightOnly github.com/marang/robotgo/agent.CancellationSupport = "preflight-only"
-const CatalogSchemaVersion untyped string = "3"
+const CatalogSchemaVersion untyped string = "4"
 const ConditionMatched github.com/marang/robotgo/agent.ConditionStatus = "matched"
 const ConditionNotMatched github.com/marang/robotgo/agent.ConditionStatus = "not-matched"
 const ConditionSchemaVersion untyped string = "1"
 const ErrorAuditDelivery github.com/marang/robotgo/agent.ErrorCode = "audit-delivery-failed"
 const ErrorBackendFailure github.com/marang/robotgo/agent.ErrorCode = "backend-failure"
 const ErrorCanceled github.com/marang/robotgo/agent.ErrorCode = "canceled"
+const ErrorCleanupFailed github.com/marang/robotgo/agent.ErrorCode = "cleanup-failed"
 const ErrorConditionNotMet github.com/marang/robotgo/agent.ErrorCode = "condition-not-met"
 const ErrorInvalidInput github.com/marang/robotgo/agent.ErrorCode = "invalid-input"
 const ErrorPermissionDenied github.com/marang/robotgo/agent.ErrorCode = "permission-denied"
@@ -561,24 +562,36 @@ const ErrorSessionBusy github.com/marang/robotgo/agent.ErrorCode = "session-busy
 const ErrorSessionClosed github.com/marang/robotgo/agent.ErrorCode = "session-closed"
 const ErrorStaleTarget github.com/marang/robotgo/agent.ErrorCode = "stale-target"
 const ErrorTimedOut github.com/marang/robotgo/agent.ErrorCode = "timed-out"
+const ErrorUnavailable github.com/marang/robotgo/agent.ErrorCode = "unavailable"
 const ErrorUnsupported github.com/marang/robotgo/agent.ErrorCode = "unsupported"
 const ErrorVerification github.com/marang/robotgo/agent.ErrorCode = "verification-failed"
+const KeyModifierAlt github.com/marang/robotgo/agent.KeyModifier = "alt"
+const KeyModifierControl github.com/marang/robotgo/agent.KeyModifier = "control"
+const KeyModifierMeta github.com/marang/robotgo/agent.KeyModifier = "meta"
+const KeyModifierShift github.com/marang/robotgo/agent.KeyModifier = "shift"
 const MouseButtonLeft github.com/marang/robotgo/agent.MouseButton = "left"
 const MouseButtonMiddle github.com/marang/robotgo/agent.MouseButton = "center"
 const MouseButtonRight github.com/marang/robotgo/agent.MouseButton = "right"
 const ObservationSchemaVersion untyped string = "1"
+const OperationActivate github.com/marang/robotgo/agent.Operation = "window.activate"
 const OperationClick github.com/marang/robotgo/agent.Operation = "pointer.click"
+const OperationDrag github.com/marang/robotgo/agent.Operation = "pointer.drag"
 const OperationFindColor github.com/marang/robotgo/agent.Operation = "desktop.find-color"
+const OperationKeyChord github.com/marang/robotgo/agent.Operation = "keyboard.chord"
 const OperationMove github.com/marang/robotgo/agent.Operation = "pointer.move"
 const OperationObserve github.com/marang/robotgo/agent.Operation = "desktop.observe"
+const OperationScroll github.com/marang/robotgo/agent.Operation = "pointer.scroll"
 const OperationTypeText github.com/marang/robotgo/agent.Operation = "keyboard.type-text"
 const OperationWaitColor github.com/marang/robotgo/agent.Operation = "desktop.wait-color"
+const RiskElevatedMutation github.com/marang/robotgo/agent.RiskClass = "elevated-mutation"
 const RiskReversibleMutation github.com/marang/robotgo/agent.RiskClass = "reversible-mutation"
 const RiskSensitiveRead github.com/marang/robotgo/agent.RiskClass = "sensitive-read"
 const VerificationCaptureChanged github.com/marang/robotgo/agent.VerificationCondition = "capture-changed"
 const VerificationCaptureUnchanged github.com/marang/robotgo/agent.VerificationCondition = "capture-unchanged"
 const VerificationFailed github.com/marang/robotgo/agent.VerificationStatus = "failed"
 const VerificationPassed github.com/marang/robotgo/agent.VerificationStatus = "passed"
+const WindowTargetHandle github.com/marang/robotgo/agent.WindowTargetKind = "handle"
+const WindowTargetProcess github.com/marang/robotgo/agent.WindowTargetKind = "process"
 func NewSession(github.com/marang/robotgo/agent.Config) (*github.com/marang/robotgo/agent.Session, error)
 methodset *ActionError.Error() string
 methodset *ActionError.Unwrap() error
@@ -594,9 +607,10 @@ methodset *Session.ReleaseObservation(string) error
 methodset *Session.WaitColor(context.Context, github.com/marang/robotgo/agent.WaitColorRequest) (github.com/marang/robotgo/agent.WaitColorResult, error)
 methodset AuditSink.Record(context.Context, github.com/marang/robotgo/agent.AuditEvent) error
 type ActionError struct{Code github.com/marang/robotgo/agent.ErrorCode tag "json:\"code\""; Operation github.com/marang/robotgo/agent.Operation tag "json:\"operation,omitempty\""; Message string tag "json:\"message\""; <private fields present>}
-type ActionRequest struct{Operation github.com/marang/robotgo/agent.Operation tag "json:\"operation\""; Confirmed bool tag "json:\"confirmed,omitempty\""; Move *github.com/marang/robotgo/agent.MoveAction tag "json:\"move,omitempty\""; Click *github.com/marang/robotgo/agent.ClickAction tag "json:\"click,omitempty\""; TypeText *github.com/marang/robotgo/agent.TypeTextAction tag "json:\"type_text,omitempty\""; Precondition *github.com/marang/robotgo/agent.ObservationPrecondition tag "json:\"precondition,omitempty\""; Verification *github.com/marang/robotgo/agent.VerificationRequest tag "json:\"verification,omitempty\""}
+type ActionRequest struct{Operation github.com/marang/robotgo/agent.Operation tag "json:\"operation\""; Confirmed bool tag "json:\"confirmed,omitempty\""; Move *github.com/marang/robotgo/agent.MoveAction tag "json:\"move,omitempty\""; Click *github.com/marang/robotgo/agent.ClickAction tag "json:\"click,omitempty\""; Scroll *github.com/marang/robotgo/agent.ScrollAction tag "json:\"scroll,omitempty\""; Drag *github.com/marang/robotgo/agent.DragAction tag "json:\"drag,omitempty\""; TypeText *github.com/marang/robotgo/agent.TypeTextAction tag "json:\"type_text,omitempty\""; KeyChord *github.com/marang/robotgo/agent.KeyChordAction tag "json:\"key_chord,omitempty\""; Activate *github.com/marang/robotgo/agent.ActivateWindowAction tag "json:\"activate,omitempty\""; Precondition *github.com/marang/robotgo/agent.ObservationPrecondition tag "json:\"precondition,omitempty\""; Verification *github.com/marang/robotgo/agent.VerificationRequest tag "json:\"verification,omitempty\""}
 type ActionResult struct{ActionID string tag "json:\"action_id\""; Operation github.com/marang/robotgo/agent.Operation tag "json:\"operation\""; Status github.com/marang/robotgo/agent.ActionStatus tag "json:\"status\""; Backend string tag "json:\"backend,omitempty\""; DurationMillis int64 tag "json:\"duration_ms\""; Error *github.com/marang/robotgo/agent.ActionError tag "json:\"error,omitempty\""; PreconditionObservationID string tag "json:\"precondition_observation_id,omitempty\""; PostObservationID string tag "json:\"post_observation_id,omitempty\""; Verification *github.com/marang/robotgo/agent.VerificationResult tag "json:\"verification,omitempty\""}
 type ActionStatus string
+type ActivateWindowAction struct{Target int tag "json:\"target\""; Kind github.com/marang/robotgo/agent.WindowTargetKind tag "json:\"kind\""}
 type AuditEvent struct{SchemaVersion string tag "json:\"schema_version\""; Sequence uint64 tag "json:\"sequence\""; Kind github.com/marang/robotgo/agent.AuditKind tag "json:\"kind\""; Timestamp time.Time tag "json:\"timestamp\""; Operation github.com/marang/robotgo/agent.Operation tag "json:\"operation,omitempty\""; ActionID string tag "json:\"action_id,omitempty\""; ObservationID string tag "json:\"observation_id,omitempty\""; PreconditionObservationID string tag "json:\"precondition_observation_id,omitempty\""; PostObservationID string tag "json:\"post_observation_id,omitempty\""; ActionStatus github.com/marang/robotgo/agent.ActionStatus tag "json:\"action_status,omitempty\""; VerificationStatus github.com/marang/robotgo/agent.VerificationStatus tag "json:\"verification_status,omitempty\""; VerificationAttempts uint32 tag "json:\"verification_attempts,omitempty\""; ConditionID string tag "json:\"condition_id,omitempty\""; ConditionStatus github.com/marang/robotgo/agent.ConditionStatus tag "json:\"condition_status,omitempty\""; ConditionAttempts uint32 tag "json:\"condition_attempts,omitempty\""; ErrorCode github.com/marang/robotgo/agent.ErrorCode tag "json:\"error_code,omitempty\""}
 type AuditKind string
 type AuditSink interface{Record(context.Context, github.com/marang/robotgo/agent.AuditEvent) error}
@@ -608,20 +622,24 @@ type ColorCondition struct{Red uint8 tag "json:\"red\""; Green uint8 tag "json:\
 type ConditionStatus string
 type Config struct{Policy github.com/marang/robotgo/agent.Policy tag "json:\"policy\""; AuditSink github.com/marang/robotgo/agent.AuditSink tag "json:\"-\""}
 type DiagnosticFeature struct{Name string tag "json:\"name\""; Available bool tag "json:\"available\""; Fallback bool tag "json:\"fallback\""; Backend string tag "json:\"backend,omitempty\""; Reason string tag "json:\"reason,omitempty\""; Remediation string tag "json:\"remediation,omitempty\""}
+type DragAction struct{StartX int tag "json:\"start_x\""; StartY int tag "json:\"start_y\""; EndX int tag "json:\"end_x\""; EndY int tag "json:\"end_y\""; DisplayID int tag "json:\"display_id\""; Button github.com/marang/robotgo/agent.MouseButton tag "json:\"button\""; DurationMillis int tag "json:\"duration_ms\""}
 type ErrorCode string
 type FindColorRequest struct{ObservationID string tag "json:\"observation_id\""; Condition github.com/marang/robotgo/agent.ColorCondition tag "json:\"condition\""; Confirmed bool tag "json:\"confirmed,omitempty\""}
 type FindColorResult struct{SchemaVersion string tag "json:\"schema_version\""; ConditionID string tag "json:\"condition_id\""; ObservationID string tag "json:\"observation_id\""; Status github.com/marang/robotgo/agent.ConditionStatus tag "json:\"status\""; Match *github.com/marang/robotgo/agent.VisualMatch tag "json:\"match,omitempty\""}
+type KeyChordAction struct{Key string tag "json:\"key\""; Modifiers []github.com/marang/robotgo/agent.KeyModifier tag "json:\"modifiers,omitempty\""; TargetPID int tag "json:\"target_pid\""}
+type KeyModifier string
 type MouseButton string
 type MoveAction struct{X int tag "json:\"x\""; Y int tag "json:\"y\""; DisplayID int tag "json:\"display_id\""}
 type Observation struct{SchemaVersion string tag "json:\"schema_version\""; ObservationID string tag "json:\"observation_id\""; CreatedAt time.Time tag "json:\"created_at\""; Diagnostics github.com/marang/robotgo/agent.RuntimeDiagnostics tag "json:\"diagnostics\""; Capture *github.com/marang/robotgo/agent.CaptureMetadata tag "json:\"capture,omitempty\""; <private fields present>}
 type ObservationPrecondition struct{ObservationID string tag "json:\"observation_id\""}
 type ObserveRequest struct{Confirmed bool tag "json:\"confirmed,omitempty\""; Capture *github.com/marang/robotgo/agent.CaptureRegion tag "json:\"capture,omitempty\""}
 type Operation string
-type OperationCapability struct{Operation github.com/marang/robotgo/agent.Operation tag "json:\"operation\""; Available bool tag "json:\"available\""; PolicyAllowed bool tag "json:\"policy_allowed\""; Backend string tag "json:\"backend,omitempty\""; Fallback bool tag "json:\"fallback\""; Risk github.com/marang/robotgo/agent.RiskClass tag "json:\"risk\""; ConfirmationRequired bool tag "json:\"confirmation_required\""; Cancellation github.com/marang/robotgo/agent.CancellationSupport tag "json:\"cancellation\""; ProcessGlobalBackend bool tag "json:\"process_global_backend\""; ExclusiveAgentSession bool tag "json:\"exclusive_agent_session\""; Reason string tag "json:\"reason,omitempty\""; Remediation string tag "json:\"remediation,omitempty\""; OptionalCapture bool tag "json:\"optional_capture,omitempty\""; CaptureAvailable bool tag "json:\"capture_available,omitempty\""; CapturePolicyAllowed bool tag "json:\"capture_policy_allowed,omitempty\""; CaptureFallback bool tag "json:\"capture_fallback,omitempty\""; CaptureBackend string tag "json:\"capture_backend,omitempty\""}
+type OperationCapability struct{Operation github.com/marang/robotgo/agent.Operation tag "json:\"operation\""; Available bool tag "json:\"available\""; PolicyAllowed bool tag "json:\"policy_allowed\""; Backend string tag "json:\"backend,omitempty\""; Fallback bool tag "json:\"fallback\""; Risk github.com/marang/robotgo/agent.RiskClass tag "json:\"risk\""; ConfirmationRequired bool tag "json:\"confirmation_required\""; Cancellation github.com/marang/robotgo/agent.CancellationSupport tag "json:\"cancellation\""; ProcessGlobalBackend bool tag "json:\"process_global_backend\""; ExclusiveAgentSession bool tag "json:\"exclusive_agent_session\""; Reason string tag "json:\"reason,omitempty\""; Remediation string tag "json:\"remediation,omitempty\""; UnavailableCode github.com/marang/robotgo/agent.ErrorCode tag "json:\"unavailable_code,omitempty\""; OptionalCapture bool tag "json:\"optional_capture,omitempty\""; CaptureAvailable bool tag "json:\"capture_available,omitempty\""; CapturePolicyAllowed bool tag "json:\"capture_policy_allowed,omitempty\""; CaptureFallback bool tag "json:\"capture_fallback,omitempty\""; CaptureBackend string tag "json:\"capture_backend,omitempty\""}
 type OperationCatalog struct{SchemaVersion string tag "json:\"schema_version\""; Operations []github.com/marang/robotgo/agent.OperationCapability tag "json:\"operations\""}
-type Policy struct{AllowedOperations []github.com/marang/robotgo/agent.Operation tag "json:\"allowed_operations\""; ConfirmOperations []github.com/marang/robotgo/agent.Operation tag "json:\"confirm_operations,omitempty\""; AllowedDisplayIDs []int tag "json:\"allowed_display_ids,omitempty\""; MaxActions uint64 tag "json:\"max_actions\""; MaxTextRunes int tag "json:\"max_text_runes\""; AllowDoubleClick bool tag "json:\"allow_double_click,omitempty\""; MaxObservations uint64 tag "json:\"max_observations,omitempty\""; MaxCapturePixels uint64 tag "json:\"max_capture_pixels,omitempty\""; MaxQueries uint64 tag "json:\"max_queries,omitempty\""; WaitAttempts uint32 tag "json:\"wait_attempts,omitempty\""; WaitIntervalMillis int tag "json:\"wait_interval_ms,omitempty\""; WaitTimeoutMillis int tag "json:\"wait_timeout_ms,omitempty\""; VerificationAttempts uint32 tag "json:\"verification_attempts,omitempty\""; VerificationIntervalMillis int tag "json:\"verification_interval_ms,omitempty\""; VerificationTimeoutMillis int tag "json:\"verification_timeout_ms,omitempty\""; <private fields present>}
+type Policy struct{AllowedOperations []github.com/marang/robotgo/agent.Operation tag "json:\"allowed_operations\""; ConfirmOperations []github.com/marang/robotgo/agent.Operation tag "json:\"confirm_operations,omitempty\""; AllowedDisplayIDs []int tag "json:\"allowed_display_ids,omitempty\""; AllowedMouseButtons []github.com/marang/robotgo/agent.MouseButton tag "json:\"allowed_mouse_buttons,omitempty\""; AllowedKeys []string tag "json:\"allowed_keys,omitempty\""; AllowedModifiers []github.com/marang/robotgo/agent.KeyModifier tag "json:\"allowed_modifiers,omitempty\""; AllowedWindows []github.com/marang/robotgo/agent.WindowTarget tag "json:\"allowed_windows,omitempty\""; MaxActions uint64 tag "json:\"max_actions\""; MaxTextRunes int tag "json:\"max_text_runes\""; AllowDoubleClick bool tag "json:\"allow_double_click,omitempty\""; MaxScrollEvents uint32 tag "json:\"max_scroll_events,omitempty\""; MaxScrollDistance uint64 tag "json:\"max_scroll_distance,omitempty\""; MaxDragDistance uint64 tag "json:\"max_drag_distance,omitempty\""; MaxDragDurationMillis int tag "json:\"max_drag_duration_ms,omitempty\""; MaxChordKeys uint32 tag "json:\"max_chord_keys,omitempty\""; MinActionIntervalMillis int tag "json:\"min_action_interval_ms,omitempty\""; SessionTimeoutMillis int tag "json:\"session_timeout_ms,omitempty\""; MaxObservations uint64 tag "json:\"max_observations,omitempty\""; MaxCapturePixels uint64 tag "json:\"max_capture_pixels,omitempty\""; MaxQueries uint64 tag "json:\"max_queries,omitempty\""; WaitAttempts uint32 tag "json:\"wait_attempts,omitempty\""; WaitIntervalMillis int tag "json:\"wait_interval_ms,omitempty\""; WaitTimeoutMillis int tag "json:\"wait_timeout_ms,omitempty\""; VerificationAttempts uint32 tag "json:\"verification_attempts,omitempty\""; VerificationIntervalMillis int tag "json:\"verification_interval_ms,omitempty\""; VerificationTimeoutMillis int tag "json:\"verification_timeout_ms,omitempty\""; <private fields present>}
 type RiskClass string
 type RuntimeDiagnostics struct{GOOS string tag "json:\"goos\""; GOARCH string tag "json:\"goarch\""; CGOEnabled bool tag "json:\"cgo_enabled\""; Implementation string tag "json:\"implementation\""; DisplayServer string tag "json:\"display_server\""; Compositor string tag "json:\"compositor,omitempty\""; Features []github.com/marang/robotgo/agent.DiagnosticFeature tag "json:\"features\""}
+type ScrollAction struct{TargetX int tag "json:\"target_x\""; TargetY int tag "json:\"target_y\""; DeltaX int tag "json:\"delta_x\""; DeltaY int tag "json:\"delta_y\""; Events uint32 tag "json:\"events\""; DisplayID int tag "json:\"display_id\""}
 type Session struct{<private fields present>}
 type TypeTextAction struct{Text string tag "json:\"text\""}
 type VerificationCondition string
@@ -631,8 +649,11 @@ type VerificationStatus string
 type VisualMatch struct{X int tag "json:\"x\""; Y int tag "json:\"y\""; DisplayID int tag "json:\"display_id\""}
 type WaitColorRequest struct{Region github.com/marang/robotgo/agent.CaptureRegion tag "json:\"region\""; Condition github.com/marang/robotgo/agent.ColorCondition tag "json:\"condition\""; Confirmed bool tag "json:\"confirmed,omitempty\""}
 type WaitColorResult struct{SchemaVersion string tag "json:\"schema_version\""; ConditionID string tag "json:\"condition_id\""; Status github.com/marang/robotgo/agent.ConditionStatus tag "json:\"status\""; Attempts uint32 tag "json:\"attempts\""; ObservationID string tag "json:\"observation_id,omitempty\""; Match *github.com/marang/robotgo/agent.VisualMatch tag "json:\"match,omitempty\""}
+type WindowTarget struct{Target int tag "json:\"target\""; Kind github.com/marang/robotgo/agent.WindowTargetKind tag "json:\"kind\""; ExpectedTitle string tag "json:\"expected_title\""}
+type WindowTargetKind string
 var ErrAuditDelivery error
 var ErrConditionNotMet error
+var ErrInputCleanup error
 var ErrObservationClosed error
 var ErrPolicyDenied error
 var ErrSessionBusy error

--- a/api/compat/linux-cgo.api
+++ b/api/compat/linux-cgo.api
@@ -520,6 +520,7 @@ var ErrDmabufDevice error
 var ErrDmabufImport error
 var ErrDmabufMap error
 var ErrDmabufModifiers error
+var ErrInputNotApplied error
 var ErrInputOwnership error
 var ErrInvalidPID error
 var ErrNoOutputs error

--- a/api/compat/linux-cgo.api
+++ b/api/compat/linux-cgo.api
@@ -421,6 +421,7 @@ func ScreenCastCaptureStreams() ([]github.com/marang/robotgo/screen/portal.Scree
 func Scroll(int, int, ...int)
 func ScrollDir(int, ...interface{})
 func ScrollE(int, int, ...int) error
+func ScrollImmediateE(int, int) error
 func ScrollRelative(int, int, ...int)
 func ScrollSmooth(int, ...int)
 func SetActive(github.com/marang/robotgo.Handle)

--- a/api/compat/linux-cgo.api
+++ b/api/compat/linux-cgo.api
@@ -366,6 +366,7 @@ func Move(int, int, ...int)
 func MoveArgs(int, int) (int, int)
 func MoveClick(int, int, ...interface{})
 func MoveE(int, int, ...int) error
+func MoveImmediateE(int, int, ...int) error
 func MoveMouse(int, int)
 func MoveMouseSmooth(int, int, ...interface{}) bool
 func MoveRelative(int, int)

--- a/api/compat/linux-cgo.api
+++ b/api/compat/linux-cgo.api
@@ -396,6 +396,7 @@ func RemoteDesktopInputStreams() ([]github.com/marang/robotgo/input/portal.Strea
 func RemoteDesktopTouchDown(uint32, uint32, float64, float64) error
 func RemoteDesktopTouchMotion(uint32, uint32, float64, float64) error
 func RemoteDesktopTouchUp(uint32) error
+func ResolveWindowHandleE(int, ...int) (int, error)
 func RgbToHex(uint8, uint8, uint8) github.com/marang/robotgo._Ctype_uint
 func Run(string) ([]byte, error)
 func Save(image.Image, string, ...int) error
@@ -546,7 +547,7 @@ const AuditSchemaVersion untyped string = "2"
 const AuditVerificationFinished github.com/marang/robotgo/agent.AuditKind = "verification.finished"
 const CancellationCooperative github.com/marang/robotgo/agent.CancellationSupport = "cooperative"
 const CancellationPreflightOnly github.com/marang/robotgo/agent.CancellationSupport = "preflight-only"
-const CatalogSchemaVersion untyped string = "4"
+const CatalogSchemaVersion untyped string = "5"
 const ConditionMatched github.com/marang/robotgo/agent.ConditionStatus = "matched"
 const ConditionNotMatched github.com/marang/robotgo/agent.ConditionStatus = "not-matched"
 const ConditionSchemaVersion untyped string = "1"
@@ -586,6 +587,8 @@ const OperationWaitColor github.com/marang/robotgo/agent.Operation = "desktop.wa
 const RiskElevatedMutation github.com/marang/robotgo/agent.RiskClass = "elevated-mutation"
 const RiskReversibleMutation github.com/marang/robotgo/agent.RiskClass = "reversible-mutation"
 const RiskSensitiveRead github.com/marang/robotgo/agent.RiskClass = "sensitive-read"
+const ScrollAxisHorizontal github.com/marang/robotgo/agent.ScrollAxis = "horizontal"
+const ScrollAxisVertical github.com/marang/robotgo/agent.ScrollAxis = "vertical"
 const VerificationCaptureChanged github.com/marang/robotgo/agent.VerificationCondition = "capture-changed"
 const VerificationCaptureUnchanged github.com/marang/robotgo/agent.VerificationCondition = "capture-unchanged"
 const VerificationFailed github.com/marang/robotgo/agent.VerificationStatus = "failed"
@@ -634,12 +637,13 @@ type Observation struct{SchemaVersion string tag "json:\"schema_version\""; Obse
 type ObservationPrecondition struct{ObservationID string tag "json:\"observation_id\""}
 type ObserveRequest struct{Confirmed bool tag "json:\"confirmed,omitempty\""; Capture *github.com/marang/robotgo/agent.CaptureRegion tag "json:\"capture,omitempty\""}
 type Operation string
-type OperationCapability struct{Operation github.com/marang/robotgo/agent.Operation tag "json:\"operation\""; Available bool tag "json:\"available\""; PolicyAllowed bool tag "json:\"policy_allowed\""; Backend string tag "json:\"backend,omitempty\""; Fallback bool tag "json:\"fallback\""; Risk github.com/marang/robotgo/agent.RiskClass tag "json:\"risk\""; ConfirmationRequired bool tag "json:\"confirmation_required\""; Cancellation github.com/marang/robotgo/agent.CancellationSupport tag "json:\"cancellation\""; ProcessGlobalBackend bool tag "json:\"process_global_backend\""; ExclusiveAgentSession bool tag "json:\"exclusive_agent_session\""; Reason string tag "json:\"reason,omitempty\""; Remediation string tag "json:\"remediation,omitempty\""; UnavailableCode github.com/marang/robotgo/agent.ErrorCode tag "json:\"unavailable_code,omitempty\""; OptionalCapture bool tag "json:\"optional_capture,omitempty\""; CaptureAvailable bool tag "json:\"capture_available,omitempty\""; CapturePolicyAllowed bool tag "json:\"capture_policy_allowed,omitempty\""; CaptureFallback bool tag "json:\"capture_fallback,omitempty\""; CaptureBackend string tag "json:\"capture_backend,omitempty\""}
+type OperationCapability struct{Operation github.com/marang/robotgo/agent.Operation tag "json:\"operation\""; Available bool tag "json:\"available\""; PolicyAllowed bool tag "json:\"policy_allowed\""; Backend string tag "json:\"backend,omitempty\""; Fallback bool tag "json:\"fallback\""; Risk github.com/marang/robotgo/agent.RiskClass tag "json:\"risk\""; ConfirmationRequired bool tag "json:\"confirmation_required\""; Cancellation github.com/marang/robotgo/agent.CancellationSupport tag "json:\"cancellation\""; ProcessGlobalBackend bool tag "json:\"process_global_backend\""; ExclusiveAgentSession bool tag "json:\"exclusive_agent_session\""; Reason string tag "json:\"reason,omitempty\""; Remediation string tag "json:\"remediation,omitempty\""; UnavailableCode github.com/marang/robotgo/agent.ErrorCode tag "json:\"unavailable_code,omitempty\""; OptionalCapture bool tag "json:\"optional_capture,omitempty\""; CaptureAvailable bool tag "json:\"capture_available,omitempty\""; CapturePolicyAllowed bool tag "json:\"capture_policy_allowed,omitempty\""; CaptureFallback bool tag "json:\"capture_fallback,omitempty\""; CaptureBackend string tag "json:\"capture_backend,omitempty\""; ScrollAxes []github.com/marang/robotgo/agent.ScrollAxis tag "json:\"scroll_axes,omitempty\""}
 type OperationCatalog struct{SchemaVersion string tag "json:\"schema_version\""; Operations []github.com/marang/robotgo/agent.OperationCapability tag "json:\"operations\""}
 type Policy struct{AllowedOperations []github.com/marang/robotgo/agent.Operation tag "json:\"allowed_operations\""; ConfirmOperations []github.com/marang/robotgo/agent.Operation tag "json:\"confirm_operations,omitempty\""; AllowedDisplayIDs []int tag "json:\"allowed_display_ids,omitempty\""; AllowedMouseButtons []github.com/marang/robotgo/agent.MouseButton tag "json:\"allowed_mouse_buttons,omitempty\""; AllowedKeys []string tag "json:\"allowed_keys,omitempty\""; AllowedModifiers []github.com/marang/robotgo/agent.KeyModifier tag "json:\"allowed_modifiers,omitempty\""; AllowedWindows []github.com/marang/robotgo/agent.WindowTarget tag "json:\"allowed_windows,omitempty\""; MaxActions uint64 tag "json:\"max_actions\""; MaxTextRunes int tag "json:\"max_text_runes\""; AllowDoubleClick bool tag "json:\"allow_double_click,omitempty\""; MaxScrollEvents uint32 tag "json:\"max_scroll_events,omitempty\""; MaxScrollDistance uint64 tag "json:\"max_scroll_distance,omitempty\""; MaxDragDistance uint64 tag "json:\"max_drag_distance,omitempty\""; MaxDragDurationMillis int tag "json:\"max_drag_duration_ms,omitempty\""; MaxChordKeys uint32 tag "json:\"max_chord_keys,omitempty\""; MinActionIntervalMillis int tag "json:\"min_action_interval_ms,omitempty\""; SessionTimeoutMillis int tag "json:\"session_timeout_ms,omitempty\""; MaxObservations uint64 tag "json:\"max_observations,omitempty\""; MaxCapturePixels uint64 tag "json:\"max_capture_pixels,omitempty\""; MaxQueries uint64 tag "json:\"max_queries,omitempty\""; WaitAttempts uint32 tag "json:\"wait_attempts,omitempty\""; WaitIntervalMillis int tag "json:\"wait_interval_ms,omitempty\""; WaitTimeoutMillis int tag "json:\"wait_timeout_ms,omitempty\""; VerificationAttempts uint32 tag "json:\"verification_attempts,omitempty\""; VerificationIntervalMillis int tag "json:\"verification_interval_ms,omitempty\""; VerificationTimeoutMillis int tag "json:\"verification_timeout_ms,omitempty\""; <private fields present>}
 type RiskClass string
 type RuntimeDiagnostics struct{GOOS string tag "json:\"goos\""; GOARCH string tag "json:\"goarch\""; CGOEnabled bool tag "json:\"cgo_enabled\""; Implementation string tag "json:\"implementation\""; DisplayServer string tag "json:\"display_server\""; Compositor string tag "json:\"compositor,omitempty\""; Features []github.com/marang/robotgo/agent.DiagnosticFeature tag "json:\"features\""}
 type ScrollAction struct{TargetX int tag "json:\"target_x\""; TargetY int tag "json:\"target_y\""; DeltaX int tag "json:\"delta_x\""; DeltaY int tag "json:\"delta_y\""; Events uint32 tag "json:\"events\""; DisplayID int tag "json:\"display_id\""}
+type ScrollAxis string
 type Session struct{<private fields present>}
 type TypeTextAction struct{Text string tag "json:\"text\""}
 type VerificationCondition string

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@
   validates and mutates the same resolved native handle, and the catalog
   structurally reports supported scroll axes. Ambiguous input-down failures
   trigger an immediate release and remain session-owned if cleanup fails.
+  Explicit process identities no longer inherit the legacy handle-mode
+  default, and self-timed drag interpolation bypasses global mouse delay.
   Partial multi-step outcomes are `unverified`; failed release taints the
   session and retains its exclusive owner until cleanup succeeds. Mutation
   capabilities now provide a stable unavailable, unsupported, or

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,10 @@
   successful injection. Failed legacy tap transactions make a best-effort
   reverse-order release pass over only the successfully dispatched prefix, so
   newly visible partial failures neither leave modifier state behind nor emit
-  orphan key-up events.
+  orphan key-up events. Persistent native Windows holds record the same exact
+  prefix, reject foreign or duplicate releases, retain only failed releases
+  for retry, and report a typed no-state-acquired error after a pre-dispatch
+  failure so agent cleanup never touches foreign input.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,
   portal frontend, portal backend, and stability phases. The complete session
   must now pass three consecutive probes, later phases continuously revalidate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,8 +28,9 @@
   extended keys, release the main key before modifiers, and propagate missing
   targets plus `PostMessageW`/`SendInput` failures instead of reporting a
   successful injection. Failed legacy tap transactions make a best-effort
-  release pass so newly visible partial failures do not leave modifier state
-  behind.
+  reverse-order release pass over only the successfully dispatched prefix, so
+  newly visible partial failures neither leave modifier state behind nor emit
+  orphan key-up events.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,
   portal frontend, portal backend, and stability phases. The complete session
   must now pass three consecutive probes, later phases continuously revalidate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,7 +34,10 @@
   physical-key reference ledger: overlapping chords cannot release one
   another's modifiers, failed tap or hold releases remain retryable, and an
   attempted tap whose physical main key is already held is rejected rather
-  than reporting an unobservable transition. Native holds still record the
+  than reporting an unobservable transition. Process-targeted references are
+  bound to the exact resolved HWND, so a replacement window in the same
+  process cannot inherit modifier state; destroyed-target ownership is cleared
+  without sending releases to the replacement. Native holds still record the
   exact applied prefix, reject foreign or duplicate releases, and report a
   typed no-state-acquired error after a pre-dispatch failure so agent cleanup
   never touches foreign input.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@
   input ledger releases keys and buttons across success, failure,
   cancellation, timeout, disconnect, and close, while Wayland activation stays
   explicitly unavailable instead of inheriting a broader window capability.
+  Chords are now injected only through process-targeted backends, activation
+  validates and mutates the same resolved native handle, and the catalog
+  structurally reports supported scroll axes. Ambiguous input-down failures
+  trigger an immediate release and remain session-owned if cleanup fails.
   Partial multi-step outcomes are `unverified`; failed release taints the
   session and retains its exclusive owner until cleanup succeeds. Mutation
   capabilities now provide a stable unavailable, unsupported, or

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,8 +16,8 @@
   trigger an immediate release and remain session-owned if cleanup fails.
   Explicit process identities use a separate title-query contract and no
   longer inherit the legacy handle-mode default, while existing `GetTitleE`
-  behavior remains compatible. Self-timed drag and chord primitives bypass
-  global mouse and key delays.
+  behavior remains compatible. Self-timed drag, scroll, and chord primitives
+  bypass global mouse and key delays.
   Partial multi-step outcomes are `unverified`; failed release taints the
   session and retains its exclusive owner until cleanup succeeds. Mutation
   capabilities now provide a stable unavailable, unsupported, or

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,10 @@
   taints the session and retains its exclusive owner until cleanup succeeds.
   Mutation capabilities now provide a stable unavailable, unsupported, or
   permission-denied code without requiring reason-string parsing.
+  Native Windows process-targeted chords now preserve down/up semantics for
+  extended keys, release the main key before modifiers, and propagate missing
+  targets plus `PostMessageW`/`SendInput` failures instead of reporting a
+  successful injection.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,
   portal frontend, portal backend, and stability phases. The complete session
   must now pass three consecutive probes, later phases continuously revalidate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,10 +35,11 @@
   another's modifiers, failed tap or hold releases remain retryable, and an
   attempted tap whose physical main key is already held is rejected rather
   than reporting an unobservable transition. Process-targeted references are
-  bound to the exact resolved HWND, so a replacement window in the same
-  process cannot inherit modifier state; destroyed-target ownership is cleared
-  without sending releases to the replacement. Native holds still record the
-  exact applied prefix, reject foreign or duplicate releases, and report a
+  bound to a controller-specific property marker on the exact resolved window
+  generation, so even same-PID numeric HWND reuse cannot inherit modifier
+  state; destroyed-target ownership is cleared without sending releases to the
+  replacement, and UIPI marker denial fails closed. Native holds still record
+  the exact applied prefix, reject foreign or duplicate releases, and report a
   typed no-state-acquired error after a pre-dispatch failure so agent cleanup
   never touches foreign input.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,8 +14,10 @@
   validates and mutates the same resolved native handle, and the catalog
   structurally reports supported scroll axes. Ambiguous input-down failures
   trigger an immediate release and remain session-owned if cleanup fails.
-  Explicit process identities no longer inherit the legacy handle-mode
-  default, and self-timed drag interpolation bypasses global mouse delay.
+  Explicit process identities use a separate title-query contract and no
+  longer inherit the legacy handle-mode default, while existing `GetTitleE`
+  behavior remains compatible. Self-timed drag and chord primitives bypass
+  global mouse and key delays.
   Partial multi-step outcomes are `unverified`; failed release taints the
   session and retains its exclusive owner until cleanup succeeds. Mutation
   capabilities now provide a stable unavailable, unsupported, or

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@
   validates and mutates the same resolved native handle, and the catalog
   structurally reports supported scroll axes. Ambiguous input-down failures
   trigger an immediate release and remain session-owned if cleanup fails.
+  Explicit no-state-acquired and foreign-ownership rejections remove the
+  tentative key or button ledger entry without emitting a foreign release.
   Explicit process identities use a separate title-query contract and no
   longer inherit the legacy handle-mode default, while existing `GetTitleE`
   behavior remains compatible. The complete agent mutation driver, including

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,10 +33,11 @@
   orphan key-up events. Persistent native Windows holds and taps now share a
   physical-key reference ledger: overlapping chords cannot release one
   another's modifiers, failed tap or hold releases remain retryable, and an
-  exact tap over an existing logical hold is rejected as ambiguous. Native
-  holds still record the exact applied prefix, reject foreign or duplicate
-  releases, and report a typed no-state-acquired error after a pre-dispatch
-  failure so agent cleanup never touches foreign input.
+  attempted tap whose physical main key is already held is rejected rather
+  than reporting an unobservable transition. Native holds still record the
+  exact applied prefix, reject foreign or duplicate releases, and report a
+  typed no-state-acquired error after a pre-dispatch failure so agent cleanup
+  never touches foreign input.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,
   portal frontend, portal backend, and stability phases. The complete session
   must now pass three consecutive probes, later phases continuously revalidate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,11 +16,13 @@
   trigger an immediate release and remain session-owned if cleanup fails.
   Explicit process identities use a separate title-query contract and no
   longer inherit the legacy handle-mode default, while existing `GetTitleE`
-  behavior remains compatible. Self-timed drag, scroll, and chord primitives
-  bypass global mouse and key delays.
-  Partial multi-step outcomes are `unverified`; failed release taints the
-  session and retains its exclusive owner until cleanup succeeds. Mutation
-  capabilities now provide a stable unavailable, unsupported, or
+  behavior remains compatible. The complete agent mutation driver, including
+  move, click, text, drag, scroll, and chord primitives, bypasses global mouse
+  and key post-event delays.
+  Errors returned after any desktop mutation dispatch are `unverified`;
+  failures proven to occur during preflight remain `failed`. Failed release
+  taints the session and retains its exclusive owner until cleanup succeeds.
+  Mutation capabilities now provide a stable unavailable, unsupported, or
   permission-denied code without requiring reason-string parsing.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,
   portal frontend, portal backend, and stability phases. The complete session

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,8 @@
   process-wide ownership contract, so package-level holds, clicks, and agent
   drags cannot claim the same button or clean up a rejected down. Explicit
   close-time cleanup retries unconfirmed native hold and Windows click
-  releases.
+  releases, while `ErrInputReleasePending` lets agent sessions retain that
+  ownership, block subsequent actions, and retry during session close.
   Explicit process identities use a separate title-query contract and no
   longer inherit the legacy handle-mode default, while existing `GetTitleE`
   behavior remains compatible. The complete agent mutation driver, including

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,7 +19,8 @@
   Native CGO macOS and Windows mouse holds now participate in the same
   process-wide ownership contract, so package-level holds, clicks, and agent
   drags cannot claim the same button or clean up a rejected down. Explicit
-  close-time cleanup retries unconfirmed native releases.
+  close-time cleanup retries unconfirmed native hold and Windows click
+  releases.
   Explicit process identities use a separate title-query contract and no
   longer inherit the legacy handle-mode default, while existing `GetTitleE`
   behavior remains compatible. The complete agent mutation driver, including

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,7 +27,9 @@
   Native Windows process-targeted chords now preserve down/up semantics for
   extended keys, release the main key before modifiers, and propagate missing
   targets plus `PostMessageW`/`SendInput` failures instead of reporting a
-  successful injection.
+  successful injection. Failed legacy tap transactions make a best-effort
+  release pass so newly visible partial failures do not leave modifier state
+  behind.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,
   portal frontend, portal backend, and stability phases. The complete session
   must now pass three consecutive probes, later phases continuously revalidate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Expanded the deny-by-default agent and local MCP action contract with bounded
+  scroll, drag, canonical keyboard chord, and identity-revalidated window
+  activation operations. Extended actions require immutable event, distance,
+  duration, key/modifier/window, rate, and session-lifetime limits; drag,
+  shortcut, and activation also require confirmation. A session-owned pressed
+  input ledger releases keys and buttons across success, failure,
+  cancellation, timeout, disconnect, and close, while Wayland activation stays
+  explicitly unavailable instead of inheriting a broader window capability.
+  Partial multi-step outcomes are `unverified`; failed release taints the
+  session and retains its exclusive owner until cleanup succeeds. Mutation
+  capabilities now provide a stable unavailable, unsupported, or
+  permission-denied code without requiring reason-string parsing.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,
   portal frontend, portal backend, and stability phases. The complete session
   must now pass three consecutive probes, later phases continuously revalidate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,9 +30,12 @@
   successful injection. Failed legacy tap transactions make a best-effort
   reverse-order release pass over only the successfully dispatched prefix, so
   newly visible partial failures neither leave modifier state behind nor emit
-  orphan key-up events. Persistent native Windows holds record the same exact
-  prefix, reject foreign or duplicate releases, retain only failed releases
-  for retry, and report a typed no-state-acquired error after a pre-dispatch
+  orphan key-up events. Persistent native Windows holds and taps now share a
+  physical-key reference ledger: overlapping chords cannot release one
+  another's modifiers, failed tap or hold releases remain retryable, and an
+  exact tap over an existing logical hold is rejected as ambiguous. Native
+  holds still record the exact applied prefix, reject foreign or duplicate
+  releases, and report a typed no-state-acquired error after a pre-dispatch
   failure so agent cleanup never touches foreign input.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,
   portal frontend, portal backend, and stability phases. The complete session

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,14 +34,14 @@
   physical-key reference ledger: overlapping chords cannot release one
   another's modifiers, failed tap or hold releases remain retryable, and an
   attempted tap whose physical main key is already held is rejected rather
-  than reporting an unobservable transition. Process-targeted references are
-  bound to a controller-specific property marker on the exact resolved window
-  generation, so even same-PID numeric HWND reuse cannot inherit modifier
-  state; destroyed-target ownership is cleared without sending releases to the
-  replacement, and UIPI marker denial fails closed. Native holds still record
-  the exact applied prefix, reject foreign or duplicate releases, and report a
+  than reporting an unobservable transition. Native holds still record the
+  exact applied prefix, reject foreign or duplicate releases, and report a
   typed no-state-acquired error after a pre-dispatch failure so agent cleanup
-  never touches foreign input.
+  never touches foreign input. Native Windows PID-targeted key taps/toggles and
+  the corresponding agent chord capability now fail closed as unsupported:
+  Win32 cannot atomically bind foreign-window generation validation to message
+  dispatch, leaving an unavoidable same-PID HWND-reuse race without a
+  cooperative target backend.
 - Split KDE hosted-session readiness into bounded prerequisite, Plasma Shell,
   portal frontend, portal backend, and stability phases. The complete session
   must now pass three consecutive probes, later phases continuously revalidate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,17 +24,11 @@
   taints the session and retains its exclusive owner until cleanup succeeds.
   Mutation capabilities now provide a stable unavailable, unsupported, or
   permission-denied code without requiring reason-string parsing.
-  Native Windows process-targeted chords now preserve down/up semantics for
-  extended keys, release the main key before modifiers, and propagate missing
-  targets plus `PostMessageW`/`SendInput` failures instead of reporting a
-  successful injection. Failed legacy tap transactions make a best-effort
-  reverse-order release pass over only the successfully dispatched prefix, so
-  newly visible partial failures neither leave modifier state behind nor emit
-  orphan key-up events. Persistent native Windows holds and taps now share a
-  physical-key reference ledger: overlapping chords cannot release one
-  another's modifiers, failed tap or hold releases remain retryable, and an
-  attempted tap whose physical main key is already held is rejected rather
-  than reporting an unobservable transition. Native holds still record the
+  Native Windows global holds and taps now share a physical-key reference
+  ledger: overlapping chords cannot release one another's modifiers, failed
+  tap or hold releases remain retryable, and an attempted tap whose physical
+  main key is already held is rejected rather than reporting an unobservable
+  transition. Native holds still record the
   exact applied prefix, reject foreign or duplicate releases, and report a
   typed no-state-acquired error after a pre-dispatch failure so agent cleanup
   never touches foreign input. Native Windows PID-targeted key taps/toggles and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,10 @@
   trigger an immediate release and remain session-owned if cleanup fails.
   Explicit no-state-acquired and foreign-ownership rejections remove the
   tentative key or button ledger entry without emitting a foreign release.
+  Native CGO macOS and Windows mouse holds now participate in the same
+  process-wide ownership contract, so package-level holds, clicks, and agent
+  drags cannot claim the same button or clean up a rejected down. Explicit
+  close-time cleanup retries unconfirmed native releases.
   Explicit process identities use a separate title-query contract and no
   longer inherit the legacy handle-mode default, while existing `GetTitleE`
   behavior remains compatible. The complete agent mutation driver, including

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,9 @@ Use the following documents as the primary entry points:
   privacy guarantees, and hermetic protocol evidence.
 - [Safe agent visual conditions plan](plan/agent-visual-conditions.md) for
   explicit-observation color search, bounded region waits, quotas, and cleanup.
+- [Autonomous GUI control plan](plan/autonomous-gui-control.md) for bounded
+  scroll, drag, shortcut, and activation actions followed by accessibility,
+  explicit image, and OCR observation slices.
 - [Explicit window identity plan](plan/explicit-window-identity.md) for
   error-returning active handle/PID queries and compositor-aware Wayland
   semantics plus protected Hyprland active-window geometry evidence.

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -47,8 +47,8 @@ Unsupported targets remain explicit.
 
 Scroll and drag are cooperatively cancelable between injected events. A chord
 checks cancellation after key-down and still performs its mandatory release
-on persistent-hold backends. Linux and Pure-Go Windows chords are unavailable
-until those keyboard backends can bind input to an allowed process; a
+on persistent-hold backends. Linux and Windows chords are unavailable until
+those keyboard backends can atomically bind input to an allowed target; a
 global-focus or active-window check alone is not an authorization boundary.
 The operation catalog reports scroll axes explicitly and Pure-Go X11 currently
 accepts only vertical scroll. Native macOS CGO activation is unavailable

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -65,6 +65,12 @@ Chord key-down and key-up use the delay-free `KeyToggleImmediate` primitive,
 so the legacy global key delay cannot silently extend the bounded key hold.
 Target title checks use `GetTitleTargetE(target, isHandle)` so explicit process
 and handle identities never inherit the global legacy `TreatAsHandle` mode.
+Ordinary agent move, click, and text mutations likewise use `MoveImmediateE`,
+`ClickImmediateE`, and `TypeStrImmediateE`, isolating the complete agent
+mutation surface from legacy process-global post-event delays.
+Backend errors after any mutation dispatch are conservatively reported as
+`unverified`; validation and other failures proven to precede dispatch remain
+`failed`, preserving honest retry semantics.
 
 ## Policy and ownership
 

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -1,0 +1,109 @@
+# Autonomous GUI Control Plan
+
+Status: LAB-75 action slice in progress
+
+Linear coordination:
+
+- Project: [`RobotGo | P010 | Autonomous GUI Control`](https://linear.app/riotbox/project/robotgo-or-p010-or-autonomous-gui-control-6d7e2b70da14)
+- Project ID: `fecf551c-4a6b-43db-808b-eb7830e8d6ca`
+- Action issue: [`LAB-75`](https://linear.app/riotbox/issue/LAB-75/expand-observation-bound-mcp-actions-for-autonomous-gui-control)
+- Semantic observation: [`LAB-73`](https://linear.app/riotbox/issue/LAB-73/add-accessibility-first-semantic-gui-observations-to-the-mcp)
+- Explicit image observation: [`LAB-72`](https://linear.app/riotbox/issue/LAB-72/add-policy-gated-mcp-image-observations-for-unknown-guis)
+- OCR and visual detection: [`LAB-74`](https://linear.app/riotbox/issue/LAB-74/add-bounded-ocr-and-visual-element-detection-for-mcp-observations)
+
+## Outcome and order
+
+Extend the completed agent-session and local MCP foundations into practical
+GUI control without turning visible desktop content into authorization.
+Delivery order is:
+
+1. bounded scroll, drag, keyboard chord, and window activation
+2. accessibility-first semantic observation
+3. explicit policy-gated image content for otherwise unknown GUIs
+4. bounded OCR and visual element detection
+
+Structured accessibility data remains the preferred perception source. Image
+and OCR content are later explicit sensitive-read boundaries, not implicit
+side effects of an action.
+
+## Action contract
+
+LAB-75 adds four typed `robotgo_act` operations:
+
+- `pointer.scroll` moves to an explicit live-bounds-checked coordinate and
+  emits a bounded number of scroll events
+- `pointer.drag` keeps its start, end, path, button, distance, duration, and
+  display inside immutable policy
+- `keyboard.chord` accepts one allow-listed key plus only the canonical
+  modifiers `alt`, `control`, `meta`, and `shift`, bound to an allow-listed
+  live active process/title identity
+- `window.activate` targets one allow-listed process or native handle and
+  revalidates its expected title before dispatch
+
+Focus and activation are represented by one operation because supported
+platform backends do not expose a reliable cross-platform semantic distinction.
+Unsupported targets remain explicit.
+
+Scroll and drag are cooperatively cancelable between injected events. A chord
+checks cancellation after key-down and still performs its mandatory release
+on persistent-hold backends. Pure-Go X11 instead uses its strict backend-owned
+atomic chord transaction because persistent literal-key holds are intentionally
+unsupported there. The individual move, click, text, key-toggle, key-tap, and
+activation backend calls remain indivisible. Drag, chord, and activation
+always require `confirmed: true`, in addition to the explicit MCP
+`mode: "execute"`.
+
+## Policy and ownership
+
+The immutable policy independently bounds operations, displays, buttons, keys,
+modifiers, window identities, scroll events and distance, drag distance and
+duration, chord length, action count and rate, and total session lifetime.
+Empty allow lists deny access. Extended actions require an action interval and
+session timeout; they are never enabled by the default diagnostics-only MCP
+policy.
+
+Each mutation capability carries a stable `unavailable_code`. Callers can
+distinguish a temporarily unavailable backend, an unsupported platform
+contract, and permission denial without parsing `reason`; `fallback` remains
+separate and observable.
+
+The process-exclusive session owns a pressed-input ledger. Every key or button
+pressed by a multi-step action is released on success, backend failure,
+caller cancellation, session timeout, transport disconnect, and `Close`.
+Once injection has started, an interrupted multi-step action is reported as
+`unverified`, so callers do not mistake a partial outcome for a safe retry.
+Cleanup failure is returned rather than hidden, blocks further actions, and
+retains the process-exclusive owner until a later `Close` retry releases the
+input successfully.
+
+## Observation and privacy boundary
+
+Actions may use the existing `ObservationPrecondition`. RobotGo recaptures and
+compares the retained in-memory region after policy and audit intent checks but
+before injection. A changed region returns `stale-target`. Window activation
+also performs identity validation during preflight and again immediately
+before mutation.
+
+No action writes a screenshot, OCR input, accessibility dump, typed text,
+window title, or replay payload to disk or audit output. Tests use hermetic
+fakes or disposable self-owned fixtures only.
+
+## Evidence and exit criteria
+
+The action slice is complete when:
+
+- dry-run and execute work through the Go session and MCP schema
+- policy, confirmation, quota, stale-target, rate, and lifetime failures occur
+  before mutation
+- scroll magnitude, drag paths, chord order, and activation identity are
+  proven with hermetic fakes
+- cancellation, error, disconnect, and close cannot silently retain pressed
+  input ownership
+- native and Pure-Go builds, race tests, API compatibility, lint, and relevant
+  protected platform evidence pass
+- the public documentation describes the safe
+  observe → dry-run → confirm → execute → verify → release flow
+
+P010 exits only after the later semantic, image, and OCR slices can safely
+inspect and operate an unfamiliar self-owned GUI while releasing all sensitive
+state.

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -95,6 +95,12 @@ ownership for a later `Close` retry if cleanup also fails.
 If the backend explicitly reports that no state was acquired or that another
 RobotGo caller owns the input, the tentative entry is removed without sending
 a release that could disturb that foreign hold.
+Native CGO macOS and Windows serialize pointer operations through a shared
+process-wide ledger, preventing package-level holds, clicks, and agent drags
+from claiming the same button concurrently; a rejected agent down never sends
+an up for the pre-existing hold. `CloseMainDisplayE` remains the explicit
+process-wide cleanup boundary and retries any native release that could not be
+confirmed.
 Once injection has started, an interrupted multi-step action is reported as
 `unverified`, so callers do not mistake a partial outcome for a safe retry.
 Cleanup failure is returned rather than hidden, blocks further actions, and

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -100,7 +100,9 @@ process-wide ledger, preventing package-level holds, clicks, and agent drags
 from claiming the same button concurrently; a rejected agent down never sends
 an up for the pre-existing hold. `CloseMainDisplayE` remains the explicit
 process-wide cleanup boundary and retries any native hold or Windows click
-release that could not be confirmed.
+release that could not be confirmed. The strict click APIs identify that state
+with `ErrInputReleasePending`; the agent mirrors it into its session ledger,
+blocks subsequent actions, and retries it during `Close`.
 Once injection has started, an interrupted multi-step action is reported as
 `unverified`, so callers do not mistake a partial outcome for a safe retry.
 Cleanup failure is returned rather than hidden, blocks further actions, and

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -59,6 +59,10 @@ indivisible. Drag, chord, and activation always require `confirmed: true`, in
 addition to the explicit MCP `mode: "execute"`.
 Drag interpolation uses the delay-free `MoveImmediateE` primitive, so the
 legacy global mouse delay cannot silently extend its bounded hold schedule.
+Chord key-down and key-up use the delay-free `KeyToggleImmediate` primitive,
+so the legacy global key delay cannot silently extend the bounded key hold.
+Target title checks use `GetTitleTargetE(target, isHandle)` so explicit process
+and handle identities never inherit the global legacy `TreatAsHandle` mode.
 
 ## Policy and ownership
 

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -57,6 +57,8 @@ across validation and mutation; Pure-Go macOS supports that contract. The
 individual move, click, text, key-toggle, and activation backend calls remain
 indivisible. Drag, chord, and activation always require `confirmed: true`, in
 addition to the explicit MCP `mode: "execute"`.
+Drag interpolation uses the delay-free `MoveImmediateE` primitive, so the
+legacy global mouse delay cannot silently extend its bounded hold schedule.
 
 ## Policy and ownership
 

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -59,6 +59,8 @@ indivisible. Drag, chord, and activation always require `confirmed: true`, in
 addition to the explicit MCP `mode: "execute"`.
 Drag interpolation uses the delay-free `MoveImmediateE` primitive, so the
 legacy global mouse delay cannot silently extend its bounded hold schedule.
+Scroll positioning and events use `MoveImmediateE` and `ScrollImmediateE`, so
+the same legacy delay cannot defer cooperative cancellation or session expiry.
 Chord key-down and key-up use the delay-free `KeyToggleImmediate` primitive,
 so the legacy global key delay cannot silently extend the bounded key hold.
 Target title checks use `GetTitleTargetE(target, isHandle)` so explicit process

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -99,8 +99,8 @@ Native CGO macOS and Windows serialize pointer operations through a shared
 process-wide ledger, preventing package-level holds, clicks, and agent drags
 from claiming the same button concurrently; a rejected agent down never sends
 an up for the pre-existing hold. `CloseMainDisplayE` remains the explicit
-process-wide cleanup boundary and retries any native release that could not be
-confirmed.
+process-wide cleanup boundary and retries any native hold or Windows click
+release that could not be confirmed.
 Once injection has started, an interrupted multi-step action is reported as
 `unverified`, so callers do not mistake a partial outcome for a safe retry.
 Cleanup failure is returned rather than hidden, blocks further actions, and

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -92,6 +92,9 @@ caller cancellation, session timeout, transport disconnect, and `Close`.
 The ledger records ownership before a down call: if that call returns an
 ambiguous error, RobotGo immediately attempts the matching release and retains
 ownership for a later `Close` retry if cleanup also fails.
+If the backend explicitly reports that no state was acquired or that another
+RobotGo caller owns the input, the tentative entry is removed without sending
+a release that could disturb that foreign hold.
 Once injection has started, an interrupted multi-step action is reported as
 `unverified`, so callers do not mistake a partial outcome for a safe retry.
 Cleanup failure is returned rather than hidden, blocks further actions, and

--- a/docs/plan/autonomous-gui-control.md
+++ b/docs/plan/autonomous-gui-control.md
@@ -35,10 +35,11 @@ LAB-75 adds four typed `robotgo_act` operations:
 - `pointer.drag` keeps its start, end, path, button, distance, duration, and
   display inside immutable policy
 - `keyboard.chord` accepts one allow-listed key plus only the canonical
-  modifiers `alt`, `control`, `meta`, and `shift`, bound to an allow-listed
-  live active process/title identity
+  modifiers `alt`, `control`, `meta`, and `shift`; it validates the
+  allow-listed process title and binds both key-down and key-up to that PID
 - `window.activate` targets one allow-listed process or native handle and
-  revalidates its expected title before dispatch
+  resolves it to one exact native handle, revalidates its expected title on
+  that handle, and activates the same handle
 
 Focus and activation are represented by one operation because supported
 platform backends do not expose a reliable cross-platform semantic distinction.
@@ -46,12 +47,16 @@ Unsupported targets remain explicit.
 
 Scroll and drag are cooperatively cancelable between injected events. A chord
 checks cancellation after key-down and still performs its mandatory release
-on persistent-hold backends. Pure-Go X11 instead uses its strict backend-owned
-atomic chord transaction because persistent literal-key holds are intentionally
-unsupported there. The individual move, click, text, key-toggle, key-tap, and
-activation backend calls remain indivisible. Drag, chord, and activation
-always require `confirmed: true`, in addition to the explicit MCP
-`mode: "execute"`.
+on persistent-hold backends. Linux and Pure-Go Windows chords are unavailable
+until those keyboard backends can bind input to an allowed process; a
+global-focus or active-window check alone is not an authorization boundary.
+The operation catalog reports scroll axes explicitly and Pure-Go X11 currently
+accepts only vertical scroll. Native macOS CGO activation is unavailable
+because its legacy handle representation cannot preserve one exact reference
+across validation and mutation; Pure-Go macOS supports that contract. The
+individual move, click, text, key-toggle, and activation backend calls remain
+indivisible. Drag, chord, and activation always require `confirmed: true`, in
+addition to the explicit MCP `mode: "execute"`.
 
 ## Policy and ownership
 
@@ -70,6 +75,9 @@ separate and observable.
 The process-exclusive session owns a pressed-input ledger. Every key or button
 pressed by a multi-step action is released on success, backend failure,
 caller cancellation, session timeout, transport disconnect, and `Close`.
+The ledger records ownership before a down call: if that call returns an
+ambiguous error, RobotGo immediately attempts the matching release and retains
+ownership for a later `Close` retry if cleanup also fails.
 Once injection has started, an interrupted multi-step action is reported as
 `unverified`, so callers do not mistake a partial outcome for a safe retry.
 Cleanup failure is returned rather than hidden, blocks further actions, and

--- a/docs/plan/product-roadmap.md
+++ b/docs/plan/product-roadmap.md
@@ -66,6 +66,9 @@ adjacent [Safe Agent Visual Conditions Plan](agent-visual-conditions.md) now
 has accepted bounded `find` and `wait` semantics in Go plus a thin,
 privacy-preserving MCP projection; neither effort broadens platform backend
 support or replaces phase exit gates.
+The active [Autonomous GUI Control Plan](autonomous-gui-control.md) builds on
+that boundary with deny-by-default observation-bound actions, followed by
+accessibility-first semantics and separately authorized image/OCR perception.
 
 ## Delivery Order
 
@@ -500,6 +503,9 @@ demonstrate the difference, not merely expose more functions. The standard is:
   gates.
 - `docs/plan/agent-visual-conditions.md` defines privacy-safe visual search and
   bounded wait semantics above the accepted agent session.
+- `docs/plan/autonomous-gui-control.md` defines the ordered action,
+  accessibility, explicit-image, and OCR slices for practical autonomous GUI
+  control.
 - This document defines product direction and delivery order.
 - A roadmap item is complete only when implementation, tests, examples where
   applicable, compatibility documentation, and required CI gates are complete.

--- a/examples/agent_actions/main.go
+++ b/examples/agent_actions/main.go
@@ -1,0 +1,214 @@
+// Command agent_actions demonstrates the extended, policy-gated RobotGo agent
+// actions. It is dry-run-only unless -act is supplied.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/marang/robotgo/agent"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() (returnErr error) {
+	act := flag.Bool("act", false, "execute the action; default is dry-run")
+	confirm := flag.Bool("confirm", false, "confirm the selected action")
+	operationName := flag.String("operation", "scroll", "scroll, drag, chord, or activate")
+	displayID := flag.Int("display", 0, "explicit display ID")
+	x := flag.Int("x", 0, "scroll target or drag start x")
+	y := flag.Int("y", 0, "scroll target or drag start y")
+	endX := flag.Int("end-x", 10, "drag end x")
+	endY := flag.Int("end-y", 10, "drag end y")
+	deltaX := flag.Int("delta-x", 0, "horizontal scroll delta per event")
+	deltaY := flag.Int("delta-y", 1, "vertical scroll delta per event")
+	events := flag.Uint("events", 1, "scroll event count")
+	duration := flag.Int("duration-ms", 100, "drag duration in milliseconds")
+	key := flag.String("key", "c", "canonical chord key")
+	modifiers := flag.String("modifiers", "control", "comma-separated alt,control,meta,shift modifiers")
+	windowTarget := flag.Int("window-target", 0, "positive process ID or native handle")
+	windowKind := flag.String("window-kind", "process", "process or handle")
+	windowTitle := flag.String("window-title", "", "exact expected live title for activation")
+	flag.Parse()
+
+	operation, request, policy, err := actionConfiguration(actionFlags{
+		operationName: *operationName,
+		displayID:     *displayID,
+		x:             *x,
+		y:             *y,
+		endX:          *endX,
+		endY:          *endY,
+		deltaX:        *deltaX,
+		deltaY:        *deltaY,
+		events:        *events,
+		duration:      *duration,
+		key:           *key,
+		modifiers:     *modifiers,
+		windowTarget:  *windowTarget,
+		windowKind:    *windowKind,
+		windowTitle:   *windowTitle,
+	})
+	if err != nil {
+		return err
+	}
+	request.Operation = operation
+	request.Confirmed = *confirm
+	policy.ConfirmOperations = []agent.Operation{operation}
+
+	session, err := agent.NewSession(agent.Config{Policy: policy})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		returnErr = errors.Join(returnErr, session.Close())
+	}()
+
+	var result agent.ActionResult
+	if *act {
+		result, err = session.Execute(context.Background(), request)
+	} else {
+		result, err = session.DryRun(context.Background(), request)
+	}
+	if encodeErr := json.NewEncoder(os.Stdout).Encode(struct {
+		Catalog agent.OperationCatalog `json:"catalog"`
+		Result  agent.ActionResult     `json:"result"`
+	}{Catalog: session.Catalog(), Result: result}); encodeErr != nil {
+		return errors.Join(err, encodeErr)
+	}
+	return err
+}
+
+type actionFlags struct {
+	operationName string
+	displayID     int
+	x             int
+	y             int
+	endX          int
+	endY          int
+	deltaX        int
+	deltaY        int
+	events        uint
+	duration      int
+	key           string
+	modifiers     string
+	windowTarget  int
+	windowKind    string
+	windowTitle   string
+}
+
+func actionConfiguration(flags actionFlags) (
+	agent.Operation,
+	agent.ActionRequest,
+	agent.Policy,
+	error,
+) {
+	if flags.events > uint(^uint32(0)) {
+		return "", agent.ActionRequest{}, agent.Policy{},
+			fmt.Errorf("scroll event count exceeds uint32")
+	}
+	policy := agent.Policy{
+		MaxActions:              1,
+		MinActionIntervalMillis: 100,
+		SessionTimeoutMillis:    60_000,
+	}
+	switch flags.operationName {
+	case "scroll":
+		policy.AllowedOperations = []agent.Operation{agent.OperationScroll}
+		policy.AllowedDisplayIDs = []int{flags.displayID}
+		policy.MaxScrollEvents = uint32(flags.events)
+		policy.MaxScrollDistance = 10_000
+		return agent.OperationScroll, agent.ActionRequest{
+			Scroll: &agent.ScrollAction{
+				TargetX: flags.x, TargetY: flags.y,
+				DeltaX: flags.deltaX, DeltaY: flags.deltaY,
+				Events: uint32(flags.events), DisplayID: flags.displayID,
+			},
+		}, policy, nil
+	case "drag":
+		policy.AllowedOperations = []agent.Operation{agent.OperationDrag}
+		policy.AllowedDisplayIDs = []int{flags.displayID}
+		policy.AllowedMouseButtons = []agent.MouseButton{agent.MouseButtonLeft}
+		policy.MaxDragDistance = 10_000
+		policy.MaxDragDurationMillis = flags.duration
+		return agent.OperationDrag, agent.ActionRequest{
+			Drag: &agent.DragAction{
+				StartX: flags.x, StartY: flags.y,
+				EndX: flags.endX, EndY: flags.endY,
+				DisplayID: flags.displayID, Button: agent.MouseButtonLeft,
+				DurationMillis: flags.duration,
+			},
+		}, policy, nil
+	case "chord":
+		chordModifiers, err := parseModifiers(flags.modifiers)
+		if err != nil {
+			return "", agent.ActionRequest{}, agent.Policy{}, err
+		}
+		policy.AllowedOperations = []agent.Operation{agent.OperationKeyChord}
+		policy.AllowedKeys = []string{flags.key}
+		policy.AllowedModifiers = append([]agent.KeyModifier(nil), chordModifiers...)
+		policy.AllowedWindows = []agent.WindowTarget{{
+			Target: flags.windowTarget, Kind: agent.WindowTargetProcess,
+			ExpectedTitle: flags.windowTitle,
+		}}
+		policy.MaxChordKeys = uint32(len(chordModifiers) + 1)
+		return agent.OperationKeyChord, agent.ActionRequest{
+			KeyChord: &agent.KeyChordAction{
+				Key: flags.key, Modifiers: chordModifiers, TargetPID: flags.windowTarget,
+			},
+		}, policy, nil
+	case "activate":
+		kind, err := parseWindowKind(flags.windowKind)
+		if err != nil {
+			return "", agent.ActionRequest{}, agent.Policy{}, err
+		}
+		policy.AllowedOperations = []agent.Operation{agent.OperationActivate}
+		policy.AllowedWindows = []agent.WindowTarget{{
+			Target: flags.windowTarget, Kind: kind, ExpectedTitle: flags.windowTitle,
+		}}
+		return agent.OperationActivate, agent.ActionRequest{
+			Activate: &agent.ActivateWindowAction{Target: flags.windowTarget, Kind: kind},
+		}, policy, nil
+	default:
+		return "", agent.ActionRequest{}, agent.Policy{},
+			fmt.Errorf("unknown operation %q", flags.operationName)
+	}
+}
+
+func parseModifiers(value string) ([]agent.KeyModifier, error) {
+	if value == "" {
+		return nil, nil
+	}
+	fields := strings.Split(value, ",")
+	result := make([]agent.KeyModifier, 0, len(fields))
+	for _, field := range fields {
+		modifier := agent.KeyModifier(field)
+		switch modifier {
+		case agent.KeyModifierAlt, agent.KeyModifierControl,
+			agent.KeyModifierMeta, agent.KeyModifierShift:
+			result = append(result, modifier)
+		default:
+			return nil, fmt.Errorf("unsupported canonical modifier %q", field)
+		}
+	}
+	return result, nil
+}
+
+func parseWindowKind(value string) (agent.WindowTargetKind, error) {
+	kind := agent.WindowTargetKind(value)
+	switch kind {
+	case agent.WindowTargetProcess, agent.WindowTargetHandle:
+		return kind, nil
+	default:
+		return "", fmt.Errorf("unsupported window target kind %q", value)
+	}
+}

--- a/examples/agent_session/main.go
+++ b/examples/agent_session/main.go
@@ -37,8 +37,9 @@ func run() error {
 		ConfirmOperations: []agent.Operation{
 			agent.OperationObserve, agent.OperationMove, agent.OperationClick, agent.OperationTypeText,
 		},
-		AllowedDisplayIDs: []int{*displayID},
-		MaxActions:        1, MaxTextRunes: 256,
+		AllowedDisplayIDs:   []int{*displayID},
+		AllowedMouseButtons: []agent.MouseButton{agent.MouseButtonLeft},
+		MaxActions:          1, MaxTextRunes: 256,
 		MaxObservations: 4, MaxCapturePixels: 4 * 1024 * 1024,
 		VerificationAttempts: 2, VerificationIntervalMillis: 50,
 		VerificationTimeoutMillis: 1000,

--- a/input_backend_nocgo_test.go
+++ b/input_backend_nocgo_test.go
@@ -149,6 +149,9 @@ func TestNonCGOInputDispatchUsesSelectedPlatformBackend(t *testing.T) {
 	if err := TypeStrE("text", 0, 7); err != nil {
 		t.Fatalf("TypeStrE: %v", err)
 	}
+	if err := TypeStrImmediateE("text", 0, 7); err != nil {
+		t.Fatalf("TypeStrImmediateE: %v", err)
+	}
 	if err := UnicodeTypeE('€'); err != nil {
 		t.Fatalf("UnicodeTypeE: %v", err)
 	}
@@ -165,6 +168,9 @@ func TestNonCGOInputDispatchUsesSelectedPlatformBackend(t *testing.T) {
 	DragSmooth(50, 60, 1.0, 2.0, 0)
 	if err := ClickE("right", true); err != nil {
 		t.Fatalf("ClickE: %v", err)
+	}
+	if err := ClickImmediateE("right", true); err != nil {
+		t.Fatalf("ClickImmediateE: %v", err)
 	}
 	if err := Toggle("center", "up"); err != nil {
 		t.Fatalf("Toggle: %v", err)
@@ -192,12 +198,14 @@ func TestNonCGOInputDispatchUsesSelectedPlatformBackend(t *testing.T) {
 		"key:d:[ctrl]:0:true:false",
 		"key:d:[ctrl]:0:false:false",
 		"text:text:0:7",
+		"text:text:0:7",
 		"text:€:0:0",
 		"move:10:20:[2]",
 		"relative:-3:4",
 		"smooth:30:40:false:1:2",
 		"smooth:3:-2:true:1:2",
 		"drag:50:60:1:2",
+		"click:right:true",
 		"click:right:true",
 		"toggle:center:false",
 		"scroll:1:-2",

--- a/input_backend_nocgo_test.go
+++ b/input_backend_nocgo_test.go
@@ -137,6 +137,9 @@ func TestNonCGOInputDispatchUsesSelectedPlatformBackend(t *testing.T) {
 	if err := KeyToggle("c", "up", "alt"); err != nil {
 		t.Fatalf("KeyToggle: %v", err)
 	}
+	if err := KeyToggleImmediate("c", "up", "alt"); err != nil {
+		t.Fatalf("KeyToggleImmediate: %v", err)
+	}
 	if err := KeyDown("d", 0, []string{"ctrl"}); err != nil {
 		t.Fatalf("KeyDown: %v", err)
 	}
@@ -181,6 +184,7 @@ func TestNonCGOInputDispatchUsesSelectedPlatformBackend(t *testing.T) {
 		"key:A:[ctrl shift]:0:true:true",
 		"key:+:[shift]:0:true:true",
 		"key:b:[shift]:0:true:true",
+		"key:c:[alt]:0:false:false",
 		"key:c:[alt]:0:false:false",
 		"key:d:[ctrl]:0:true:false",
 		"key:d:[ctrl]:0:false:false",

--- a/input_backend_nocgo_test.go
+++ b/input_backend_nocgo_test.go
@@ -172,6 +172,9 @@ func TestNonCGOInputDispatchUsesSelectedPlatformBackend(t *testing.T) {
 	if err := ScrollE(1, -2, 0); err != nil {
 		t.Fatalf("ScrollE: %v", err)
 	}
+	if err := ScrollImmediateE(1, -2); err != nil {
+		t.Fatalf("ScrollImmediateE: %v", err)
+	}
 	x, y, err := LocationE()
 	if err != nil || x != -12 || y != 34 {
 		t.Fatalf("LocationE = (%d,%d,%v), want (-12,34,nil)", x, y, err)
@@ -197,6 +200,7 @@ func TestNonCGOInputDispatchUsesSelectedPlatformBackend(t *testing.T) {
 		"drag:50:60:1:2",
 		"click:right:true",
 		"toggle:center:false",
+		"scroll:1:-2",
 		"scroll:1:-2",
 		"location",
 	}

--- a/key.go
+++ b/key.go
@@ -857,7 +857,7 @@ func keyTaps(k string, keyArr []string, pid int) error {
 	return nil
 }
 
-func keyTogglesB(k string, down bool, keyArr []string, pid int) error {
+func keyTogglesB(k string, down bool, keyArr []string, pid int, applyDelay bool) error {
 	flags, err := getFlagsFromValue(keyArr)
 	if err != nil {
 		return err
@@ -873,7 +873,7 @@ func keyTogglesB(k string, down bool, keyArr []string, pid int) error {
 			C.toggleKeyCode(key, C.bool(down), flags, C.uintptr(pid)),
 			"toggle key",
 		)
-		if nativeErr == nil {
+		if nativeErr == nil && applyDelay {
 			MilliSleep(currentKeyDelay())
 		}
 		return nativeErr
@@ -892,7 +892,7 @@ func keyTogglesB(k string, down bool, keyArr []string, pid int) error {
 		if hold.backend == persistentInputBackendPortal {
 			_, err := tryPortalKeyUp(hold)
 			delete(keyboardHolds, id)
-			if err == nil {
+			if err == nil && applyDelay {
 				MilliSleep(currentKeyDelay())
 			}
 			return err
@@ -910,7 +910,7 @@ func keyTogglesB(k string, down bool, keyArr []string, pid int) error {
 		if nativeErr == nil || errors.Is(nativeErr, ErrInputOwnership) {
 			delete(keyboardHolds, id)
 		}
-		if nativeErr == nil {
+		if nativeErr == nil && applyDelay {
 			MilliSleep(currentKeyDelay())
 		}
 		return nativeErr
@@ -941,6 +941,8 @@ func keyTogglesB(k string, down bool, keyArr []string, pid int) error {
 		if used, hold, err := tryPortalKeyDown(server, k, keyArr, pid); used {
 			if err == nil {
 				keyboardHolds[id] = hold
+			}
+			if err == nil && applyDelay {
 				MilliSleep(currentKeyDelay())
 			}
 			return err
@@ -951,7 +953,9 @@ func keyTogglesB(k string, down bool, keyArr []string, pid int) error {
 		backend: persistentInputBackendNative,
 		server:  server,
 	}
-	MilliSleep(currentKeyDelay())
+	if applyDelay {
+		MilliSleep(currentKeyDelay())
+	}
 	return nil
 }
 
@@ -1063,6 +1067,16 @@ func KeyTap(key string, args ...interface{}) error {
 //	robotgo.KeyToggle("a", "up", "alt", "cmd")
 //	robotgo.KeyToggle("k", pid int)
 func KeyToggle(key string, args ...interface{}) error {
+	return keyToggle(key, true, args...)
+}
+
+// KeyToggleImmediate changes key state without applying the configured
+// post-event delay. It is intended for callers that own a bounded hold.
+func KeyToggleImmediate(key string, args ...interface{}) error {
+	return keyToggle(key, false, args...)
+}
+
+func keyToggle(key string, applyDelay bool, args ...interface{}) error {
 	key, args = appendShift(key, args...)
 	pid, down, keyArr, err := parseKeyArguments(args, true)
 	if err != nil {
@@ -1075,7 +1089,7 @@ func KeyToggle(key string, args ...interface{}) error {
 	if err := validateKeyArgument(key); err != nil {
 		return err
 	}
-	return keyTogglesB(key, down, keyArr, pid)
+	return keyTogglesB(key, down, keyArr, pid, applyDelay)
 }
 
 // KeyPress presses and releases a key as one backend transaction. It is

--- a/key.go
+++ b/key.go
@@ -365,6 +365,8 @@ func nativeKeyStatusError(status C.int, operation string) error {
 		return fmt.Errorf("robotgo: %s: active modifier or lock state cannot safely produce the requested input", operation)
 	case int(C.ROBOTGO_KEY_OWNERSHIP_CONFLICT):
 		return fmt.Errorf("%w: %s: key state is owned by another input source or has no matching RobotGo key-down", ErrInputOwnership, operation)
+	case int(C.ROBOTGO_KEY_NOT_APPLIED):
+		return fmt.Errorf("%w: %s: native keyboard injection failed before acquiring key state", ErrInputNotApplied, operation)
 	default:
 		return fmt.Errorf("robotgo: %s: unknown native keyboard status %d", operation, int(status))
 	}

--- a/key.go
+++ b/key.go
@@ -1238,6 +1238,16 @@ func TypeStr(str string, args ...int) {
 
 // TypeStrE sends a UTF-8 string and reports backend or key injection errors.
 func TypeStrE(str string, args ...int) error {
+	return typeStrE(str, true, args...)
+}
+
+// TypeStrImmediateE sends a UTF-8 string without applying the configured
+// post-input delay. Explicit per-rune delay arguments remain honored.
+func TypeStrImmediateE(str string, args ...int) error {
+	return typeStrE(str, false, args...)
+}
+
+func typeStrE(str string, applyDelay bool, args ...int) error {
 	pid, tm, err := parseTextInput(str, args)
 	if err != nil {
 		return err
@@ -1269,7 +1279,9 @@ func TypeStrE(str string, args ...int) error {
 			}
 			MilliSleep(tm)
 		}
-		MilliSleep(currentKeyDelay())
+		if applyDelay {
+			MilliSleep(currentKeyDelay())
+		}
 		return nil
 	})
 	if nativeErr != nil && shouldTryRemoteDesktopAfterNative(server, ready, nativeErr) {

--- a/key/keypress.h
+++ b/key/keypress.h
@@ -51,7 +51,7 @@
 
 #if defined(IS_WINDOWS)
 	/* Send win32 key event for given key. */
-	void win32KeyEvent(int key, MMKeyFlags flags, uintptr pid, int8_t isPid);
+	int win32KeyEvent(int key, MMKeyFlags flags, uintptr pid, int8_t isPid);
 #endif
 
 #endif /* KEYPRESS_H */

--- a/key/keypress.h
+++ b/key/keypress.h
@@ -49,9 +49,4 @@
 	typedef unsigned int MMKeyFlags;
 #endif
 
-#if defined(IS_WINDOWS)
-	/* Send win32 key event for given key. */
-	int win32KeyEvent(int key, MMKeyFlags flags, uintptr pid, int8_t isPid);
-#endif
-
 #endif /* KEYPRESS_H */

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -2098,6 +2098,18 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 		}
+		RobotGoWin32PhysicalKey *unused_free_key = NULL;
+		if (ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
+			code, pid, &unused_free_key
+		) != NULL) {
+			/*
+			 * A tap needs its own observable main-key transition. Sharing
+			 * modifiers is safe, but refcounting an already held main key
+			 * would report success without emitting the requested tap.
+			 */
+			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
+		}
 
 		RobotGoWin32ToggleRecord *record = free_record;
 		record->active = true;

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -26,7 +26,8 @@ enum RobotGoKeyStatus {
         ROBOTGO_KEY_UNSUPPORTED = 4,
         ROBOTGO_KEY_INVALID = 5,
         ROBOTGO_KEY_STATE_CONFLICT = 6,
-        ROBOTGO_KEY_OWNERSHIP_CONFLICT = 7
+        ROBOTGO_KEY_OWNERSHIP_CONFLICT = 7,
+        ROBOTGO_KEY_NOT_APPLIED = 8
 };
 
 #if defined(IS_MACOSX)
@@ -1885,6 +1886,117 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		}
 		return first_error;
 	}
+
+	enum {
+		ROBOTGO_WIN32_MAX_TOGGLE_RECORDS = 64
+	};
+
+	typedef struct RobotGoWin32ToggleRecord {
+		bool active;
+		MMKeyCode code;
+		MMKeyFlags flags;
+		uintptr pid;
+		MMKeyCode pressed[5];
+		size_t pressed_length;
+	} RobotGoWin32ToggleRecord;
+
+	static SRWLOCK robotgo_win32_toggle_lock = SRWLOCK_INIT;
+	static RobotGoWin32ToggleRecord
+		robotgo_win32_toggle_records[ROBOTGO_WIN32_MAX_TOGGLE_RECORDS];
+
+	static bool ROBOTGO_WIN32_TOGGLE_RECORD_MATCHES(
+		const RobotGoWin32ToggleRecord *record,
+		MMKeyCode code,
+		MMKeyFlags flags,
+		uintptr pid
+	) {
+		return record->active &&
+			record->code == code &&
+			record->flags == flags &&
+			record->pid == pid;
+	}
+
+	static int ROBOTGO_WIN32_TOGGLE_OWNED_KEY_CODE(
+		MMKeyCode code,
+		const bool down,
+		MMKeyFlags flags,
+		uintptr pid
+	) {
+		AcquireSRWLockExclusive(&robotgo_win32_toggle_lock);
+		RobotGoWin32ToggleRecord *record = NULL;
+		RobotGoWin32ToggleRecord *free_record = NULL;
+		for (size_t index = 0;
+			index < ROBOTGO_WIN32_MAX_TOGGLE_RECORDS;
+			index++) {
+			RobotGoWin32ToggleRecord *candidate =
+				&robotgo_win32_toggle_records[index];
+			if (ROBOTGO_WIN32_TOGGLE_RECORD_MATCHES(
+				candidate, code, flags, pid
+			)) {
+				record = candidate;
+				break;
+			}
+			if (!candidate->active && free_record == NULL) {
+				free_record = candidate;
+			}
+		}
+
+		if (down) {
+			if (record != NULL || free_record == NULL) {
+				ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+				return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
+			}
+			record = free_record;
+			record->active = true;
+			record->code = code;
+			record->flags = flags;
+			record->pid = pid;
+			record->pressed_length = 0;
+			int status = ROBOTGO_WIN32_TOGGLE_KEY_CODE(
+				code, true, flags, pid,
+				record->pressed, &record->pressed_length
+			);
+			if (status != ROBOTGO_KEY_OK && record->pressed_length == 0) {
+				memset(record, 0, sizeof(*record));
+				status = ROBOTGO_KEY_NOT_APPLIED;
+			}
+			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+			return status;
+		}
+
+		if (record == NULL) {
+			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
+		}
+		bool failed[5] = { false, false, false, false, false };
+		int first_error = ROBOTGO_KEY_OK;
+		for (size_t index = record->pressed_length; index > 0; index--) {
+			size_t pressed_index = index - 1;
+			int status = WIN32_KEY_EVENT_WAIT(
+				record->pressed[pressed_index],
+				KEYEVENTF_KEYUP,
+				pid
+			);
+			if (status != ROBOTGO_KEY_OK) {
+				failed[pressed_index] = true;
+				if (first_error == ROBOTGO_KEY_OK) {
+					first_error = status;
+				}
+			}
+		}
+		size_t remaining = 0;
+		for (size_t index = 0; index < record->pressed_length; index++) {
+			if (failed[index]) {
+				record->pressed[remaining++] = record->pressed[index];
+			}
+		}
+		record->pressed_length = remaining;
+		if (remaining == 0) {
+			memset(record, 0, sizeof(*record));
+		}
+		ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+		return first_error;
+	}
 #endif
 
 int toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags, uintptr pid) {
@@ -1920,9 +2032,7 @@ int toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags, uintptr pid
 	}
 	return ROBOTGO_KEY_OK;
 #elif defined(IS_WINDOWS)
-	return ROBOTGO_WIN32_TOGGLE_KEY_CODE(
-		code, down, flags, pid, NULL, NULL
-	);
+	return ROBOTGO_WIN32_TOGGLE_OWNED_KEY_CODE(code, down, flags, pid);
 #elif defined(IS_LINUX)
 	#ifdef ROBOTGO_USE_WAYLAND
 	        if (robotgo_wayland_keyboard_backend_selected()) {

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -1959,6 +1959,15 @@ int robotgo_tap_key_code(MMKeyCode code, MMKeyFlags flags, uintptr pid) {
 #else
 	int status = toggleKeyCode(code, true, flags, pid);
 	if (status != ROBOTGO_KEY_OK) {
+#if defined(IS_WINDOWS)
+		/*
+		 * Windows modifier dispatch can partially succeed before a later
+		 * PostMessageW/SendInput failure. A tap has no external owner that
+		 * can release that partial state, so make one best-effort release
+		 * pass before returning the original injection failure.
+		 */
+		(void)toggleKeyCode(code, false, flags, pid);
+#endif
 		return status;
 	}
 	microsleep(3.0);

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -68,9 +68,12 @@ enum RobotGoKeyStatus {
 		return hwnd;	
 	}
 
-	void WIN32_KEY_EVENT_WAIT(MMKeyCode key, DWORD flags, uintptr pid) {
-		win32KeyEvent(key, flags, pid, 0); 
-		Sleep(DEADBEEF_RANDRANGE(0, 1));
+	int WIN32_KEY_EVENT_WAIT(MMKeyCode key, DWORD flags, uintptr pid) {
+		int status = win32KeyEvent(key, flags, pid, 0);
+		if (status == ROBOTGO_KEY_OK) {
+			Sleep(DEADBEEF_RANDRANGE(0, 1));
+		}
+		return status;
 	}
 #elif defined(IS_LINUX)
         #if !defined(DISPLAY_SERVER_WAYLAND)
@@ -1754,8 +1757,9 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 	}
 #elif defined(IS_WINDOWS)
 
-	void win32KeyEvent(int key, MMKeyFlags flags, uintptr pid, int8_t isPid) {
+	int win32KeyEvent(int key, MMKeyFlags flags, uintptr pid, int8_t isPid) {
 		int scan = MapVirtualKey(key & 0xff, MAPVK_VK_TO_VSC);
+		UINT message = (flags & KEYEVENTF_KEYUP) != 0 ? WM_KEYUP : WM_KEYDOWN;
 
 		/* Set the scan code for extended keys */
 		switch (key){
@@ -1800,11 +1804,12 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		// todo: test this
 		if (pid != 0) {
 			HWND hwnd = getHwnd(pid, isPid);
-
-			int down = (flags == 0 ? WM_KEYDOWN : WM_KEYUP);
+			if (hwnd == NULL) {
+				return ROBOTGO_KEY_INJECTION_FAILED;
+			}
 			// SendMessage(hwnd, down, key, 0);
-			PostMessageW(hwnd, down, key, 0);
-			return;
+			return PostMessageW(hwnd, message, key, 0)
+				? ROBOTGO_KEY_OK : ROBOTGO_KEY_INJECTION_FAILED;
 		}
 
 		/* Set the scan code for keyup */
@@ -1821,7 +1826,8 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		keyInput.ki.dwFlags = flags;
 		keyInput.ki.time = 0;
 		keyInput.ki.dwExtraInfo = 0;
-		SendInput(1, &keyInput, sizeof(keyInput));
+		return SendInput(1, &keyInput, sizeof(keyInput)) == 1
+			? ROBOTGO_KEY_OK : ROBOTGO_KEY_INJECTION_FAILED;
 	}
 #endif
 
@@ -1859,15 +1865,43 @@ int toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags, uintptr pid
 	return ROBOTGO_KEY_OK;
 #elif defined(IS_WINDOWS)
 	const DWORD dwFlags = down ? 0 : KEYEVENTF_KEYUP;
+	MMKeyCode sequence[5];
+	size_t sequence_length = 0;
 
-	/* Parse modifier keys. */
-	if (flags & MOD_META) { WIN32_KEY_EVENT_WAIT(K_META, dwFlags, pid); }
-	if (flags & MOD_ALT) { WIN32_KEY_EVENT_WAIT(K_ALT, dwFlags, pid); }
-	if (flags & MOD_CONTROL) { WIN32_KEY_EVENT_WAIT(K_CONTROL, dwFlags, pid); }
-	if (flags & MOD_SHIFT) { WIN32_KEY_EVENT_WAIT(K_SHIFT, dwFlags, pid); }
+	if (down) {
+		/* Press modifiers before the main key. */
+		if (flags & MOD_META) { sequence[sequence_length++] = K_META; }
+		if (flags & MOD_ALT) { sequence[sequence_length++] = K_ALT; }
+		if (flags & MOD_CONTROL) { sequence[sequence_length++] = K_CONTROL; }
+		if (flags & MOD_SHIFT) { sequence[sequence_length++] = K_SHIFT; }
+		sequence[sequence_length++] = code;
+	} else {
+		/* Release the main key first, followed by modifiers in reverse order. */
+		sequence[sequence_length++] = code;
+		if (flags & MOD_SHIFT) { sequence[sequence_length++] = K_SHIFT; }
+		if (flags & MOD_CONTROL) { sequence[sequence_length++] = K_CONTROL; }
+		if (flags & MOD_ALT) { sequence[sequence_length++] = K_ALT; }
+		if (flags & MOD_META) { sequence[sequence_length++] = K_META; }
+	}
 
-	win32KeyEvent(code, dwFlags, pid, 0);
-	return ROBOTGO_KEY_OK;
+	int first_error = ROBOTGO_KEY_OK;
+	for (size_t index = 0; index < sequence_length; index++) {
+		int status = WIN32_KEY_EVENT_WAIT(sequence[index], dwFlags, pid);
+		if (status == ROBOTGO_KEY_OK) {
+			continue;
+		}
+		if (first_error == ROBOTGO_KEY_OK) {
+			first_error = status;
+		}
+		/*
+		 * Do not emit a main key after a failed modifier press. Releases
+		 * continue so cleanup has the best chance of clearing every key.
+		 */
+		if (down) {
+			break;
+		}
+	}
+	return first_error;
 #elif defined(IS_LINUX)
 	#ifdef ROBOTGO_USE_WAYLAND
 	        if (robotgo_wayland_keyboard_backend_selected()) {

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -69,24 +69,10 @@ enum RobotGoKeyStatus {
 		return hwnd;	
 	}
 
-	int win32KeyEventToTarget(
-		int key,
-		MMKeyFlags flags,
-		uintptr pid,
-		HWND target,
-		HANDLE generation
-	);
+	static int ROBOTGO_WIN32_KEY_EVENT(int key, MMKeyFlags flags);
 
-	int WIN32_KEY_EVENT_TARGET_WAIT(
-		MMKeyCode key,
-		DWORD flags,
-		uintptr pid,
-		HWND target,
-		HANDLE generation
-	) {
-		int status = win32KeyEventToTarget(
-			key, flags, pid, target, generation
-		);
+	static int WIN32_KEY_EVENT_WAIT(MMKeyCode key, DWORD flags) {
+		int status = ROBOTGO_WIN32_KEY_EVENT(key, flags);
 		if (status == ROBOTGO_KEY_OK) {
 			Sleep(DEADBEEF_RANDRANGE(0, 1));
 		}
@@ -1773,127 +1759,8 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		return sEventDrvrRef;
 	}
 #elif defined(IS_WINDOWS)
-
-	static WCHAR robotgo_win32_target_property_name[96];
-	static bool robotgo_win32_target_property_name_initialized = false;
-	static uintptr robotgo_win32_target_generation = 0;
-
-	static bool ROBOTGO_WIN32_INIT_TARGET_PROPERTY_NAME(void) {
-		if (robotgo_win32_target_property_name_initialized) {
-			return true;
-		}
-		FILETIME creation = {0};
-		FILETIME exit = {0};
-		FILETIME kernel = {0};
-		FILETIME user = {0};
-		if (!GetProcessTimes(
-			GetCurrentProcess(),
-			&creation,
-			&exit,
-			&kernel,
-			&user
-		)) {
-			return false;
-		}
-		int length = wsprintfW(
-			robotgo_win32_target_property_name,
-			L"RobotGo.NativeKeyOwnership.%08lx.%08lx.%08lx",
-			(unsigned long)GetCurrentProcessId(),
-			(unsigned long)creation.dwHighDateTime,
-			(unsigned long)creation.dwLowDateTime
-		);
-		if (length <= 0 ||
-			(size_t)length >=
-				sizeof(robotgo_win32_target_property_name) /
-				sizeof(robotgo_win32_target_property_name[0])) {
-			memset(
-				robotgo_win32_target_property_name,
-				0,
-				sizeof(robotgo_win32_target_property_name)
-			);
-			return false;
-		}
-		robotgo_win32_target_property_name_initialized = true;
-		return true;
-	}
-
-	static bool ROBOTGO_WIN32_TARGET_PID_MATCHES(
-		HWND target,
-		uintptr pid
-	) {
-		if (pid == 0) {
-			return target == NULL;
-		}
-		if ((uintptr)(DWORD)pid != pid ||
-			target == NULL ||
-			!IsWindow(target)) {
-			return false;
-		}
-		DWORD target_pid = 0;
-		(void)GetWindowThreadProcessId(target, &target_pid);
-		return target_pid == (DWORD)pid;
-	}
-
-	static bool ROBOTGO_WIN32_TARGET_MATCHES(
-		HWND target,
-		uintptr pid,
-		HANDLE generation
-	) {
-		if (pid == 0) {
-			return target == NULL && generation == NULL;
-		}
-		return generation != NULL &&
-			ROBOTGO_WIN32_TARGET_PID_MATCHES(target, pid) &&
-			ROBOTGO_WIN32_INIT_TARGET_PROPERTY_NAME() &&
-			GetPropW(
-				target,
-				robotgo_win32_target_property_name
-			) == generation;
-	}
-
-	static HWND ROBOTGO_WIN32_RESOLVE_TARGET(
-		uintptr pid,
-		HANDLE *generation
-	) {
-		*generation = NULL;
-		if (pid == 0 || (uintptr)(DWORD)pid != pid ||
-			!ROBOTGO_WIN32_INIT_TARGET_PROPERTY_NAME()) {
-			return NULL;
-		}
-		HWND target = getHwnd(pid, 0);
-		if (!ROBOTGO_WIN32_TARGET_PID_MATCHES(target, pid)) {
-			return NULL;
-		}
-		HANDLE marker = GetPropW(
-			target,
-			robotgo_win32_target_property_name
-		);
-		if (marker == NULL) {
-			do {
-				robotgo_win32_target_generation++;
-			} while (robotgo_win32_target_generation == 0);
-			marker = (HANDLE)robotgo_win32_target_generation;
-			if (!SetPropW(
-				target,
-				robotgo_win32_target_property_name,
-				marker
-			)) {
-				return NULL;
-			}
-		}
-		*generation = marker;
-		return target;
-	}
-
-	int win32KeyEventToTarget(
-		int key,
-		MMKeyFlags flags,
-		uintptr pid,
-		HWND target,
-		HANDLE generation
-	) {
+	static int ROBOTGO_WIN32_KEY_EVENT(int key, MMKeyFlags flags) {
 		int scan = MapVirtualKey(key & 0xff, MAPVK_VK_TO_VSC);
-		UINT message = (flags & KEYEVENTF_KEYUP) != 0 ? WM_KEYUP : WM_KEYDOWN;
 
 		/* Set the scan code for extended keys */
 		switch (key){
@@ -1935,18 +1802,6 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			}
 		}
 
-		// todo: test this
-		if (pid != 0) {
-			if (!ROBOTGO_WIN32_TARGET_MATCHES(
-				target, pid, generation
-			)) {
-				return ROBOTGO_KEY_INJECTION_FAILED;
-			}
-			// SendMessage(hwnd, down, key, 0);
-			return PostMessageW(target, message, key, 0)
-				? ROBOTGO_KEY_OK : ROBOTGO_KEY_INJECTION_FAILED;
-		}
-
 		/* Set the scan code for keyup */
 		// if ( flags & KEYEVENTF_KEYUP ) {
 		// 	scan |= 0x80;
@@ -1975,9 +1830,6 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		bool active;
 		MMKeyCode code;
 		MMKeyFlags flags;
-		uintptr pid;
-		HWND target;
-		HANDLE generation;
 		MMKeyCode pressed[5];
 		size_t pressed_length;
 	} RobotGoWin32ToggleRecord;
@@ -1985,9 +1837,6 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 	typedef struct RobotGoWin32PhysicalKey {
 		bool active;
 		MMKeyCode code;
-		uintptr pid;
-		HWND target;
-		HANDLE generation;
 		size_t references;
 	} RobotGoWin32PhysicalKey;
 
@@ -2000,19 +1849,16 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 	static bool ROBOTGO_WIN32_TOGGLE_RECORD_MATCHES(
 		const RobotGoWin32ToggleRecord *record,
 		MMKeyCode code,
-		MMKeyFlags flags,
-		uintptr pid
+		MMKeyFlags flags
 	) {
 		return record->active &&
 			record->code == code &&
-			record->flags == flags &&
-			record->pid == pid;
+			record->flags == flags;
 	}
 
 	static RobotGoWin32ToggleRecord *ROBOTGO_WIN32_FIND_TOGGLE_RECORD(
 		MMKeyCode code,
 		MMKeyFlags flags,
-		uintptr pid,
 		RobotGoWin32ToggleRecord **free_record
 	) {
 		RobotGoWin32ToggleRecord *record = NULL;
@@ -2023,7 +1869,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			RobotGoWin32ToggleRecord *candidate =
 				&robotgo_win32_toggle_records[index];
 			if (ROBOTGO_WIN32_TOGGLE_RECORD_MATCHES(
-				candidate, code, flags, pid
+				candidate, code, flags
 			)) {
 				record = candidate;
 				break;
@@ -2037,9 +1883,6 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 
 	static RobotGoWin32PhysicalKey *ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
 		MMKeyCode code,
-		uintptr pid,
-		HWND target,
-		HANDLE generation,
 		RobotGoWin32PhysicalKey **free_key
 	) {
 		RobotGoWin32PhysicalKey *physical = NULL;
@@ -2050,10 +1893,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			RobotGoWin32PhysicalKey *candidate =
 				&robotgo_win32_physical_keys[index];
 			if (candidate->active &&
-				candidate->code == code &&
-				candidate->pid == pid &&
-				candidate->target == target &&
-				candidate->generation == generation) {
+				candidate->code == code) {
 				physical = candidate;
 				break;
 			}
@@ -2075,9 +1915,6 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		RobotGoWin32PhysicalKey *physical =
 			ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
 				code,
-				record->pid,
-				record->target,
-				record->generation,
 				&free_key
 			);
 		if (physical != NULL) {
@@ -2089,21 +1926,12 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 		}
 
-		int status = WIN32_KEY_EVENT_TARGET_WAIT(
-			code,
-			0,
-			record->pid,
-			record->target,
-			record->generation
-		);
+		int status = WIN32_KEY_EVENT_WAIT(code, 0);
 		if (status != ROBOTGO_KEY_OK) {
 			return status;
 		}
 		free_key->active = true;
 		free_key->code = code;
-		free_key->pid = record->pid;
-		free_key->target = record->target;
-		free_key->generation = record->generation;
 		free_key->references = 1;
 		record->pressed[record->pressed_length++] = code;
 		return ROBOTGO_KEY_OK;
@@ -2141,91 +1969,15 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		return ROBOTGO_KEY_OK;
 	}
 
-	static void ROBOTGO_WIN32_CLEAR_TARGET_OWNERSHIP(
-		uintptr pid,
-		HWND target,
-		HANDLE generation
-	) {
-		for (size_t index = 0;
-			index < ROBOTGO_WIN32_MAX_TOGGLE_RECORDS;
-			index++) {
-			RobotGoWin32ToggleRecord *record =
-				&robotgo_win32_toggle_records[index];
-			if (record->active &&
-				record->pid == pid &&
-				record->target == target &&
-				record->generation == generation) {
-				memset(record, 0, sizeof(*record));
-			}
-		}
-		for (size_t index = 0;
-			index < ROBOTGO_WIN32_MAX_PHYSICAL_KEYS;
-			index++) {
-			RobotGoWin32PhysicalKey *physical =
-				&robotgo_win32_physical_keys[index];
-			if (physical->active &&
-				physical->pid == pid &&
-				physical->target == target &&
-				physical->generation == generation) {
-				memset(physical, 0, sizeof(*physical));
-			}
-		}
-	}
-
 	static void ROBOTGO_WIN32_CLEAR_TOGGLE_RECORD(
 		RobotGoWin32ToggleRecord *record
 	) {
-		uintptr pid = record->pid;
-		HWND target = record->target;
-		HANDLE generation = record->generation;
 		memset(record, 0, sizeof(*record));
-		if (pid == 0) {
-			return;
-		}
-		for (size_t index = 0;
-			index < ROBOTGO_WIN32_MAX_TOGGLE_RECORDS;
-			index++) {
-			RobotGoWin32ToggleRecord *candidate =
-				&robotgo_win32_toggle_records[index];
-			if (candidate->active &&
-				candidate->pid == pid &&
-				candidate->target == target &&
-				candidate->generation == generation) {
-				return;
-			}
-		}
-		if (ROBOTGO_WIN32_TARGET_MATCHES(
-			target, pid, generation
-		)) {
-			(void)RemovePropW(
-				target,
-				robotgo_win32_target_property_name
-			);
-		}
 	}
 
 	static int ROBOTGO_WIN32_RELEASE_TOGGLE_RECORD(
 		RobotGoWin32ToggleRecord *record
 	) {
-		if (record->pid != 0 &&
-			!ROBOTGO_WIN32_TARGET_MATCHES(
-				record->target,
-				record->pid,
-				record->generation
-			)) {
-			/*
-			 * Posted key state belongs to the exact window. Once that HWND
-			 * is gone or belongs to another process, its state cannot
-			 * remain pressed and must never be released into a replacement.
-			 */
-			ROBOTGO_WIN32_CLEAR_TARGET_OWNERSHIP(
-				record->pid,
-				record->target,
-				record->generation
-			);
-			return ROBOTGO_KEY_OK;
-		}
-
 		bool failed[5] = { false, false, false, false, false };
 		int first_error = ROBOTGO_KEY_OK;
 
@@ -2236,9 +1988,6 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			RobotGoWin32PhysicalKey *physical =
 				ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
 					record->pressed[pressed_index],
-					record->pid,
-					record->target,
-					record->generation,
 					&unused_free_key
 				);
 			int status = ROBOTGO_KEY_OK;
@@ -2247,12 +1996,9 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			} else if (physical->references > 1) {
 				physical->references--;
 			} else {
-				status = WIN32_KEY_EVENT_TARGET_WAIT(
+				status = WIN32_KEY_EVENT_WAIT(
 					record->pressed[pressed_index],
-					KEYEVENTF_KEYUP,
-					record->pid,
-					record->target,
-					record->generation
+					KEYEVENTF_KEYUP
 				);
 				if (status == ROBOTGO_KEY_OK) {
 					memset(physical, 0, sizeof(*physical));
@@ -2282,11 +2028,14 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		MMKeyFlags flags,
 		uintptr pid
 	) {
+		if (pid != 0) {
+			return ROBOTGO_KEY_UNSUPPORTED;
+		}
 		AcquireSRWLockExclusive(&robotgo_win32_toggle_lock);
 		RobotGoWin32ToggleRecord *free_record = NULL;
 		RobotGoWin32ToggleRecord *record =
 			ROBOTGO_WIN32_FIND_TOGGLE_RECORD(
-				code, flags, pid, &free_record
+				code, flags, &free_record
 			);
 
 		if (down) {
@@ -2294,21 +2043,10 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 				ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 				return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 			}
-			HANDLE generation = NULL;
-			HWND target = ROBOTGO_WIN32_RESOLVE_TARGET(
-				pid, &generation
-			);
-			if (pid != 0 && target == NULL) {
-				ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
-				return ROBOTGO_KEY_NOT_APPLIED;
-			}
 			record = free_record;
 			record->active = true;
 			record->code = code;
 			record->flags = flags;
-			record->pid = pid;
-			record->target = target;
-			record->generation = generation;
 			record->pressed_length = 0;
 			int status = ROBOTGO_WIN32_ACQUIRE_TOGGLE_RECORD(record);
 			if (status != ROBOTGO_KEY_OK && record->pressed_length == 0) {
@@ -2338,30 +2076,22 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		MMKeyFlags flags,
 		uintptr pid
 	) {
+		if (pid != 0) {
+			return ROBOTGO_KEY_UNSUPPORTED;
+		}
 		AcquireSRWLockExclusive(&robotgo_win32_toggle_lock);
 		RobotGoWin32ToggleRecord *free_record = NULL;
 		RobotGoWin32ToggleRecord *existing =
 			ROBOTGO_WIN32_FIND_TOGGLE_RECORD(
-				code, flags, pid, &free_record
+				code, flags, &free_record
 			);
 		if (existing != NULL || free_record == NULL) {
 			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 		}
-		HANDLE generation = NULL;
-		HWND target = ROBOTGO_WIN32_RESOLVE_TARGET(
-			pid, &generation
-		);
-		if (pid != 0 && target == NULL) {
-			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
-			return ROBOTGO_KEY_NOT_APPLIED;
-		}
 		RobotGoWin32PhysicalKey *unused_free_key = NULL;
 		if (ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
 			code,
-			pid,
-			target,
-			generation,
 			&unused_free_key
 		) != NULL) {
 			/*
@@ -2377,9 +2107,6 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		record->active = true;
 		record->code = code;
 		record->flags = flags;
-		record->pid = pid;
-		record->target = target;
-		record->generation = generation;
 		record->pressed_length = 0;
 		int status = ROBOTGO_WIN32_ACQUIRE_TOGGLE_RECORD(record);
 		if (status != ROBOTGO_KEY_OK) {
@@ -2445,6 +2172,9 @@ int toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags, uintptr pid
 	}
 	return ROBOTGO_KEY_OK;
 #elif defined(IS_WINDOWS)
+	if (pid != 0) {
+		return ROBOTGO_KEY_UNSUPPORTED;
+	}
 	return ROBOTGO_WIN32_TOGGLE_OWNED_KEY_CODE(code, down, flags, pid);
 #elif defined(IS_LINUX)
 	#ifdef ROBOTGO_USE_WAYLAND
@@ -2501,6 +2231,9 @@ int robotgo_tap_key_code(MMKeyCode code, MMKeyFlags flags, uintptr pid) {
 	XSync(display, false);
 	return status;
 #elif defined(IS_WINDOWS)
+	if (pid != 0) {
+		return ROBOTGO_KEY_UNSUPPORTED;
+	}
 	return ROBOTGO_WIN32_TAP_OWNED_KEY_CODE(code, flags, pid);
 #else
 	int status = toggleKeyCode(code, true, flags, pid);

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -1831,64 +1831,10 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			? ROBOTGO_KEY_OK : ROBOTGO_KEY_INJECTION_FAILED;
 	}
 
-	static int ROBOTGO_WIN32_TOGGLE_KEY_CODE(
-		MMKeyCode code,
-		const bool down,
-		MMKeyFlags flags,
-		uintptr pid,
-		MMKeyCode *successful_sequence,
-		size_t *successful_length
-	) {
-		const DWORD event_flags = down ? 0 : KEYEVENTF_KEYUP;
-		MMKeyCode sequence[5];
-		size_t sequence_length = 0;
-
-		if (successful_length != NULL) {
-			*successful_length = 0;
-		}
-		if (down) {
-			/* Press modifiers before the main key. */
-			if (flags & MOD_META) { sequence[sequence_length++] = K_META; }
-			if (flags & MOD_ALT) { sequence[sequence_length++] = K_ALT; }
-			if (flags & MOD_CONTROL) { sequence[sequence_length++] = K_CONTROL; }
-			if (flags & MOD_SHIFT) { sequence[sequence_length++] = K_SHIFT; }
-			sequence[sequence_length++] = code;
-		} else {
-			/* Release the main key first, followed by modifiers in reverse order. */
-			sequence[sequence_length++] = code;
-			if (flags & MOD_SHIFT) { sequence[sequence_length++] = K_SHIFT; }
-			if (flags & MOD_CONTROL) { sequence[sequence_length++] = K_CONTROL; }
-			if (flags & MOD_ALT) { sequence[sequence_length++] = K_ALT; }
-			if (flags & MOD_META) { sequence[sequence_length++] = K_META; }
-		}
-
-		int first_error = ROBOTGO_KEY_OK;
-		for (size_t index = 0; index < sequence_length; index++) {
-			int status = WIN32_KEY_EVENT_WAIT(sequence[index], event_flags, pid);
-			if (status == ROBOTGO_KEY_OK) {
-				if (down && successful_sequence != NULL &&
-					successful_length != NULL) {
-					successful_sequence[*successful_length] = sequence[index];
-					(*successful_length)++;
-				}
-				continue;
-			}
-			if (first_error == ROBOTGO_KEY_OK) {
-				first_error = status;
-			}
-			/*
-			 * Do not emit a main key after a failed modifier press. Releases
-			 * continue so cleanup has the best chance of clearing every key.
-			 */
-			if (down) {
-				break;
-			}
-		}
-		return first_error;
-	}
-
 	enum {
-		ROBOTGO_WIN32_MAX_TOGGLE_RECORDS = 64
+		ROBOTGO_WIN32_MAX_TOGGLE_RECORDS = 64,
+		ROBOTGO_WIN32_MAX_PHYSICAL_KEYS =
+			ROBOTGO_WIN32_MAX_TOGGLE_RECORDS * 5
 	};
 
 	typedef struct RobotGoWin32ToggleRecord {
@@ -1900,9 +1846,18 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		size_t pressed_length;
 	} RobotGoWin32ToggleRecord;
 
+	typedef struct RobotGoWin32PhysicalKey {
+		bool active;
+		MMKeyCode code;
+		uintptr pid;
+		size_t references;
+	} RobotGoWin32PhysicalKey;
+
 	static SRWLOCK robotgo_win32_toggle_lock = SRWLOCK_INIT;
 	static RobotGoWin32ToggleRecord
 		robotgo_win32_toggle_records[ROBOTGO_WIN32_MAX_TOGGLE_RECORDS];
+	static RobotGoWin32PhysicalKey
+		robotgo_win32_physical_keys[ROBOTGO_WIN32_MAX_PHYSICAL_KEYS];
 
 	static bool ROBOTGO_WIN32_TOGGLE_RECORD_MATCHES(
 		const RobotGoWin32ToggleRecord *record,
@@ -1916,15 +1871,14 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			record->pid == pid;
 	}
 
-	static int ROBOTGO_WIN32_TOGGLE_OWNED_KEY_CODE(
+	static RobotGoWin32ToggleRecord *ROBOTGO_WIN32_FIND_TOGGLE_RECORD(
 		MMKeyCode code,
-		const bool down,
 		MMKeyFlags flags,
-		uintptr pid
+		uintptr pid,
+		RobotGoWin32ToggleRecord **free_record
 	) {
-		AcquireSRWLockExclusive(&robotgo_win32_toggle_lock);
 		RobotGoWin32ToggleRecord *record = NULL;
-		RobotGoWin32ToggleRecord *free_record = NULL;
+		*free_record = NULL;
 		for (size_t index = 0;
 			index < ROBOTGO_WIN32_MAX_TOGGLE_RECORDS;
 			index++) {
@@ -1936,10 +1890,164 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 				record = candidate;
 				break;
 			}
-			if (!candidate->active && free_record == NULL) {
-				free_record = candidate;
+			if (!candidate->active && *free_record == NULL) {
+				*free_record = candidate;
 			}
 		}
+		return record;
+	}
+
+	static RobotGoWin32PhysicalKey *ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
+		MMKeyCode code,
+		uintptr pid,
+		RobotGoWin32PhysicalKey **free_key
+	) {
+		RobotGoWin32PhysicalKey *physical = NULL;
+		*free_key = NULL;
+		for (size_t index = 0;
+			index < ROBOTGO_WIN32_MAX_PHYSICAL_KEYS;
+			index++) {
+			RobotGoWin32PhysicalKey *candidate =
+				&robotgo_win32_physical_keys[index];
+			if (candidate->active &&
+				candidate->code == code &&
+				candidate->pid == pid) {
+				physical = candidate;
+				break;
+			}
+			if (!candidate->active && *free_key == NULL) {
+				*free_key = candidate;
+			}
+		}
+		return physical;
+	}
+
+	static int ROBOTGO_WIN32_ACQUIRE_PHYSICAL_KEY(
+		RobotGoWin32ToggleRecord *record,
+		MMKeyCode code
+	) {
+		if (record->pressed_length >= 5) {
+			return ROBOTGO_KEY_INVALID;
+		}
+		RobotGoWin32PhysicalKey *free_key = NULL;
+		RobotGoWin32PhysicalKey *physical =
+			ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
+				code, record->pid, &free_key
+		);
+		if (physical != NULL) {
+			physical->references++;
+			record->pressed[record->pressed_length++] = code;
+			return ROBOTGO_KEY_OK;
+		}
+		if (free_key == NULL) {
+			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
+		}
+
+		int status = WIN32_KEY_EVENT_WAIT(code, 0, record->pid);
+		if (status != ROBOTGO_KEY_OK) {
+			return status;
+		}
+		free_key->active = true;
+		free_key->code = code;
+		free_key->pid = record->pid;
+		free_key->references = 1;
+		record->pressed[record->pressed_length++] = code;
+		return ROBOTGO_KEY_OK;
+	}
+
+	static int ROBOTGO_WIN32_ACQUIRE_TOGGLE_RECORD(
+		RobotGoWin32ToggleRecord *record
+	) {
+		MMKeyCode sequence[5];
+		size_t sequence_length = 0;
+
+		/* Acquire modifiers before the main key. */
+		if (record->flags & MOD_META) {
+			sequence[sequence_length++] = K_META;
+		}
+		if (record->flags & MOD_ALT) {
+			sequence[sequence_length++] = K_ALT;
+		}
+		if (record->flags & MOD_CONTROL) {
+			sequence[sequence_length++] = K_CONTROL;
+		}
+		if (record->flags & MOD_SHIFT) {
+			sequence[sequence_length++] = K_SHIFT;
+		}
+		sequence[sequence_length++] = record->code;
+
+		for (size_t index = 0; index < sequence_length; index++) {
+			int status = ROBOTGO_WIN32_ACQUIRE_PHYSICAL_KEY(
+				record, sequence[index]
+			);
+			if (status != ROBOTGO_KEY_OK) {
+				return status;
+			}
+		}
+		return ROBOTGO_KEY_OK;
+	}
+
+	static int ROBOTGO_WIN32_RELEASE_TOGGLE_RECORD(
+		RobotGoWin32ToggleRecord *record
+	) {
+		bool failed[5] = { false, false, false, false, false };
+		int first_error = ROBOTGO_KEY_OK;
+
+		/* Release the main key first, followed by modifiers in reverse. */
+		for (size_t index = record->pressed_length; index > 0; index--) {
+			size_t pressed_index = index - 1;
+			RobotGoWin32PhysicalKey *unused_free_key = NULL;
+			RobotGoWin32PhysicalKey *physical =
+				ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
+					record->pressed[pressed_index],
+					record->pid,
+					&unused_free_key
+				);
+			int status = ROBOTGO_KEY_OK;
+			if (physical == NULL || physical->references == 0) {
+				status = ROBOTGO_KEY_OWNERSHIP_CONFLICT;
+			} else if (physical->references > 1) {
+				physical->references--;
+			} else {
+				status = WIN32_KEY_EVENT_WAIT(
+					record->pressed[pressed_index],
+					KEYEVENTF_KEYUP,
+					record->pid
+				);
+				if (status == ROBOTGO_KEY_OK) {
+					memset(physical, 0, sizeof(*physical));
+				}
+			}
+			if (status != ROBOTGO_KEY_OK) {
+				failed[pressed_index] = true;
+				if (first_error == ROBOTGO_KEY_OK) {
+					first_error = status;
+				}
+			}
+		}
+
+		size_t remaining = 0;
+		for (size_t index = 0; index < record->pressed_length; index++) {
+			if (failed[index]) {
+				record->pressed[remaining++] = record->pressed[index];
+			}
+		}
+		record->pressed_length = remaining;
+		return first_error;
+	}
+
+	static int ROBOTGO_WIN32_TOGGLE_OWNED_KEY_CODE(
+		MMKeyCode code,
+		const bool down,
+		MMKeyFlags flags,
+		uintptr pid
+	) {
+		AcquireSRWLockExclusive(&robotgo_win32_toggle_lock);
+		RobotGoWin32ToggleRecord *free_record = NULL;
+		RobotGoWin32ToggleRecord *record =
+			ROBOTGO_WIN32_FIND_TOGGLE_RECORD(
+				code, flags, pid, &free_record
+			);
 
 		if (down) {
 			if (record != NULL || free_record == NULL) {
@@ -1952,13 +2060,12 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			record->flags = flags;
 			record->pid = pid;
 			record->pressed_length = 0;
-			int status = ROBOTGO_WIN32_TOGGLE_KEY_CODE(
-				code, true, flags, pid,
-				record->pressed, &record->pressed_length
-			);
+			int status = ROBOTGO_WIN32_ACQUIRE_TOGGLE_RECORD(record);
 			if (status != ROBOTGO_KEY_OK && record->pressed_length == 0) {
 				memset(record, 0, sizeof(*record));
-				status = ROBOTGO_KEY_NOT_APPLIED;
+				if (status == ROBOTGO_KEY_INJECTION_FAILED) {
+					status = ROBOTGO_KEY_NOT_APPLIED;
+				}
 			}
 			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 			return status;
@@ -1968,34 +2075,64 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 		}
-		bool failed[5] = { false, false, false, false, false };
-		int first_error = ROBOTGO_KEY_OK;
-		for (size_t index = record->pressed_length; index > 0; index--) {
-			size_t pressed_index = index - 1;
-			int status = WIN32_KEY_EVENT_WAIT(
-				record->pressed[pressed_index],
-				KEYEVENTF_KEYUP,
-				pid
-			);
-			if (status != ROBOTGO_KEY_OK) {
-				failed[pressed_index] = true;
-				if (first_error == ROBOTGO_KEY_OK) {
-					first_error = status;
-				}
-			}
-		}
-		size_t remaining = 0;
-		for (size_t index = 0; index < record->pressed_length; index++) {
-			if (failed[index]) {
-				record->pressed[remaining++] = record->pressed[index];
-			}
-		}
-		record->pressed_length = remaining;
-		if (remaining == 0) {
+		int status = ROBOTGO_WIN32_RELEASE_TOGGLE_RECORD(record);
+		if (record->pressed_length == 0) {
 			memset(record, 0, sizeof(*record));
 		}
 		ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
-		return first_error;
+		return status;
+	}
+
+	static int ROBOTGO_WIN32_TAP_OWNED_KEY_CODE(
+		MMKeyCode code,
+		MMKeyFlags flags,
+		uintptr pid
+	) {
+		AcquireSRWLockExclusive(&robotgo_win32_toggle_lock);
+		RobotGoWin32ToggleRecord *free_record = NULL;
+		RobotGoWin32ToggleRecord *existing =
+			ROBOTGO_WIN32_FIND_TOGGLE_RECORD(
+				code, flags, pid, &free_record
+			);
+		if (existing != NULL || free_record == NULL) {
+			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
+		}
+
+		RobotGoWin32ToggleRecord *record = free_record;
+		record->active = true;
+		record->code = code;
+		record->flags = flags;
+		record->pid = pid;
+		record->pressed_length = 0;
+		int status = ROBOTGO_WIN32_ACQUIRE_TOGGLE_RECORD(record);
+		if (status != ROBOTGO_KEY_OK) {
+			if (record->pressed_length == 0) {
+				memset(record, 0, sizeof(*record));
+				if (status == ROBOTGO_KEY_INJECTION_FAILED) {
+					status = ROBOTGO_KEY_NOT_APPLIED;
+				}
+			} else {
+				/*
+				 * Roll back every acquired reference. Any failed physical
+				 * release stays in this logical record so KeyUp can retry it.
+				 */
+				(void)ROBOTGO_WIN32_RELEASE_TOGGLE_RECORD(record);
+				if (record->pressed_length == 0) {
+					memset(record, 0, sizeof(*record));
+				}
+			}
+			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+			return status;
+		}
+
+		microsleep(3.0);
+		status = ROBOTGO_WIN32_RELEASE_TOGGLE_RECORD(record);
+		if (record->pressed_length == 0) {
+			memset(record, 0, sizeof(*record));
+		}
+		ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+		return status;
 	}
 #endif
 
@@ -2088,27 +2225,7 @@ int robotgo_tap_key_code(MMKeyCode code, MMKeyFlags flags, uintptr pid) {
 	XSync(display, false);
 	return status;
 #elif defined(IS_WINDOWS)
-	MMKeyCode successful_sequence[5];
-	size_t successful_length = 0;
-	int status = ROBOTGO_WIN32_TOGGLE_KEY_CODE(
-		code, true, flags, pid,
-		successful_sequence, &successful_length
-	);
-	if (status != ROBOTGO_KEY_OK) {
-		while (successful_length > 0) {
-			successful_length--;
-			(void)WIN32_KEY_EVENT_WAIT(
-				successful_sequence[successful_length],
-				KEYEVENTF_KEYUP,
-				pid
-			);
-		}
-		return status;
-	}
-	microsleep(3.0);
-	return ROBOTGO_WIN32_TOGGLE_KEY_CODE(
-		code, false, flags, pid, NULL, NULL
-	);
+	return ROBOTGO_WIN32_TAP_OWNED_KEY_CODE(code, flags, pid);
 #else
 	int status = toggleKeyCode(code, true, flags, pid);
 	if (status != ROBOTGO_KEY_OK) {

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -69,8 +69,20 @@ enum RobotGoKeyStatus {
 		return hwnd;	
 	}
 
-	int WIN32_KEY_EVENT_WAIT(MMKeyCode key, DWORD flags, uintptr pid) {
-		int status = win32KeyEvent(key, flags, pid, 0);
+	int win32KeyEventToTarget(
+		int key,
+		MMKeyFlags flags,
+		uintptr pid,
+		HWND target
+	);
+
+	int WIN32_KEY_EVENT_TARGET_WAIT(
+		MMKeyCode key,
+		DWORD flags,
+		uintptr pid,
+		HWND target
+	) {
+		int status = win32KeyEventToTarget(key, flags, pid, target);
 		if (status == ROBOTGO_KEY_OK) {
 			Sleep(DEADBEEF_RANDRANGE(0, 1));
 		}
@@ -1758,7 +1770,35 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 	}
 #elif defined(IS_WINDOWS)
 
-	int win32KeyEvent(int key, MMKeyFlags flags, uintptr pid, int8_t isPid) {
+	static bool ROBOTGO_WIN32_TARGET_MATCHES(HWND target, uintptr pid) {
+		if (pid == 0) {
+			return target == NULL;
+		}
+		if ((uintptr)(DWORD)pid != pid ||
+			target == NULL ||
+			!IsWindow(target)) {
+			return false;
+		}
+		DWORD target_pid = 0;
+		(void)GetWindowThreadProcessId(target, &target_pid);
+		return target_pid == (DWORD)pid;
+	}
+
+	static HWND ROBOTGO_WIN32_RESOLVE_TARGET(uintptr pid) {
+		if (pid == 0 || (uintptr)(DWORD)pid != pid) {
+			return NULL;
+		}
+		HWND target = getHwnd(pid, 0);
+		return ROBOTGO_WIN32_TARGET_MATCHES(target, pid)
+			? target : NULL;
+	}
+
+	int win32KeyEventToTarget(
+		int key,
+		MMKeyFlags flags,
+		uintptr pid,
+		HWND target
+	) {
 		int scan = MapVirtualKey(key & 0xff, MAPVK_VK_TO_VSC);
 		UINT message = (flags & KEYEVENTF_KEYUP) != 0 ? WM_KEYUP : WM_KEYDOWN;
 
@@ -1804,12 +1844,11 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 
 		// todo: test this
 		if (pid != 0) {
-			HWND hwnd = getHwnd(pid, isPid);
-			if (hwnd == NULL) {
+			if (!ROBOTGO_WIN32_TARGET_MATCHES(target, pid)) {
 				return ROBOTGO_KEY_INJECTION_FAILED;
 			}
 			// SendMessage(hwnd, down, key, 0);
-			return PostMessageW(hwnd, message, key, 0)
+			return PostMessageW(target, message, key, 0)
 				? ROBOTGO_KEY_OK : ROBOTGO_KEY_INJECTION_FAILED;
 		}
 
@@ -1842,6 +1881,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		MMKeyCode code;
 		MMKeyFlags flags;
 		uintptr pid;
+		HWND target;
 		MMKeyCode pressed[5];
 		size_t pressed_length;
 	} RobotGoWin32ToggleRecord;
@@ -1850,6 +1890,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		bool active;
 		MMKeyCode code;
 		uintptr pid;
+		HWND target;
 		size_t references;
 	} RobotGoWin32PhysicalKey;
 
@@ -1900,6 +1941,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 	static RobotGoWin32PhysicalKey *ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
 		MMKeyCode code,
 		uintptr pid,
+		HWND target,
 		RobotGoWin32PhysicalKey **free_key
 	) {
 		RobotGoWin32PhysicalKey *physical = NULL;
@@ -1911,7 +1953,8 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 				&robotgo_win32_physical_keys[index];
 			if (candidate->active &&
 				candidate->code == code &&
-				candidate->pid == pid) {
+				candidate->pid == pid &&
+				candidate->target == target) {
 				physical = candidate;
 				break;
 			}
@@ -1932,8 +1975,8 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		RobotGoWin32PhysicalKey *free_key = NULL;
 		RobotGoWin32PhysicalKey *physical =
 			ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
-				code, record->pid, &free_key
-		);
+				code, record->pid, record->target, &free_key
+			);
 		if (physical != NULL) {
 			physical->references++;
 			record->pressed[record->pressed_length++] = code;
@@ -1943,13 +1986,16 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 		}
 
-		int status = WIN32_KEY_EVENT_WAIT(code, 0, record->pid);
+		int status = WIN32_KEY_EVENT_TARGET_WAIT(
+			code, 0, record->pid, record->target
+		);
 		if (status != ROBOTGO_KEY_OK) {
 			return status;
 		}
 		free_key->active = true;
 		free_key->code = code;
 		free_key->pid = record->pid;
+		free_key->target = record->target;
 		free_key->references = 1;
 		record->pressed[record->pressed_length++] = code;
 		return ROBOTGO_KEY_OK;
@@ -1987,9 +2033,52 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		return ROBOTGO_KEY_OK;
 	}
 
+	static void ROBOTGO_WIN32_CLEAR_TARGET_OWNERSHIP(
+		uintptr pid,
+		HWND target
+	) {
+		for (size_t index = 0;
+			index < ROBOTGO_WIN32_MAX_TOGGLE_RECORDS;
+			index++) {
+			RobotGoWin32ToggleRecord *record =
+				&robotgo_win32_toggle_records[index];
+			if (record->active &&
+				record->pid == pid &&
+				record->target == target) {
+				memset(record, 0, sizeof(*record));
+			}
+		}
+		for (size_t index = 0;
+			index < ROBOTGO_WIN32_MAX_PHYSICAL_KEYS;
+			index++) {
+			RobotGoWin32PhysicalKey *physical =
+				&robotgo_win32_physical_keys[index];
+			if (physical->active &&
+				physical->pid == pid &&
+				physical->target == target) {
+				memset(physical, 0, sizeof(*physical));
+			}
+		}
+	}
+
 	static int ROBOTGO_WIN32_RELEASE_TOGGLE_RECORD(
 		RobotGoWin32ToggleRecord *record
 	) {
+		if (record->pid != 0 &&
+			!ROBOTGO_WIN32_TARGET_MATCHES(
+				record->target, record->pid
+			)) {
+			/*
+			 * Posted key state belongs to the exact window. Once that HWND
+			 * is gone or belongs to another process, its state cannot
+			 * remain pressed and must never be released into a replacement.
+			 */
+			ROBOTGO_WIN32_CLEAR_TARGET_OWNERSHIP(
+				record->pid, record->target
+			);
+			return ROBOTGO_KEY_OK;
+		}
+
 		bool failed[5] = { false, false, false, false, false };
 		int first_error = ROBOTGO_KEY_OK;
 
@@ -2001,6 +2090,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 				ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
 					record->pressed[pressed_index],
 					record->pid,
+					record->target,
 					&unused_free_key
 				);
 			int status = ROBOTGO_KEY_OK;
@@ -2009,10 +2099,11 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			} else if (physical->references > 1) {
 				physical->references--;
 			} else {
-				status = WIN32_KEY_EVENT_WAIT(
+				status = WIN32_KEY_EVENT_TARGET_WAIT(
 					record->pressed[pressed_index],
 					KEYEVENTF_KEYUP,
-					record->pid
+					record->pid,
+					record->target
 				);
 				if (status == ROBOTGO_KEY_OK) {
 					memset(physical, 0, sizeof(*physical));
@@ -2054,11 +2145,17 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 				ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 				return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 			}
+			HWND target = ROBOTGO_WIN32_RESOLVE_TARGET(pid);
+			if (pid != 0 && target == NULL) {
+				ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+				return ROBOTGO_KEY_NOT_APPLIED;
+			}
 			record = free_record;
 			record->active = true;
 			record->code = code;
 			record->flags = flags;
 			record->pid = pid;
+			record->target = target;
 			record->pressed_length = 0;
 			int status = ROBOTGO_WIN32_ACQUIRE_TOGGLE_RECORD(record);
 			if (status != ROBOTGO_KEY_OK && record->pressed_length == 0) {
@@ -2098,9 +2195,14 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 		}
+		HWND target = ROBOTGO_WIN32_RESOLVE_TARGET(pid);
+		if (pid != 0 && target == NULL) {
+			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
+			return ROBOTGO_KEY_NOT_APPLIED;
+		}
 		RobotGoWin32PhysicalKey *unused_free_key = NULL;
 		if (ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
-			code, pid, &unused_free_key
+			code, pid, target, &unused_free_key
 		) != NULL) {
 			/*
 			 * A tap needs its own observable main-key transition. Sharing
@@ -2116,6 +2218,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		record->code = code;
 		record->flags = flags;
 		record->pid = pid;
+		record->target = target;
 		record->pressed_length = 0;
 		int status = ROBOTGO_WIN32_ACQUIRE_TOGGLE_RECORD(record);
 		if (status != ROBOTGO_KEY_OK) {

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -1829,6 +1829,62 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		return SendInput(1, &keyInput, sizeof(keyInput)) == 1
 			? ROBOTGO_KEY_OK : ROBOTGO_KEY_INJECTION_FAILED;
 	}
+
+	static int ROBOTGO_WIN32_TOGGLE_KEY_CODE(
+		MMKeyCode code,
+		const bool down,
+		MMKeyFlags flags,
+		uintptr pid,
+		MMKeyCode *successful_sequence,
+		size_t *successful_length
+	) {
+		const DWORD event_flags = down ? 0 : KEYEVENTF_KEYUP;
+		MMKeyCode sequence[5];
+		size_t sequence_length = 0;
+
+		if (successful_length != NULL) {
+			*successful_length = 0;
+		}
+		if (down) {
+			/* Press modifiers before the main key. */
+			if (flags & MOD_META) { sequence[sequence_length++] = K_META; }
+			if (flags & MOD_ALT) { sequence[sequence_length++] = K_ALT; }
+			if (flags & MOD_CONTROL) { sequence[sequence_length++] = K_CONTROL; }
+			if (flags & MOD_SHIFT) { sequence[sequence_length++] = K_SHIFT; }
+			sequence[sequence_length++] = code;
+		} else {
+			/* Release the main key first, followed by modifiers in reverse order. */
+			sequence[sequence_length++] = code;
+			if (flags & MOD_SHIFT) { sequence[sequence_length++] = K_SHIFT; }
+			if (flags & MOD_CONTROL) { sequence[sequence_length++] = K_CONTROL; }
+			if (flags & MOD_ALT) { sequence[sequence_length++] = K_ALT; }
+			if (flags & MOD_META) { sequence[sequence_length++] = K_META; }
+		}
+
+		int first_error = ROBOTGO_KEY_OK;
+		for (size_t index = 0; index < sequence_length; index++) {
+			int status = WIN32_KEY_EVENT_WAIT(sequence[index], event_flags, pid);
+			if (status == ROBOTGO_KEY_OK) {
+				if (down && successful_sequence != NULL &&
+					successful_length != NULL) {
+					successful_sequence[*successful_length] = sequence[index];
+					(*successful_length)++;
+				}
+				continue;
+			}
+			if (first_error == ROBOTGO_KEY_OK) {
+				first_error = status;
+			}
+			/*
+			 * Do not emit a main key after a failed modifier press. Releases
+			 * continue so cleanup has the best chance of clearing every key.
+			 */
+			if (down) {
+				break;
+			}
+		}
+		return first_error;
+	}
 #endif
 
 int toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags, uintptr pid) {
@@ -1864,44 +1920,9 @@ int toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags, uintptr pid
 	}
 	return ROBOTGO_KEY_OK;
 #elif defined(IS_WINDOWS)
-	const DWORD dwFlags = down ? 0 : KEYEVENTF_KEYUP;
-	MMKeyCode sequence[5];
-	size_t sequence_length = 0;
-
-	if (down) {
-		/* Press modifiers before the main key. */
-		if (flags & MOD_META) { sequence[sequence_length++] = K_META; }
-		if (flags & MOD_ALT) { sequence[sequence_length++] = K_ALT; }
-		if (flags & MOD_CONTROL) { sequence[sequence_length++] = K_CONTROL; }
-		if (flags & MOD_SHIFT) { sequence[sequence_length++] = K_SHIFT; }
-		sequence[sequence_length++] = code;
-	} else {
-		/* Release the main key first, followed by modifiers in reverse order. */
-		sequence[sequence_length++] = code;
-		if (flags & MOD_SHIFT) { sequence[sequence_length++] = K_SHIFT; }
-		if (flags & MOD_CONTROL) { sequence[sequence_length++] = K_CONTROL; }
-		if (flags & MOD_ALT) { sequence[sequence_length++] = K_ALT; }
-		if (flags & MOD_META) { sequence[sequence_length++] = K_META; }
-	}
-
-	int first_error = ROBOTGO_KEY_OK;
-	for (size_t index = 0; index < sequence_length; index++) {
-		int status = WIN32_KEY_EVENT_WAIT(sequence[index], dwFlags, pid);
-		if (status == ROBOTGO_KEY_OK) {
-			continue;
-		}
-		if (first_error == ROBOTGO_KEY_OK) {
-			first_error = status;
-		}
-		/*
-		 * Do not emit a main key after a failed modifier press. Releases
-		 * continue so cleanup has the best chance of clearing every key.
-		 */
-		if (down) {
-			break;
-		}
-	}
-	return first_error;
+	return ROBOTGO_WIN32_TOGGLE_KEY_CODE(
+		code, down, flags, pid, NULL, NULL
+	);
 #elif defined(IS_LINUX)
 	#ifdef ROBOTGO_USE_WAYLAND
 	        if (robotgo_wayland_keyboard_backend_selected()) {
@@ -1956,18 +1977,31 @@ int robotgo_tap_key_code(MMKeyCode code, MMKeyFlags flags, uintptr pid) {
 	XUngrabServer(display);
 	XSync(display, false);
 	return status;
+#elif defined(IS_WINDOWS)
+	MMKeyCode successful_sequence[5];
+	size_t successful_length = 0;
+	int status = ROBOTGO_WIN32_TOGGLE_KEY_CODE(
+		code, true, flags, pid,
+		successful_sequence, &successful_length
+	);
+	if (status != ROBOTGO_KEY_OK) {
+		while (successful_length > 0) {
+			successful_length--;
+			(void)WIN32_KEY_EVENT_WAIT(
+				successful_sequence[successful_length],
+				KEYEVENTF_KEYUP,
+				pid
+			);
+		}
+		return status;
+	}
+	microsleep(3.0);
+	return ROBOTGO_WIN32_TOGGLE_KEY_CODE(
+		code, false, flags, pid, NULL, NULL
+	);
 #else
 	int status = toggleKeyCode(code, true, flags, pid);
 	if (status != ROBOTGO_KEY_OK) {
-#if defined(IS_WINDOWS)
-		/*
-		 * Windows modifier dispatch can partially succeed before a later
-		 * PostMessageW/SendInput failure. A tap has no external owner that
-		 * can release that partial state, so make one best-effort release
-		 * pass before returning the original injection failure.
-		 */
-		(void)toggleKeyCode(code, false, flags, pid);
-#endif
 		return status;
 	}
 	microsleep(3.0);

--- a/key/keypress_c.h
+++ b/key/keypress_c.h
@@ -73,16 +73,20 @@ enum RobotGoKeyStatus {
 		int key,
 		MMKeyFlags flags,
 		uintptr pid,
-		HWND target
+		HWND target,
+		HANDLE generation
 	);
 
 	int WIN32_KEY_EVENT_TARGET_WAIT(
 		MMKeyCode key,
 		DWORD flags,
 		uintptr pid,
-		HWND target
+		HWND target,
+		HANDLE generation
 	) {
-		int status = win32KeyEventToTarget(key, flags, pid, target);
+		int status = win32KeyEventToTarget(
+			key, flags, pid, target, generation
+		);
 		if (status == ROBOTGO_KEY_OK) {
 			Sleep(DEADBEEF_RANDRANGE(0, 1));
 		}
@@ -1770,7 +1774,53 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 	}
 #elif defined(IS_WINDOWS)
 
-	static bool ROBOTGO_WIN32_TARGET_MATCHES(HWND target, uintptr pid) {
+	static WCHAR robotgo_win32_target_property_name[96];
+	static bool robotgo_win32_target_property_name_initialized = false;
+	static uintptr robotgo_win32_target_generation = 0;
+
+	static bool ROBOTGO_WIN32_INIT_TARGET_PROPERTY_NAME(void) {
+		if (robotgo_win32_target_property_name_initialized) {
+			return true;
+		}
+		FILETIME creation = {0};
+		FILETIME exit = {0};
+		FILETIME kernel = {0};
+		FILETIME user = {0};
+		if (!GetProcessTimes(
+			GetCurrentProcess(),
+			&creation,
+			&exit,
+			&kernel,
+			&user
+		)) {
+			return false;
+		}
+		int length = wsprintfW(
+			robotgo_win32_target_property_name,
+			L"RobotGo.NativeKeyOwnership.%08lx.%08lx.%08lx",
+			(unsigned long)GetCurrentProcessId(),
+			(unsigned long)creation.dwHighDateTime,
+			(unsigned long)creation.dwLowDateTime
+		);
+		if (length <= 0 ||
+			(size_t)length >=
+				sizeof(robotgo_win32_target_property_name) /
+				sizeof(robotgo_win32_target_property_name[0])) {
+			memset(
+				robotgo_win32_target_property_name,
+				0,
+				sizeof(robotgo_win32_target_property_name)
+			);
+			return false;
+		}
+		robotgo_win32_target_property_name_initialized = true;
+		return true;
+	}
+
+	static bool ROBOTGO_WIN32_TARGET_PID_MATCHES(
+		HWND target,
+		uintptr pid
+	) {
 		if (pid == 0) {
 			return target == NULL;
 		}
@@ -1784,20 +1834,63 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		return target_pid == (DWORD)pid;
 	}
 
-	static HWND ROBOTGO_WIN32_RESOLVE_TARGET(uintptr pid) {
-		if (pid == 0 || (uintptr)(DWORD)pid != pid) {
+	static bool ROBOTGO_WIN32_TARGET_MATCHES(
+		HWND target,
+		uintptr pid,
+		HANDLE generation
+	) {
+		if (pid == 0) {
+			return target == NULL && generation == NULL;
+		}
+		return generation != NULL &&
+			ROBOTGO_WIN32_TARGET_PID_MATCHES(target, pid) &&
+			ROBOTGO_WIN32_INIT_TARGET_PROPERTY_NAME() &&
+			GetPropW(
+				target,
+				robotgo_win32_target_property_name
+			) == generation;
+	}
+
+	static HWND ROBOTGO_WIN32_RESOLVE_TARGET(
+		uintptr pid,
+		HANDLE *generation
+	) {
+		*generation = NULL;
+		if (pid == 0 || (uintptr)(DWORD)pid != pid ||
+			!ROBOTGO_WIN32_INIT_TARGET_PROPERTY_NAME()) {
 			return NULL;
 		}
 		HWND target = getHwnd(pid, 0);
-		return ROBOTGO_WIN32_TARGET_MATCHES(target, pid)
-			? target : NULL;
+		if (!ROBOTGO_WIN32_TARGET_PID_MATCHES(target, pid)) {
+			return NULL;
+		}
+		HANDLE marker = GetPropW(
+			target,
+			robotgo_win32_target_property_name
+		);
+		if (marker == NULL) {
+			do {
+				robotgo_win32_target_generation++;
+			} while (robotgo_win32_target_generation == 0);
+			marker = (HANDLE)robotgo_win32_target_generation;
+			if (!SetPropW(
+				target,
+				robotgo_win32_target_property_name,
+				marker
+			)) {
+				return NULL;
+			}
+		}
+		*generation = marker;
+		return target;
 	}
 
 	int win32KeyEventToTarget(
 		int key,
 		MMKeyFlags flags,
 		uintptr pid,
-		HWND target
+		HWND target,
+		HANDLE generation
 	) {
 		int scan = MapVirtualKey(key & 0xff, MAPVK_VK_TO_VSC);
 		UINT message = (flags & KEYEVENTF_KEYUP) != 0 ? WM_KEYUP : WM_KEYDOWN;
@@ -1844,7 +1937,9 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 
 		// todo: test this
 		if (pid != 0) {
-			if (!ROBOTGO_WIN32_TARGET_MATCHES(target, pid)) {
+			if (!ROBOTGO_WIN32_TARGET_MATCHES(
+				target, pid, generation
+			)) {
 				return ROBOTGO_KEY_INJECTION_FAILED;
 			}
 			// SendMessage(hwnd, down, key, 0);
@@ -1882,6 +1977,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		MMKeyFlags flags;
 		uintptr pid;
 		HWND target;
+		HANDLE generation;
 		MMKeyCode pressed[5];
 		size_t pressed_length;
 	} RobotGoWin32ToggleRecord;
@@ -1891,6 +1987,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		MMKeyCode code;
 		uintptr pid;
 		HWND target;
+		HANDLE generation;
 		size_t references;
 	} RobotGoWin32PhysicalKey;
 
@@ -1942,6 +2039,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		MMKeyCode code,
 		uintptr pid,
 		HWND target,
+		HANDLE generation,
 		RobotGoWin32PhysicalKey **free_key
 	) {
 		RobotGoWin32PhysicalKey *physical = NULL;
@@ -1954,7 +2052,8 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			if (candidate->active &&
 				candidate->code == code &&
 				candidate->pid == pid &&
-				candidate->target == target) {
+				candidate->target == target &&
+				candidate->generation == generation) {
 				physical = candidate;
 				break;
 			}
@@ -1975,7 +2074,11 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		RobotGoWin32PhysicalKey *free_key = NULL;
 		RobotGoWin32PhysicalKey *physical =
 			ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
-				code, record->pid, record->target, &free_key
+				code,
+				record->pid,
+				record->target,
+				record->generation,
+				&free_key
 			);
 		if (physical != NULL) {
 			physical->references++;
@@ -1987,7 +2090,11 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		}
 
 		int status = WIN32_KEY_EVENT_TARGET_WAIT(
-			code, 0, record->pid, record->target
+			code,
+			0,
+			record->pid,
+			record->target,
+			record->generation
 		);
 		if (status != ROBOTGO_KEY_OK) {
 			return status;
@@ -1996,6 +2103,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		free_key->code = code;
 		free_key->pid = record->pid;
 		free_key->target = record->target;
+		free_key->generation = record->generation;
 		free_key->references = 1;
 		record->pressed[record->pressed_length++] = code;
 		return ROBOTGO_KEY_OK;
@@ -2035,7 +2143,8 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 
 	static void ROBOTGO_WIN32_CLEAR_TARGET_OWNERSHIP(
 		uintptr pid,
-		HWND target
+		HWND target,
+		HANDLE generation
 	) {
 		for (size_t index = 0;
 			index < ROBOTGO_WIN32_MAX_TOGGLE_RECORDS;
@@ -2044,7 +2153,8 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 				&robotgo_win32_toggle_records[index];
 			if (record->active &&
 				record->pid == pid &&
-				record->target == target) {
+				record->target == target &&
+				record->generation == generation) {
 				memset(record, 0, sizeof(*record));
 			}
 		}
@@ -2055,9 +2165,42 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 				&robotgo_win32_physical_keys[index];
 			if (physical->active &&
 				physical->pid == pid &&
-				physical->target == target) {
+				physical->target == target &&
+				physical->generation == generation) {
 				memset(physical, 0, sizeof(*physical));
 			}
+		}
+	}
+
+	static void ROBOTGO_WIN32_CLEAR_TOGGLE_RECORD(
+		RobotGoWin32ToggleRecord *record
+	) {
+		uintptr pid = record->pid;
+		HWND target = record->target;
+		HANDLE generation = record->generation;
+		memset(record, 0, sizeof(*record));
+		if (pid == 0) {
+			return;
+		}
+		for (size_t index = 0;
+			index < ROBOTGO_WIN32_MAX_TOGGLE_RECORDS;
+			index++) {
+			RobotGoWin32ToggleRecord *candidate =
+				&robotgo_win32_toggle_records[index];
+			if (candidate->active &&
+				candidate->pid == pid &&
+				candidate->target == target &&
+				candidate->generation == generation) {
+				return;
+			}
+		}
+		if (ROBOTGO_WIN32_TARGET_MATCHES(
+			target, pid, generation
+		)) {
+			(void)RemovePropW(
+				target,
+				robotgo_win32_target_property_name
+			);
 		}
 	}
 
@@ -2066,7 +2209,9 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 	) {
 		if (record->pid != 0 &&
 			!ROBOTGO_WIN32_TARGET_MATCHES(
-				record->target, record->pid
+				record->target,
+				record->pid,
+				record->generation
 			)) {
 			/*
 			 * Posted key state belongs to the exact window. Once that HWND
@@ -2074,7 +2219,9 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			 * remain pressed and must never be released into a replacement.
 			 */
 			ROBOTGO_WIN32_CLEAR_TARGET_OWNERSHIP(
-				record->pid, record->target
+				record->pid,
+				record->target,
+				record->generation
 			);
 			return ROBOTGO_KEY_OK;
 		}
@@ -2091,6 +2238,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 					record->pressed[pressed_index],
 					record->pid,
 					record->target,
+					record->generation,
 					&unused_free_key
 				);
 			int status = ROBOTGO_KEY_OK;
@@ -2103,7 +2251,8 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 					record->pressed[pressed_index],
 					KEYEVENTF_KEYUP,
 					record->pid,
-					record->target
+					record->target,
+					record->generation
 				);
 				if (status == ROBOTGO_KEY_OK) {
 					memset(physical, 0, sizeof(*physical));
@@ -2145,7 +2294,10 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 				ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 				return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 			}
-			HWND target = ROBOTGO_WIN32_RESOLVE_TARGET(pid);
+			HANDLE generation = NULL;
+			HWND target = ROBOTGO_WIN32_RESOLVE_TARGET(
+				pid, &generation
+			);
 			if (pid != 0 && target == NULL) {
 				ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 				return ROBOTGO_KEY_NOT_APPLIED;
@@ -2156,10 +2308,11 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			record->flags = flags;
 			record->pid = pid;
 			record->target = target;
+			record->generation = generation;
 			record->pressed_length = 0;
 			int status = ROBOTGO_WIN32_ACQUIRE_TOGGLE_RECORD(record);
 			if (status != ROBOTGO_KEY_OK && record->pressed_length == 0) {
-				memset(record, 0, sizeof(*record));
+				ROBOTGO_WIN32_CLEAR_TOGGLE_RECORD(record);
 				if (status == ROBOTGO_KEY_INJECTION_FAILED) {
 					status = ROBOTGO_KEY_NOT_APPLIED;
 				}
@@ -2174,7 +2327,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		}
 		int status = ROBOTGO_WIN32_RELEASE_TOGGLE_RECORD(record);
 		if (record->pressed_length == 0) {
-			memset(record, 0, sizeof(*record));
+			ROBOTGO_WIN32_CLEAR_TOGGLE_RECORD(record);
 		}
 		ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 		return status;
@@ -2195,14 +2348,21 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 			return ROBOTGO_KEY_OWNERSHIP_CONFLICT;
 		}
-		HWND target = ROBOTGO_WIN32_RESOLVE_TARGET(pid);
+		HANDLE generation = NULL;
+		HWND target = ROBOTGO_WIN32_RESOLVE_TARGET(
+			pid, &generation
+		);
 		if (pid != 0 && target == NULL) {
 			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 			return ROBOTGO_KEY_NOT_APPLIED;
 		}
 		RobotGoWin32PhysicalKey *unused_free_key = NULL;
 		if (ROBOTGO_WIN32_FIND_PHYSICAL_KEY(
-			code, pid, target, &unused_free_key
+			code,
+			pid,
+			target,
+			generation,
+			&unused_free_key
 		) != NULL) {
 			/*
 			 * A tap needs its own observable main-key transition. Sharing
@@ -2219,11 +2379,12 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		record->flags = flags;
 		record->pid = pid;
 		record->target = target;
+		record->generation = generation;
 		record->pressed_length = 0;
 		int status = ROBOTGO_WIN32_ACQUIRE_TOGGLE_RECORD(record);
 		if (status != ROBOTGO_KEY_OK) {
 			if (record->pressed_length == 0) {
-				memset(record, 0, sizeof(*record));
+				ROBOTGO_WIN32_CLEAR_TOGGLE_RECORD(record);
 				if (status == ROBOTGO_KEY_INJECTION_FAILED) {
 					status = ROBOTGO_KEY_NOT_APPLIED;
 				}
@@ -2234,7 +2395,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 				 */
 				(void)ROBOTGO_WIN32_RELEASE_TOGGLE_RECORD(record);
 				if (record->pressed_length == 0) {
-					memset(record, 0, sizeof(*record));
+					ROBOTGO_WIN32_CLEAR_TOGGLE_RECORD(record);
 				}
 			}
 			ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
@@ -2244,7 +2405,7 @@ static inline int robotgo_wayland_type_codepoints(const uint32_t *values,
 		microsleep(3.0);
 		status = ROBOTGO_WIN32_RELEASE_TOGGLE_RECORD(record);
 		if (record->pressed_length == 0) {
-			memset(record, 0, sizeof(*record));
+			ROBOTGO_WIN32_CLEAR_TOGGLE_RECORD(record);
 		}
 		ReleaseSRWLockExclusive(&robotgo_win32_toggle_lock);
 		return status;

--- a/mouse_ownership_cgo_test.go
+++ b/mouse_ownership_cgo_test.go
@@ -1,0 +1,128 @@
+//go:build cgo
+
+package robotgo
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestToggleTrackedNativeMouseHoldCoordinatesOwnership(t *testing.T) {
+	holds := make(map[string]mouseHold)
+	var transitions []bool
+	toggle := func(down bool) error {
+		transitions = append(transitions, down)
+		return nil
+	}
+
+	if err := toggleTrackedNativeMouseHold(holds, "left", true, toggle); err != nil {
+		t.Fatalf("first down: %v", err)
+	}
+	if err := toggleTrackedNativeMouseHold(holds, "left", true, toggle); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("duplicate down error = %v", err)
+	}
+	if len(transitions) != 1 || !transitions[0] {
+		t.Fatalf("duplicate down transitions = %v", transitions)
+	}
+
+	if err := toggleTrackedNativeMouseHold(holds, "left", false, toggle); err != nil {
+		t.Fatalf("owned up: %v", err)
+	}
+	if len(transitions) != 2 || transitions[1] {
+		t.Fatalf("owned up transitions = %v", transitions)
+	}
+	if _, held := holds["left"]; held {
+		t.Fatal("successful up retained native mouse ownership")
+	}
+
+	if err := toggleTrackedNativeMouseHold(holds, "left", false, toggle); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("orphan up error = %v", err)
+	}
+	if len(transitions) != 2 {
+		t.Fatalf("orphan up emitted transition: %v", transitions)
+	}
+}
+
+func TestToggleTrackedNativeMouseHoldRetainsAmbiguousRelease(t *testing.T) {
+	holds := map[string]mouseHold{
+		"right": {backend: persistentInputBackendNative},
+	}
+	releaseFailures := 1
+	toggle := func(bool) error {
+		if releaseFailures > 0 {
+			releaseFailures--
+			return errors.New("release failed")
+		}
+		return nil
+	}
+
+	if err := toggleTrackedNativeMouseHold(holds, "right", false, toggle); err == nil {
+		t.Fatal("ambiguous release succeeded")
+	}
+	if _, held := holds["right"]; !held {
+		t.Fatal("ambiguous release discarded retryable ownership")
+	}
+	if err := toggleTrackedNativeMouseHold(holds, "right", false, toggle); err != nil {
+		t.Fatalf("release retry: %v", err)
+	}
+	if _, held := holds["right"]; held {
+		t.Fatal("successful release retry retained ownership")
+	}
+}
+
+func TestToggleTrackedNativeMouseHoldClearsLostBackendOwnership(t *testing.T) {
+	holds := map[string]mouseHold{
+		"center": {backend: persistentInputBackendNative},
+	}
+	if err := toggleTrackedNativeMouseHold(
+		holds,
+		"center",
+		false,
+		func(bool) error { return ErrInputOwnership },
+	); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("lost backend ownership error = %v", err)
+	}
+	if _, held := holds["center"]; held {
+		t.Fatal("lost backend ownership retained an unreleasable hold")
+	}
+}
+
+func TestToggleTrackedNativeMouseHoldDoesNotReleaseOtherBackend(t *testing.T) {
+	holds := map[string]mouseHold{
+		"left": {backend: persistentInputBackendPortal},
+	}
+	called := false
+	if err := toggleTrackedNativeMouseHold(
+		holds,
+		"left",
+		false,
+		func(bool) error {
+			called = true
+			return nil
+		},
+	); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("foreign backend release error = %v", err)
+	}
+	if called {
+		t.Fatal("foreign backend release reached native toggle")
+	}
+	if _, held := holds["left"]; !held {
+		t.Fatal("foreign backend release discarded portal ownership")
+	}
+}
+
+func TestToggleTrackedNativeMouseHoldDoesNotRecordRejectedDown(t *testing.T) {
+	holds := make(map[string]mouseHold)
+	wantErr := errors.New("down rejected")
+	if err := toggleTrackedNativeMouseHold(
+		holds,
+		"left",
+		true,
+		func(bool) error { return wantErr },
+	); !errors.Is(err, wantErr) {
+		t.Fatalf("rejected down error = %v", err)
+	}
+	if len(holds) != 0 {
+		t.Fatalf("rejected down recorded ownership: %+v", holds)
+	}
+}

--- a/mouse_ownership_cgo_test.go
+++ b/mouse_ownership_cgo_test.go
@@ -148,7 +148,7 @@ func TestClickTrackedNativeMouseHoldRetainsAmbiguousRelease(t *testing.T) {
 		toggle,
 		func(delay time.Duration) { delays = append(delays, delay) },
 	)
-	if !errors.Is(err, wantErr) {
+	if !errors.Is(err, wantErr) || !errors.Is(err, ErrInputReleasePending) {
 		t.Fatalf("click error = %v", err)
 	}
 	if len(transitions) != 2 || !transitions[0] || transitions[1] {

--- a/mouse_ownership_cgo_test.go
+++ b/mouse_ownership_cgo_test.go
@@ -5,6 +5,7 @@ package robotgo
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestToggleTrackedNativeMouseHoldCoordinatesOwnership(t *testing.T) {
@@ -124,5 +125,83 @@ func TestToggleTrackedNativeMouseHoldDoesNotRecordRejectedDown(t *testing.T) {
 	}
 	if len(holds) != 0 {
 		t.Fatalf("rejected down recorded ownership: %+v", holds)
+	}
+}
+
+func TestClickTrackedNativeMouseHoldRetainsAmbiguousRelease(t *testing.T) {
+	holds := make(map[string]mouseHold)
+	wantErr := errors.New("release unconfirmed")
+	var transitions []bool
+	var delays []time.Duration
+	toggle := func(down bool) error {
+		transitions = append(transitions, down)
+		if !down {
+			return wantErr
+		}
+		return nil
+	}
+
+	err := clickTrackedNativeMouseHold(
+		holds,
+		"left",
+		false,
+		toggle,
+		func(delay time.Duration) { delays = append(delays, delay) },
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("click error = %v", err)
+	}
+	if len(transitions) != 2 || !transitions[0] || transitions[1] {
+		t.Fatalf("click transitions = %v", transitions)
+	}
+	if len(delays) != 1 || delays[0] != 5*time.Millisecond {
+		t.Fatalf("click delays = %v", delays)
+	}
+	if hold, held := holds["left"]; !held || hold.backend != persistentInputBackendNative {
+		t.Fatalf("ambiguous click release ownership = %+v, held = %v", hold, held)
+	}
+}
+
+func TestClickTrackedNativeMouseHoldTracksBothDoubleClickReleases(t *testing.T) {
+	holds := make(map[string]mouseHold)
+	var transitions []bool
+	var delays []time.Duration
+
+	if err := clickTrackedNativeMouseHold(
+		holds,
+		"right",
+		true,
+		func(down bool) error {
+			transitions = append(transitions, down)
+			return nil
+		},
+		func(delay time.Duration) { delays = append(delays, delay) },
+	); err != nil {
+		t.Fatalf("double click: %v", err)
+	}
+	wantTransitions := []bool{true, false, true, false}
+	if len(transitions) != len(wantTransitions) {
+		t.Fatalf("double-click transitions = %v", transitions)
+	}
+	for i := range wantTransitions {
+		if transitions[i] != wantTransitions[i] {
+			t.Fatalf("double-click transitions = %v", transitions)
+		}
+	}
+	wantDelays := []time.Duration{
+		5 * time.Millisecond,
+		200 * time.Millisecond,
+		5 * time.Millisecond,
+	}
+	if len(delays) != len(wantDelays) {
+		t.Fatalf("double-click delays = %v", delays)
+	}
+	for i := range wantDelays {
+		if delays[i] != wantDelays[i] {
+			t.Fatalf("double-click delays = %v", delays)
+		}
+	}
+	if _, held := holds["right"]; held {
+		t.Fatal("successful double click retained native mouse ownership")
 	}
 }

--- a/remote_desktop_input.go
+++ b/remote_desktop_input.go
@@ -105,6 +105,11 @@ var ErrInputOwnership = errors.New("robotgo: input state has no matching RobotGo
 // backend proved that it acquired no key or button state.
 var ErrInputNotApplied = errors.New("robotgo: input backend applied no key or button state")
 
+// ErrInputReleasePending reports that RobotGo successfully acquired input
+// state but could not confirm its release. The matching Up operation or an
+// explicit backend close can retry the RobotGo-owned release safely.
+var ErrInputReleasePending = errors.New("robotgo: input release remains pending")
+
 // StartRemoteDesktopInput opens a consent-aware portal session and makes it
 // available to supported high-level input APIs when native Wayland input is
 // unavailable. Replacing an existing session closes the old one.

--- a/remote_desktop_input.go
+++ b/remote_desktop_input.go
@@ -101,6 +101,10 @@ var (
 // session replacement between the two transitions.
 var ErrInputOwnership = errors.New("robotgo: input state has no matching RobotGo-owned key or button down")
 
+// ErrInputNotApplied reports a failed stateful input transition for which the
+// backend proved that it acquired no key or button state.
+var ErrInputNotApplied = errors.New("robotgo: input backend applied no key or button state")
+
 // StartRemoteDesktopInput opens a consent-aware portal session and makes it
 // available to supported high-level input APIs when native Wayland input is
 // unavailable. Replacing an existing session closes the old one.

--- a/remote_desktop_input_cgo_test.go
+++ b/remote_desktop_input_cgo_test.go
@@ -45,6 +45,9 @@ func TestHighLevelInputFallsBackToActiveRemoteDesktopSession(t *testing.T) {
 	if err := ScrollE(2, -3, 7); err != nil {
 		t.Fatalf("ScrollE error: %v", err)
 	}
+	if err := ScrollImmediateE(2, -3); err != nil {
+		t.Fatalf("ScrollImmediateE error: %v", err)
+	}
 	if err := KeyTap("a"); err != nil {
 		t.Fatalf("KeyTap error: %v", err)
 	}
@@ -74,6 +77,8 @@ func TestHighLevelInputFallsBackToActiveRemoteDesktopSession(t *testing.T) {
 		"button:272:false",
 		"button:273:true",
 		"button:273:false",
+		"axis:1:2",
+		"axis:0:3",
 		"axis:1:2",
 		"axis:0:3",
 		"keysym:97:true",

--- a/remote_desktop_input_cgo_test.go
+++ b/remote_desktop_input_cgo_test.go
@@ -36,6 +36,9 @@ func TestHighLevelInputFallsBackToActiveRemoteDesktopSession(t *testing.T) {
 	if err := ClickE("left"); err != nil {
 		t.Fatalf("ClickE error: %v", err)
 	}
+	if err := ClickImmediateE("left"); err != nil {
+		t.Fatalf("ClickImmediateE error: %v", err)
+	}
 	if err := Toggle("right"); err != nil {
 		t.Fatalf("Toggle error: %v", err)
 	}
@@ -73,6 +76,8 @@ func TestHighLevelInputFallsBackToActiveRemoteDesktopSession(t *testing.T) {
 	wantPrefixes := []string{
 		"absolute:77:20:100",
 		"motion:4:-3",
+		"button:272:true",
+		"button:272:false",
 		"button:272:true",
 		"button:272:false",
 		"button:273:true",

--- a/remote_desktop_input_nocgo_test.go
+++ b/remote_desktop_input_nocgo_test.go
@@ -35,6 +35,9 @@ func TestNonCGOHighLevelPortalInput(t *testing.T) {
 	if err := ScrollE(0, 2, 7); err != nil {
 		t.Fatalf("ScrollE error: %v", err)
 	}
+	if err := ScrollImmediateE(0, 2); err != nil {
+		t.Fatalf("ScrollImmediateE error: %v", err)
+	}
 	if err := TypeStrE("x"); err != nil {
 		t.Fatalf("TypeStrE error: %v", err)
 	}
@@ -56,8 +59,8 @@ func TestNonCGOHighLevelPortalInput(t *testing.T) {
 	}
 	assertRemoteDesktopMouseDelays(t, *delays, []int{23, 23, 23, 30})
 	events, _ := session.snapshot()
-	if len(events) != 23 {
-		t.Fatalf("events = %#v, want 23", events)
+	if len(events) != 24 {
+		t.Fatalf("events = %#v, want 24", events)
 	}
 	wantTail := []string{
 		"keysym:65507:true",

--- a/remote_desktop_input_nocgo_test.go
+++ b/remote_desktop_input_nocgo_test.go
@@ -32,6 +32,9 @@ func TestNonCGOHighLevelPortalInput(t *testing.T) {
 	if err := ClickE("left"); err != nil {
 		t.Fatalf("ClickE error: %v", err)
 	}
+	if err := ClickImmediateE("left"); err != nil {
+		t.Fatalf("ClickImmediateE error: %v", err)
+	}
 	if err := ScrollE(0, 2, 7); err != nil {
 		t.Fatalf("ScrollE error: %v", err)
 	}
@@ -59,8 +62,8 @@ func TestNonCGOHighLevelPortalInput(t *testing.T) {
 	}
 	assertRemoteDesktopMouseDelays(t, *delays, []int{23, 23, 23, 30})
 	events, _ := session.snapshot()
-	if len(events) != 24 {
-		t.Fatalf("events = %#v, want 24", events)
+	if len(events) != 26 {
+		t.Fatalf("events = %#v, want 26", events)
 	}
 	wantTail := []string{
 		"keysym:65507:true",

--- a/robotgo.go
+++ b/robotgo.go
@@ -1752,8 +1752,9 @@ func getXDisplayNameLocked() string {
 // compatibility. Prefer CloseMainDisplayE in new code.
 func CloseMainDisplay() { _ = CloseMainDisplayE() }
 
-// CloseMainDisplayE releases RobotGo-owned native X11 keys and closes the
-// native main display.
+// CloseMainDisplayE releases RobotGo-owned native mouse holds and X11 keys,
+// then closes the native main display. Failed mouse releases remain owned so a
+// later call can retry them.
 func CloseMainDisplayE() error {
 	unlockMouse := lockLinuxMouse()
 	defer unlockMouse()
@@ -1912,6 +1913,20 @@ func clearPortalMouseGenerationLocked(generation uint64) {
 
 func releaseNativeMouseHoldsLocked(server DisplayServer) error {
 	var releaseErr error
+	if runtime.GOOS != "linux" {
+		for name, hold := range mouseHolds {
+			if hold.backend != persistentInputBackendNative {
+				continue
+			}
+			releaseErr = errors.Join(releaseErr, toggleTrackedNativeMouseHold(
+				mouseHolds,
+				name,
+				false,
+				func(down bool) error { return nativeTrackedMouseToggle(name, down) },
+			))
+		}
+		return releaseErr
+	}
 	if server == DisplayServerX11 {
 		releaseErr = nativeMouseStatusError(
 			C.robotgo_x11_release_owned_buttons(),
@@ -2008,11 +2023,11 @@ func tryPortalMouseUp(hold mouseHold) (bool, error) {
 }
 
 func lockLinuxMouse() func() {
-	if runtime.GOOS == "linux" {
-		waylandMouseMu.Lock()
-		return waylandMouseMu.Unlock
-	}
-	return func() {}
+	// This lock originated with the Wayland/X11 fallback transaction. Native
+	// macOS and Windows now use the same lock because their Go ownership ledger
+	// must also serialize package-level holds, clicks, and agent drags.
+	waylandMouseMu.Lock()
+	return waylandMouseMu.Unlock
 }
 
 func lockNativeMouseDisplay(server DisplayServer) func() {
@@ -2369,10 +2384,8 @@ func clickE(applyDelay bool, args ...interface{}) error {
 	unlockMouse := lockLinuxMouse()
 	defer unlockMouse()
 	name = canonicalMouseHoldName(name)
-	if runtime.GOOS == "linux" {
-		if _, held := mouseHolds[name]; held {
-			return ErrInputOwnership
-		}
+	if _, held := mouseHolds[name]; held {
+		return ErrInputOwnership
 	}
 	server := selectedDisplayServer()
 	button := CheckMouse(name)
@@ -2442,9 +2455,11 @@ func Toggle(key ...interface{}) error {
 	defer unlockMouse()
 	name = canonicalMouseHoldName(name)
 	if runtime.GOOS != "linux" {
-		if err := nativeMouseStatusError(
-			C.toggleMouse(C.bool(down), CheckMouse(name)),
-			"toggle mouse button",
+		if err := toggleTrackedNativeMouseHold(
+			mouseHolds,
+			name,
+			down,
+			func(down bool) error { return nativeTrackedMouseToggle(name, down) },
 		); err != nil {
 			return err
 		}
@@ -2512,6 +2527,45 @@ func Toggle(key ...interface{}) error {
 	}
 
 	return nil
+}
+
+func nativeTrackedMouseToggle(name string, down bool) error {
+	err := nativeMouseStatusError(
+		C.toggleMouse(C.bool(down), CheckMouse(name)),
+		"toggle mouse button",
+	)
+	if down && runtime.GOOS == "windows" && err != nil {
+		return errors.Join(ErrInputNotApplied, err)
+	}
+	return err
+}
+
+func toggleTrackedNativeMouseHold(
+	holds map[string]mouseHold,
+	name string,
+	down bool,
+	toggle func(bool) error,
+) error {
+	if down {
+		if _, held := holds[name]; held {
+			return ErrInputOwnership
+		}
+		if err := toggle(true); err != nil {
+			return err
+		}
+		holds[name] = mouseHold{backend: persistentInputBackendNative}
+		return nil
+	}
+
+	hold, held := holds[name]
+	if !held || hold.backend != persistentInputBackendNative {
+		return ErrInputOwnership
+	}
+	err := toggle(false)
+	if err == nil || errors.Is(err, ErrInputOwnership) {
+		delete(holds, name)
+	}
+	return err
 }
 
 // MouseDown send mouse down event

--- a/robotgo.go
+++ b/robotgo.go
@@ -2352,6 +2352,16 @@ func Click(args ...interface{}) {
 
 // ClickE clicks a mouse button and reports backend availability errors.
 func ClickE(args ...interface{}) error {
+	return clickE(true, args...)
+}
+
+// ClickImmediateE clicks without applying the configured post-click delay.
+// It is intended for callers that provide bounded scheduling.
+func ClickImmediateE(args ...interface{}) error {
+	return clickE(false, args...)
+}
+
+func clickE(applyDelay bool, args ...interface{}) error {
 	name, double, err := parseClickArguments(args)
 	if err != nil {
 		return err
@@ -2376,13 +2386,18 @@ func ClickE(args ...interface{}) error {
 		if shouldTryRemoteDesktopAfterNative(server, ready, nativeErr) {
 			used, err := tryRemoteDesktopClick(name, double)
 			if used {
-				return finishRemoteDesktopMouseEvent(err, 0)
+				if applyDelay {
+					return finishRemoteDesktopMouseEvent(err, 0)
+				}
+				return err
 			}
 		}
 		return nativeErr
 	}
 
-	MilliSleep(currentMouseDelay())
+	if applyDelay {
+		MilliSleep(currentMouseDelay())
+	}
 	return nil
 }
 

--- a/robotgo.go
+++ b/robotgo.go
@@ -2525,6 +2525,16 @@ func Scroll(x, y int, args ...int) {
 
 // ScrollE scrolls the mouse and reports backend availability errors.
 func ScrollE(x, y int, args ...int) error {
+	return scrollE(x, y, true, args...)
+}
+
+// ScrollImmediateE scrolls without applying a configured or per-call
+// post-event delay. It is intended for callers that provide bounded scheduling.
+func ScrollImmediateE(x, y int) error {
+	return scrollE(x, y, false)
+}
+
+func scrollE(x, y int, applyDelay bool, args ...int) error {
 	msDelay, validationErr := parseScrollDelay(args)
 	if validationErr != nil {
 		return validationErr
@@ -2540,12 +2550,17 @@ func ScrollE(x, y int, args ...int) error {
 		if shouldTryRemoteDesktopAfterNative(server, ready, nativeErr) {
 			used, err := tryRemoteDesktopScroll(x, y)
 			if used {
-				return finishRemoteDesktopMouseEvent(err, msDelay)
+				if applyDelay {
+					return finishRemoteDesktopMouseEvent(err, msDelay)
+				}
+				return err
 			}
 		}
 		return nativeErr
 	}
-	MilliSleep(currentMouseDelay() + msDelay)
+	if applyDelay {
+		MilliSleep(currentMouseDelay() + msDelay)
+	}
 	return nil
 }
 

--- a/robotgo.go
+++ b/robotgo.go
@@ -2596,7 +2596,7 @@ func clickTrackedNativeMouseHold(
 		if err := toggleTrackedNativeMouseHold(holds, name, false, toggle); err != nil {
 			// An ambiguous release remains in holds so an explicit Up or
 			// CloseMainDisplayE can retry it without touching foreign input.
-			return err
+			return errors.Join(ErrInputReleasePending, err)
 		}
 		if click+1 < clicks {
 			sleep(200 * time.Millisecond)

--- a/robotgo.go
+++ b/robotgo.go
@@ -2390,6 +2390,15 @@ func clickE(applyDelay bool, args ...interface{}) error {
 	server := selectedDisplayServer()
 	button := CheckMouse(name)
 	ready, nativeErr := runNativeMouseOperation(server, func() error {
+		if runtime.GOOS == "windows" {
+			return clickTrackedNativeMouseHold(
+				mouseHolds,
+				name,
+				double,
+				func(down bool) error { return nativeTrackedMouseToggle(name, down) },
+				time.Sleep,
+			)
+		}
 		if !double {
 			return nativeMouseStatusError(C.clickMouse(button), "click mouse button")
 		}
@@ -2566,6 +2575,34 @@ func toggleTrackedNativeMouseHold(
 		delete(holds, name)
 	}
 	return err
+}
+
+func clickTrackedNativeMouseHold(
+	holds map[string]mouseHold,
+	name string,
+	double bool,
+	toggle func(bool) error,
+	sleep func(time.Duration),
+) error {
+	clicks := 1
+	if double {
+		clicks = 2
+	}
+	for click := 0; click < clicks; click++ {
+		if err := toggleTrackedNativeMouseHold(holds, name, true, toggle); err != nil {
+			return err
+		}
+		sleep(5 * time.Millisecond)
+		if err := toggleTrackedNativeMouseHold(holds, name, false, toggle); err != nil {
+			// An ambiguous release remains in holds so an explicit Up or
+			// CloseMainDisplayE can retry it without touching foreign input.
+			return err
+		}
+		if click+1 < clicks {
+			sleep(200 * time.Millisecond)
+		}
+	}
+	return nil
 }
 
 // MouseDown send mouse down event

--- a/robotgo.go
+++ b/robotgo.go
@@ -2789,7 +2789,7 @@ func nativeGetMainTitle() string {
 }
 
 func nativeGetInternalTitle(pid int, isPid int) string {
-	return strictInternalGetTitle(pid, isPid != 0)
+	return internalGetTitle(pid, isPid)
 }
 
 // GetActive get the active window
@@ -3039,6 +3039,26 @@ func GetTitle(args ...int) string {
 // on Wayland sessions.
 func GetTitleE(args ...int) (string, error) {
 	return resolveWindowBackend().Title(args...)
+}
+
+// GetTitleTargetE gets the title of an explicit process or window handle.
+// Unlike GetTitleE, isHandle does not inherit the legacy TreatAsHandle setting.
+func GetTitleTargetE(target int, isHandle bool) (string, error) {
+	if target <= 0 {
+		return "", fmt.Errorf(
+			"%w: invalid window target %d",
+			errWindowTitleUnavailable,
+			target,
+		)
+	}
+	if err := nativeX11WindowReady(); err != nil {
+		return "", err
+	}
+	title := strictInternalGetTitle(target, isHandle)
+	if title == "" || title == "is_valid failed." {
+		return "", errWindowTitleUnavailable
+	}
+	return title, nil
 }
 
 // GetPid get the process id return int32

--- a/robotgo.go
+++ b/robotgo.go
@@ -2132,6 +2132,16 @@ func moveAbsoluteWithFallback(
 // MoveE moves the mouse to (x, y) and reports backend availability errors.
 // Prefer it over Move when the caller must know whether injection succeeded.
 func MoveE(x, y int, displayId ...int) error {
+	return moveE(x, y, true, displayId...)
+}
+
+// MoveImmediateE moves the mouse without applying the configured post-move
+// delay. It is intended for callers that provide their own bounded schedule.
+func MoveImmediateE(x, y int, displayId ...int) error {
+	return moveE(x, y, false, displayId...)
+}
+
+func moveE(x, y int, applyDelay bool, displayId ...int) error {
 	unlockMouse := lockLinuxMouse()
 	defer unlockMouse()
 	server := selectedDisplayServer()
@@ -2149,13 +2159,18 @@ func MoveE(x, y int, displayId ...int) error {
 		tryRemoteDesktopMoveAbsolute,
 	)
 	if usedPortal {
-		return finishRemoteDesktopMouseEvent(err, 0)
+		if applyDelay {
+			return finishRemoteDesktopMouseEvent(err, 0)
+		}
+		return err
 	}
 	if err != nil {
 		return err
 	}
 
-	MilliSleep(currentMouseDelay())
+	if applyDelay {
+		MilliSleep(currentMouseDelay())
+	}
 	return nil
 }
 
@@ -2774,7 +2789,7 @@ func nativeGetMainTitle() string {
 }
 
 func nativeGetInternalTitle(pid int, isPid int) string {
-	return internalGetTitle(pid, isPid)
+	return strictInternalGetTitle(pid, isPid != 0)
 }
 
 // GetActive get the active window

--- a/robotgo_linux.go
+++ b/robotgo_linux.go
@@ -126,24 +126,15 @@ func nativeX11WindowGeometryE(
 	return rect.X, rect.Y, rect.W, rect.H, nil
 }
 
-// internalGetTitle get the window title
-func internalGetTitle(pid int, args ...int) string {
-	if !nativeX11BackendCompiled() {
-		return ""
+func strictInternalGetTitle(target int, isHandle bool) string {
+	if isHandle {
+		return cgetTitle(target, 1)
 	}
-	var isPid int
-	if len(args) > 0 || currentTreatAsHandle() {
-		isPid = 1
-		return cgetTitle(pid, isPid)
-	}
-
-	xid, err := GetXid(nil, pid)
+	xid, err := GetXid(nil, target)
 	if err != nil {
-		log.Println("Get Xid from Pid errors is: ", err)
 		return ""
 	}
-
-	return cgetTitle(int(xid), isPid)
+	return cgetTitle(int(xid), 1)
 }
 
 // ActivePidC active the window by Pid,
@@ -227,7 +218,7 @@ func ResolveWindowHandleE(target int, args ...int) (int, error) {
 	if base.DetectDisplayServer() == base.Wayland {
 		return 0, waylandWindowNotSupported("resolve an exact window handle")
 	}
-	isHandle := len(args) > 0 || currentTreatAsHandle()
+	isHandle := len(args) > 0
 	handle := target
 	if !isHandle {
 		xid, err := GetXid(nil, target)

--- a/robotgo_linux.go
+++ b/robotgo_linux.go
@@ -218,6 +218,30 @@ func ActivePid(pid int, args ...int) error {
 	return nil
 }
 
+// ResolveWindowHandleE resolves a process ID to one validated X11 window
+// handle, or validates the supplied handle when args is non-empty.
+func ResolveWindowHandleE(target int, args ...int) (int, error) {
+	if target <= 0 {
+		return 0, fmt.Errorf("%w: invalid window target %d", errWindowIdentityUnavailable, target)
+	}
+	if base.DetectDisplayServer() == base.Wayland {
+		return 0, waylandWindowNotSupported("resolve an exact window handle")
+	}
+	isHandle := len(args) > 0 || currentTreatAsHandle()
+	handle := target
+	if !isHandle {
+		xid, err := GetXid(nil, target)
+		if err != nil {
+			return 0, fmt.Errorf("%w: %w", errWindowIdentityUnavailable, err)
+		}
+		handle = int(xid)
+	}
+	if _, err := GetTitleE(handle, 1); err != nil {
+		return 0, err
+	}
+	return handle, nil
+}
+
 // GetXid get the xid return window and error
 func GetXid(xu *xgbutil.XUtil, pid int) (xproto.Window, error) {
 	owned := false

--- a/robotgo_linux.go
+++ b/robotgo_linux.go
@@ -126,15 +126,43 @@ func nativeX11WindowGeometryE(
 	return rect.X, rect.Y, rect.W, rect.H, nil
 }
 
+// internalGetTitle preserves the historical variadic and TreatAsHandle
+// interpretation used by GetTitleE.
+func internalGetTitle(pid int, args ...int) string {
+	if !nativeX11BackendCompiled() {
+		return ""
+	}
+	var isPid int
+	if len(args) > 0 || currentTreatAsHandle() {
+		isPid = 1
+		return cgetTitle(pid, isPid)
+	}
+
+	xid, err := GetXid(nil, pid)
+	if err != nil {
+		log.Println("Get Xid from Pid errors is: ", err)
+		return ""
+	}
+
+	return cgetTitle(int(xid), isPid)
+}
+
 func strictInternalGetTitle(target int, isHandle bool) string {
 	if isHandle {
 		return cgetTitle(target, 1)
 	}
-	xid, err := GetXid(nil, target)
+	unlock := lockNativeX11Display()
+	defer unlock()
+	xu, err := xgbutil.NewConnDisplay(getXDisplayNameLocked())
 	if err != nil {
 		return ""
 	}
-	return cgetTitle(int(xid), 1)
+	defer xu.Conn().Close()
+	xid, err := GetXidFromPid(xu, target)
+	if err != nil {
+		return ""
+	}
+	return cgetTitleLocked(int(xid), 1)
 }
 
 // ActivePidC active the window by Pid,

--- a/robotgo_linux_x11.go
+++ b/robotgo_linux_x11.go
@@ -116,15 +116,46 @@ func checkedNativeWindowGeometry(x, y, width, height int) (int, int, int, int, e
 	return rect.X, rect.Y, rect.W, rect.H, nil
 }
 
+// internalGetTitle preserves the historical variadic and TreatAsHandle
+// interpretation used by GetTitleE.
+func internalGetTitle(pid int, args ...int) string {
+	var isPid int
+	if len(args) > 0 || currentTreatAsHandle() {
+		isPid = 1
+		return cgetTitle(pid, isPid)
+	}
+	unlock := lockNativeX11Display()
+	defer unlock()
+	xu, err := newX11XUtilForDisplay(getXDisplayNameLocked())
+	if err != nil {
+		log.Println("Open configured X11 target errors is: ", err)
+		return ""
+	}
+	defer xu.Conn().Close()
+	xid, err := GetXidFromPid(xu, pid)
+	if err != nil {
+		log.Println("Get Xid from Pid errors is: ", err)
+		return ""
+	}
+	return cgetTitleLocked(int(xid), isPid)
+}
+
 func strictInternalGetTitle(target int, isHandle bool) string {
 	if isHandle {
 		return cgetTitle(target, 1)
 	}
-	xid, err := GetXid(nil, target)
+	unlock := lockNativeX11Display()
+	defer unlock()
+	xu, err := newX11XUtilForDisplay(getXDisplayNameLocked())
 	if err != nil {
 		return ""
 	}
-	return cgetTitle(int(xid), 1)
+	defer xu.Conn().Close()
+	xid, err := GetXidFromPid(xu, target)
+	if err != nil {
+		return ""
+	}
+	return cgetTitleLocked(int(xid), 1)
 }
 
 // ActivePidC activates the window by PID via X11.

--- a/robotgo_linux_x11.go
+++ b/robotgo_linux_x11.go
@@ -116,27 +116,15 @@ func checkedNativeWindowGeometry(x, y, width, height int) (int, int, int, int, e
 	return rect.X, rect.Y, rect.W, rect.H, nil
 }
 
-// internalGetTitle gets the window title using X11.
-func internalGetTitle(pid int, args ...int) string {
-	var isPid int
-	if len(args) > 0 || currentTreatAsHandle() {
-		isPid = 1
-		return cgetTitle(pid, isPid)
+func strictInternalGetTitle(target int, isHandle bool) string {
+	if isHandle {
+		return cgetTitle(target, 1)
 	}
-	unlock := lockNativeX11Display()
-	defer unlock()
-	xu, err := newX11XUtilForDisplay(getXDisplayNameLocked())
+	xid, err := GetXid(nil, target)
 	if err != nil {
-		log.Println("Open configured X11 target errors is: ", err)
 		return ""
 	}
-	defer xu.Conn().Close()
-	xid, err := GetXidFromPid(xu, pid)
-	if err != nil {
-		log.Println("Get Xid from Pid errors is: ", err)
-		return ""
-	}
-	return cgetTitleLocked(int(xid), isPid)
+	return cgetTitle(int(xid), 1)
 }
 
 // ActivePidC activates the window by PID via X11.
@@ -197,7 +185,7 @@ func ResolveWindowHandleE(target int, args ...int) (int, error) {
 	if target <= 0 {
 		return 0, fmt.Errorf("%w: invalid window target %d", errWindowIdentityUnavailable, target)
 	}
-	isHandle := len(args) > 0 || currentTreatAsHandle()
+	isHandle := len(args) > 0
 	handle := target
 	if !isHandle {
 		xid, err := GetXid(nil, target)

--- a/robotgo_linux_x11.go
+++ b/robotgo_linux_x11.go
@@ -191,6 +191,27 @@ func ActivePid(pid int, args ...int) error {
 	return nil
 }
 
+// ResolveWindowHandleE resolves a process ID to one validated X11 window
+// handle, or validates the supplied handle when args is non-empty.
+func ResolveWindowHandleE(target int, args ...int) (int, error) {
+	if target <= 0 {
+		return 0, fmt.Errorf("%w: invalid window target %d", errWindowIdentityUnavailable, target)
+	}
+	isHandle := len(args) > 0 || currentTreatAsHandle()
+	handle := target
+	if !isHandle {
+		xid, err := GetXid(nil, target)
+		if err != nil {
+			return 0, fmt.Errorf("%w: %w", errWindowIdentityUnavailable, err)
+		}
+		handle = int(xid)
+	}
+	if _, err := GetTitleE(handle, 1); err != nil {
+		return 0, err
+	}
+	return handle, nil
+}
+
 // GetXid gets the XID for a given PID.
 func GetXid(xu *xgbutil.XUtil, pid int) (xproto.Window, error) {
 	owned := false

--- a/robotgo_mac_win.go
+++ b/robotgo_mac_win.go
@@ -22,6 +22,7 @@ import "C"
 
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -99,6 +100,35 @@ func ActivePid(pid int, args ...int) error {
 		return fmt.Errorf("%w: native backend could not activate target window", errWindowOperationFailed)
 	}
 	return nil
+}
+
+// ResolveWindowHandleE resolves a process ID to one validated native window
+// handle, or validates the supplied handle when args is non-empty.
+func ResolveWindowHandleE(target int, args ...int) (int, error) {
+	if target <= 0 {
+		return 0, fmt.Errorf("%w: invalid window target %d", errWindowIdentityUnavailable, target)
+	}
+	if runtime.GOOS == "darwin" {
+		return 0, fmt.Errorf(
+			"%w: native macOS CGO cannot expose one serializable exact window reference",
+			ErrNotSupported,
+		)
+	}
+	handle := target
+	if len(args) == 0 && !currentTreatAsHandle() {
+		handle = GetHWNDByPid(target)
+		if handle <= 0 {
+			return 0, fmt.Errorf(
+				"%w: no native window matched process %d",
+				errWindowIdentityUnavailable,
+				target,
+			)
+		}
+	}
+	if _, err := GetTitleE(handle, 1); err != nil {
+		return 0, err
+	}
+	return handle, nil
 }
 
 // DisplaysNum get the count of displays

--- a/robotgo_mac_win.go
+++ b/robotgo_mac_win.go
@@ -20,7 +20,10 @@ package robotgo
 */
 import "C"
 
-import "unsafe"
+import (
+	"fmt"
+	"unsafe"
+)
 
 // GetBounds get the window bounds
 func GetBounds(pid int, args ...int) (int, int, int, int) {
@@ -92,7 +95,9 @@ func ActivePid(pid int, args ...int) error {
 		isPid = 1
 	}
 
-	internalActive(pid, isPid)
+	if !internalActive(pid, isPid) {
+		return fmt.Errorf("%w: native backend could not activate target window", errWindowOperationFailed)
+	}
 	return nil
 }
 

--- a/robotgo_mac_win.go
+++ b/robotgo_mac_win.go
@@ -71,6 +71,16 @@ func checkedPlatformWindowGeometry(x, y, width, height int) (int, int, int, int,
 	return rect.X, rect.Y, rect.W, rect.H, nil
 }
 
+// internalGetTitle preserves the historical variadic and TreatAsHandle
+// interpretation used by GetTitleE.
+func internalGetTitle(pid int, args ...int) string {
+	var isPid int
+	if len(args) > 0 || currentTreatAsHandle() {
+		isPid = 1
+	}
+	return cgetTitle(pid, isPid)
+}
+
 func strictInternalGetTitle(target int, isHandle bool) string {
 	flag := 0
 	if isHandle {

--- a/robotgo_mac_win.go
+++ b/robotgo_mac_win.go
@@ -71,15 +71,12 @@ func checkedPlatformWindowGeometry(x, y, width, height int) (int, int, int, int,
 	return rect.X, rect.Y, rect.W, rect.H, nil
 }
 
-// internalGetTitle get the window title
-func internalGetTitle(pid int, args ...int) string {
-	var isPid int
-	if len(args) > 0 || currentTreatAsHandle() {
-		isPid = 1
+func strictInternalGetTitle(target int, isHandle bool) string {
+	flag := 0
+	if isHandle {
+		flag = 1
 	}
-	gtitle := cgetTitle(pid, isPid)
-
-	return gtitle
+	return cgetTitle(target, flag)
 }
 
 // ActivePid active the window by PID,
@@ -115,7 +112,7 @@ func ResolveWindowHandleE(target int, args ...int) (int, error) {
 		)
 	}
 	handle := target
-	if len(args) == 0 && !currentTreatAsHandle() {
+	if len(args) == 0 {
 		handle = GetHWNDByPid(target)
 		if handle <= 0 {
 			return 0, fmt.Errorf(

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -808,6 +808,16 @@ func Toggle(args ...interface{}) error {
 }
 func Scroll(x, y int, args ...int) { _ = ScrollE(x, y, args...) }
 func ScrollE(x, y int, args ...int) error {
+	return scrollE(x, y, true, args...)
+}
+
+// ScrollImmediateE scrolls without applying a configured or per-call
+// post-event delay. It is intended for callers that provide bounded scheduling.
+func ScrollImmediateE(x, y int) error {
+	return scrollE(x, y, false)
+}
+
+func scrollE(x, y int, applyDelay bool, args ...int) error {
 	msDelay, validationErr := parseScrollDelay(args)
 	if validationErr != nil {
 		return validationErr
@@ -816,13 +826,19 @@ func ScrollE(x, y int, args ...int) error {
 		return backend.Scroll(x, y)
 	})
 	if used {
-		return finishNonCGOMouseEvent(err, msDelay)
+		if applyDelay {
+			return finishNonCGOMouseEvent(err, msDelay)
+		}
+		return err
 	}
 	used, err = tryRemoteDesktopScroll(x, y)
 	if !used {
 		return ErrNotSupported
 	}
-	return finishRemoteDesktopMouseEvent(err, msDelay)
+	if applyDelay {
+		return finishRemoteDesktopMouseEvent(err, msDelay)
+	}
+	return err
 }
 func ScrollDir(amount int, direction ...interface{}) {
 	name, err := parseScrollDirection(direction)

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -404,7 +404,7 @@ func SetActiveE(handle Handle) error {
 func ResolveWindowHandleE(target int, args ...int) (int, error) {
 	handle, err := pureGoWindowResolve(
 		target,
-		len(args) > 0 || currentTreatAsHandle(),
+		len(args) > 0,
 	)
 	if err != nil {
 		return 0, err
@@ -665,17 +665,33 @@ func CharCodeAt(s string, n int) rune {
 
 func Move(x, y int, displayID ...int) { _ = MoveE(x, y, displayID...) }
 func MoveE(x, y int, displayID ...int) error {
+	return moveE(x, y, true, displayID...)
+}
+
+// MoveImmediateE moves the mouse without applying the configured post-move
+// delay. It is intended for callers that provide their own bounded schedule.
+func MoveImmediateE(x, y int, displayID ...int) error {
+	return moveE(x, y, false, displayID...)
+}
+
+func moveE(x, y int, applyDelay bool, displayID ...int) error {
 	used, err := withPureGoInputBackend(func(backend pureGoInputBackend) error {
 		return backend.MoveAbsolute(x, y, append([]int(nil), displayID...))
 	})
 	if used {
-		return finishNonCGOMouseEvent(err, 0)
+		if applyDelay {
+			return finishNonCGOMouseEvent(err, 0)
+		}
+		return err
 	}
 	used, err = tryRemoteDesktopMoveAbsolute(x, y, displayID)
 	if !used {
 		return ErrNotSupported
 	}
-	return finishRemoteDesktopMouseEvent(err, 0)
+	if applyDelay {
+		return finishRemoteDesktopMouseEvent(err, 0)
+	}
+	return err
 }
 func MoveRelative(x, y int) { _ = MoveRelativeE(x, y) }
 func MoveRelativeE(x, y int) error {

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -512,6 +512,16 @@ func KeyTap(key string, args ...interface{}) error {
 // KeyToggle changes a key state through the selected Pure-Go platform backend
 // or an authorized RemoteDesktop session.
 func KeyToggle(key string, args ...interface{}) error {
+	return keyToggle(key, true, args...)
+}
+
+// KeyToggleImmediate changes key state without applying the configured
+// post-event delay. It is intended for callers that own a bounded hold.
+func KeyToggleImmediate(key string, args ...interface{}) error {
+	return keyToggle(key, false, args...)
+}
+
+func keyToggle(key string, applyDelay bool, args ...interface{}) error {
 	pid, down, modifiers, err := parseKeyArguments(args, true)
 	if err != nil {
 		return err
@@ -536,7 +546,7 @@ func KeyToggle(key string, args ...interface{}) error {
 		})
 	})
 	if used {
-		if err == nil {
+		if err == nil && applyDelay {
 			MilliSleep(currentKeyDelay())
 		}
 		return err
@@ -554,7 +564,7 @@ func KeyToggle(key string, args ...interface{}) error {
 	if !used {
 		return ErrNotSupported
 	}
-	if err == nil {
+	if err == nil && applyDelay {
 		MilliSleep(currentKeyDelay())
 	}
 	return err

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -398,6 +398,26 @@ func SetActiveE(handle Handle) error {
 	}
 	return backend.Activate(windowbackend.Handle(handle))
 }
+
+// ResolveWindowHandleE resolves a process ID to one validated Pure-Go window
+// handle, or validates the supplied handle when args is non-empty.
+func ResolveWindowHandleE(target int, args ...int) (int, error) {
+	handle, err := pureGoWindowResolve(
+		target,
+		len(args) > 0 || currentTreatAsHandle(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return 0, err
+	}
+	if _, err := backend.Title(handle); err != nil {
+		return 0, err
+	}
+	return int(handle), nil
+}
 func ActivePid(target int, args ...int) error {
 	backend, err := pureGoWindowBackend()
 	if err != nil {

--- a/robotgo_nocgo.go
+++ b/robotgo_nocgo.go
@@ -616,6 +616,16 @@ func UnicodeTypeE(value uint32, args ...int) error {
 }
 func TypeStr(text string, args ...int) { _ = TypeStrE(text, args...) }
 func TypeStrE(text string, args ...int) error {
+	return typeStrE(text, args...)
+}
+
+// TypeStrImmediateE sends a UTF-8 string without applying a configured
+// post-input delay. Pure-Go text injection is already delay-explicit.
+func TypeStrImmediateE(text string, args ...int) error {
+	return typeStrE(text, args...)
+}
+
+func typeStrE(text string, args ...int) error {
 	pid, delay, validationErr := parseTextInput(text, args)
 	if validationErr != nil {
 		return validationErr
@@ -760,6 +770,16 @@ func DragSmooth(x, y int, args ...interface{}) {
 }
 func Click(args ...interface{}) { _ = ClickE(args...) }
 func ClickE(args ...interface{}) error {
+	return clickE(true, args...)
+}
+
+// ClickImmediateE clicks without applying the configured post-click delay.
+// It is intended for callers that provide bounded scheduling.
+func ClickImmediateE(args ...interface{}) error {
+	return clickE(false, args...)
+}
+
+func clickE(applyDelay bool, args ...interface{}) error {
 	name, double, err := parseClickArguments(args)
 	if err != nil {
 		return err
@@ -768,13 +788,19 @@ func ClickE(args ...interface{}) error {
 		return backend.Click(name, double)
 	})
 	if used {
-		return finishNonCGOMouseEvent(err, 0)
+		if applyDelay {
+			return finishNonCGOMouseEvent(err, 0)
+		}
+		return err
 	}
 	used, err = tryRemoteDesktopClick(name, double)
 	if !used {
 		return ErrNotSupported
 	}
-	return finishRemoteDesktopMouseEvent(err, 0)
+	if applyDelay {
+		return finishRemoteDesktopMouseEvent(err, 0)
+	}
+	return err
 }
 
 func tryRemoteDesktopToggle(name string, down bool) (bool, error) {

--- a/robotgo_nocgo_parity.go
+++ b/robotgo_nocgo_parity.go
@@ -124,10 +124,25 @@ func getLocationColorWith(
 
 func GetMousePos() (int, int)               { return Location() }
 func GetTitleE(args ...int) (string, error) { return pureGoWindowTitle(args...) }
-func GetXDisplayName() string               { return "" }
-func SetXDisplayName(string) error          { return ErrNotSupported }
-func Is64Bit() bool                         { return strconv.IntSize == 64 }
-func IsMain(displayID int) bool             { return displayID == GetMainId() }
+
+// GetTitleTargetE gets the title of an explicit process or window handle.
+// Unlike GetTitleE, isHandle does not inherit the legacy TreatAsHandle setting.
+func GetTitleTargetE(target int, isHandle bool) (string, error) {
+	handle, err := pureGoWindowResolve(target, isHandle)
+	if err != nil {
+		return "", err
+	}
+	backend, err := pureGoWindowBackend()
+	if err != nil {
+		return "", err
+	}
+	return backend.Title(handle)
+}
+
+func GetXDisplayName() string      { return "" }
+func SetXDisplayName(string) error { return ErrNotSupported }
+func Is64Bit() bool                { return strconv.IntSize == 64 }
+func IsMain(displayID int) bool    { return displayID == GetMainId() }
 func IsValid() bool {
 	_, err := pureGoWindowActive()
 	return err == nil

--- a/windows_native_key_integration_test.go
+++ b/windows_native_key_integration_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -27,169 +26,24 @@ type nativeWindowsKeyMessage struct {
 	key     uintptr
 }
 
-func TestNativeWindowsTargetedExtendedKeyDispatch(t *testing.T) {
-	messages, stop := startNativeWindowsKeyTarget(t)
-	pid := os.Getpid()
-
-	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); !errors.Is(err, ErrInputOwnership) {
-		t.Fatalf("orphan extended key up error = %v", err)
-	}
-	assertNoNativeWindowsKeyMessage(t, messages)
-
-	if err := KeyToggleImmediate("delete", "down", "ctrl", pid); err != nil {
-		t.Fatalf("extended key down: %v", err)
-	}
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x11)
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x2e)
-
-	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); err != nil {
-		t.Fatalf("extended key up: %v", err)
-	}
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x2e)
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x11)
-
-	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); !errors.Is(err, ErrInputOwnership) {
-		t.Fatalf("duplicate extended key up error = %v", err)
-	}
-	assertNoNativeWindowsKeyMessage(t, messages)
-
-	stop()
-	err := KeyToggleImmediate("delete", "down", pid)
-	if !errors.Is(err, ErrInputNotApplied) ||
-		!strings.Contains(err.Error(), "native keyboard injection failed") {
-		t.Fatalf("missing target key down error = %v", err)
-	}
-	if err := KeyToggleImmediate("delete", "up", pid); !errors.Is(err, ErrInputOwnership) {
-		t.Fatalf("failed key-down retained ownership: %v", err)
-	}
-}
-
-func TestNativeWindowsSharedModifierOwnership(t *testing.T) {
+func TestNativeWindowsProcessTargetedKeyInputFailsClosed(t *testing.T) {
 	messages, _ := startNativeWindowsKeyTarget(t)
 	pid := os.Getpid()
 
-	if err := KeyToggleImmediate("c", "down", "ctrl", pid); err != nil {
-		t.Fatalf("Ctrl+C down: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = KeyToggleImmediate("c", "up", "ctrl", pid)
-	})
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x11)
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 'C')
-
-	if err := KeyToggleImmediate("v", "down", "ctrl", pid); err != nil {
-		t.Fatalf("Ctrl+V down: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = KeyToggleImmediate("v", "up", "ctrl", pid)
-	})
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 'V')
-	assertNoNativeWindowsKeyMessage(t, messages)
-
-	if err := KeyToggleImmediate("c", "up", "ctrl", pid); err != nil {
-		t.Fatalf("Ctrl+C up: %v", err)
-	}
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 'C')
-	assertNoNativeWindowsKeyMessage(t, messages)
-
-	if err := KeyToggleImmediate("v", "up", "ctrl", pid); err != nil {
-		t.Fatalf("Ctrl+V up: %v", err)
-	}
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 'V')
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x11)
-}
-
-func TestNativeWindowsTapPreservesSharedModifierHold(t *testing.T) {
-	messages, _ := startNativeWindowsKeyTarget(t)
-	pid := os.Getpid()
-
-	if err := KeyToggleImmediate("c", "down", "ctrl", pid); err != nil {
-		t.Fatalf("Ctrl+C down: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = KeyToggleImmediate("c", "up", "ctrl", pid)
-	})
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x11)
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 'C')
-
-	if err := KeyTap("c", "ctrl", pid); !errors.Is(err, ErrInputOwnership) {
-		t.Fatalf("tap exact held chord error = %v", err)
+	if err := KeyToggleImmediate("delete", "down", "ctrl", pid); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("process-targeted extended key down error = %v", err)
 	}
 	assertNoNativeWindowsKeyMessage(t, messages)
 
-	if err := KeyTap("c", "alt", pid); !errors.Is(err, ErrInputOwnership) {
-		t.Fatalf("tap held physical main key error = %v", err)
+	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("process-targeted extended key up error = %v", err)
 	}
 	assertNoNativeWindowsKeyMessage(t, messages)
 
-	if err := KeyTap("v", "ctrl", pid); err != nil {
-		t.Fatalf("tap Ctrl+V while Ctrl+C is held: %v", err)
+	if err := KeyTap("v", "ctrl", pid); !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("process-targeted key tap error = %v", err)
 	}
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 'V')
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 'V')
 	assertNoNativeWindowsKeyMessage(t, messages)
-
-	if err := KeyToggleImmediate("c", "up", "ctrl", pid); err != nil {
-		t.Fatalf("Ctrl+C up: %v", err)
-	}
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 'C')
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x11)
-}
-
-func TestNativeWindowsOwnershipIsScopedToResolvedTarget(t *testing.T) {
-	messages, stop := startNativeWindowsKeyTarget(t)
-	pid := os.Getpid()
-
-	if err := KeyToggleImmediate("delete", "down", "ctrl", pid); err != nil {
-		t.Fatalf("extended key down: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = KeyToggleImmediate("delete", "up", "ctrl", pid)
-	})
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x11)
-	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x2e)
-	stop()
-
-	replacementMessages, _ := startNativeWindowsKeyTarget(t)
-	if err := KeyTap("v", "ctrl", pid); err != nil {
-		t.Fatalf("tap against replacement target: %v", err)
-	}
-	assertNativeWindowsKeyMessage(t, replacementMessages, win.WM_KEYDOWN, 0x11)
-	assertNativeWindowsKeyMessage(t, replacementMessages, win.WM_KEYDOWN, 'V')
-	assertNativeWindowsKeyMessage(t, replacementMessages, win.WM_KEYUP, 'V')
-	assertNativeWindowsKeyMessage(t, replacementMessages, win.WM_KEYUP, 0x11)
-
-	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); err != nil {
-		t.Fatalf("release ownership for destroyed original target: %v", err)
-	}
-	assertNoNativeWindowsKeyMessage(t, replacementMessages)
-	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); !errors.Is(err, ErrInputOwnership) {
-		t.Fatalf("duplicate release after target cleanup error = %v", err)
-	}
-	assertNoNativeWindowsKeyMessage(t, replacementMessages)
-}
-
-func assertNativeWindowsKeyMessage(
-	t *testing.T,
-	messages <-chan nativeWindowsKeyMessage,
-	wantMessage uint32,
-	wantKey uintptr,
-) {
-	t.Helper()
-	select {
-	case message := <-messages:
-		if message.message != wantMessage || message.key != wantKey {
-			t.Fatalf(
-				"targeted key message = {message:%#x key:%#x}, want {message:%#x key:%#x}",
-				message.message,
-				message.key,
-				wantMessage,
-				wantKey,
-			)
-		}
-	case <-time.After(nativeWindowsKeyMessageTimeout):
-		t.Fatalf("timed out waiting for targeted key message %#x", wantMessage)
-	}
 }
 
 func assertNoNativeWindowsKeyMessage(

--- a/windows_native_key_integration_test.go
+++ b/windows_native_key_integration_test.go
@@ -117,6 +117,11 @@ func TestNativeWindowsTapPreservesSharedModifierHold(t *testing.T) {
 	}
 	assertNoNativeWindowsKeyMessage(t, messages)
 
+	if err := KeyTap("c", "alt", pid); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("tap held physical main key error = %v", err)
+	}
+	assertNoNativeWindowsKeyMessage(t, messages)
+
 	if err := KeyTap("v", "ctrl", pid); err != nil {
 		t.Fatalf("tap Ctrl+V while Ctrl+C is held: %v", err)
 	}

--- a/windows_native_key_integration_test.go
+++ b/windows_native_key_integration_test.go
@@ -1,0 +1,213 @@
+//go:build windows && cgo
+
+package robotgo
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/tailscale/win"
+)
+
+const nativeWindowsKeyMessageTimeout = 3 * time.Second
+
+type nativeWindowsKeyMessage struct {
+	message uint32
+	key     uintptr
+}
+
+func TestNativeWindowsTargetedExtendedKeyDispatch(t *testing.T) {
+	messages, stop := startNativeWindowsKeyTarget(t)
+	pid := os.Getpid()
+
+	if err := KeyToggleImmediate("delete", "down", "ctrl", pid); err != nil {
+		t.Fatalf("extended key down: %v", err)
+	}
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x11)
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x2e)
+
+	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); err != nil {
+		t.Fatalf("extended key up: %v", err)
+	}
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x2e)
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x11)
+
+	stop()
+	err := KeyToggleImmediate("delete", "down", pid)
+	if err == nil || !strings.Contains(err.Error(), "native keyboard injection failed") {
+		t.Fatalf("missing target key down error = %v", err)
+	}
+}
+
+func assertNativeWindowsKeyMessage(
+	t *testing.T,
+	messages <-chan nativeWindowsKeyMessage,
+	wantMessage uint32,
+	wantKey uintptr,
+) {
+	t.Helper()
+	select {
+	case message := <-messages:
+		if message.message != wantMessage || message.key != wantKey {
+			t.Fatalf(
+				"targeted key message = {message:%#x key:%#x}, want {message:%#x key:%#x}",
+				message.message,
+				message.key,
+				wantMessage,
+				wantKey,
+			)
+		}
+	case <-time.After(nativeWindowsKeyMessageTimeout):
+		t.Fatalf("timed out waiting for targeted key message %#x", wantMessage)
+	}
+}
+
+func startNativeWindowsKeyTarget(t *testing.T) (<-chan nativeWindowsKeyMessage, func()) {
+	t.Helper()
+	type createdWindow struct {
+		handle win.HWND
+	}
+	created := make(chan createdWindow, 1)
+	failed := make(chan error, 1)
+	stopped := make(chan error, 1)
+	messages := make(chan nativeWindowsKeyMessage, 4)
+
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		var stopErr error
+		defer func() {
+			stopped <- stopErr
+			close(stopped)
+		}()
+
+		instance := win.GetModuleHandle(nil)
+		className, err := syscall.UTF16PtrFromString(
+			fmt.Sprintf("RobotGoNativeKeyTarget%d", os.Getpid()),
+		)
+		if err != nil {
+			failed <- err
+			return
+		}
+		windowProc := syscall.NewCallback(func(
+			handle uintptr,
+			message uint32,
+			wParam, lParam uintptr,
+		) uintptr {
+			switch message {
+			case win.WM_KEYDOWN, win.WM_KEYUP:
+				messages <- nativeWindowsKeyMessage{message: message, key: wParam}
+				return 0
+			case win.WM_DESTROY:
+				win.PostQuitMessage(0)
+				return 0
+			}
+			return win.DefWindowProc(win.HWND(handle), message, wParam, lParam)
+		})
+		class := win.WNDCLASSEX{
+			CbSize:        uint32(unsafe.Sizeof(win.WNDCLASSEX{})),
+			LpfnWndProc:   windowProc,
+			HInstance:     instance,
+			LpszClassName: className,
+		}
+		if atom := win.RegisterClassEx(&class); atom == 0 {
+			failed <- nativeWindowsCallError("RegisterClassEx")
+			return
+		}
+		defer func() {
+			unregistered, _, callErr := syscall.NewLazyDLL("user32.dll").
+				NewProc("UnregisterClassW").
+				Call(uintptr(unsafe.Pointer(className)), uintptr(instance))
+			runtime.KeepAlive(className)
+			if unregistered == 0 {
+				stopErr = errors.Join(
+					stopErr,
+					nativeWindowsCallResultError("UnregisterClassW", callErr),
+				)
+			}
+		}()
+
+		title, err := syscall.UTF16PtrFromString("RobotGo native key target")
+		if err != nil {
+			failed <- err
+			return
+		}
+		handle := win.CreateWindowEx(
+			0,
+			className,
+			title,
+			win.WS_OVERLAPPED,
+			0, 0, 100, 100,
+			0, 0, instance, nil,
+		)
+		if handle == 0 {
+			failed <- nativeWindowsCallError("CreateWindowEx")
+			return
+		}
+		created <- createdWindow{handle: handle}
+
+		var message win.MSG
+		for {
+			result := win.GetMessage(&message, 0, 0, 0)
+			if result == 0 {
+				break
+			}
+			if int32(result) == -1 {
+				stopErr = nativeWindowsCallError("GetMessage")
+				return
+			}
+			win.TranslateMessage(&message)
+			win.DispatchMessage(&message)
+		}
+		runtime.KeepAlive(windowProc)
+	}()
+
+	var window createdWindow
+	select {
+	case window = <-created:
+	case err := <-failed:
+		t.Fatalf("create native Windows key target: %v", err)
+	case <-time.After(nativeWindowsKeyMessageTimeout):
+		t.Fatal("timed out creating native Windows key target")
+	}
+
+	var stopOnce sync.Once
+	stop := func() {
+		t.Helper()
+		stopOnce.Do(func() {
+			if posted := win.PostMessage(window.handle, win.WM_CLOSE, 0, 0); posted == 0 {
+				t.Errorf("close native Windows key target: %v", nativeWindowsCallError("PostMessage"))
+				return
+			}
+			select {
+			case stopErr := <-stopped:
+				if stopErr != nil {
+					t.Errorf("stop native Windows key target: %v", stopErr)
+				}
+			case <-time.After(nativeWindowsKeyMessageTimeout):
+				t.Error("timed out stopping native Windows key target")
+			}
+		})
+	}
+	t.Cleanup(stop)
+	return messages, stop
+}
+
+func nativeWindowsCallError(operation string) error {
+	return nativeWindowsCallResultError(operation, syscall.GetLastError())
+}
+
+func nativeWindowsCallResultError(operation string, callErr error) error {
+	if callErr == nil || callErr == syscall.Errno(0) {
+		return fmt.Errorf("%s failed without Win32 error information", operation)
+	}
+	return fmt.Errorf("%s failed: %w", operation, callErr)
+}

--- a/windows_native_key_integration_test.go
+++ b/windows_native_key_integration_test.go
@@ -28,6 +28,11 @@ func TestNativeWindowsTargetedExtendedKeyDispatch(t *testing.T) {
 	messages, stop := startNativeWindowsKeyTarget(t)
 	pid := os.Getpid()
 
+	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("orphan extended key up error = %v", err)
+	}
+	assertNoNativeWindowsKeyMessage(t, messages)
+
 	if err := KeyToggleImmediate("delete", "down", "ctrl", pid); err != nil {
 		t.Fatalf("extended key down: %v", err)
 	}
@@ -40,10 +45,19 @@ func TestNativeWindowsTargetedExtendedKeyDispatch(t *testing.T) {
 	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x2e)
 	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x11)
 
+	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("duplicate extended key up error = %v", err)
+	}
+	assertNoNativeWindowsKeyMessage(t, messages)
+
 	stop()
 	err := KeyToggleImmediate("delete", "down", pid)
-	if err == nil || !strings.Contains(err.Error(), "native keyboard injection failed") {
+	if !errors.Is(err, ErrInputNotApplied) ||
+		!strings.Contains(err.Error(), "native keyboard injection failed") {
 		t.Fatalf("missing target key down error = %v", err)
+	}
+	if err := KeyToggleImmediate("delete", "up", pid); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("failed key-down retained ownership: %v", err)
 	}
 }
 
@@ -67,6 +81,22 @@ func assertNativeWindowsKeyMessage(
 		}
 	case <-time.After(nativeWindowsKeyMessageTimeout):
 		t.Fatalf("timed out waiting for targeted key message %#x", wantMessage)
+	}
+}
+
+func assertNoNativeWindowsKeyMessage(
+	t *testing.T,
+	messages <-chan nativeWindowsKeyMessage,
+) {
+	t.Helper()
+	select {
+	case message := <-messages:
+		t.Fatalf(
+			"ownership rejection emitted key message {message:%#x key:%#x}",
+			message.message,
+			message.key,
+		)
+	default:
 	}
 }
 

--- a/windows_native_key_integration_test.go
+++ b/windows_native_key_integration_test.go
@@ -17,7 +17,10 @@ import (
 	"github.com/tailscale/win"
 )
 
-const nativeWindowsKeyMessageTimeout = 3 * time.Second
+const (
+	nativeWindowsKeyMessageTimeout   = 3 * time.Second
+	nativeWindowsNoKeyMessageTimeout = 100 * time.Millisecond
+)
 
 type nativeWindowsKeyMessage struct {
 	message uint32
@@ -61,6 +64,98 @@ func TestNativeWindowsTargetedExtendedKeyDispatch(t *testing.T) {
 	}
 }
 
+func TestNativeWindowsSharedModifierOwnership(t *testing.T) {
+	messages, _ := startNativeWindowsKeyTarget(t)
+	pid := os.Getpid()
+
+	if err := KeyToggleImmediate("c", "down", "ctrl", pid); err != nil {
+		t.Fatalf("Ctrl+C down: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = KeyToggleImmediate("c", "up", "ctrl", pid)
+	})
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x11)
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 'C')
+
+	if err := KeyToggleImmediate("v", "down", "ctrl", pid); err != nil {
+		t.Fatalf("Ctrl+V down: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = KeyToggleImmediate("v", "up", "ctrl", pid)
+	})
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 'V')
+	assertNoNativeWindowsKeyMessage(t, messages)
+
+	if err := KeyToggleImmediate("c", "up", "ctrl", pid); err != nil {
+		t.Fatalf("Ctrl+C up: %v", err)
+	}
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 'C')
+	assertNoNativeWindowsKeyMessage(t, messages)
+
+	if err := KeyToggleImmediate("v", "up", "ctrl", pid); err != nil {
+		t.Fatalf("Ctrl+V up: %v", err)
+	}
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 'V')
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x11)
+}
+
+func TestNativeWindowsTapPreservesSharedModifierHold(t *testing.T) {
+	messages, _ := startNativeWindowsKeyTarget(t)
+	pid := os.Getpid()
+
+	if err := KeyToggleImmediate("c", "down", "ctrl", pid); err != nil {
+		t.Fatalf("Ctrl+C down: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = KeyToggleImmediate("c", "up", "ctrl", pid)
+	})
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x11)
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 'C')
+
+	if err := KeyTap("c", "ctrl", pid); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("tap exact held chord error = %v", err)
+	}
+	assertNoNativeWindowsKeyMessage(t, messages)
+
+	if err := KeyTap("v", "ctrl", pid); err != nil {
+		t.Fatalf("tap Ctrl+V while Ctrl+C is held: %v", err)
+	}
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 'V')
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 'V')
+	assertNoNativeWindowsKeyMessage(t, messages)
+
+	if err := KeyToggleImmediate("c", "up", "ctrl", pid); err != nil {
+		t.Fatalf("Ctrl+C up: %v", err)
+	}
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 'C')
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x11)
+}
+
+func TestNativeWindowsFailedReleaseRetainsOwnershipForRetry(t *testing.T) {
+	messages, stop := startNativeWindowsKeyTarget(t)
+	pid := os.Getpid()
+
+	if err := KeyToggleImmediate("delete", "down", "ctrl", pid); err != nil {
+		t.Fatalf("extended key down: %v", err)
+	}
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x11)
+	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x2e)
+	stop()
+
+	err := KeyToggleImmediate("delete", "up", "ctrl", pid)
+	if err == nil || errors.Is(err, ErrInputOwnership) ||
+		!strings.Contains(err.Error(), "native keyboard injection failed") {
+		t.Fatalf("release after target loss error = %v", err)
+	}
+
+	retryMessages, _ := startNativeWindowsKeyTarget(t)
+	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); err != nil {
+		t.Fatalf("retry extended key up: %v", err)
+	}
+	assertNativeWindowsKeyMessage(t, retryMessages, win.WM_KEYUP, 0x2e)
+	assertNativeWindowsKeyMessage(t, retryMessages, win.WM_KEYUP, 0x11)
+}
+
 func assertNativeWindowsKeyMessage(
 	t *testing.T,
 	messages <-chan nativeWindowsKeyMessage,
@@ -96,7 +191,7 @@ func assertNoNativeWindowsKeyMessage(
 			message.message,
 			message.key,
 		)
-	default:
+	case <-time.After(nativeWindowsNoKeyMessageTimeout):
 	}
 }
 

--- a/windows_native_key_integration_test.go
+++ b/windows_native_key_integration_test.go
@@ -136,29 +136,37 @@ func TestNativeWindowsTapPreservesSharedModifierHold(t *testing.T) {
 	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYUP, 0x11)
 }
 
-func TestNativeWindowsFailedReleaseRetainsOwnershipForRetry(t *testing.T) {
+func TestNativeWindowsOwnershipIsScopedToResolvedTarget(t *testing.T) {
 	messages, stop := startNativeWindowsKeyTarget(t)
 	pid := os.Getpid()
 
 	if err := KeyToggleImmediate("delete", "down", "ctrl", pid); err != nil {
 		t.Fatalf("extended key down: %v", err)
 	}
+	t.Cleanup(func() {
+		_ = KeyToggleImmediate("delete", "up", "ctrl", pid)
+	})
 	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x11)
 	assertNativeWindowsKeyMessage(t, messages, win.WM_KEYDOWN, 0x2e)
 	stop()
 
-	err := KeyToggleImmediate("delete", "up", "ctrl", pid)
-	if err == nil || errors.Is(err, ErrInputOwnership) ||
-		!strings.Contains(err.Error(), "native keyboard injection failed") {
-		t.Fatalf("release after target loss error = %v", err)
+	replacementMessages, _ := startNativeWindowsKeyTarget(t)
+	if err := KeyTap("v", "ctrl", pid); err != nil {
+		t.Fatalf("tap against replacement target: %v", err)
 	}
+	assertNativeWindowsKeyMessage(t, replacementMessages, win.WM_KEYDOWN, 0x11)
+	assertNativeWindowsKeyMessage(t, replacementMessages, win.WM_KEYDOWN, 'V')
+	assertNativeWindowsKeyMessage(t, replacementMessages, win.WM_KEYUP, 'V')
+	assertNativeWindowsKeyMessage(t, replacementMessages, win.WM_KEYUP, 0x11)
 
-	retryMessages, _ := startNativeWindowsKeyTarget(t)
 	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); err != nil {
-		t.Fatalf("retry extended key up: %v", err)
+		t.Fatalf("release ownership for destroyed original target: %v", err)
 	}
-	assertNativeWindowsKeyMessage(t, retryMessages, win.WM_KEYUP, 0x2e)
-	assertNativeWindowsKeyMessage(t, retryMessages, win.WM_KEYUP, 0x11)
+	assertNoNativeWindowsKeyMessage(t, replacementMessages)
+	if err := KeyToggleImmediate("delete", "up", "ctrl", pid); !errors.Is(err, ErrInputOwnership) {
+		t.Fatalf("duplicate release after target cleanup error = %v", err)
+	}
+	assertNoNativeWindowsKeyMessage(t, replacementMessages)
 }
 
 func assertNativeWindowsKeyMessage(

--- a/windows_window_integration_test.go
+++ b/windows_window_integration_test.go
@@ -80,6 +80,14 @@ func TestPureGoWindowsWindowRuntime(t *testing.T) {
 	if err != nil || title != "RobotGo Pure-Go window integration" {
 		t.Fatalf("GetTitleE(pid) = %q, %v", title, err)
 	}
+	title, err = GetTitleTargetE(int(handle), true)
+	if err != nil || title != "RobotGo Pure-Go window integration" {
+		t.Fatalf("GetTitleTargetE(handle) = %q, %v", title, err)
+	}
+	title, err = GetTitleTargetE(pid, false)
+	if err != nil || title != "RobotGo Pure-Go window integration" {
+		t.Fatalf("GetTitleTargetE(pid) = %q, %v", title, err)
+	}
 	if resolved := GetHWNDByPid(pid); resolved != int(handle) {
 		t.Fatalf("GetHWNDByPid(%d) = %#x, want %#x", pid, resolved, handle)
 	}

--- a/x11_window_native_integration_test.go
+++ b/x11_window_native_integration_test.go
@@ -99,6 +99,7 @@ func TestNativeX11ConfiguredTargetAppliesToWindowAndScale(t *testing.T) {
 	harness := newX11InputHarness(t)
 	assertExpectedX11Implementation(t)
 	configureX11WindowMetadata(t, harness, "robotgo-x11-target")
+	setX11ClientList(t, harness, harness.window)
 
 	original := robotgo.GetXDisplayName()
 	display := os.Getenv("DISPLAY")

--- a/x11_window_native_integration_test.go
+++ b/x11_window_native_integration_test.go
@@ -116,6 +116,21 @@ func TestNativeX11ConfiguredTargetAppliesToWindowAndScale(t *testing.T) {
 	if err != nil || title != "robotgo-x11-target" {
 		t.Fatalf("GetTitleE on configured X11 target = %q, %v", title, err)
 	}
+	// Native GetTitleE historically treats the presence of its first variadic
+	// target as handle mode. Keep that compatibility separate from the new
+	// explicit process/handle API.
+	title, err = robotgo.GetTitleE(int(harness.window))
+	if err != nil || title != "robotgo-x11-target" {
+		t.Fatalf("legacy GetTitleE(handle) = %q, %v", title, err)
+	}
+	title, err = robotgo.GetTitleTargetE(int(harness.window), true)
+	if err != nil || title != "robotgo-x11-target" {
+		t.Fatalf("GetTitleTargetE(handle) = %q, %v", title, err)
+	}
+	title, err = robotgo.GetTitleTargetE(os.Getpid(), false)
+	if err != nil || title != "robotgo-x11-target" {
+		t.Fatalf("GetTitleTargetE(pid) = %q, %v", title, err)
+	}
 	active, err := robotgo.GetActiveE()
 	if err != nil || active == (robotgo.Handle{}) {
 		t.Fatalf("GetActiveE on configured X11 target = %#v, %v", active, err)

--- a/x11_window_nocgo_integration_test.go
+++ b/x11_window_nocgo_integration_test.go
@@ -372,6 +372,14 @@ func TestPureGoX11WindowIntrospectionAndControl(t *testing.T) {
 		title != "RobotGo Pure-Go X11" {
 		t.Fatalf("GetTitleE(handle) = %q, %v", title, err)
 	}
+	if title, err := robotgo.GetTitleTargetE(int(harness.window), true); err != nil ||
+		title != "RobotGo Pure-Go X11" {
+		t.Fatalf("GetTitleTargetE(handle) = %q, %v", title, err)
+	}
+	if title, err := robotgo.GetTitleTargetE(os.Getpid(), false); err != nil ||
+		title != "RobotGo Pure-Go X11" {
+		t.Fatalf("GetTitleTargetE(pid) = %q, %v", title, err)
+	}
 	if x, y, width, height := robotgo.GetClient(os.Getpid()); x != x11WindowX ||
 		y != x11WindowY || width != x11WindowWidth || height != x11WindowHeight {
 		t.Fatalf(


### PR DESCRIPTION
## Summary

Implements [LAB-75](https://linear.app/riotbox/issue/LAB-75/expand-observation-bound-mcp-actions-for-autonomous-gui-control) as the first delivery slice of P010 Autonomous GUI Control.

- adds typed, deny-by-default `pointer.scroll`, `pointer.drag`, `keyboard.chord`, and `window.activate` actions to the Go agent contract and local MCP schema
- adds immutable limits for displays, buttons, keys, modifiers, window identities, event/distance/duration budgets, action rate, and session lifetime
- revalidates live display bounds and exact process/handle identity before mutation
- adds mandatory confirmation for drag, chords, and activation while preserving MCP dry-run by default
- adds cooperative cancellation and a session-owned pressed-input ledger with retryable close-time cleanup
- reports backend-specific scroll axes plus stable unavailable, unsupported, and permission-denied capability codes
- keeps chords unavailable on Linux and Windows until input can be atomically bound to an allow-listed target; global-focus checks are not treated as authorization
- keeps global foreign-window activation explicitly unsupported on Wayland
- documents the P010 delivery order and provides a bounded action example

## Safety and compatibility

Actions remain unavailable until every required allow list and hard bound is present. Changed targets fail before injection. Activation resolves, validates, and mutates the same exact handle. Errors returned after any desktop mutation dispatch are `unverified`; failures proven to occur during preflight remain `failed`; cleanup failure takes priority in MCP errors, taints the session, and retains process-exclusive ownership until a later `Close` succeeds.

The legacy package-level API remains source-compatible. New strict helpers `MoveImmediateE`, `ClickImmediateE`, `ScrollImmediateE`, `TypeStrImmediateE`, `KeyToggleImmediate`, `ResolveWindowHandleE`, and `GetTitleTargetE` let policy-bounded agent operations avoid legacy global delays and target-mode defaults without changing `MoveE`, `KeyToggle`, or `GetTitleE`. Native macOS CGO activation remains unavailable because its legacy representation cannot preserve an exact serializable handle. The public API freeze and operation catalog schema v5 are updated.

## Validation

- `./scripts/run-local-ci-preflight.sh`
- `go test -race ./...`
- `go test -tags wayland ./...`
- targeted hermetic tests for policy denial, capability states, stale identities, cancellation, cleanup retry, input ownership, delay-free bounded drag/chords, backend scroll axes, MCP schema, and MCP close sanitization
- native/Pure-Go X11 and Pure-Go Windows integration assertions for explicit PID/handle title lookup (run by CI; `xvfb-run` is unavailable locally)
- hermetic native Windows evidence that process-targeted taps and toggles fail closed with ErrNotSupported and emit no Win32 key messages; global native input retains exact-prefix ownership, shared-modifier reference counting, held-main-key rejection, and retryable failed releases
- hermetic native CGO mouse-ownership evidence that package holds, clicks, and agent drags cannot release one another; `ErrInputReleasePending` makes failed Windows click releases retryable through explicit Up or close cleanup, and agent sessions remain tainted until that cleanup succeeds

No test captures or drives the developer desktop; all new default-suite action evidence uses in-process fake backends, and integration windows are synthetic/self-owned.