### PR TITLE
fix(release): fail closed on evidence asset collisions

### DIFF
--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -410,6 +410,9 @@ jobs:
   publish:
     if: github.event_name == 'release'
     needs: package
+    concurrency:
+      group: release-evidence-publish-${{ github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -426,8 +429,20 @@ jobs:
         run: |
           set -euo pipefail
           cd bundle
-          sha256sum -c "${{ needs.package.outputs.checksum }}"
+          archive="${{ needs.package.outputs.archive }}"
+          checksum="${{ needs.package.outputs.checksum }}"
+          published_assets="$(
+            gh release view "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json assets \
+              --jq '.assets[].name'
+          )"
+          if grep -Fqx -e "$archive" -e "$checksum" <<<"$published_assets"; then
+            echo "release evidence asset already exists; refusing to publish" >&2
+            exit 1
+          fi
+          sha256sum -c "$checksum"
           gh release upload "$GITHUB_REF_NAME" \
-            "${{ needs.package.outputs.archive }}" \
-            "${{ needs.package.outputs.checksum }}" \
+            "$archive" \
+            "$checksum" \
             --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -430,5 +430,4 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" \
             "${{ needs.package.outputs.archive }}" \
             "${{ needs.package.outputs.checksum }}" \
-            --repo "$GITHUB_REPOSITORY" \
-            --clobber
+            --repo "$GITHUB_REPOSITORY"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Made published release-evidence assets fail closed on filename collisions.
+  The write-authorized release job still checksum-verifies and uploads a new
+  exact-tag bundle, but it can no longer delete or replace an existing archive
+  or checksum during a rerun.
+
 - Added the schema-v8, deny-by-default `desktop.ocr` and
   `desktop.detect-elements` contracts plus their separately image-enabled MCP
   tools. Both consume only an explicit subregion of a live, already-redacted

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## Unreleased
 
 - Made published release-evidence assets fail closed on filename collisions.
-  The write-authorized release job still checksum-verifies and uploads a new
-  exact-tag bundle, but it can no longer delete or replace an existing archive
-  or checksum during a rerun.
+  The write-authorized release job serializes same-tag publishers, rejects
+  either existing exact-tag filename before upload, and still checksum-verifies
+  new bundles, so a rerun can no longer mix assets from different runs, delete,
+  or replace an archive/checksum pair. A transport failure can still leave an
+  incomplete same-run pair, which later reruns preserve and reject.
 
 - Added the schema-v8, deny-by-default `desktop.ocr` and
   `desktop.detect-elements` contracts plus their separately image-enabled MCP

--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -63,14 +63,19 @@ robotgo-release-evidence-<tag>-<commit>.tar.gz.sha256
 
 For a GitHub `release.published` event these files are attached to the existing
 release. The write-authorized publish job does not check out or execute
-repository code; it only verifies the already packaged SHA-256 and uploads the
-two assets. Manual runs retain the bundle as a GitHub Actions artifact for 90
-days and do not modify a release.
+repository code; it only queries existing release-asset names, verifies the
+already packaged SHA-256, and uploads the two new assets. Manual runs retain the
+bundle as a GitHub Actions artifact for 90 days and do not modify a release.
 
-The upload deliberately has no overwrite or delete path. If either exact
-commit-bound asset name already exists, the publish job fails and leaves the
-existing release assets untouched. A rerun therefore cannot replace historical
-evidence, even when repository-level immutable releases are unavailable.
+Same-tag publish jobs are serialized. Each job enumerates the release's
+existing asset names before it uploads either file, and the upload deliberately
+has no overwrite or delete path. If either exact commit-bound asset name already
+exists, the job fails and leaves the existing release assets untouched. A rerun
+therefore cannot replace historical evidence or combine assets from different
+same-tag runs, even when repository-level immutable releases are unavailable.
+The two uploads are not transactional: an upload or network failure can still
+leave an incomplete pair from one run. A later rerun fails closed on that
+collision instead of silently filling or replacing the partial publication.
 
 The published post-API-freeze RC contract passes in
 [`v1.0.0-rc.1` Release Evidence run 30442843617](https://github.com/marang/robotgo/actions/runs/30442843617)

--- a/docs/compatibility/release-evidence-v1.md
+++ b/docs/compatibility/release-evidence-v1.md
@@ -67,6 +67,11 @@ repository code; it only verifies the already packaged SHA-256 and uploads the
 two assets. Manual runs retain the bundle as a GitHub Actions artifact for 90
 days and do not modify a release.
 
+The upload deliberately has no overwrite or delete path. If either exact
+commit-bound asset name already exists, the publish job fails and leaves the
+existing release assets untouched. A rerun therefore cannot replace historical
+evidence, even when repository-level immutable releases are unavailable.
+
 The published post-API-freeze RC contract passes in
 [`v1.0.0-rc.1` Release Evidence run 30442843617](https://github.com/marang/robotgo/actions/runs/30442843617)
 on tagged commit

--- a/docs/plan/stable-release-readiness.md
+++ b/docs/plan/stable-release-readiness.md
@@ -52,6 +52,11 @@ than `2026-08-05T10:13:46Z`.
   GNOME/KDE portal/bounds lanes and Hyprland. Its two public assets have the
   independently verified archive SHA-256
   `7761b673a8f6a8de8e36e74232149a24491fe8ef87dabd8023a665f313f31738`.
+- [LAB-78](https://linear.app/riotbox/issue/LAB-78/make-published-release-evidence-assets-fail-closed-on-collisions)
+  makes the release write boundary fail closed on an existing asset name. The
+  workflow no longer permits `gh release upload --clobber`, so a rerun cannot
+  delete or replace published evidence when repository-level immutable
+  releases are unavailable.
 - P005 is complete with all five milestones at 100%.
 - `go doc` currently exposes 259 root declarations, 44 `agent` declarations,
   and 12 `input/portal` declarations. That breadth makes an automated API

--- a/docs/plan/stable-release-readiness.md
+++ b/docs/plan/stable-release-readiness.md
@@ -54,9 +54,12 @@ than `2026-08-05T10:13:46Z`.
   `7761b673a8f6a8de8e36e74232149a24491fe8ef87dabd8023a665f313f31738`.
 - [LAB-78](https://linear.app/riotbox/issue/LAB-78/make-published-release-evidence-assets-fail-closed-on-collisions)
   makes the release write boundary fail closed on an existing asset name. The
-  workflow no longer permits `gh release upload --clobber`, so a rerun cannot
-  delete or replace published evidence when repository-level immutable
-  releases are unavailable.
+  workflow serializes same-tag publishers, checks both exact asset names before
+  either upload, and no longer permits `gh release upload --clobber`, so a rerun
+  cannot mix assets from different runs, delete, or replace published evidence
+  when repository-level immutable releases are unavailable. The non-transactional
+  two-file upload can still leave an incomplete same-run pair after a transport
+  failure; later reruns fail closed rather than repairing it implicitly.
 - P005 is complete with all five milestones at 100%.
 - `go doc` currently exposes 259 root declarations, 44 `agent` declarations,
   and 12 `input/portal` declarations. That breadth makes an automated API

--- a/scripts/release_evidence_workflow_test.go
+++ b/scripts/release_evidence_workflow_test.go
@@ -106,6 +106,8 @@ func TestPublishedReleaseEvidenceCannotReplaceExistingAssets(t *testing.T) {
 	publish := text[publishStart:]
 	for _, required := range []string{
 		"if: github.event_name == 'release'",
+		"group: release-evidence-publish-${{ github.ref }}",
+		"cancel-in-progress: false",
 		"contents: write",
 	} {
 		if !strings.Contains(publish, required) {
@@ -128,10 +130,22 @@ func TestPublishedReleaseEvidenceCannotReplaceExistingAssets(t *testing.T) {
         run: |
           set -euo pipefail
           cd bundle
-          sha256sum -c "${{ needs.package.outputs.checksum }}"
+          archive="${{ needs.package.outputs.archive }}"
+          checksum="${{ needs.package.outputs.checksum }}"
+          published_assets="$(
+            gh release view "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json assets \
+              --jq '.assets[].name'
+          )"
+          if grep -Fqx -e "$archive" -e "$checksum" <<<"$published_assets"; then
+            echo "release evidence asset already exists; refusing to publish" >&2
+            exit 1
+          fi
+          sha256sum -c "$checksum"
           gh release upload "$GITHUB_REF_NAME" \
-            "${{ needs.package.outputs.archive }}" \
-            "${{ needs.package.outputs.checksum }}" \
+            "$archive" \
+            "$checksum" \
             --repo "$GITHUB_REPOSITORY"`
 	if got := strings.TrimSpace(publish[stepsStart:]); got != strings.TrimSpace(allowedSteps) {
 		t.Errorf(

--- a/scripts/release_evidence_workflow_test.go
+++ b/scripts/release_evidence_workflow_test.go
@@ -92,6 +92,56 @@ func TestReleaseEvidenceRequiresEveryPromotedHostedCheck(t *testing.T) {
 	}
 }
 
+func TestPublishedReleaseEvidenceCannotReplaceExistingAssets(t *testing.T) {
+	t.Parallel()
+	workflow, err := os.ReadFile("../.github/workflows/release-evidence.yml")
+	if err != nil {
+		t.Fatalf("read release-evidence workflow: %v", err)
+	}
+	text := normalizeWorkflowText(workflow)
+	publishStart := strings.Index(text, "  publish:")
+	if publishStart < 0 {
+		t.Fatal("release evidence does not define a publish job")
+	}
+	publish := text[publishStart:]
+	for _, required := range []string{
+		"if: github.event_name == 'release'",
+		"contents: write",
+	} {
+		if !strings.Contains(publish, required) {
+			t.Errorf("release evidence publish job omits %q", required)
+		}
+	}
+	stepsStart := strings.Index(publish, "    steps:\n")
+	if stepsStart < 0 {
+		t.Fatal("release evidence publish job does not define steps")
+	}
+	const allowedSteps = `    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-evidence-bundle
+          path: bundle
+      - name: Verify and attach evidence to published release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cd bundle
+          sha256sum -c "${{ needs.package.outputs.checksum }}"
+          gh release upload "$GITHUB_REF_NAME" \
+            "${{ needs.package.outputs.archive }}" \
+            "${{ needs.package.outputs.checksum }}" \
+            --repo "$GITHUB_REPOSITORY"`
+	if got := strings.TrimSpace(publish[stepsStart:]); got != strings.TrimSpace(allowedSteps) {
+		t.Errorf(
+			"release evidence publish steps changed outside the fail-closed allowlist\n--- got ---\n%s\n--- want ---\n%s",
+			got,
+			strings.TrimSpace(allowedSteps),
+		)
+	}
+}
+
 func TestReleaseEvidenceCallsRealDesktopProofBeforeCollection(t *testing.T) {
 	t.Parallel()
 	workflow, err := os.ReadFile("../.github/workflows/release-evidence.yml")


### PR DESCRIPTION
## Result

Published release-evidence assets can no longer be deleted or replaced by rerunning the release workflow. Same-tag publishers are serialized, and a collision on either exact archive/checksum filename fails before either upload.

## Why

The publish job used `gh release upload --clobber`. GitHub CLI implements that flag by deleting an existing asset before uploading its replacement, so a failed rerun could also lose the historical artifact.

## Changes

- serialize write-authorized publish jobs per exact release ref
- preflight both release asset names before either upload and fail closed on lookup errors or collisions
- remove `--clobber` from the exact-tag evidence upload
- lock the complete write-authorized publish steps behind an exact regression-test allowlist
- document both the immutable collision boundary and the remaining non-transactional transport-failure risk

## Risk and compatibility

This changes only release publication behavior. Runtime APIs, desktop backends, platform behavior, and public API manifests are unchanged. A collision intentionally stops publication; there is no delete/replace fallback and no sensitive desktop data is added. The two uploads remain non-transactional, so a transport failure may leave an incomplete same-run pair; a later rerun preserves it and fails closed instead of repairing it implicitly.

## Validation

- `go test ./...`
- `go test ./scripts -count=1`
- `go test -race ./scripts`
- `bash scripts/run-local-ci-preflight.sh`
- `git diff --check`
- independent Ultra review of GitHub CLI, Bash, concurrency, and documentation semantics

Linear: https://linear.app/riotbox/issue/LAB-78/make-published-release-evidence-assets-fail-closed-on-collisions